### PR TITLE
release: v0.3.1-alpha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: go build -o muninndb-server ./cmd/muninn/...
 
       - name: Run Go tests
-        run: go test ./... -timeout 300s -race -coverprofile=coverage.out -covermode=atomic
+        run: go test -tags localassets ./... -timeout 300s -race -coverprofile=coverage.out -covermode=atomic
 
       - name: Coverage summary
         run: go tool cover -func=coverage.out | tail -1
@@ -94,7 +94,7 @@ jobs:
       # TestMain builds the binary itself; we just need Go + assets present.
       # Tests exercise: help, unknown-command, init, start, stop, restart, status, MCP round-trip.
       - name: Run CLI integration tests
-        run: go test -tags integration -v -timeout 120s ./cmd/muninn/...
+        run: go test -tags localassets,integration -v -timeout 120s ./cmd/muninn/...
 
   # ── Windows: build + smoke test ───────────────────────────────────────
   windows:
@@ -148,7 +148,7 @@ jobs:
         run: go build -o muninn.exe ./cmd/muninn/...
 
       - name: Run unit tests
-        run: go test ./cmd/muninn/... -timeout 120s -count=1
+        run: go test -tags localassets ./cmd/muninn/... -timeout 120s -count=1
 
       - name: Smoke test — version and help
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,21 @@ go run ./cmd/muninn/... start
 
 See the [README](README.md) for full install options and configuration.
 
+## Running tests
+
+Basic unit tests (no assets required):
+
+```bash
+go test ./...
+```
+
+Tests requiring embedded ML assets (download first):
+
+```bash
+make fetch-assets
+go test -tags localassets ./...
+```
+
 ---
 
 ## Branch model (Git Flow)

--- a/internal/auth/vault_config.go
+++ b/internal/auth/vault_config.go
@@ -90,6 +90,12 @@ func (s *Store) RenameVaultConfig(oldName, newName string) error {
 	return nil
 }
 
+// DeleteVaultConfig removes the vault configuration for the named vault.
+// If no config exists for the vault, this is a no-op and returns nil (idempotent).
+func (s *Store) DeleteVaultConfig(name string) error {
+	return s.db.Delete(vaultConfigKey(name), pebble.Sync)
+}
+
 // ListVaultConfigs returns all explicitly configured vaults.
 func (s *Store) ListVaultConfigs() ([]VaultConfig, error) {
 	lower := []byte{prefixVaultCfg}

--- a/internal/auth/vault_config_test.go
+++ b/internal/auth/vault_config_test.go
@@ -218,3 +218,103 @@ func TestRenameVaultConfig_SetVaultConfigError(t *testing.T) {
 // tested above. The individual Set/Delete error paths no longer exist.
 // The branch is defensive code for hypothetical storage backends where db.Set
 // can succeed but a subsequent db.Delete fails.
+
+// TestDeleteVaultConfig_DeletesExisting verifies that DeleteVaultConfig removes
+// a previously-stored vault config entry.
+func TestDeleteVaultConfig_DeletesExisting(t *testing.T) {
+	s := auth.NewStore(openTestDB(t))
+
+	// Set a config so there is something to delete.
+	if err := s.SetVaultConfig(auth.VaultConfig{Name: "to-delete", Public: true}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+
+	// Confirm it was persisted.
+	cfgs, err := s.ListVaultConfigs()
+	if err != nil {
+		t.Fatalf("ListVaultConfigs before delete: %v", err)
+	}
+	found := false
+	for _, c := range cfgs {
+		if c.Name == "to-delete" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected vault config to be present before delete")
+	}
+
+	// Delete it.
+	if err := s.DeleteVaultConfig("to-delete"); err != nil {
+		t.Fatalf("DeleteVaultConfig: %v", err)
+	}
+
+	// GetVaultConfig should now return the fail-closed default (no persisted entry).
+	cfg, err := s.GetVaultConfig("to-delete")
+	if err != nil {
+		t.Fatalf("GetVaultConfig after delete: %v", err)
+	}
+	if cfg.Public {
+		t.Error("expected fail-closed default (Public=false) after delete, got Public=true")
+	}
+
+	// ListVaultConfigs should no longer include the deleted vault.
+	cfgs, err = s.ListVaultConfigs()
+	if err != nil {
+		t.Fatalf("ListVaultConfigs after delete: %v", err)
+	}
+	for _, c := range cfgs {
+		if c.Name == "to-delete" {
+			t.Error("deleted vault config still appears in ListVaultConfigs")
+		}
+	}
+}
+
+// TestDeleteVaultConfig_Idempotent verifies that calling DeleteVaultConfig on a
+// vault that has no config entry returns nil (no error).
+func TestDeleteVaultConfig_Idempotent(t *testing.T) {
+	s := auth.NewStore(openTestDB(t))
+
+	// Delete a vault that was never configured — must not error.
+	if err := s.DeleteVaultConfig("nonexistent"); err != nil {
+		t.Fatalf("DeleteVaultConfig on non-existent vault: %v", err)
+	}
+
+	// Calling again must still return nil.
+	if err := s.DeleteVaultConfig("nonexistent"); err != nil {
+		t.Fatalf("second DeleteVaultConfig on non-existent vault: %v", err)
+	}
+}
+
+// TestDeleteVaultConfig_Roundtrip verifies that after a Set → Delete cycle,
+// a subsequent SetVaultConfig on the same name works correctly.
+func TestDeleteVaultConfig_Roundtrip(t *testing.T) {
+	s := auth.NewStore(openTestDB(t))
+
+	// First write.
+	if err := s.SetVaultConfig(auth.VaultConfig{Name: "roundtrip-vault", Public: true}); err != nil {
+		t.Fatalf("first SetVaultConfig: %v", err)
+	}
+
+	// Delete.
+	if err := s.DeleteVaultConfig("roundtrip-vault"); err != nil {
+		t.Fatalf("DeleteVaultConfig: %v", err)
+	}
+
+	// Second write with different settings.
+	if err := s.SetVaultConfig(auth.VaultConfig{Name: "roundtrip-vault", Public: false}); err != nil {
+		t.Fatalf("second SetVaultConfig: %v", err)
+	}
+
+	// Verify the second write is what we read back.
+	cfg, err := s.GetVaultConfig("roundtrip-vault")
+	if err != nil {
+		t.Fatalf("GetVaultConfig after roundtrip: %v", err)
+	}
+	if cfg.Public {
+		t.Error("expected Public=false from second SetVaultConfig, got Public=true")
+	}
+	if cfg.Name != "roundtrip-vault" {
+		t.Errorf("expected Name=%q, got %q", "roundtrip-vault", cfg.Name)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1860,9 +1860,25 @@ func (e *Engine) Forget(ctx context.Context, req *mbp.ForgetRequest) (*mbp.Forge
 // Stat implements mbp.EngineAPI.Stat.
 func (e *Engine) Stat(ctx context.Context, req *mbp.StatRequest) (*mbp.StatResponse, error) {
 	vaultNames, _ := e.store.ListVaultNames()
-	vaultCount := len(vaultNames)
+
+	// Count all vaults: data vaults + config-only (empty) vaults, deduplicated.
+	// A vault created via `muninn vault create` only writes an auth config entry
+	// until the first engram is stored. Without this merge, the dashboard would
+	// show a lower vault count than `muninn vault list`.
+	vaultSet := make(map[string]struct{}, len(vaultNames))
+	for _, n := range vaultNames {
+		vaultSet[n] = struct{}{}
+	}
+	if e.authStore != nil {
+		if cfgs, err := e.authStore.ListVaultConfigs(); err == nil {
+			for _, cfg := range cfgs {
+				vaultSet[cfg.Name] = struct{}{}
+			}
+		}
+	}
+	vaultCount := len(vaultSet)
 	if vaultCount == 0 {
-		vaultCount = 1
+		vaultCount = 1 // preserve the existing "minimum 1" semantics
 	}
 
 	engramCount := e.engramCount.Load()

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1816,3 +1816,83 @@ func TestActivateCore_VaultDefaultRecallMode(t *testing.T) {
 		t.Fatal("expected non-nil response for recent vault")
 	}
 }
+
+// TestStat_CountsConfigOnlyVaults verifies that vaults created via authStore
+// (with no engrams written) are counted by Stat(). This is the core regression:
+// dashboard "Vaults" stat card must match `muninn vault list` output.
+//
+// The test adds two config-only vaults and then asserts VaultCount==2, proving
+// that config-only vaults (not just data-layer vaults) are included in the count.
+func TestStat_CountsConfigOnlyVaults(t *testing.T) {
+	eng, authStore, _, cleanup := testEnvWithAuth(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Create two config-only vaults (no engrams written — simulates `muninn vault create`).
+	for _, name := range []string{"config-only-alpha", "config-only-beta"} {
+		if err := authStore.SetVaultConfig(auth.VaultConfig{Name: name, Public: false}); err != nil {
+			t.Fatalf("SetVaultConfig(%q): %v", name, err)
+		}
+	}
+
+	// Stat() must count both config-only vaults (no data written to either).
+	resp, err := eng.Stat(ctx, &mbp.StatRequest{})
+	if err != nil {
+		t.Fatalf("Stat after SetVaultConfig: %v", err)
+	}
+	if resp.VaultCount != 2 {
+		t.Errorf("expected VaultCount=2 (two config-only vaults), got %d", resp.VaultCount)
+	}
+}
+
+// TestStat_DeduplicatesVaultCount verifies that a vault appearing in BOTH the
+// data store (has engrams) AND the auth config store is counted exactly once.
+func TestStat_DeduplicatesVaultCount(t *testing.T) {
+	eng, authStore, _, cleanup := testEnvWithAuth(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const sharedVault = "shared-vault"
+
+	// Write an engram so the vault appears in the data store.
+	if _, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   sharedVault,
+		Concept: "dedup test",
+		Content: "this vault exists in both stores",
+	}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Also add a config entry for the same vault (mirrors real usage where
+	// vault create + write both happen).
+	if err := authStore.SetVaultConfig(auth.VaultConfig{Name: sharedVault, Public: false}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+
+	resp, err := eng.Stat(ctx, &mbp.StatRequest{})
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	// sharedVault must be counted once, not twice.
+	// Total is 1 (sharedVault) — no other vaults exist.
+	if resp.VaultCount != 1 {
+		t.Errorf("expected VaultCount=1 (deduplicated), got %d", resp.VaultCount)
+	}
+}
+
+// TestStat_DefaultVaultMinimum verifies that Stat() returns VaultCount >= 1
+// even when both the data store and the auth config store are completely empty.
+// This preserves the existing "minimum 1" semantics for the dashboard.
+func TestStat_DefaultVaultMinimum(t *testing.T) {
+	eng, _, _, cleanup := testEnvWithAuth(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := eng.Stat(ctx, &mbp.StatRequest{})
+	if err != nil {
+		t.Fatalf("Stat on empty engine: %v", err)
+	}
+	if resp.VaultCount < 1 {
+		t.Errorf("expected VaultCount >= 1 (minimum floor), got %d", resp.VaultCount)
+	}
+}

--- a/internal/engine/engine_vault.go
+++ b/internal/engine/engine_vault.go
@@ -135,6 +135,14 @@ func (e *Engine) DeleteVault(ctx context.Context, vaultName string) error {
 			"vault", vaultName, "err", err)
 		return fmt.Errorf("delete vault (name cleanup): %w", err)
 	}
+
+	// Auth config: remove config entry if present.
+	if e.authStore != nil {
+		if err := e.authStore.DeleteVaultConfig(vaultName); err != nil {
+			slog.Warn("delete vault: auth config cleanup failed", "vault", vaultName, "err", err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/engine/engine_vault_test.go
+++ b/internal/engine/engine_vault_test.go
@@ -483,6 +483,100 @@ func TestEngineRenameVault_ClosedDB(t *testing.T) {
 	}
 }
 
+// TestDeleteVault_CleansAuthStore verifies that after DeleteVault, the vault
+// name no longer appears in authStore.ListVaultConfigs. This is the primary
+// regression test for the ghost vault bug: DeleteVault must clean up both the
+// engine data store and the auth config store.
+func TestDeleteVault_CleansAuthStore(t *testing.T) {
+	eng, authStore, _, cleanup := testEnvWithAuth(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vaultName = "auth-delete-vault"
+
+	// Register the vault by writing an engram.
+	if _, err := eng.Write(ctx, writeReq(vaultName, "concept", "content")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	// Explicitly configure the vault in authStore so there is an entry to clean up.
+	if err := authStore.SetVaultConfig(auth.VaultConfig{Name: vaultName, Public: true}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+
+	// Confirm the config entry exists before deletion.
+	cfgs, err := authStore.ListVaultConfigs()
+	if err != nil {
+		t.Fatalf("ListVaultConfigs before delete: %v", err)
+	}
+	found := false
+	for _, c := range cfgs {
+		if c.Name == vaultName {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected vault config to be present before DeleteVault")
+	}
+
+	// Delete the vault.
+	if err := eng.DeleteVault(ctx, vaultName); err != nil {
+		t.Fatalf("DeleteVault: %v", err)
+	}
+
+	// The auth config entry must be gone after DeleteVault.
+	cfgs, err = authStore.ListVaultConfigs()
+	if err != nil {
+		t.Fatalf("ListVaultConfigs after delete: %v", err)
+	}
+	for _, c := range cfgs {
+		if c.Name == vaultName {
+			t.Errorf("vault config still present in authStore after DeleteVault — ghost vault bug")
+		}
+	}
+}
+
+// TestDeleteVault_NotFoundAfterDelete verifies that calling DeleteVault a second
+// time on an already-deleted vault returns an error, not "vault still exists".
+// This tests the observable symptom of the ghost vault bug: if authStore cleanup
+// is missing, the vault would re-appear in ListVaults and the second delete would
+// either succeed (masking the ghost) or fail in an unexpected way.
+func TestDeleteVault_NotFoundAfterDelete(t *testing.T) {
+	eng, _, _, cleanup := testEnvWithAuth(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vaultName = "double-delete-vault"
+
+	// Register and delete the vault.
+	if _, err := eng.Write(ctx, writeReq(vaultName, "concept", "content")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	if err := eng.DeleteVault(ctx, vaultName); err != nil {
+		t.Fatalf("first DeleteVault: %v", err)
+	}
+
+	// Second delete must return an error (vault not found).
+	err := eng.DeleteVault(ctx, vaultName)
+	if err == nil {
+		t.Fatal("expected error on second DeleteVault, got nil")
+	}
+
+	// The vault must not appear in ListVaults — no ghost entry.
+	vaults, listErr := eng.ListVaults(ctx)
+	if listErr != nil {
+		t.Fatalf("ListVaults: %v", listErr)
+	}
+	for _, v := range vaults {
+		if v == vaultName {
+			t.Errorf("deleted vault still appears in ListVaults — ghost vault bug")
+		}
+	}
+}
+
 // TestEngineRenameVault_JobActive verifies that renaming a vault with an
 // active clone/merge job targeting it returns ErrVaultJobActive.
 func TestEngineRenameVault_JobActive(t *testing.T) {

--- a/internal/plugin/embed/local_assets_common.go
+++ b/internal/plugin/embed/local_assets_common.go
@@ -1,3 +1,5 @@
+//go:build localassets
+
 package embed
 
 import _ "embed"

--- a/internal/plugin/embed/local_assets_darwin_amd64.go
+++ b/internal/plugin/embed/local_assets_darwin_amd64.go
@@ -1,4 +1,4 @@
-//go:build darwin && amd64
+//go:build darwin && amd64 && localassets
 
 package embed
 

--- a/internal/plugin/embed/local_assets_darwin_arm64.go
+++ b/internal/plugin/embed/local_assets_darwin_arm64.go
@@ -1,4 +1,4 @@
-//go:build darwin && arm64
+//go:build darwin && arm64 && localassets
 
 package embed
 

--- a/internal/plugin/embed/local_assets_linux_amd64.go
+++ b/internal/plugin/embed/local_assets_linux_amd64.go
@@ -1,4 +1,4 @@
-//go:build linux && amd64
+//go:build linux && amd64 && localassets
 
 package embed
 

--- a/internal/plugin/embed/local_assets_noembed.go
+++ b/internal/plugin/embed/local_assets_noembed.go
@@ -1,0 +1,18 @@
+//go:build !localassets
+
+package embed
+
+// Stub declarations used when building without embedded assets (no -tags localassets).
+// Run `make fetch-assets` then use `-tags localassets` to build with real assets.
+
+var embeddedNativeLib []byte
+var embeddedModel []byte
+var embeddedTokenizer []byte
+
+const nativeLibFilename = ""
+
+// LocalAvailable reports whether the bundled ONNX model and tokenizer were
+// embedded at build time. Always returns false when built without -tags localassets.
+func LocalAvailable() bool {
+	return false
+}

--- a/internal/plugin/embed/local_assets_unsupported.go
+++ b/internal/plugin/embed/local_assets_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !(darwin && arm64) && !(darwin && amd64) && !(linux && amd64) && !(windows && amd64)
+//go:build localassets && !(darwin && arm64) && !(darwin && amd64) && !(linux && amd64) && !(windows && amd64)
 
 package embed
 

--- a/internal/plugin/embed/local_assets_windows_amd64.go
+++ b/internal/plugin/embed/local_assets_windows_amd64.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows && amd64 && localassets
 
 package embed
 

--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -7,7 +7,9 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/scrypster/muninndb/internal/auth"
 	plugincfg "github.com/scrypster/muninndb/internal/config"
@@ -44,6 +46,36 @@ func isValidVaultName(name string) bool {
 		}
 	}
 	return true
+}
+
+// canonicalize returns a lowercase alphanumeric-only string for collision detection.
+// Used to detect near-duplicate vault names (e.g. "datadog-clone" == "datadogclone").
+func canonicalize(name string) string {
+	return strings.Map(func(r rune) rune {
+		lower := unicode.ToLower(r)
+		if lower >= 'a' && lower <= 'z' || lower >= '0' && lower <= '9' {
+			return lower
+		}
+		return -1
+	}, name)
+}
+
+// vaultNameCollision checks if newName canonically collides with any of the
+// provided existing vault names. It returns the first conflicting name found,
+// or empty string if there is no collision. An exact name match is not a
+// collision (it represents an update/overwrite of an existing vault).
+func vaultNameCollision(existingNames []string, newName string) string {
+	canon := canonicalize(newName)
+	for _, existing := range existingNames {
+		if existing == newName {
+			// Exact match is an update, not a collision.
+			continue
+		}
+		if canonicalize(existing) == canon {
+			return existing
+		}
+	}
+	return ""
 }
 
 func (s *Server) handleCreateAPIKey(authStore *auth.Store) http.HandlerFunc {
@@ -212,12 +244,60 @@ func (s *Server) handleSetVaultConfig(authStore *auth.Store) http.HandlerFunc {
 			s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "invalid vault name")
 			return
 		}
+
+		// Collision check: detect near-duplicate vault names unless ?force=true.
+		if r.URL.Query().Get("force") != "true" {
+			existingNames := s.collectVaultNames(r, authStore)
+			if conflict := vaultNameCollision(existingNames, cfg.Name); conflict != "" {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				json.NewEncoder(w).Encode(map[string]string{
+					"error":      "vault name collision detected",
+					"code":       "VAULT_NAME_COLLISION",
+					"conflict":   conflict,
+					"normalized": canonicalize(cfg.Name),
+				})
+				return
+			}
+		}
+
 		if err := authStore.SetVaultConfig(cfg); err != nil {
 			s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
 			return
 		}
 		s.sendJSON(w, http.StatusOK, cfg)
 	}
+}
+
+// collectVaultNames merges vault names from the engine and the auth store into
+// a deduplicated slice. Used for canonicalize-based collision detection.
+func (s *Server) collectVaultNames(r *http.Request, authStore *auth.Store) []string {
+	seen := make(map[string]struct{})
+	var names []string
+
+	if s.engine != nil {
+		if engineVaults, err := s.engine.ListVaults(r.Context()); err == nil {
+			for _, n := range engineVaults {
+				if _, ok := seen[n]; !ok {
+					seen[n] = struct{}{}
+					names = append(names, n)
+				}
+			}
+		}
+	}
+
+	if authStore != nil {
+		if cfgs, err := authStore.ListVaultConfigs(); err == nil {
+			for _, cfg := range cfgs {
+				if _, ok := seen[cfg.Name]; !ok {
+					seen[cfg.Name] = struct{}{}
+					names = append(names, cfg.Name)
+				}
+			}
+		}
+	}
+
+	return names
 }
 
 // handleGetVaultPlasticity returns the raw PlasticityConfig (may be nil) and
@@ -485,6 +565,31 @@ func (s *Server) handleRenameVault(w http.ResponseWriter, r *http.Request) {
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "new_name must differ from current name")
 		return
 	}
+
+	// Collision check: detect near-duplicate target name unless ?force=true.
+	// Exclude the vault being renamed so it doesn't collide with itself.
+	if r.URL.Query().Get("force") != "true" {
+		existingNames := s.collectVaultNames(r, s.authStore)
+		// Remove the current vault name so renaming doesn't self-collide.
+		filtered := make([]string, 0, len(existingNames))
+		for _, n := range existingNames {
+			if n != name {
+				filtered = append(filtered, n)
+			}
+		}
+		if conflict := vaultNameCollision(filtered, req.NewName); conflict != "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]string{
+				"error":      "vault name collision detected",
+				"code":       "VAULT_NAME_COLLISION",
+				"conflict":   conflict,
+				"normalized": canonicalize(req.NewName),
+			})
+			return
+		}
+	}
+
 	if err := s.engine.RenameVault(r.Context(), name, req.NewName); err != nil {
 		if errors.Is(err, engine.ErrVaultNotFound) {
 			s.sendError(r, w, http.StatusNotFound, ErrVaultNotFound, err.Error())

--- a/internal/transport/rest/admin_handlers_test.go
+++ b/internal/transport/rest/admin_handlers_test.go
@@ -511,3 +511,167 @@ func TestReplicationPromote_WithCoordinator(t *testing.T) {
 		t.Error("expected triggered=true in response")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// canonicalize() tests
+// ---------------------------------------------------------------------------
+
+func TestCanonicalize(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"datadog-clone", "datadogclone"},
+		{"FOO_BAR", "foobar"},
+		{"my-vault-2", "myvault2"},
+		{"hello world", "helloworld"},
+		{"café", "caf"},
+		{"vault.name", "vaultname"},
+		{"123-abc", "123abc"},
+		{"", ""},
+		{"---", ""},
+		{"HELLO", "hello"},
+		{"a1b2c3", "a1b2c3"},
+	}
+	for _, tc := range cases {
+		got := canonicalize(tc.input)
+		if got != tc.want {
+			t.Errorf("canonicalize(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleSetVaultConfig — collision detection tests
+// ---------------------------------------------------------------------------
+
+// newCollisionTestServer builds a Server pre-seeded with existingVaultNames in the
+// auth store so that collectVaultNames detects near-duplicate names.
+func newCollisionTestServer(t *testing.T, existingVaultNames []string) (*Server, *auth.Store) {
+	t.Helper()
+	store := newTestAuthStore(t)
+	// Pre-populate the existing vault names into the auth store so
+	// collectVaultNames picks them up via ListVaultConfigs.
+	for _, name := range existingVaultNames {
+		if err := store.SetVaultConfig(auth.VaultConfig{Name: name}); err != nil {
+			t.Fatalf("seed vault %q: %v", name, err)
+		}
+	}
+	srv := newTestServer(t, store)
+	return srv, store
+}
+
+func TestHandleSetVaultConfig_DuplicateDetection(t *testing.T) {
+	// "datadog-clone" already exists; creating "datadogclone" should yield 409.
+	srv, _ := newCollisionTestServer(t, []string{"datadog-clone"})
+
+	body, _ := json.Marshal(map[string]interface{}{"name": "datadogclone"})
+	req := httptest.NewRequest("PUT", "/api/admin/vaults/config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for collision, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["code"] != "VAULT_NAME_COLLISION" {
+		t.Errorf("expected code=VAULT_NAME_COLLISION, got %q", resp["code"])
+	}
+	if resp["conflict"] != "datadog-clone" {
+		t.Errorf("expected conflict=datadog-clone, got %q", resp["conflict"])
+	}
+	if resp["normalized"] != "datadogclone" {
+		t.Errorf("expected normalized=datadogclone, got %q", resp["normalized"])
+	}
+}
+
+func TestHandleSetVaultConfig_ForceOverride(t *testing.T) {
+	// Same scenario with ?force=true — should succeed (200 OK).
+	srv, _ := newCollisionTestServer(t, []string{"datadog-clone"})
+
+	body, _ := json.Marshal(map[string]interface{}{"name": "datadogclone"})
+	req := httptest.NewRequest("PUT", "/api/admin/vaults/config?force=true", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with force=true, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSetVaultConfig_ForcePreservesAuth(t *testing.T) {
+	// force=true bypasses collision check but NOT auth.
+	// When the server has a session secret, unauthenticated requests return 401.
+	store := newTestAuthStore(t)
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "datadog-clone"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	secret := []byte("test-secret")
+	srv := NewServer("localhost:0", &MockEngine{}, store, secret, nil, EmbedInfo{}, nil, "", nil)
+
+	body, _ := json.Marshal(map[string]interface{}{"name": "datadogclone"})
+	req := httptest.NewRequest("PUT", "/api/admin/vaults/config?force=true", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// No session cookie — should be rejected by admin auth middleware.
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without auth (force=true must not bypass auth), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSetVaultConfig_ExactNameIsUpdate(t *testing.T) {
+	// Creating/updating a vault with the exact same name as an existing vault
+	// is NOT a collision — it's an update/overwrite and should return 200.
+	srv, _ := newCollisionTestServer(t, []string{"myvault"})
+
+	body, _ := json.Marshal(map[string]interface{}{"name": "myvault", "public": true})
+	req := httptest.NewRequest("PUT", "/api/admin/vaults/config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for exact name update (not a collision), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleRenameVault — collision detection test
+// ---------------------------------------------------------------------------
+
+func TestHandleRenameVault_DuplicateDetection(t *testing.T) {
+	// Vault "my-vault" exists. Rename "source" to "myvault" → canonical collision → 409.
+	store := newTestAuthStore(t)
+	// Seed "my-vault" into the auth store so collectVaultNames finds it.
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "my-vault"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	srv := newTestServer(t, store)
+
+	body, _ := json.Marshal(map[string]string{"new_name": "myvault"})
+	req := httptest.NewRequest("POST", "/api/admin/vaults/source/rename", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for rename collision, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["code"] != "VAULT_NAME_COLLISION" {
+		t.Errorf("expected code=VAULT_NAME_COLLISION, got %q", resp["code"])
+	}
+	if resp["conflict"] != "my-vault" {
+		t.Errorf("expected conflict=my-vault, got %q", resp["conflict"])
+	}
+}

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -163,6 +163,7 @@ func NewServer(addr string, engine EngineAPI, authStore *auth.Store, sessionSecr
 	mux.HandleFunc("GET /api/engrams", s.withMiddleware(s.handleListEngrams))
 	mux.HandleFunc("GET /api/engrams/{id}/links", s.withMiddleware(s.handleGetEngramLinks))
 	mux.HandleFunc("GET /api/vaults", s.withMiddleware(s.handleListVaults))
+	mux.HandleFunc("GET /api/vaults/stats", s.withAdminMiddleware(s.handleVaultStats()))
 	mux.HandleFunc("GET /api/session", s.withMiddleware(s.handleGetSession))
 	// SSE subscribe — long-lived; bypasses write timeout via ResponseController.
 	mux.HandleFunc("GET /api/subscribe", s.withMiddleware(s.handleSubscribe))
@@ -1102,6 +1103,33 @@ func (s *Server) handleListVaults(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.sendJSON(w, http.StatusOK, vaults)
+}
+
+func (s *Server) handleVaultStats() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Get all vaults using the same merge pattern as handleListVaults.
+		if _, err := s.engine.ListVaults(r.Context()); err != nil {
+			s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
+			return
+		}
+		vaultNames := s.collectVaultNames(r, s.authStore)
+
+		type vaultStat struct {
+			Name        string `json:"name"`
+			EngramCount int64  `json:"engram_count"`
+		}
+
+		result := make([]vaultStat, 0, len(vaultNames))
+		for _, name := range vaultNames {
+			req := &mbp.StatRequest{Vault: name}
+			stat, err := s.engine.Stat(r.Context(), req)
+			if err != nil {
+				stat = &mbp.StatResponse{}
+			}
+			result = append(result, vaultStat{Name: name, EngramCount: stat.EngramCount})
+		}
+		s.sendJSON(w, http.StatusOK, result)
+	}
 }
 
 func (s *Server) handleGetSession(w http.ResponseWriter, r *http.Request) {

--- a/internal/transport/rest/server_test.go
+++ b/internal/transport/rest/server_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/auth"
 	"github.com/scrypster/muninndb/internal/cognitive"
 	"github.com/scrypster/muninndb/internal/config"
 	"github.com/scrypster/muninndb/internal/engine"
@@ -1953,5 +1954,137 @@ func TestEntityGraphVisualization_MCPInfoEndpoint(t *testing.T) {
 	// Expected 401 because no admin session is present; URL structure verified in integration tests.
 	if w.Code != http.StatusUnauthorized && w.Code != http.StatusOK {
 		t.Logf("MCP info endpoint returned %d (expected 401 without auth)", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleVaultStats tests
+// ---------------------------------------------------------------------------
+
+// vaultStatsEngine is an engine whose ListVaults and Stat return configurable values.
+type vaultStatsEngine struct {
+	MockEngine
+	vaults []string
+	counts map[string]int64 // per-vault engram count
+}
+
+func (e *vaultStatsEngine) ListVaults(_ context.Context) ([]string, error) {
+	return e.vaults, nil
+}
+
+func (e *vaultStatsEngine) Stat(_ context.Context, req *StatRequest) (*StatResponse, error) {
+	count, ok := e.counts[req.Vault]
+	if !ok {
+		return &StatResponse{}, nil
+	}
+	return &StatResponse{EngramCount: count, VaultCount: 1, StorageBytes: 0}, nil
+}
+
+// TestHandleVaultStats_ReturnsAllVaults verifies that vaults which exist only in
+// the auth store config (no engrams yet) appear in the response with engram_count 0.
+func TestHandleVaultStats_ReturnsAllVaults(t *testing.T) {
+	eng := &vaultStatsEngine{
+		vaults: []string{"default"},
+		counts: map[string]int64{"default": 5},
+	}
+	store := newTestAuthStore(t)
+	// Make "default" public so the vault-auth middleware passes without an API key.
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "default", Public: true}); err != nil {
+		t.Fatalf("SetVaultConfig default: %v", err)
+	}
+	// "config-only" vault exists in auth config but not returned by ListVaults.
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "config-only", Public: false}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+
+	srv := NewServer("localhost:0", eng, store, nil, nil, EmbedInfo{}, nil, "", nil)
+	req := httptest.NewRequest("GET", "/api/vaults/stats", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	type vaultStat struct {
+		Name        string `json:"name"`
+		EngramCount int64  `json:"engram_count"`
+	}
+	var resp []vaultStat
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	found := map[string]int64{}
+	for _, vs := range resp {
+		found[vs.Name] = vs.EngramCount
+	}
+
+	if _, ok := found["config-only"]; !ok {
+		t.Error("expected config-only vault to appear in response")
+	}
+	if found["config-only"] != 0 {
+		t.Errorf("expected engram_count 0 for config-only vault, got %d", found["config-only"])
+	}
+	if _, ok := found["default"]; !ok {
+		t.Error("expected default vault to appear in response")
+	}
+}
+
+// TestHandleVaultStats_AccurateCount verifies that each vault's engram count
+// is accurately reported from the engine's Stat response.
+func TestHandleVaultStats_AccurateCount(t *testing.T) {
+	eng := &vaultStatsEngine{
+		vaults: []string{"alpha", "beta"},
+		counts: map[string]int64{
+			"alpha": 42,
+			"beta":  7,
+		},
+	}
+	srv := NewServer("localhost:0", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	req := httptest.NewRequest("GET", "/api/vaults/stats", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	type vaultStat struct {
+		Name        string `json:"name"`
+		EngramCount int64  `json:"engram_count"`
+	}
+	var resp []vaultStat
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	found := map[string]int64{}
+	for _, vs := range resp {
+		found[vs.Name] = vs.EngramCount
+	}
+
+	if found["alpha"] != 42 {
+		t.Errorf("expected alpha engram_count 42, got %d", found["alpha"])
+	}
+	if found["beta"] != 7 {
+		t.Errorf("expected beta engram_count 7, got %d", found["beta"])
+	}
+}
+
+func TestHandleVaultStats_RequiresAdminAuth(t *testing.T) {
+	// GET /api/vaults/stats is an admin endpoint; requests without a valid
+	// session cookie must be rejected with 401.
+	store := newTestAuthStore(t)
+	secret := []byte("test-secret")
+	srv := NewServer("localhost:0", &MockEngine{}, store, secret, nil, EmbedInfo{}, nil, "", nil)
+
+	req := httptest.NewRequest("GET", "/api/vaults/stats", nil)
+	// No session cookie — should be rejected by admin auth middleware.
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without auth, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -8,9 +8,10 @@ document.addEventListener('alpine:init', () => {
     currentView: 'dashboard',
     vault: localStorage.getItem('muninnVault') || 'default',
     vaults: ['default'],
+    vaultStats: {},
     vaultModalOpen: false,
     vaultPickerSearch: '',
-    newVaultModal: { show: false, name: '', error: '', loading: false },
+    newVaultModal: { show: false, name: '', error: '', loading: false, collision: null },
     isDarkMode: localStorage.getItem('muninnTheme') !== 'light',
     liveConnected: false,
     appVersion: '',
@@ -296,6 +297,11 @@ document.addEventListener('alpine:init', () => {
 
       // Load initial data (gated on auth check)
       await this.checkAuth();
+
+      // Fetch vault engram counts whenever the vault picker modal opens.
+      this.$watch('vaultModalOpen', (open) => {
+        if (open) this.loadVaultStats();
+      });
     },
 
     // ── Auth ───────────────────────────────────────────────────────────────
@@ -588,6 +594,19 @@ document.addEventListener('alpine:init', () => {
         }
       } catch (_) {
         this.vaults = ['default'];
+      }
+    },
+
+    async loadVaultStats() {
+      try {
+        const data = await this.apiCall('/api/vaults/stats');
+        if (Array.isArray(data)) {
+          const map = {};
+          data.forEach(s => { map[s.name] = s.engram_count; });
+          this.vaultStats = map;
+        }
+      } catch (_) {
+        // Non-critical — swallow silently
       }
     },
 
@@ -1004,10 +1023,10 @@ document.addEventListener('alpine:init', () => {
 
     // ── Create vault ───────────────────────────────────────────────────────
     createVault() {
-      this.newVaultModal = { show: true, name: '', error: '', loading: false };
+      this.newVaultModal = { show: true, name: '', error: '', loading: false, collision: null };
     },
 
-    async submitNewVault() {
+    async submitNewVault(force) {
       const name = this.newVaultModal.name.trim();
       if (!name) return;
       const valid = /^[a-z0-9_-]{1,64}$/.test(name);
@@ -1017,12 +1036,24 @@ document.addEventListener('alpine:init', () => {
       }
       this.newVaultModal.loading = true;
       this.newVaultModal.error = '';
+      this.newVaultModal.collision = null;
       try {
-        const r = await fetch('/api/admin/vaults/config', {
+        const url = force ? '/api/admin/vaults/config?force=true' : '/api/admin/vaults/config';
+        const r = await fetch(url, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ name }),
         });
+        if (r.status === 409) {
+          const data = await r.json().catch(() => null);
+          if (data && data.code === 'VAULT_NAME_COLLISION') {
+            this.newVaultModal.collision = data;
+            this.newVaultModal.loading = false;
+            return;
+          }
+          const text = await r.text().catch(() => r.statusText);
+          throw new Error(r.status + ': ' + text);
+        }
         if (!r.ok) {
           const text = await r.text().catch(() => r.statusText);
           throw new Error(r.status + ': ' + text);
@@ -2206,16 +2237,26 @@ document.addEventListener('alpine:init', () => {
       this.renameVault(newName);
     },
 
-    async renameVault(newName) {
+    async renameVault(newName, force) {
       try {
-        const r = await fetch(
-          '/api/admin/vaults/' + encodeURIComponent(this.vault) + '/rename',
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ new_name: newName }),
+        const url = '/api/admin/vaults/' + encodeURIComponent(this.vault) + '/rename' + (force ? '?force=true' : '');
+        const r = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ new_name: newName }),
+        });
+        if (r.status === 409) {
+          const data = await r.json().catch(() => null);
+          if (data && data.code === 'VAULT_NAME_COLLISION') {
+            const proceed = confirm(
+              'A vault named "' + data.conflict + '" already exists with a similar name.\n\nCreate "' + newName + '" anyway?'
+            );
+            if (proceed) {
+              this.renameVault(newName, true);
+            }
+            return;
           }
-        );
+        }
         if (!r.ok) {
           const err = await r.json().catch(() => null);
           const msg = err && err.error && err.error.message ? err.error.message : 'HTTP ' + r.status;

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -203,9 +203,9 @@
           <div class="stat-value" x-text="stats.vaultCount">0</div>
           <div class="stat-label">Vaults</div>
         </div>
-        <div class="stat-card" title="Disk space used by the memory database">
+        <div class="stat-card" :title="`Disk space used by the '${vault}' vault`">
           <div class="stat-value" x-text="formatBytes(stats.storageBytes)">0 B</div>
-          <div class="stat-label">Storage</div>
+          <div class="stat-label">Vault Storage</div>
         </div>
         <div class="stat-card" title="Disk space used by the semantic similarity index (HNSW vector index)">
           <div class="stat-value" x-text="formatBytes(stats.indexSize)">0 B</div>
@@ -2404,6 +2404,7 @@ Authorization = "Bearer &lt;token from ~/.muninn/mcp.token&gt;"</pre>
           <div class="vault-modal-item" :class="{'is-active': v===vault}" @click="pickVault(v)">
             <svg class="vault-item-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14a9 3 0 0018 0V5"/><path d="M3 12a9 3 0 0018 0"/></svg>
             <span class="vault-item-name" x-text="v"></span>
+            <span class="vault-item-count" x-show="vaultStats[v] !== undefined" x-text="vaultStats[v] + (vaultStats[v] === 1 ? ' engram' : ' engrams')"></span>
             <svg x-show="v===vault" class="vault-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
           </div>
         </template>
@@ -2419,12 +2420,21 @@ Authorization = "Bearer &lt;token from ~/.muninn/mcp.token&gt;"</pre>
         <h2 style="margin:0;font-size:1.125rem;">New Vault</h2>
         <button class="btn-ghost" style="padding:0.25rem 0.375rem;line-height:1;" @click="newVaultModal.show=false">✕</button>
       </div>
-      <form @submit.prevent="submitNewVault()">
+      <form @submit.prevent="submitNewVault(false)">
         <div class="form-group" style="margin-bottom:1rem;">
           <label>Vault name</label>
-          <input class="input-field" style="margin-top:0.375rem;" type="text" placeholder="my-vault" x-model="newVaultModal.name" x-effect="if(newVaultModal.show) $nextTick(()=>$el.focus())" @input="newVaultModal.error=''" autocomplete="off" spellcheck="false">
+          <input class="input-field" style="margin-top:0.375rem;" type="text" placeholder="my-vault" x-model="newVaultModal.name" x-effect="if(newVaultModal.show) $nextTick(()=>$el.focus())" @input="newVaultModal.error='';newVaultModal.collision=null" autocomplete="off" spellcheck="false">
           <span x-show="newVaultModal.error" x-text="newVaultModal.error" style="font-size:0.8125rem;color:var(--danger);margin-top:0.375rem;"></span>
           <span style="font-size:0.75rem;color:var(--text-muted);margin-top:0.375rem;">Lowercase letters, digits, hyphens, underscores · 1–64 chars</span>
+        </div>
+        <!-- Collision warning banner — shown only when backend returns VAULT_NAME_COLLISION -->
+        <div x-show="newVaultModal.collision" style="background:var(--warning-bg,#fffbeb);border:1px solid var(--warning-border,#f59e0b);border-radius:0.375rem;padding:0.75rem;margin-bottom:1rem;font-size:0.875rem;">
+          <div style="font-weight:600;margin-bottom:0.25rem;">Similar vault name detected</div>
+          <div>A vault named <strong x-text="newVaultModal.collision && newVaultModal.collision.conflict"></strong> already exists with a similar name. Create anyway?</div>
+          <div style="display:flex;gap:0.5rem;margin-top:0.75rem;">
+            <button type="button" class="btn-secondary" style="font-size:0.8125rem;padding:0.25rem 0.625rem;" @click="newVaultModal.collision=null">Cancel</button>
+            <button type="button" class="btn-primary" style="font-size:0.8125rem;padding:0.25rem 0.625rem;" @click="submitNewVault(true)">Create anyway</button>
+          </div>
         </div>
         <div style="display:flex;gap:0.75rem;justify-content:flex-end;">
           <button type="button" class="btn-secondary" @click="newVaultModal.show=false">Cancel</button>


### PR DESCRIPTION
Merges develop into main for the v0.3.1-alpha release.

## What's in this release

- **fix:** vault delete now cleans up authStore config (ghost vault bug)
- **fix:** dashboard vault count now matches `muninn vault list`
- **fix:** near-duplicate vault name detection on create and rename
- **fix:** "Storage" stat label clarified to "Vault Storage" with vault-scoped tooltip
- **fix:** `go test ./...` no longer fails without pre-downloaded ONNX assets
- **feat:** vault switcher modal now shows engram counts per vault

22 new regression tests added across auth, engine, and REST transport packages.