### PR TITLE
fix: session item click — fetch full engram + update URL

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -791,11 +791,21 @@ document.addEventListener('alpine:init', () => {
       this.loadContradictions();
     },
 
-    openMemory(m) {
+    async openMemory(m) {
+      // Session entries only have id/concept/createdAt — fetch full engram if content is missing.
+      if (!m.content && m.id) {
+        try {
+          const resp = await fetch('/api/engrams/' + encodeURIComponent(m.id) + '?vault=' + encodeURIComponent(this.vault));
+          if (resp.ok) {
+            const full = await resp.json();
+            m = { ...m, ...full };
+          }
+        } catch (e) { /* fall through with partial data */ }
+      }
       this.selectedMemory = m;
-      // Navigate to memories view if not there
+      // Navigate to memories view and update URL
       if (this.currentView !== 'memories') {
-        this.currentView = 'memories';
+        this.navigateTo('memories');
       }
     },
 


### PR DESCRIPTION
## Summary
Two bugs when clicking a session timeline entry:

1. **URL not updated** — URL stayed at `#/session` while view switched to memories. Sidebar highlighted Memories but browser URL was wrong.
2. **Empty detail panel** — Session entries only have `id`/`concept`/`createdAt` (no content). Detail panel opened with empty Content, Confidence, and Tags.

## Fix
- `openMemory()` now fetches the full engram via `GET /api/engrams/{id}` when content is missing
- Uses `navigateTo('memories')` instead of just setting `currentView` to update both view and URL hash

## Test plan
- [ ] Click a session entry → URL changes to `#/memories`, detail panel shows full content
- [ ] Click a memory card in memories view → still works as before (no extra fetch)
- [ ] `go build ./...` clean