### PR TITLE
feat(ui): --ui-addr flag, remote bind security hardening

### DIFF
--- a/cmd/muninn/lifecycle.go
+++ b/cmd/muninn/lifecycle.go
@@ -11,6 +11,43 @@ import (
 	"time"
 )
 
+// buildDaemonArgs constructs the argument list for the forked daemon process.
+// It forwards --listen-host when non-default and --cors-origins when non-empty.
+func buildDaemonArgs(dataDir string, dev bool, mcpToken string, osArgs []string, listenHostEnv, corsOriginsEnv string) []string {
+	args := []string{"--daemon", "--data", dataDir}
+	if dev {
+		args = append(args, "--dev")
+	}
+	if mcpToken != "" {
+		args = append(args, "--mcp-token", mcpToken)
+	}
+	// --listen-host: forward when non-default
+	listenHost := parseListenHost(osArgs, listenHostEnv)
+	if listenHost != "127.0.0.1" {
+		args = append(args, "--listen-host", listenHost)
+	}
+	// --cors-origins: forward from flag or env
+	corsOrigins := corsOriginsEnv
+	for i, arg := range osArgs {
+		if (arg == "--cors-origins" || arg == "-cors-origins") && i+1 < len(osArgs) {
+			corsOrigins = osArgs[i+1]
+			break
+		}
+		if after, ok := strings.CutPrefix(arg, "--cors-origins="); ok {
+			corsOrigins = after
+			break
+		}
+		if after, ok := strings.CutPrefix(arg, "-cors-origins="); ok {
+			corsOrigins = after
+			break
+		}
+	}
+	if corsOrigins != "" {
+		args = append(args, "--cors-origins", corsOrigins)
+	}
+	return args
+}
+
 // runStart forks muninn as a background daemon and waits for health check.
 func runStart(webEnabled bool) {
 	dataDir := defaultDataDir()
@@ -37,44 +74,18 @@ func runStart(webEnabled bool) {
 		os.Exit(1)
 	}
 
-	args := []string{"--daemon", "--data", dataDir}
-	if !webEnabled {
-		args = append(args, "--no-web")
-	}
-	// Pass through --dev flag if present
+	// Determine dev mode from os.Args
+	dev := false
 	for _, arg := range os.Args {
 		if arg == "--dev" {
-			args = append(args, "--dev")
+			dev = true
 			break
 		}
 	}
-	// Pass MCP token from token file if present
-	if tok := readTokenFile(); tok != "" {
-		args = append(args, "--mcp-token", tok)
-	}
-	// Pass through --listen-host if it differs from the default
-	listenHost := parseListenHost(os.Args[1:], os.Getenv("MUNINN_LISTEN_HOST"))
-	if listenHost != "127.0.0.1" {
-		args = append(args, "--listen-host", listenHost)
-	}
-	// Pass through --cors-origins if non-empty
-	corsOrigins := os.Getenv("MUNINN_CORS_ORIGINS")
-	for i, arg := range os.Args {
-		if (arg == "--cors-origins" || arg == "-cors-origins") && i+1 < len(os.Args) {
-			corsOrigins = os.Args[i+1]
-			break
-		}
-		if after, ok := strings.CutPrefix(arg, "--cors-origins="); ok {
-			corsOrigins = after
-			break
-		}
-		if after, ok := strings.CutPrefix(arg, "-cors-origins="); ok {
-			corsOrigins = after
-			break
-		}
-	}
-	if corsOrigins != "" {
-		args = append(args, "--cors-origins", corsOrigins)
+
+	args := buildDaemonArgs(dataDir, dev, readTokenFile(), os.Args[1:], os.Getenv("MUNINN_LISTEN_HOST"), os.Getenv("MUNINN_CORS_ORIGINS"))
+	if !webEnabled {
+		args = append(args, "--no-web")
 	}
 
 	cmd := exec.Command(os.Args[0], args...)

--- a/cmd/muninn/lifecycle.go
+++ b/cmd/muninn/lifecycle.go
@@ -83,7 +83,7 @@ func runStart(webEnabled bool) {
 	}
 
 	// Wait for health check (up to 5s)
-	mcpHealthURL := "http://" + defaultMCPAddr + "/mcp/health"
+	mcpHealthURL := "http://127.0.0.1:" + defaultMCPPort + "/mcp/health"
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		time.Sleep(200 * time.Millisecond)

--- a/cmd/muninn/lifecycle.go
+++ b/cmd/muninn/lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -50,6 +51,30 @@ func runStart(webEnabled bool) {
 	// Pass MCP token from token file if present
 	if tok := readTokenFile(); tok != "" {
 		args = append(args, "--mcp-token", tok)
+	}
+	// Pass through --listen-host if it differs from the default
+	listenHost := parseListenHost(os.Args[1:], os.Getenv("MUNINN_LISTEN_HOST"))
+	if listenHost != "127.0.0.1" {
+		args = append(args, "--listen-host", listenHost)
+	}
+	// Pass through --cors-origins if non-empty
+	corsOrigins := os.Getenv("MUNINN_CORS_ORIGINS")
+	for i, arg := range os.Args {
+		if (arg == "--cors-origins" || arg == "-cors-origins") && i+1 < len(os.Args) {
+			corsOrigins = os.Args[i+1]
+			break
+		}
+		if after, ok := strings.CutPrefix(arg, "--cors-origins="); ok {
+			corsOrigins = after
+			break
+		}
+		if after, ok := strings.CutPrefix(arg, "-cors-origins="); ok {
+			corsOrigins = after
+			break
+		}
+	}
+	if corsOrigins != "" {
+		args = append(args, "--cors-origins", corsOrigins)
 	}
 
 	cmd := exec.Command(os.Args[0], args...)

--- a/cmd/muninn/lifecycle_test.go
+++ b/cmd/muninn/lifecycle_test.go
@@ -6,6 +6,102 @@ import (
 	"testing"
 )
 
+func TestBuildDaemonArgs(t *testing.T) {
+	cases := []struct {
+		name           string
+		dataDir        string
+		dev            bool
+		mcpToken       string
+		osArgs         []string
+		listenHostEnv  string
+		corsOriginsEnv string
+		wantContains   []string
+		wantAbsent     []string
+	}{
+		{
+			name:    "default listen-host not forwarded",
+			dataDir: "/tmp/data",
+			osArgs:  []string{},
+			wantAbsent: []string{"--listen-host"},
+		},
+		{
+			name:    "non-default listen-host forwarded",
+			dataDir: "/tmp/data",
+			osArgs:  []string{"--listen-host", "0.0.0.0"},
+			wantContains: []string{"--listen-host", "0.0.0.0"},
+		},
+		{
+			name:    "cors-origins flag in osArgs forwarded",
+			dataDir: "/tmp/data",
+			osArgs:  []string{"--cors-origins", "http://flag.local"},
+			wantContains: []string{"--cors-origins", "http://flag.local"},
+		},
+		{
+			name:           "cors-origins from env when no flag",
+			dataDir:        "/tmp/data",
+			osArgs:         []string{},
+			corsOriginsEnv: "http://env.local",
+			wantContains:   []string{"--cors-origins", "http://env.local"},
+		},
+		{
+			name:           "flag wins over env for cors-origins",
+			dataDir:        "/tmp/data",
+			osArgs:         []string{"--cors-origins", "http://flag.local"},
+			corsOriginsEnv: "http://env.local",
+			wantContains:   []string{"--cors-origins", "http://flag.local"},
+			wantAbsent:     []string{"http://env.local"},
+		},
+		{
+			name:         "neither cors flag nor env not forwarded",
+			dataDir:      "/tmp/data",
+			osArgs:       []string{},
+			wantAbsent:   []string{"--cors-origins"},
+		},
+		{
+			name:         "dev true forwarded",
+			dataDir:      "/tmp/data",
+			dev:          true,
+			osArgs:       []string{},
+			wantContains: []string{"--dev"},
+		},
+		{
+			name:         "mcpToken set forwarded",
+			dataDir:      "/tmp/data",
+			mcpToken:     "tok123",
+			osArgs:       []string{},
+			wantContains: []string{"--mcp-token", "tok123"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildDaemonArgs(tc.dataDir, tc.dev, tc.mcpToken, tc.osArgs, tc.listenHostEnv, tc.corsOriginsEnv)
+
+			for _, want := range tc.wantContains {
+				found := false
+				for _, arg := range got {
+					if arg == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected %q in args %v", want, got)
+				}
+			}
+
+			for _, absent := range tc.wantAbsent {
+				for _, arg := range got {
+					if arg == absent {
+						t.Errorf("expected %q to be absent from args %v", absent, got)
+						break
+					}
+				}
+			}
+		})
+	}
+}
+
 // TestIsProcessRunningCurrentProcess checks if the current process is identified as running.
 func TestIsProcessRunningCurrentProcess(t *testing.T) {
 	pid := os.Getpid()

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -443,6 +443,11 @@ func runServer() {
 	mcpAddr := flag.String("mcp-addr", defaultMCPAddr, "MCP JSON-RPC listen address")
 	grpcAddr := flag.String("grpc-addr", "127.0.0.1:8477", "gRPC listen address")
 	metricsAddr := flag.String("metrics-addr", "", "Prometheus /metrics listen address (empty = disabled)")
+	uiAddrDefault := "127.0.0.1:8476"
+	if v := os.Getenv("MUNINN_UI_ADDR"); v != "" {
+		uiAddrDefault = v
+	}
+	uiAddr := flag.String("ui-addr", uiAddrDefault, "Web UI HTTP listen address")
 	mcpToken := flag.String("mcp-token", "", "Bearer token for MCP auth (empty = no auth)")
 	dev := flag.Bool("dev", false, "serve web assets from ./web directory (development mode)")
 	backupInterval := flag.String("backup-interval", "", "Automated backup interval (e.g. 6h, 30m); empty = disabled")
@@ -530,7 +535,7 @@ func runServer() {
 
 	// Validate address flags early so misconfigurations are caught before any
 	// resources are allocated. metricsAddr is optional (empty = disabled).
-	addrsToValidate := []string{*mbpAddr, *restAddr, *mcpAddr, *grpcAddr}
+	addrsToValidate := []string{*mbpAddr, *restAddr, *mcpAddr, *grpcAddr, *uiAddr}
 	if *metricsAddr != "" {
 		addrsToValidate = append(addrsToValidate, *metricsAddr)
 	}
@@ -967,7 +972,7 @@ func runServer() {
 	}()
 
 	// Start UI server
-	uiSrv, err := ui.NewServer(webFS, restWrapper, restServer.Handler(), authStore, sessionSecret, ring, clientTLS)
+	uiSrv, err := ui.NewServer(webFS, restWrapper, restServer.Handler(), authStore, sessionSecret, ring, clientTLS, corsOrigins)
 	if err != nil {
 		slog.Error("create ui server", "err", err)
 		os.Exit(1)
@@ -983,11 +988,11 @@ func runServer() {
 		})
 		uiSrv.Broadcast(data)
 	})
-	if err := uiSrv.Start(ctx, "127.0.0.1:8476"); err != nil {
+	if err := uiSrv.Start(ctx, *uiAddr); err != nil {
 		slog.Error("start ui server", "err", err)
 		os.Exit(1)
 	}
-	slog.Info("UI server listening", "addr", "127.0.0.1:8476")
+	slog.Info("UI server listening", "addr", *uiAddr)
 
 	slog.Info("vault fail-closed: unconfigured vaults require an API key; use muninn api-key create to grant access")
 

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -48,7 +48,7 @@ import (
 	webui "github.com/scrypster/muninndb/web"
 )
 
-const defaultMCPAddr = "127.0.0.1:8750"
+const defaultMCPPort = "8750"
 
 const vaultUpgradeWarning = `
 ================================================================
@@ -432,18 +432,48 @@ func validateServerFlags(addrs ...string) error {
 	return nil
 }
 
+// parseListenHost extracts the --listen-host value from args, falling back to
+// envVal and then "127.0.0.1". It is a pure function so it can be tested
+// without parsing the real flag set.
+func parseListenHost(args []string, envVal string) string {
+	host := "127.0.0.1"
+	if envVal != "" {
+		host = envVal
+	}
+	for i, arg := range args {
+		if (arg == "--listen-host" || arg == "-listen-host") && i+1 < len(args) {
+			host = args[i+1]
+			break
+		}
+		if after, ok := strings.CutPrefix(arg, "--listen-host="); ok {
+			host = after
+			break
+		}
+		if after, ok := strings.CutPrefix(arg, "-listen-host="); ok {
+			host = after
+			break
+		}
+	}
+	return host
+}
+
 func runServer() {
 	// Apply memory limits before any significant allocations.
 	applyMemoryLimits()
 
+	// Pre-scan os.Args for --listen-host so we can use it as the default host
+	// for all --*-addr flags. Explicit --*-addr flags will still override it.
+	listenHost := parseListenHost(os.Args[1:], os.Getenv("MUNINN_LISTEN_HOST"))
+
 	// Flags
 	dataDir := flag.String("data", "./muninn-data", "data directory")
-	mbpAddr := flag.String("mbp-addr", "127.0.0.1:8474", "MBP TCP listen address")
-	restAddr := flag.String("rest-addr", "127.0.0.1:8475", "REST HTTP listen address")
-	mcpAddr := flag.String("mcp-addr", defaultMCPAddr, "MCP JSON-RPC listen address")
-	grpcAddr := flag.String("grpc-addr", "127.0.0.1:8477", "gRPC listen address")
+	_ = flag.String("listen-host", listenHost, `host to bind all servers to (default "127.0.0.1"; use 0.0.0.0 for LAN/remote access)`)
+	mbpAddr := flag.String("mbp-addr", listenHost+":8474", "MBP TCP listen address")
+	restAddr := flag.String("rest-addr", listenHost+":8475", "REST HTTP listen address")
+	mcpAddr := flag.String("mcp-addr", listenHost+":"+defaultMCPPort, "MCP JSON-RPC listen address")
+	grpcAddr := flag.String("grpc-addr", listenHost+":8477", "gRPC listen address")
 	metricsAddr := flag.String("metrics-addr", "", "Prometheus /metrics listen address (empty = disabled)")
-	uiAddrDefault := "127.0.0.1:8476"
+	uiAddrDefault := listenHost + ":8476"
 	if v := os.Getenv("MUNINN_UI_ADDR"); v != "" {
 		uiAddrDefault = v
 	}
@@ -455,6 +485,8 @@ func runServer() {
 	backupRetain := flag.Int("backup-retain", 5, "Number of automated backups to keep")
 	tlsCert := flag.String("tls-cert", "", "Path to TLS certificate file (PEM)")
 	tlsKey  := flag.String("tls-key",  "", "Path to TLS private key file (PEM)")
+	corsOriginsDefault := os.Getenv("MUNINN_CORS_ORIGINS")
+	corsOriginsFlag := flag.String("cors-origins", corsOriginsDefault, "Comma-separated allowed CORS origins for browser clients (e.g. http://myapp.local:3000); overrides MUNINN_CORS_ORIGINS")
 	var logLevelStr string
 	flag.StringVar(&logLevelStr, "log-level", "info", "Log level: debug, info, warn, error")
 	flag.Usage = func() {
@@ -811,7 +843,7 @@ func runServer() {
 
 	// Build transport servers
 	mbpServer := mbp.NewServer(*mbpAddr, eng, authStore, clientTLS)
-	corsOrigins := parseCORSOrigins(os.Getenv("MUNINN_CORS_ORIGINS"))
+	corsOrigins := parseCORSOrigins(*corsOriginsFlag)
 	restServer := rest.NewServer(*restAddr, restWrapper, authStore, sessionSecret, corsOrigins, embedInfo, pluginRegistry, *dataDir, clientTLS, rest.MCPInfo{
 		Addr:     *mcpAddr,
 		HasToken: *mcpToken != "",

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -503,6 +503,7 @@ func runServer() {
 		fmt.Fprintf(os.Stderr, "  MUNINN_LOCAL_EMBED           Set to \"0\" to disable bundled ONNX embedder\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_ENRICH_URL            LLM enrichment endpoint URL (optional)\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_ENRICH_API_KEY        API key for enrichment (or MUNINN_ANTHROPIC_KEY)\n")
+		fmt.Fprintf(os.Stderr, "  MUNINN_LISTEN_HOST           Host to bind all servers to (e.g. 0.0.0.0 for LAN access)\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_CORS_ORIGINS          Comma-separated CORS allowed origins\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_MEM_LIMIT_GB          Memory limit in GB (default: 4)\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_GC_PERCENT            Go GC target percentage (default: 200)\n")
@@ -574,6 +575,10 @@ func runServer() {
 	if err := validateServerFlags(addrsToValidate...); err != nil {
 		slog.Error("invalid server address flag", "err", err)
 		os.Exit(1)
+	}
+
+	if listenHost == "0.0.0.0" {
+		slog.Warn("all services bound to 0.0.0.0 — ensure firewall rules are in place")
 	}
 
 	var logLevel slog.Level

--- a/cmd/muninn/server_test.go
+++ b/cmd/muninn/server_test.go
@@ -291,9 +291,12 @@ func TestParseListenHost_SingleDashSpaceSyntax(t *testing.T) {
 // set, the mcp-addr default is built from that host.
 func TestListenHostFlag_OverridesAddrDefaults(t *testing.T) {
 	host := parseListenHost([]string{"--listen-host", "10.0.0.1"}, "")
-	wantMCPAddr := host + ":" + defaultMCPPort
-	if wantMCPAddr != "10.0.0.1:"+defaultMCPPort {
-		t.Errorf("expected mcp addr default 10.0.0.1:%s, got %q", defaultMCPPort, wantMCPAddr)
+	if host != "10.0.0.1" {
+		t.Fatalf("expected 10.0.0.1, got %s", host)
+	}
+	gotAddr := host + ":" + defaultMCPPort
+	if gotAddr != "10.0.0.1:8750" {
+		t.Fatalf("expected 10.0.0.1:8750, got %s", gotAddr)
 	}
 }
 

--- a/cmd/muninn/server_test.go
+++ b/cmd/muninn/server_test.go
@@ -245,6 +245,76 @@ func TestApplyMemoryLimits_ZeroValues(t *testing.T) {
 	applyMemoryLimits()
 }
 
+func TestParseListenHost_Default(t *testing.T) {
+	got := parseListenHost([]string{}, "")
+	if got != "127.0.0.1" {
+		t.Errorf("expected 127.0.0.1, got %q", got)
+	}
+}
+
+func TestParseListenHost_EnvOverride(t *testing.T) {
+	got := parseListenHost([]string{}, "10.0.0.1")
+	if got != "10.0.0.1" {
+		t.Errorf("expected 10.0.0.1, got %q", got)
+	}
+}
+
+func TestParseListenHost_ArgOverridesEnv(t *testing.T) {
+	got := parseListenHost([]string{"--listen-host", "0.0.0.0"}, "10.0.0.1")
+	if got != "0.0.0.0" {
+		t.Errorf("expected 0.0.0.0, got %q", got)
+	}
+}
+
+func TestParseListenHost_EqualsSyntax(t *testing.T) {
+	got := parseListenHost([]string{"--listen-host=192.168.1.5"}, "")
+	if got != "192.168.1.5" {
+		t.Errorf("expected 192.168.1.5, got %q", got)
+	}
+}
+
+func TestParseListenHost_SingleDashEqualsSyntax(t *testing.T) {
+	got := parseListenHost([]string{"-listen-host=172.16.0.1"}, "")
+	if got != "172.16.0.1" {
+		t.Errorf("expected 172.16.0.1, got %q", got)
+	}
+}
+
+func TestParseListenHost_SingleDashSpaceSyntax(t *testing.T) {
+	got := parseListenHost([]string{"-listen-host", "10.10.10.10"}, "")
+	if got != "10.10.10.10" {
+		t.Errorf("expected 10.10.10.10, got %q", got)
+	}
+}
+
+// TestListenHostFlag_OverridesAddrDefaults confirms that when --listen-host is
+// set, the mcp-addr default is built from that host.
+func TestListenHostFlag_OverridesAddrDefaults(t *testing.T) {
+	host := parseListenHost([]string{"--listen-host", "10.0.0.1"}, "")
+	wantMCPAddr := host + ":" + defaultMCPPort
+	if wantMCPAddr != "10.0.0.1:"+defaultMCPPort {
+		t.Errorf("expected mcp addr default 10.0.0.1:%s, got %q", defaultMCPPort, wantMCPAddr)
+	}
+}
+
+// TestListenHostFlag_ExplicitAddrOverrides confirms that an explicit --mcp-addr
+// takes precedence over the --listen-host default. This is handled naturally by
+// flag.Parse() since the flag default is set to listenHost+port and an explicit
+// --mcp-addr value overwrites it. The test verifies the pre-scan does not
+// interfere with other args.
+func TestListenHostFlag_ExplicitAddrOverrides(t *testing.T) {
+	// Even if listen-host is 0.0.0.0, parseListenHost only affects the
+	// default value; flag.Parse() will use the explicitly-supplied --mcp-addr.
+	// Here we just verify parseListenHost doesn't accidentally consume the
+	// mcp-addr value.
+	host := parseListenHost([]string{"--listen-host", "0.0.0.0", "--mcp-addr", "127.0.0.1:" + defaultMCPPort}, "")
+	if host != "0.0.0.0" {
+		t.Errorf("expected listen-host=0.0.0.0, got %q", host)
+	}
+	// The explicit mcp-addr would be handled by flag.Parse(); we can only test
+	// that the listen-host pre-scan correctly picks up 0.0.0.0 here.
+}
+
 // clearEmbedEnv unsets all embed-related env vars for a clean test.
 func clearEmbedEnv(t *testing.T) {
 	t.Helper()

--- a/cmd/muninn/server_test.go
+++ b/cmd/muninn/server_test.go
@@ -7,6 +7,81 @@ import (
 	plugincfg "github.com/scrypster/muninndb/internal/config"
 )
 
+func TestAllAddrDefaults_UseListenHost(t *testing.T) {
+	host := parseListenHost([]string{"--listen-host", "10.0.0.1"}, "")
+	cases := []struct{ name, port, want string }{
+		{"mbp", "8474", "10.0.0.1:8474"},
+		{"rest", "8475", "10.0.0.1:8475"},
+		{"mcp", "8750", "10.0.0.1:8750"},
+		{"grpc", "8477", "10.0.0.1:8477"},
+		{"ui", "8476", "10.0.0.1:8476"},
+	}
+	for _, c := range cases {
+		got := host + ":" + c.port
+		if got != c.want {
+			t.Errorf("%s addr: got %s, want %s", c.name, got, c.want)
+		}
+	}
+}
+
+func TestMUNINN_UI_ADDR_EnvOverridesListenHost(t *testing.T) {
+	t.Setenv("MUNINN_UI_ADDR", "192.168.1.100:9999")
+	uiAddrDefault := "10.0.0.1:8476"
+	if v := os.Getenv("MUNINN_UI_ADDR"); v != "" {
+		uiAddrDefault = v
+	}
+	if uiAddrDefault != "192.168.1.100:9999" {
+		t.Errorf("expected 192.168.1.100:9999, got %s", uiAddrDefault)
+	}
+}
+
+func TestCORSOriginsResolution(t *testing.T) {
+	cases := []struct {
+		input string
+		want  []string
+	}{
+		{"http://flag.local", []string{"http://flag.local"}},
+		{"http://env.local", []string{"http://env.local"}},
+		{"http://a.com,http://b.com", []string{"http://a.com", "http://b.com"}},
+		{"", nil},
+	}
+	for _, tc := range cases {
+		got := parseCORSOrigins(tc.input)
+		if len(got) != len(tc.want) {
+			t.Errorf("parseCORSOrigins(%q): got %v (len %d), want %v (len %d)", tc.input, got, len(got), tc.want, len(tc.want))
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("parseCORSOrigins(%q)[%d]: got %q, want %q", tc.input, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestBuildDaemonArgs_CORSFlagBeatsEnv(t *testing.T) {
+	osArgs := []string{"--cors-origins=http://flag.local"}
+	corsOriginsEnv := "http://env.local"
+	got := buildDaemonArgs("/tmp/data", false, "", osArgs, "", corsOriginsEnv)
+
+	foundFlag := false
+	foundEnv := false
+	for _, arg := range got {
+		if arg == "http://flag.local" {
+			foundFlag = true
+		}
+		if arg == "http://env.local" {
+			foundEnv = true
+		}
+	}
+	if !foundFlag {
+		t.Errorf("expected http://flag.local in args %v", got)
+	}
+	if foundEnv {
+		t.Errorf("expected http://env.local to be absent from args %v", got)
+	}
+}
+
 func TestResolveEmbedInfo_EnvOllama(t *testing.T) {
 	clearEmbedEnv(t)
 	t.Setenv("MUNINN_OLLAMA_URL", "ollama://localhost:11434/nomic-embed-text")

--- a/internal/ui/coverage_test.go
+++ b/internal/ui/coverage_test.go
@@ -36,7 +36,7 @@ func TestHandleAdminLogin_Success(t *testing.T) {
 	sessionSecret := []byte("test-session-secret-32-bytes-ok!")
 
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), as, sessionSecret, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), as, sessionSecret, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestHandleAdminLogin_InvalidCredentials(t *testing.T) {
 	sessionSecret := []byte("test-session-secret-32-bytes-ok!")
 
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), as, sessionSecret, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), as, sessionSecret, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestHandleAdminLogin_InvalidJSON(t *testing.T) {
 	sessionSecret := []byte("test-session-secret-32-bytes-ok!")
 
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), as, sessionSecret, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), as, sessionSecret, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestHandleAdminLogin_InvalidJSON(t *testing.T) {
 
 func TestHandleAdminLogout(t *testing.T) {
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestHandleAdminLogout(t *testing.T) {
 
 func TestBroadcast_SendsToClients(t *testing.T) {
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestBroadcast_SendsToClients(t *testing.T) {
 func TestBroadcastStats_ViaStatsMockEngine(t *testing.T) {
 	eng := &statsMockEngine{engramCount: 42}
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestBroadcastStats_ViaStatsMockEngine(t *testing.T) {
 
 func TestHandleLogs_NilRingBuffer(t *testing.T) {
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, nil, nil)
+	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestHandleLogs_NilRingBuffer(t *testing.T) {
 func TestHandleLogs_EmptyRingBuffer(t *testing.T) {
 	rb := logging.NewRingBuffer(10, nil)
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, rb, nil)
+	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, rb, nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestHandleLogs_EmptyRingBuffer(t *testing.T) {
 
 func TestAuthCheck_NoAuth(t *testing.T) {
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -251,7 +251,7 @@ func TestNewServer_BadStaticFS(t *testing.T) {
 func TestSSEBroadcast_Integration(t *testing.T) {
 	eng := &statsMockEngine{engramCount: 10}
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestSSEBroadcast_Integration(t *testing.T) {
 
 func TestHandleAdminLogin_NoAuthStore(t *testing.T) {
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -307,7 +307,7 @@ func TestAuthCheck_WithAuthStore(t *testing.T) {
 	sessionSecret := []byte("test-session-secret-32-bytes-ok!")
 
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), as, sessionSecret, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), as, sessionSecret, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -331,7 +331,7 @@ func TestHandleAdminLogout_ClearsSessionCookie(t *testing.T) {
 	sessionSecret := []byte("test-session-secret-32-bytes-ok!")
 
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), as, sessionSecret, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), as, sessionSecret, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -356,7 +356,7 @@ func TestHandleAdminLogout_ClearsSessionCookie(t *testing.T) {
 func TestBroadcastStats_StatsUpdate(t *testing.T) {
 	eng := &statsMockEngine{engramCount: 42}
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -393,7 +393,7 @@ func TestBroadcast_MemoryAdded(t *testing.T) {
 		},
 	}
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -414,7 +414,7 @@ func TestAPIProxy(t *testing.T) {
 	})
 
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, &mockEngine{}, apiHandler, nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, &mockEngine{}, apiHandler, nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -432,7 +432,7 @@ func TestAPIProxy(t *testing.T) {
 
 func TestStaticHandler_NotFound(t *testing.T) {
 	webFS := makeMockFS()
-	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, &mockEngine{}, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -144,7 +144,7 @@ func (s *Server) Start(ctx context.Context, addr string) error {
 	if err != nil {
 		return err
 	}
-	s.ln = ln
+	s.ln = ln // store raw listener for Addr(); TLS wrapper (if any) shares the same addr
 	s.server.Addr = ln.Addr().String()
 	if s.tlsConfig != nil {
 		ln = tls.NewListener(ln, s.tlsConfig)
@@ -163,6 +163,7 @@ func (s *Server) Start(ctx context.Context, addr string) error {
 }
 
 // Addr returns the server's resolved listening address after Start has been called.
+// Safe to call from the same goroutine as Start; no concurrent access is expected.
 func (s *Server) Addr() string {
 	if s.ln != nil {
 		return s.ln.Addr().String()

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -31,6 +31,7 @@ type Server struct {
 	sessionSecret []byte
 	ring          *logging.RingBuffer
 	tlsConfig     *tls.Config // nil = plain TCP
+	corsOrigins   []string
 }
 
 // sseHub manages connected SSE clients.
@@ -74,7 +75,8 @@ func (h *sseHub) broadcast(data []byte) {
 // apiHandler is mounted at /api/ so the SPA can make same-origin API calls.
 // authStore and sessionSecret are used to handle admin login/logout via cookie sessions.
 // tlsConfig, if non-nil, enables TLS on the listener.
-func NewServer(webFS fs.FS, engine rest.EngineAPI, apiHandler http.Handler, authStore *auth.Store, sessionSecret []byte, ring *logging.RingBuffer, tlsConfig *tls.Config) (*Server, error) {
+// corsOrigins is the list of allowed CORS origins for the SSE endpoint.
+func NewServer(webFS fs.FS, engine rest.EngineAPI, apiHandler http.Handler, authStore *auth.Store, sessionSecret []byte, ring *logging.RingBuffer, tlsConfig *tls.Config, corsOrigins []string) (*Server, error) {
 	staticFS, err := fs.Sub(webFS, "static")
 	if err != nil {
 		return nil, err
@@ -94,11 +96,11 @@ func NewServer(webFS fs.FS, engine rest.EngineAPI, apiHandler http.Handler, auth
 		sessionSecret: sessionSecret,
 		ring:          ring,
 		tlsConfig:     tlsConfig,
+		corsOrigins:   corsOrigins,
 	}
 
 	mux := http.NewServeMux()
 	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
-	mux.HandleFunc("/events", s.handleSSE)
 	// Login/logout are handled by the UI server itself (cookie sessions).
 	// These must be registered before the /api/ catch-all so they take precedence.
 	mux.HandleFunc("POST /api/auth/login", s.handleAdminLogin)
@@ -109,11 +111,14 @@ func NewServer(webFS fs.FS, engine rest.EngineAPI, apiHandler http.Handler, auth
 	})
 	if s.authStore != nil && len(s.sessionSecret) > 0 {
 		mux.HandleFunc("GET /api/auth/check", s.authStore.AdminAPIMiddleware(s.sessionSecret, authCheckHandler))
+		mux.HandleFunc("GET /logs", s.authStore.AdminAPIMiddleware(s.sessionSecret, s.handleLogs))
+		mux.HandleFunc("/events", s.authStore.AdminAPIMiddleware(s.sessionSecret, s.handleSSE))
 	} else {
 		mux.HandleFunc("GET /api/auth/check", authCheckHandler)
+		mux.HandleFunc("GET /logs", s.handleLogs)
+		mux.HandleFunc("/events", s.handleSSE)
 	}
 	mux.Handle("/api/", apiHandler)
-	mux.HandleFunc("GET /logs", s.handleLogs)
 	mux.HandleFunc("/", s.handleSPA)
 
 	s.mux = mux
@@ -190,7 +195,32 @@ func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(out)
 }
 
+// setCORSIfAllowed sets Access-Control-Allow-Origin + Vary: Origin if the
+// request origin is in s.corsOrigins. Also handles OPTIONS preflight with 204.
+// Returns true if the request was a preflight (caller should return early).
+func (s *Server) setCORSIfAllowed(w http.ResponseWriter, r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin != "" {
+		for _, allowed := range s.corsOrigins {
+			if origin == allowed {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Vary", "Origin")
+				break
+			}
+		}
+	}
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return true
+	}
+	return false
+}
+
 func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
+	if s.setCORSIfAllowed(w, r) {
+		return
+	}
+
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
@@ -200,7 +230,6 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("X-Accel-Buffering", "no") // disable nginx buffering
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
@@ -257,6 +286,7 @@ func (s *Server) handleAdminLogin(w http.ResponseWriter, r *http.Request) {
 		Path:     "/",
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
+		Secure:   s.tlsConfig != nil,
 		MaxAge:   86400,
 	})
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -32,6 +32,7 @@ type Server struct {
 	ring          *logging.RingBuffer
 	tlsConfig     *tls.Config // nil = plain TCP
 	corsOrigins   []string
+	ln            net.Listener
 }
 
 // sseHub manages connected SSE clients.
@@ -143,11 +144,12 @@ func (s *Server) Start(ctx context.Context, addr string) error {
 	if err != nil {
 		return err
 	}
+	s.ln = ln
+	s.server.Addr = ln.Addr().String()
 	if s.tlsConfig != nil {
 		ln = tls.NewListener(ln, s.tlsConfig)
 		slog.Info("ui: TLS enabled", "addr", ln.Addr().String())
 	}
-	s.server.Addr = addr
 
 	go func() {
 		if err := s.server.Serve(ln); err != nil && err != http.ErrServerClosed {
@@ -158,6 +160,14 @@ func (s *Server) Start(ctx context.Context, addr string) error {
 	go s.broadcaster(ctx)
 
 	return nil
+}
+
+// Addr returns the server's resolved listening address after Start has been called.
+func (s *Server) Addr() string {
+	if s.ln != nil {
+		return s.ln.Addr().String()
+	}
+	return s.server.Addr
 }
 
 // Stop gracefully shuts down the UI server.

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -200,16 +200,25 @@ func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
 // Returns true if the request was a preflight (caller should return early).
 func (s *Server) setCORSIfAllowed(w http.ResponseWriter, r *http.Request) bool {
 	origin := r.Header.Get("Origin")
-	if origin != "" {
+	matched := false
+	if origin != "" && len(s.corsOrigins) > 0 {
 		for _, allowed := range s.corsOrigins {
 			if origin == allowed {
 				w.Header().Set("Access-Control-Allow-Origin", origin)
-				w.Header().Set("Vary", "Origin")
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+				matched = true
 				break
 			}
 		}
+		// Vary must be set unconditionally when this endpoint is CORS-aware
+		// so caches don't serve one origin's response to another origin.
+		w.Header().Set("Vary", "Origin")
 	}
 	if r.Method == http.MethodOptions {
+		if matched {
+			w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+		}
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -640,8 +640,8 @@ func TestUIServerBindsToAddr(t *testing.T) {
 	}
 	resp.Body.Close()
 	// Any HTTP response (200, 302, 401) proves the server is listening
-	if resp.StatusCode == 0 {
-		t.Fatalf("expected a valid HTTP status, got 0")
+	if resp.StatusCode < 100 || resp.StatusCode > 599 {
+		t.Fatalf("expected valid HTTP status code, got %d", resp.StatusCode)
 	}
 	t.Logf("server listening on %s, status %d", addr, resp.StatusCode)
 }

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -609,6 +609,43 @@ func TestEvents_RequiresAuth(t *testing.T) {
 	}
 }
 
+func TestUIServerBindsToAddr(t *testing.T) {
+	webFS := makeMockFS()
+	eng := &mockEngine{}
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := srv.Start(ctx, "127.0.0.1:0"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer stopCancel()
+		srv.Stop(stopCtx)
+	}()
+
+	addr := srv.Addr()
+	if addr == "" || addr == "127.0.0.1:0" {
+		t.Fatalf("expected resolved addr, got %q", addr)
+	}
+
+	resp, err := http.Get("http://" + addr + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	resp.Body.Close()
+	// Any HTTP response (200, 302, 401) proves the server is listening
+	if resp.StatusCode == 0 {
+		t.Fatalf("expected a valid HTTP status, got 0")
+	}
+	t.Logf("server listening on %s, status %d", addr, resp.StatusCode)
+}
+
 func TestSessionCookie_SecureFlagWithTLS(t *testing.T) {
 	db := openTestPebble(t)
 	store := auth.NewStore(db)

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -2,6 +2,7 @@ package ui_test
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"io/fs"
@@ -12,6 +13,9 @@ import (
 	"testing/fstest"
 	"time"
 
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/scrypster/muninndb/internal/auth"
 	"github.com/scrypster/muninndb/internal/cognitive"
 	"github.com/scrypster/muninndb/internal/engine"
 	"github.com/scrypster/muninndb/internal/engine/trigger"
@@ -187,7 +191,7 @@ func makeMockFS() fs.FS {
 func TestNewServer(t *testing.T) {
 	webFS := makeMockFS()
 	eng := &mockEngine{}
-	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -199,7 +203,7 @@ func TestNewServer(t *testing.T) {
 func TestSPAHandler(t *testing.T) {
 	webFS := makeMockFS()
 	eng := &mockEngine{}
-	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -221,7 +225,7 @@ func TestSPAHandler(t *testing.T) {
 func TestStaticHandler(t *testing.T) {
 	webFS := makeMockFS()
 	eng := &mockEngine{}
-	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -239,7 +243,7 @@ func TestSPAHandlerNonRoot(t *testing.T) {
 	// All non-static paths should serve index.html (SPA catch-all)
 	webFS := makeMockFS()
 	eng := &mockEngine{}
-	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -263,7 +267,7 @@ func TestSSEResponseHeaders(t *testing.T) {
 	// Test SSE headers using a real httptest server (needs actual streaming)
 	webFS := makeMockFS()
 	eng := &mockEngine{}
-	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -295,16 +299,13 @@ func TestSSEResponseHeaders(t *testing.T) {
 		if resp.Header.Get("Cache-Control") != "no-cache" {
 			t.Errorf("expected Cache-Control: no-cache, got %q", resp.Header.Get("Cache-Control"))
 		}
-		if resp.Header.Get("Access-Control-Allow-Origin") != "*" {
-			t.Errorf("expected Access-Control-Allow-Origin: *, got %q", resp.Header.Get("Access-Control-Allow-Origin"))
-		}
 	}
 }
 
 func TestServerStartStop(t *testing.T) {
 	webFS := makeMockFS()
 	eng := &mockEngine{}
-	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -330,7 +331,7 @@ func TestSPAHandlerMissingIndex(t *testing.T) {
 		"templates/.keep":     &fstest.MapFile{Data: []byte("")},
 	}
 	eng := &mockEngine{}
-	srv, err := ui.NewServer(badFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil)
+	srv, err := ui.NewServer(badFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -361,7 +362,7 @@ func TestHandleLogs_ReturnsSnapshot(t *testing.T) {
 
 	webFS := makeMockFS()
 	eng := &mockEngine{}
-	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, rb, nil)
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, rb, nil, nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -389,5 +390,242 @@ func TestHandleLogs_ReturnsSnapshot(t *testing.T) {
 	}
 	if result[1]["level"] != "WARN" {
 		t.Errorf("expected second entry level=WARN, got %q", result[1]["level"])
+	}
+}
+
+// openTestPebble opens an in-memory Pebble DB for testing.
+func openTestPebble(t *testing.T) *pebble.DB {
+	t.Helper()
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// newAuthServer creates a UI server with a real authStore and session secret.
+func newAuthServer(t *testing.T, corsOrigins []string) (*ui.Server, *auth.Store, []byte) {
+	t.Helper()
+	db := openTestPebble(t)
+	store := auth.NewStore(db)
+	if err := store.CreateAdmin("admin", "password"); err != nil {
+		t.Fatalf("CreateAdmin: %v", err)
+	}
+	secret, err := auth.GenerateSecret()
+	if err != nil {
+		t.Fatalf("GenerateSecret: %v", err)
+	}
+	webFS := makeMockFS()
+	eng := &mockEngine{}
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), store, secret, logging.NewRingBuffer(10, nil), nil, corsOrigins)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv, store, secret
+}
+
+func TestSSECORS_AllowlistedOrigin(t *testing.T) {
+	webFS := makeMockFS()
+	eng := &mockEngine{}
+	origins := []string{"http://example.com"}
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, origins)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/events", nil)
+	req.Header.Set("Origin", "http://example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil && resp == nil {
+		t.Skipf("could not establish SSE connection: %v", err)
+		return
+	}
+	if resp != nil {
+		defer resp.Body.Close()
+		if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "http://example.com" {
+			t.Errorf("expected Access-Control-Allow-Origin: http://example.com, got %q", got)
+		}
+		if got := resp.Header.Get("Vary"); got != "Origin" {
+			t.Errorf("expected Vary: Origin, got %q", got)
+		}
+	}
+}
+
+func TestSSECORS_NonAllowlistedOrigin(t *testing.T) {
+	webFS := makeMockFS()
+	eng := &mockEngine{}
+	origins := []string{"http://example.com"}
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, origins)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/events", nil)
+	req.Header.Set("Origin", "http://evil.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil && resp == nil {
+		t.Skipf("could not establish SSE connection: %v", err)
+		return
+	}
+	if resp != nil {
+		defer resp.Body.Close()
+		if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("expected no Access-Control-Allow-Origin header, got %q", got)
+		}
+	}
+}
+
+func TestSSECORS_EmptyCORSOrigins(t *testing.T) {
+	webFS := makeMockFS()
+	eng := &mockEngine{}
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/events", nil)
+	req.Header.Set("Origin", "http://anywhere.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil && resp == nil {
+		t.Skipf("could not establish SSE connection: %v", err)
+		return
+	}
+	if resp != nil {
+		defer resp.Body.Close()
+		if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("expected no Access-Control-Allow-Origin header, got %q", got)
+		}
+	}
+}
+
+func TestLogs_RequiresAuth(t *testing.T) {
+	srv, _, _ := newAuthServer(t, nil)
+
+	req := httptest.NewRequest("GET", "/logs", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without session cookie, got %d", w.Code)
+	}
+}
+
+func TestLogs_AllowedWithValidSession(t *testing.T) {
+	srv, _, secret := newAuthServer(t, nil)
+
+	token, err := auth.NewSessionToken("admin", secret)
+	if err != nil {
+		t.Fatalf("NewSessionToken: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/logs", nil)
+	req.AddCookie(&http.Cookie{Name: "muninn_session", Value: token})
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 with valid session cookie, got %d", w.Code)
+	}
+}
+
+func TestEvents_RequiresAuth(t *testing.T) {
+	srv, _, _ := newAuthServer(t, nil)
+
+	req := httptest.NewRequest("GET", "/events", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without session cookie, got %d", w.Code)
+	}
+}
+
+func TestSessionCookie_SecureFlagWithTLS(t *testing.T) {
+	db := openTestPebble(t)
+	store := auth.NewStore(db)
+	if err := store.CreateAdmin("admin", "password"); err != nil {
+		t.Fatalf("CreateAdmin: %v", err)
+	}
+	secret, err := auth.GenerateSecret()
+	if err != nil {
+		t.Fatalf("GenerateSecret: %v", err)
+	}
+
+	// Use a non-nil tls.Config to signal TLS mode.
+	tlsCfg := &tls.Config{}
+	webFS := makeMockFS()
+	eng := &mockEngine{}
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), store, secret, logging.NewRingBuffer(10, nil), tlsCfg, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	body := `{"username":"admin","password":"password"}`
+	req := httptest.NewRequest("POST", "/api/auth/login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 from login, got %d: %s", w.Code, w.Body.String())
+	}
+
+	setCookie := w.Header().Get("Set-Cookie")
+	if !strings.Contains(setCookie, "Secure") {
+		t.Errorf("expected Set-Cookie to contain Secure flag, got: %q", setCookie)
+	}
+}
+
+func TestSessionCookie_NoSecureFlagWithoutTLS(t *testing.T) {
+	db := openTestPebble(t)
+	store := auth.NewStore(db)
+	if err := store.CreateAdmin("admin", "password"); err != nil {
+		t.Fatalf("CreateAdmin: %v", err)
+	}
+	secret, err := auth.GenerateSecret()
+	if err != nil {
+		t.Fatalf("GenerateSecret: %v", err)
+	}
+
+	webFS := makeMockFS()
+	eng := &mockEngine{}
+	// nil tlsConfig = no TLS, Secure flag should NOT be set
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), store, secret, logging.NewRingBuffer(10, nil), nil, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	body := `{"username":"admin","password":"password"}`
+	req := httptest.NewRequest("POST", "/api/auth/login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 from login, got %d: %s", w.Code, w.Body.String())
+	}
+
+	setCookie := w.Header().Get("Set-Cookie")
+	if strings.Contains(setCookie, "Secure") {
+		t.Errorf("expected Set-Cookie to NOT contain Secure flag, got: %q", setCookie)
 	}
 }

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -488,6 +488,56 @@ func TestSSECORS_NonAllowlistedOrigin(t *testing.T) {
 	}
 }
 
+func TestSSECORS_Preflight(t *testing.T) {
+	webFS := makeMockFS()
+	eng := &mockEngine{}
+	origins := []string{"http://example.com"}
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, origins)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodOptions, "/events", nil)
+	req.Header.Set("Origin", "http://example.com")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "http://example.com" {
+		t.Errorf("expected Access-Control-Allow-Origin: http://example.com, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, "GET") {
+		t.Errorf("expected Access-Control-Allow-Methods to contain GET, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Errorf("expected Access-Control-Allow-Credentials: true, got %q", got)
+	}
+}
+
+func TestSSECORS_Preflight_NonAllowlisted(t *testing.T) {
+	webFS := makeMockFS()
+	eng := &mockEngine{}
+	origins := []string{"http://example.com"}
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, logging.NewRingBuffer(10, nil), nil, origins)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodOptions, "/events", nil)
+	req.Header.Set("Origin", "http://evil.com")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("expected no Access-Control-Allow-Origin header, got %q", got)
+	}
+}
+
 func TestSSECORS_EmptyCORSOrigins(t *testing.T) {
 	webFS := makeMockFS()
 	eng := &mockEngine{}


### PR DESCRIPTION
Closes #37

## Summary

- **`--listen-host`** (env `MUNINN_LISTEN_HOST`): sets the bind host for all services at once. `muninn serve --listen-host 0.0.0.0` exposes MCP, REST, gRPC, MBP, and UI on all interfaces. Individual `--*-addr` flags override it per-service. Logs a warning when bound to `0.0.0.0`.
- **`--cors-origins`** (env `MUNINN_CORS_ORIGINS`): CLI flag for allowed CORS origins — previously env-var only, now consistent with all other flags.
- **`--ui-addr`** (env `MUNINN_UI_ADDR`): UI server bind address — previously hardcoded to `127.0.0.1:8476`.
- **SSE CORS allowlist**: Replaces hardcoded `Access-Control-Allow-Origin: *` on `/events` with the same allowlist logic as the REST server. Includes `Access-Control-Allow-Credentials: true` and correct preflight handling.
- **Session cookie `Secure` flag**: Set to `true` when TLS is active.
- **Auth gate on `/logs` and `/events`**: Requires admin session when auth is configured.

## Usage

```bash
# All OpenClaw clients on your LAN point to one MuninnDB
muninn serve --listen-host 0.0.0.0

# Or via env (good for Docker/systemd)
MUNINN_LISTEN_HOST=0.0.0.0 muninn serve

# Custom browser dashboard on a different origin
muninn serve --listen-host 0.0.0.0 --cors-origins "http://myapp.local:3000"

# Individual service override still works
muninn serve --listen-host 0.0.0.0 --ui-addr 127.0.0.1:8476
```

## ⚠️ Breaking change

`/events` (SSE) previously sent `Access-Control-Allow-Origin: *`. It now requires an explicit allowlist via `--cors-origins` / `MUNINN_CORS_ORIGINS`. If you have a custom browser client consuming the SSE stream cross-origin, set that env var. MCP clients (OpenClaw, Claude Desktop, etc.) are unaffected — CORS is browser-only.

## Test Plan

- [ ] `TestParseListenHost_*` — pre-scan logic for all arg forms
- [ ] `TestListenHostFlag_*` — addr defaults constructed from listen-host
- [ ] `TestSSECORS_*` — allowlist, preflight, empty origins
- [ ] `TestLogs_RequiresAuth` / `TestLogs_AllowedWithValidSession`
- [ ] `TestEvents_RequiresAuth`
- [ ] `TestSessionCookie_SecureFlagWithTLS` / `TestSessionCookie_NoSecureFlagWithoutTLS`
- [ ] All 47 packages pass `go test ./... -count=1`