### PR TITLE
docs: SDK publish workflow, CONTRIBUTING rewrite, patent notice

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -77,6 +77,43 @@ jobs:
         if: github.event.inputs.dry_run == 'true'
         run: echo "Dry run complete. Packages built but not uploaded."
 
+  # ── Node SDK → npm (OIDC trusted publishing — no token) ──────────────────
+  publish-node:
+    name: Build & publish @muninndb/client to npm
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Inject version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "s/\"version\": \"0.0.0-dev\"/\"version\": \"${VERSION}\"/" sdk/node/package.json
+
+      - name: Install and build
+        working-directory: sdk/node
+        run: |
+          npm ci
+          npm run build
+
+      - name: Publish to npm
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: sdk/node
+        run: npm publish --access public
+
+      - name: Dry run — skip npm publish
+        if: github.event.inputs.dry_run == 'true'
+        run: echo "Dry run: Node package built but not published."
+
   # ── PHP SDK → Packagist (via subtree split to muninndb-php repo) ─────────
   publish-php:
     name: Sync PHP SDK to muninndb-php

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,33 @@
 # Contributing to MuninnDB
 
-Thanks for your interest in contributing. This document describes our branching model and how to get changes merged.
+**Let's build the memory layer for agents together.**
+
+MuninnDB exists for the AI agent community — indie hackers wiring up Claude, researchers experimenting with cognitive architectures, or anyone who wants better long-term memory in their tools. Your input makes it better.
+
+The project is under the [Business Source License 1.1](LICENSE) and has a provisional patent on the core cognitive primitives. Those exist to protect the project so we can keep developing it full-time and prevent big-tech forks from closing the open vision. **Normal use, modifications, and contributions are welcome and encouraged.** All contributions are licensed under the same BSL 1.1 (see [CLA](CLA.md)).
+
+---
+
+## How to contribute
+
+1. **Bug reports or ideas** — Open an issue. Even a one-line "this broke my agent workflow" helps.
+2. **Code changes** — Fork, make the change, open a PR.
+   - Small fixes (typos, docs, tests) → we'll merge quickly.
+   - New features (extra embedders, SDK improvements, UI) → open an issue first so we can align on the cognitive model.
+3. **Documentation** — Improving examples, adding recipes, or translating → always valuable.
+4. **Testing** — Run MuninnDB on your workloads and share results. Real-world numbers help.
+
+**Development setup:** Clone the repo, then build and run from source:
+
+```bash
+git clone https://github.com/scrypster/muninndb
+cd muninndb
+go run ./cmd/muninn/... start
+```
+
+See the [README](README.md) for full install options and configuration.
+
+---
 
 ## Branch model (Git Flow)
 
@@ -28,7 +55,7 @@ We use a **develop → main** flow:
    Once the PR is approved (if required) and CI is green, merge. Do **not** push directly to `develop` or `main`.
 
 5. **Releases:**  
-   When we’re ready to release, we merge `develop` into `main` (via PR) and push a version tag (e.g. `v0.2.4`). That triggers builds, PyPI publish, PHP Packagist sync, and GitHub Release.
+   When we're ready to release, we merge `develop` into `main` (via PR) and push a version tag (e.g. `v0.2.4`). That triggers builds, PyPI publish, PHP Packagist sync, and GitHub Release.
 
 ## Summary
 
@@ -36,6 +63,8 @@ We use a **develop → main** flow:
 - **develop** → open PR → **main** (when releasing)
 - **Tag on main** → release artifacts and package publishes
 
+---
+
 ## Legal
 
-By contributing, you agree that your contributions will be licensed under the [Apache 2.0 license](LICENSE) and that you have read our [Contributor License Agreement](CLA.md).
+By contributing, you agree that your contributions will be licensed under the [Business Source License 1.1](LICENSE) and that you have read our [Contributor License Agreement](CLA.md).

--- a/NOTICE
+++ b/NOTICE
@@ -7,3 +7,5 @@ MJ Bonanno (https://scrypster.com).
 MuninnDB is a trademark of Scrypster / MJ Bonanno.
 The MuninnDB name and logo may not be used to endorse or promote
 products derived from this software without specific prior written permission.
+
+MuninnDB is covered by U.S. Provisional Patent Application No. 63/991,402.

--- a/README.md
+++ b/README.md
@@ -408,3 +408,7 @@ The bundled local embedder uses ONNX Runtime, which requires the Visual C++ Redi
 *Named after Muninn — one of Odin's two ravens, whose name means "memory" in Old Norse. Muninn flies across the nine worlds and returns what has been forgotten.*
 
 Built by [MJ Bonanno](https://scrypster.com) · [muninndb.com](https://muninndb.com) · BSL 1.1
+
+---
+
+*MuninnDB is patent pending (U.S. Provisional Patent Application No. 63/991,402) and licensed under BSL 1.1.*

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muninndb/client",
-  "version": "0.0.0-dev",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@muninndb/client",
-      "version": "0.0.0-dev",
+      "version": "0.2.3",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3"

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muninndb/client",
-  "version": "0.0.0-dev",
+  "version": "0.2.3",
   "description": "Official TypeScript/Node.js SDK for MuninnDB — the cognitive memory database",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Stashed changes from a separate session — SDK publishing and documentation updates.

## Changes
- Add Node SDK publish job to `publish-sdk.yml` (OIDC trusted publishing, no token needed)
- Rewrite `CONTRIBUTING.md` with community-focused tone and dev setup instructions
- Add U.S. Provisional Patent Application No. 63/991,402 to `NOTICE`
- Update `README.md` footer with patent pending notice under BSL 1.1
- Bump Node SDK version placeholder in `package.json`

## Test plan
- [ ] CI passes (no Go code changes)
- [ ] `publish-sdk.yml` YAML is valid