### PR TITLE
feat: contradiction resolution + graph visualization improvements

### DIFF
--- a/internal/engine/query.go
+++ b/internal/engine/query.go
@@ -54,6 +54,27 @@ func (e *Engine) GetContradictions(ctx context.Context, vault string) ([][2]stor
 	return e.store.GetContradictions(ctx, ws)
 }
 
+// ResolveContradiction removes the contradiction marker for the pair (idA, idB)
+// and updates the vault coherence counters.
+func (e *Engine) ResolveContradiction(ctx context.Context, vault, idA, idB string) error {
+	a, err := storage.ParseULID(idA)
+	if err != nil {
+		return fmt.Errorf("parse id_a: %w", err)
+	}
+	b, err := storage.ParseULID(idB)
+	if err != nil {
+		return fmt.Errorf("parse id_b: %w", err)
+	}
+	ws := e.store.ResolveVaultPrefix(vault)
+	if err := e.store.ResolveContradiction(ctx, ws, a, b); err != nil {
+		return err
+	}
+	if e.coherence != nil {
+		e.coherence.GetOrCreate(vault).RecordContradictionResolved()
+	}
+	return nil
+}
+
 // Traverse performs a bounded BFS from startID, following association edges.
 func (e *Engine) Traverse(ctx context.Context, vault, startID string, maxHops, maxNodes int) ([]TraversalNode, []TraversalEdge, error) {
 	ws := e.store.ResolveVaultPrefix(vault)

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -481,6 +481,28 @@ func (ps *PebbleStore) FlagContradiction(ctx context.Context, wsPrefix [8]byte, 
 	return nil
 }
 
+// ResolveContradiction deletes the contradiction marker(s) for the pair (a,b).
+// Contradictions are stored bidirectionally, so both directions are removed.
+func (ps *PebbleStore) ResolveContradiction(ctx context.Context, wsPrefix [8]byte, a, b ULID) error {
+	batch := ps.db.NewBatch()
+	defer batch.Close()
+
+	var aBytes [16]byte = [16]byte(a)
+	var bBytes [16]byte = [16]byte(b)
+
+	// Delete both directions regardless of canonical ordering — the caller may pass
+	// (a,b) or (b,a) so we always remove the marker written for each direction.
+	contraKeyAB := keys.ContradictionKey(wsPrefix, 0, 0, aBytes)
+	contraKeyBA := keys.ContradictionKey(wsPrefix, 0, 0, bBytes)
+	batch.Delete(contraKeyAB, nil)
+	batch.Delete(contraKeyBA, nil)
+
+	if err := batch.Commit(pebble.NoSync); err != nil {
+		return fmt.Errorf("resolve contradiction: %w", err)
+	}
+	return nil
+}
+
 // GetContradictions returns all contradiction pairs in the vault by scanning the 0x0A prefix.
 // The key structure is: 0x0A | wsPrefix(8) | conceptHash(4) | relType(2) | id(16) = 31 bytes.
 // The value is the partner ULID (16 bytes).

--- a/internal/storage/association_test.go
+++ b/internal/storage/association_test.go
@@ -224,6 +224,68 @@ func TestGetContradictions_WithPairs(t *testing.T) {
 }
 
 
+// TestResolveContradiction verifies that ResolveContradiction removes both
+// directions of the contradiction marker and GetContradictions no longer returns the pair.
+func TestResolveContradiction(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("contra-resolve")
+
+	idA := NewULID()
+	idB := NewULID()
+	idC := NewULID()
+
+	// Flag two pairs.
+	if err := store.FlagContradiction(ctx, ws, idA, idB); err != nil {
+		t.Fatalf("FlagContradiction(A,B): %v", err)
+	}
+	if err := store.FlagContradiction(ctx, ws, idA, idC); err != nil {
+		t.Fatalf("FlagContradiction(A,C): %v", err)
+	}
+
+	// Resolve the (A,B) pair.
+	if err := store.ResolveContradiction(ctx, ws, idA, idB); err != nil {
+		t.Fatalf("ResolveContradiction(A,B): %v", err)
+	}
+
+	pairs, err := store.GetContradictions(ctx, ws)
+	if err != nil {
+		t.Fatalf("GetContradictions: %v", err)
+	}
+	// Only (A,C) should remain.
+	if len(pairs) != 1 {
+		t.Fatalf("expected 1 pair after resolve, got %d: %v", len(pairs), pairs)
+	}
+}
+
+// TestResolveContradiction_BothDirections verifies that ResolveContradiction works
+// regardless of which direction (a,b) or (b,a) the caller passes.
+func TestResolveContradiction_BothDirections(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("contra-resolve-dir")
+
+	idA := NewULID()
+	idB := NewULID()
+
+	if err := store.FlagContradiction(ctx, ws, idA, idB); err != nil {
+		t.Fatalf("FlagContradiction: %v", err)
+	}
+
+	// Resolve using (b,a) order — must still remove both directions.
+	if err := store.ResolveContradiction(ctx, ws, idB, idA); err != nil {
+		t.Fatalf("ResolveContradiction(B,A): %v", err)
+	}
+
+	pairs, err := store.GetContradictions(ctx, ws)
+	if err != nil {
+		t.Fatalf("GetContradictions: %v", err)
+	}
+	if len(pairs) != 0 {
+		t.Fatalf("expected 0 pairs after resolve, got %d: %v", len(pairs), pairs)
+	}
+}
+
 // newTestStore creates a PebbleStore backed by a temp dir.
 // openTestPebble already registers Cleanup for the DB; we just wrap it in a store.
 func newTestStore(t *testing.T) *PebbleStore {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -88,6 +88,10 @@ type EngineStore interface {
 	// GetContradictions returns all contradiction pairs in the vault by scanning the 0x0A prefix.
 	GetContradictions(ctx context.Context, wsPrefix [8]byte) ([][2]ULID, error)
 
+	// ResolveContradiction deletes the contradiction marker(s) for the pair (a,b).
+	// Both directions are removed (the pair is stored bidirectionally).
+	ResolveContradiction(ctx context.Context, wsPrefix [8]byte, a, b ULID) error
+
 	// ListByState returns up to limit engram IDs whose lifecycle state matches,
 	// using the 0x0B state secondary index.
 	ListByState(ctx context.Context, wsPrefix [8]byte, state LifecycleState, limit int) ([]ULID, error)

--- a/internal/transport/rest/engine_adapter.go
+++ b/internal/transport/rest/engine_adapter.go
@@ -465,6 +465,10 @@ func (w *RESTEngineWrapper) RetryEnrich(ctx context.Context, vault, engramID str
 	}, nil
 }
 
+func (w *RESTEngineWrapper) ResolveContradiction(ctx context.Context, vault, idA, idB string) error {
+	return w.engine.ResolveContradiction(ctx, vault, idA, idB)
+}
+
 func (w *RESTEngineWrapper) GetContradictions(ctx context.Context, vault string) (*ContradictionsResponse, error) {
 	pairs, err := w.engine.GetContradictions(ctx, vault)
 	if err != nil {

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -206,6 +206,7 @@ func NewServer(addr string, engine EngineAPI, authStore *auth.Store, sessionSecr
 	mux.HandleFunc("POST /api/admin/vaults/{name}/rename", s.withAdminMiddleware(s.handleRenameVault))
 	mux.HandleFunc("POST /api/admin/backup", s.withAdminMiddleware(s.handleBackup))
 	mux.HandleFunc("GET /api/admin/observability", s.withAdminMiddleware(s.handleObservability))
+	mux.HandleFunc("POST /api/admin/contradictions/resolve", s.withAdminMiddleware(s.handleResolveContradiction))
 
 	// Cluster management — session auth required
 	mux.HandleFunc("GET /api/admin/cluster/token", s.withAdminMiddleware(s.handleAdminClusterToken))
@@ -1343,6 +1344,27 @@ func (s *Server) handleContradictions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.sendJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleResolveContradiction(w http.ResponseWriter, r *http.Request) {
+	var req ResolveContradictionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, err.Error())
+		return
+	}
+	if req.IDA == "" || req.IDB == "" {
+		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "id_a and id_b are required")
+		return
+	}
+	vault := req.Vault
+	if vault == "" {
+		vault = ctxVault(r)
+	}
+	if err := s.engine.ResolveContradiction(r.Context(), vault, req.IDA, req.IDB); err != nil {
+		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
+		return
+	}
+	s.sendJSON(w, http.StatusOK, ResolveContradictionResponse{Resolved: true})
 }
 
 func (s *Server) handleGuide(w http.ResponseWriter, r *http.Request) {

--- a/internal/transport/rest/server_test.go
+++ b/internal/transport/rest/server_test.go
@@ -253,6 +253,10 @@ func (m *MockEngine) GetContradictions(ctx context.Context, vault string) (*Cont
 	}, nil
 }
 
+func (m *MockEngine) ResolveContradiction(ctx context.Context, vault, idA, idB string) error {
+	return nil
+}
+
 func (m *MockEngine) GetGuide(ctx context.Context, vault string) (string, error) {
 	return "MuninnDB Guide for vault \"default\"\n\nThis vault has 100 memories.", nil
 }
@@ -1840,6 +1844,67 @@ func TestContradictions_EngineError(t *testing.T) {
 	server := NewServer("localhost:8080", &contradictionsErrEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/contradictions?vault=default", nil)
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+// ── POST /api/admin/contradictions/resolve ────────────────────────────────────
+
+// TestResolveContradiction_Success verifies the happy path returns {resolved:true}.
+func TestResolveContradiction_Success(t *testing.T) {
+	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+
+	body := `{"vault":"default","id_a":"01ARZ3NDEKTSV4RRFFQ69G5FAV","id_b":"01ARZ3NDEKTSV4RRFFQ69G5FAW"}`
+	req := httptest.NewRequest("POST", "/api/admin/contradictions/resolve", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["resolved"] != true {
+		t.Errorf("expected resolved=true, got %v", resp["resolved"])
+	}
+}
+
+// TestResolveContradiction_MissingIDs verifies missing IDs returns 400.
+func TestResolveContradiction_MissingIDs(t *testing.T) {
+	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+
+	body := `{"vault":"default","id_a":"","id_b":""}`
+	req := httptest.NewRequest("POST", "/api/admin/contradictions/resolve", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// resolveContradictionErrEngine returns an error from ResolveContradiction.
+type resolveContradictionErrEngine struct{ MockEngine }
+
+func (e *resolveContradictionErrEngine) ResolveContradiction(ctx context.Context, vault, idA, idB string) error {
+	return fmt.Errorf("storage error")
+}
+
+// TestResolveContradiction_EngineError verifies engine error → 500.
+func TestResolveContradiction_EngineError(t *testing.T) {
+	server := NewServer("localhost:8080", &resolveContradictionErrEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+
+	body := `{"vault":"default","id_a":"01ARZ3NDEKTSV4RRFFQ69G5FAV","id_b":"01ARZ3NDEKTSV4RRFFQ69G5FAW"}`
+	req := httptest.NewRequest("POST", "/api/admin/contradictions/resolve", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	server.mux.ServeHTTP(w, req)
 

--- a/internal/transport/rest/types.go
+++ b/internal/transport/rest/types.go
@@ -130,6 +130,7 @@ type EngineAPI interface {
 	ListDeleted(ctx context.Context, vault string, limit int) (*ListDeletedResponse, error)
 	RetryEnrich(ctx context.Context, vault, engramID string) (*RetryEnrichResponse, error)
 	GetContradictions(ctx context.Context, vault string) (*ContradictionsResponse, error)
+	ResolveContradiction(ctx context.Context, vault, idA, idB string) error
 	GetGuide(ctx context.Context, vault string) (string, error)
 }
 
@@ -377,6 +378,18 @@ type ContradictionItem struct {
 // ContradictionsResponse is returned by the contradictions endpoint.
 type ContradictionsResponse struct {
 	Contradictions []ContradictionItem `json:"contradictions"`
+}
+
+// ResolveContradictionRequest is the body for POST /api/admin/contradictions/resolve.
+type ResolveContradictionRequest struct {
+	Vault string `json:"vault"`
+	IDA   string `json:"id_a"`
+	IDB   string `json:"id_b"`
+}
+
+// ResolveContradictionResponse is returned by the resolve-contradiction endpoint.
+type ResolveContradictionResponse struct {
+	Resolved bool `json:"resolved"`
 }
 
 // GuideResponse is returned by the guide endpoint.

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -152,6 +152,10 @@ func (m *mockEngine) RetryEnrich(ctx context.Context, vault, engramID string) (*
 func (m *mockEngine) GetContradictions(ctx context.Context, vault string) (*rest.ContradictionsResponse, error) {
 	return &rest.ContradictionsResponse{}, nil
 }
+
+func (m *mockEngine) ResolveContradiction(ctx context.Context, vault, idA, idB string) error {
+	return nil
+}
 func (m *mockEngine) GetGuide(ctx context.Context, vault string) (string, error) {
 	return "", nil
 }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -734,6 +734,63 @@ document.addEventListener('alpine:init', () => {
       }
     },
 
+    async resolveContradiction(idA, idB, action) {
+      const vault = this.vault;
+      try {
+        if (action === 'keep_a') {
+          // A supersedes B; archive B
+          await fetch('/api/link', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ source_id: idA, target_id: idB, rel_type: 4, weight: 1.0, vault }),
+          });
+          await fetch('/api/engrams/' + encodeURIComponent(idB) + '/state', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ vault, state: 'archived' }),
+          });
+          await fetch('/api/admin/contradictions/resolve', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
+          });
+        } else if (action === 'keep_b') {
+          // B supersedes A; archive A
+          await fetch('/api/link', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ source_id: idB, target_id: idA, rel_type: 4, weight: 1.0, vault }),
+          });
+          await fetch('/api/engrams/' + encodeURIComponent(idA) + '/state', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ vault, state: 'archived' }),
+          });
+          await fetch('/api/admin/contradictions/resolve', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
+          });
+        } else if (action === 'dismiss') {
+          await fetch('/api/admin/contradictions/resolve', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
+          });
+        } else if (action === 'merge') {
+          // Open consolidate modal pre-filled with both IDs
+          this.multiSelectMode = true;
+          this.selectedMemoryIds = [idA, idB];
+          this.consolidateModal = { show: true, mergedContent: '(Merge contradicting memories here)' };
+          return; // don't reload contradictions yet
+        }
+        this.addNotification('success', 'Contradiction resolved');
+      } catch (err) {
+        this.addNotification('error', 'Resolve failed: ' + err.message);
+      }
+      this.loadContradictions();
+    },
+
     openMemory(m) {
       this.selectedMemory = m;
       // Navigate to memories view if not there
@@ -957,6 +1014,8 @@ document.addEventListener('alpine:init', () => {
     },
 
     // ── Graph ──────────────────────────────────────────────────────────────
+    graphShowOrphans: false,
+
     async loadGraph() {
       this.addNotification('info', 'Loading graph…');
       try {
@@ -969,18 +1028,6 @@ document.addEventListener('alpine:init', () => {
           this.addNotification('error', 'No engrams to graph');
           return;
         }
-
-        // Build node elements
-        const elements = engrams.map(e => ({
-          data: {
-            id: e.id,
-            label: e.concept || e.id.slice(0, 8),
-            size: 20 + (e.confidence || 0.5) * 20,
-            color: (e.confidence || 0) > 0.7 ? '#06b6d4'
-                 : (e.confidence || 0) > 0.4 ? '#a855f7' : '#eab308',
-            snippet: (e.content || '').slice(0, 80),
-          },
-        }));
 
         // Load links for first 20 engrams in parallel
         const nodeIdSet = new Set(engrams.map(e => e.id));
@@ -1001,14 +1048,43 @@ document.addEventListener('alpine:init', () => {
         );
         const edgeBatches = await Promise.all(linkPromises);
         const edgeSet = new Set();
-        for (const edges of edgeBatches) {
-          for (const edge of edges) {
+        const edges = [];
+        const connectedNodeIds = new Set();
+        for (const batch of edgeBatches) {
+          for (const edge of batch) {
             if (nodeIdSet.has(edge.data.target) && !edgeSet.has(edge.data.id)) {
               edgeSet.add(edge.data.id);
-              elements.push(edge);
+              edges.push(edge);
+              connectedNodeIds.add(edge.data.source);
+              connectedNodeIds.add(edge.data.target);
             }
           }
         }
+
+        // Filter orphan nodes (nodes with 0 edges) unless showOrphans is toggled on
+        const showOrphans = this.graphShowOrphans;
+        const filteredEngrams = showOrphans
+          ? engrams
+          : engrams.filter(e => connectedNodeIds.has(e.id));
+
+        // If no connected nodes, fall back to all engrams so the graph isn't empty
+        const nodesToRender = filteredEngrams.length > 0 ? filteredEngrams : engrams;
+
+        // Build node elements
+        const nodeElements = nodesToRender.map(e => ({
+          data: {
+            id: e.id,
+            label: e.concept || e.id.slice(0, 8),
+            size: connectedNodeIds.has(e.id) ? 20 + (e.confidence || 0.5) * 20 : 12,
+            color: !connectedNodeIds.has(e.id) ? '#64748b'
+                 : (e.confidence || 0) > 0.7 ? '#06b6d4'
+                 : (e.confidence || 0) > 0.4 ? '#a855f7' : '#eab308',
+            orphan: !connectedNodeIds.has(e.id),
+            snippet: (e.content || '').slice(0, 80),
+          },
+        }));
+
+        const elements = [...nodeElements, ...edges];
 
         // Init or reinit Cytoscape
         if (this._cy) { this._cy.destroy(); this._cy = null; }
@@ -1034,6 +1110,13 @@ document.addEventListener('alpine:init', () => {
               },
             },
             {
+              selector: 'node[?orphan]',
+              style: {
+                'opacity': 0.45,
+                'border-style': 'dashed',
+              },
+            },
+            {
               selector: 'edge',
               style: {
                 'line-color': 'rgba(168,85,247,0.4)',
@@ -1048,6 +1131,7 @@ document.addEventListener('alpine:init', () => {
             },
           ],
           layout: { name: 'fcose', animate: true, animationDuration: 600 },
+          wheelSensitivity: 0.3,
         });
 
         this._cy.on('tap', 'node', (evt) => {
@@ -1059,10 +1143,23 @@ document.addEventListener('alpine:init', () => {
         });
 
         this.graphLoaded = true;
-        this.addNotification('success', 'Graph loaded (' + engrams.length + ' nodes)');
+        const orphanCount = engrams.length - connectedNodeIds.size;
+        const msg = 'Graph loaded (' + nodesToRender.length + ' nodes' +
+          (orphanCount > 0 && !showOrphans ? ', ' + orphanCount + ' orphans hidden' : '') + ')';
+        this.addNotification('success', msg);
       } catch (err) {
         this.addNotification('error', 'Graph failed: ' + err.message);
       }
+    },
+
+    graphZoomIn() {
+      if (this._cy) { this._cy.zoom(this._cy.zoom() * 1.25); this._cy.center(); }
+    },
+    graphZoomOut() {
+      if (this._cy) { this._cy.zoom(this._cy.zoom() * 0.8); this._cy.center(); }
+    },
+    graphFit() {
+      if (this._cy) { this._cy.fit(); }
     },
 
     // ── Session ────────────────────────────────────────────────────────────

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -453,6 +453,18 @@
                     @click="openMemory({id:pair.id_b, concept:pair.concept_b, content:'', vault:vault}); memoriesSubTab='list'">View</button>
                 </div>
               </div>
+              <!-- Resolution actions -->
+              <div style="display:flex;gap:0.5rem;margin-top:0.875rem;flex-wrap:wrap;align-items:center;">
+                <span style="font-size:0.75rem;color:var(--text-muted);margin-right:0.25rem;">Resolve:</span>
+                <button class="btn-secondary" style="font-size:0.75rem;padding:0.25rem 0.625rem;" title="Keep Memory A — archives B and marks A as superseding"
+                  @click="resolveContradiction(pair.id_a, pair.id_b, 'keep_a')">Keep A</button>
+                <button class="btn-secondary" style="font-size:0.75rem;padding:0.25rem 0.625rem;" title="Keep Memory B — archives A and marks B as superseding"
+                  @click="resolveContradiction(pair.id_a, pair.id_b, 'keep_b')">Keep B</button>
+                <button class="btn-secondary" style="font-size:0.75rem;padding:0.25rem 0.625rem;" title="Merge both memories into a single consolidated memory"
+                  @click="resolveContradiction(pair.id_a, pair.id_b, 'merge')">Merge</button>
+                <button class="btn-secondary" style="font-size:0.75rem;padding:0.25rem 0.625rem;opacity:0.7;" title="Dismiss this contradiction flag without archiving either memory"
+                  @click="resolveContradiction(pair.id_a, pair.id_b, 'dismiss')">Dismiss</button>
+              </div>
               <div x-show="pair.detected_at" style="font-size:0.75rem;color:var(--text-muted);margin-top:0.625rem;">
                 Detected: <span x-text="pair.detected_at ? new Date(pair.detected_at * 1000).toLocaleString() : ''"></span>
               </div>
@@ -611,19 +623,30 @@
         edges represent associations — <em>supports</em>, <em>contradicts</em>, <em>depends on</em>, etc.
         Click a node to preview its content.
       </p>
-      <div style="display:flex;gap:1rem;margin-bottom:1rem;align-items:center;">
+      <div style="display:flex;gap:0.75rem;margin-bottom:1rem;align-items:center;flex-wrap:wrap;">
         <button class="btn-primary" @click="loadGraph()">Load Graph</button>
         <span style="color:var(--text-muted);font-size:0.875rem;">Top 50 active engrams + associations</span>
+        <!-- Orphan toggle -->
+        <label style="display:flex;align-items:center;gap:0.375rem;font-size:0.8125rem;color:var(--text-muted);cursor:pointer;" title="Show engrams with no associations (orphan nodes)">
+          <input type="checkbox" x-model="graphShowOrphans" @change="graphLoaded && loadGraph()" />
+          Show orphans
+        </label>
         <span x-show="graphLoaded" class="badge-success">Loaded</span>
+        <!-- Zoom controls -->
+        <div x-show="graphLoaded" style="display:flex;gap:0.375rem;margin-left:auto;">
+          <button class="btn-secondary" style="padding:0.25rem 0.625rem;font-size:0.875rem;" title="Zoom in" @click="graphZoomIn()">+</button>
+          <button class="btn-secondary" style="padding:0.25rem 0.625rem;font-size:0.875rem;" title="Zoom out" @click="graphZoomOut()">−</button>
+          <button class="btn-secondary" style="padding:0.25rem 0.75rem;font-size:0.8125rem;" title="Fit all nodes in view" @click="graphFit()">Fit</button>
+        </div>
       </div>
-      <div x-show="!graphLoaded" style="flex:1;border:1px solid var(--border);border-radius:0.75rem;display:flex;align-items:center;justify-content:center;color:var(--text-muted);">
+      <div x-show="!graphLoaded" style="flex:1;min-height:500px;border:1px solid var(--border);border-radius:0.75rem;display:flex;align-items:center;justify-content:center;color:var(--text-muted);">
         <div style="text-align:center;">
           <div style="font-size:2rem;margin-bottom:0.75rem;">⬡</div>
           <div>Click <strong>Load Graph</strong> to visualize memory connections</div>
           <div style="font-size:0.8125rem;margin-top:0.5rem;">Requires at least 2 memories with associations</div>
         </div>
       </div>
-      <div id="cy" x-show="graphLoaded" style="flex:1;border:1px solid var(--border);border-radius:0.75rem;"></div>
+      <div id="cy" x-show="graphLoaded" style="flex:1;min-height:500px;border:1px solid var(--border);border-radius:0.75rem;"></div>
     </div>
 
     <!-- ── Observability View ─────────────────────────────────────── -->


### PR DESCRIPTION
## Summary
Adds contradiction resolution workflow and fixes graph visualization issues.

## Contradiction Resolution
- New `ResolveContradiction` storage method (deletes both 0x0A key directions in atomic batch)
- New `Engine.ResolveContradiction` with coherence counter update (nil-guarded)
- REST: `POST /api/admin/contradictions/resolve` with `{vault, id_a, id_b}`
- UI actions per contradiction pair:
  - **Keep A** — A supersedes B, B archived, contradiction resolved
  - **Keep B** — reverse
  - **Merge** — opens consolidate modal pre-filled with both IDs
  - **Dismiss** — removes flag without archiving either

## Graph Visualization
- Orphan nodes hidden by default (toggle: "Show orphans")
- Zoom controls: +, −, Fit buttons
- Smoother mouse-wheel zoom
- 500px min container height

## Tests
- Storage: `TestResolveContradiction`, `TestResolveContradiction_BothDirections`
- REST: `TestResolveContradiction_Success`, `_MissingIDs`, `_EngineError`
- All 17 packages pass with `-race`

## Test plan
- [ ] `go build ./...` clean
- [ ] `go vet ./...` clean
- [ ] `go test -race ./...` passes
- [ ] Contradiction page shows resolution buttons
- [ ] "Keep A" archives B, creates supersedes link, removes contradiction
- [ ] "Dismiss" removes flag, both memories remain active
- [ ] Graph: orphans hidden by default, +/−/Fit zoom controls work