### PR TITLE
fix(ci): add Windows binary to release, fix PyPI auto-publish

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,9 +1,12 @@
 name: Publish Python SDK to PyPI
 
-# Triggers on a GitHub Release (tag v*) OR manually from the Actions tab.
+# Triggers on version tag push OR manually from the Actions tab.
+# NOTE: We use push→tags instead of release→published because GitHub's
+# GITHUB_TOKEN events do not trigger downstream workflows.
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -52,7 +55,7 @@ jobs:
           ls -lh dist-all/
 
       - name: Publish to PyPI
-        if: github.event_name == 'release' || github.event.inputs.dry_run == 'false'
+        if: github.event.inputs.dry_run != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist-all/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,58 @@ jobs:
           name: muninn-${{ matrix.goos }}-${{ matrix.goarch }}
           path: muninn-${{ matrix.goos }}-${{ matrix.goarch }}
 
+  # ── Build Windows binary (separate job — different asset-fetch steps) ──
+  build-windows:
+    name: Build windows/amd64
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Cache embed assets (Windows)
+        id: asset-cache-win
+        uses: actions/cache@v4
+        with:
+          path: internal/plugin/embed/assets
+          key: embed-assets-ort-1.24.2-minilm-v2-windows-amd64
+
+      - name: Fetch model assets
+        if: steps.asset-cache-win.outputs.cache-hit != 'true'
+        run: |
+          New-Item -ItemType Directory -Path internal/plugin/embed/assets -Force | Out-Null
+          Invoke-WebRequest -Uri "https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main/onnx/model_int8.onnx" -OutFile "internal/plugin/embed/assets/model_int8.onnx"
+          Invoke-WebRequest -Uri "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json" -OutFile "internal/plugin/embed/assets/tokenizer.json"
+        shell: pwsh
+
+      - name: Fetch ORT DLL
+        if: steps.asset-cache-win.outputs.cache-hit != 'true'
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/microsoft/onnxruntime/releases/download/v1.24.2/onnxruntime-win-x64-1.24.2.zip" -OutFile "$env:TEMP\ort-win-x64.zip"
+          Expand-Archive -Path "$env:TEMP\ort-win-x64.zip" -DestinationPath "$env:TEMP\ort-extract" -Force
+          $dll = Get-ChildItem -Path "$env:TEMP\ort-extract" -Recurse -Filter "onnxruntime.dll" | Select-Object -First 1
+          Copy-Item $dll.FullName -Destination "internal/plugin/embed/assets/onnxruntime_windows_amd64.dll"
+        shell: pwsh
+
+      - name: Build binary
+        run: |
+          go build -ldflags "-X main.version=$env:GITHUB_REF_NAME" -o muninn-windows-amd64.exe ./cmd/muninn/...
+        shell: pwsh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: muninn-windows-amd64
+          path: muninn-windows-amd64.exe
+
   # ── Create GitHub Release and attach all binaries ───────────────────────
   release:
     name: Create GitHub Release
-    needs: build
+    needs: [build, build-windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -98,7 +146,8 @@ jobs:
             --generate-notes \
             muninn-darwin-arm64 \
             muninn-darwin-amd64 \
-            muninn-linux-amd64
+            muninn-linux-amd64 \
+            muninn-windows-amd64.exe
 
   # ── Update Homebrew formula with new version + SHA256s ──────────────────
   update-formula:


### PR DESCRIPTION
## Summary

- Adds a `build-windows` job to the release workflow that produces `muninn-windows-amd64.exe` and attaches it to the GitHub Release alongside darwin and linux binaries.
- Switches `publish-sdk.yml` trigger from `release: published` to `push: tags: ['v*']` so PyPI publishing fires directly from the version tag (the old trigger never worked because `GITHUB_TOKEN` events don't trigger downstream workflows).

## Test plan

- [ ] CI passes on this PR (validates YAML syntax and existing tests still work)
- [ ] After merge + tag, verify the release workflow produces 4 binaries (darwin-arm64, darwin-amd64, linux-amd64, windows-amd64.exe)
- [ ] After merge + tag, verify publish-sdk workflow triggers and publishes to PyPI

Made with [Cursor](https://cursor.com)