### PR TITLE
feat(upgrade): self-update wizard — atomic binary replace, Homebrew detection, interactive UI

### DIFF
--- a/cmd/muninn/upgrade.go
+++ b/cmd/muninn/upgrade.go
@@ -375,7 +375,8 @@ func verifyBinary(path, expectedVersion string) error {
 	if err != nil {
 		return fmt.Errorf("stat: %w", err)
 	}
-	if fi.Mode()&0111 == 0 {
+	// Windows does not use Unix execute bits — skip permission check.
+	if runtime.GOOS != "windows" && fi.Mode()&0111 == 0 {
 		return fmt.Errorf("%s is not executable", path)
 	}
 	if expectedVersion == "" {

--- a/cmd/muninn/upgrade_test.go
+++ b/cmd/muninn/upgrade_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -124,6 +125,9 @@ func TestVerifyBinary(t *testing.T) {
 }
 
 func TestVerifyBinary_NotExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod has no effect on Windows — execute bit check is skipped there")
+	}
 	f, err := os.CreateTemp("", "muninn-test-*")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

Replaces `muninn upgrade` (which just printed instructions) with a full interactive self-update wizard that actually performs the upgrade.

- **Homebrew detection** — if the binary lives under a Homebrew prefix (`/Cellar/`, `/opt/homebrew/`, `/usr/local/opt/`), delegates to `brew upgrade scrypster/tap/muninn` with live output. No self-replace for Brew-owned binaries.
- **Atomic self-replace** — for curl/manual installs: downloads the release archive to a temp file on the **same filesystem** as the binary, extracts, verifies, `os.Rename` (atomic). Data directory is never touched.
- **Interactive wizard UI** — banner, version delta (`v0.9.1 → v1.0.0`), release notes link, `runSingleSelect` confirmation prompt (matching `muninn init` style), inline MB download progress, per-step ✓/✗ feedback.
- **Daemon lifecycle** — stops daemon before replace, restarts after (if it was running). Safe stop via PID file check (no `os.Exit` on missing PID).
- **Windows fallback** — prints download link, attempts to open browser.
- **`--check` flag** — preserved (exit 1 if update available, for scripting).
- **`--yes`/`-y` flag** — skips confirmation for non-interactive use.

## Test Plan

- [ ] All 45 packages pass (`go test ./... -count=1`)
- [ ] `go vet ./...` clean
- [ ] CI passes
- [ ] `muninn upgrade --check` exits 1 when update available, 0 when up-to-date
- [ ] Homebrew detection tested with path-based unit tests
- [ ] Download + extraction tested with `httptest` server serving real tar.gz
- [ ] `verifyBinary` tested with real and non-executable files