### PR TITLE
feat: add linux/arm64 support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,7 +49,6 @@ jobs:
           context: .
           push: true
           platforms: ${{ matrix.platform }}
-          build-args: TARGETARCH=${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.arch }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,11 +10,76 @@ permissions:
 
 jobs:
   build-and-push:
-    name: Build and push Docker image
-    runs-on: ubuntu-latest
+    name: Build and push ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            arch: arm64
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: ${{ matrix.platform }}
+          build-args: TARGETARCH=${{ matrix.arch }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-manifests:
+    name: Merge manifests
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -36,13 +101,10 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create and push manifest
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
+        working-directory: /tmp/digests
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
             goos: darwin
             goarch: amd64
             ort_target: _ort-darwin-amd64
+            # ORT dropped Intel Mac support after v1.23.2; this pin is intentional.
             cache_key: embed-assets-ort-1.23.2-minilm-v2-darwin-amd64
             cc: "clang -arch x86_64"
 
@@ -36,6 +37,13 @@ jobs:
             goarch: amd64
             ort_target: _ort-linux-amd64
             cache_key: embed-assets-ort-1.24.2-minilm-v2-linux-amd64
+            cc: ""
+
+          - runner: ubuntu-24.04-arm  # Native linux/arm64 runner
+            goos: linux
+            goarch: arm64
+            ort_target: _ort-linux-arm64
+            cache_key: embed-assets-ort-1.24.2-minilm-v2-linux-arm64
             cc: ""
 
     steps:
@@ -178,10 +186,12 @@ jobs:
             muninn-darwin-arm64 \
             muninn-darwin-amd64 \
             muninn-linux-amd64 \
+            muninn-linux-arm64 \
             muninn-windows-amd64.exe \
             muninn_${GITHUB_REF_NAME}_darwin_arm64.tar.gz \
             muninn_${GITHUB_REF_NAME}_darwin_amd64.tar.gz \
             muninn_${GITHUB_REF_NAME}_linux_amd64.tar.gz \
+            muninn_${GITHUB_REF_NAME}_linux_arm64.tar.gz \
             muninn_${GITHUB_REF_NAME}_windows_amd64.zip
 
   # ── Update Homebrew formula with new version + SHA256s ──────────────────
@@ -201,7 +211,7 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME}"
           BASE="https://github.com/scrypster/muninndb/releases/download/${VERSION}"
-          for platform in darwin-arm64 darwin-amd64 linux-amd64; do
+          for platform in darwin-arm64 darwin-amd64 linux-amd64 linux-arm64; do
             curl -fsSL "${BASE}/muninn-${platform}" -o "muninn-${platform}"
             sha256sum "muninn-${platform}" | cut -d' ' -f1 > "sha256-${platform}.txt"
             echo "${platform}: $(cat sha256-${platform}.txt)"
@@ -213,6 +223,7 @@ jobs:
           ARM64_SHA=$(cat sha256-darwin-arm64.txt)
           AMD64_MAC_SHA=$(cat sha256-darwin-amd64.txt)
           AMD64_LIN_SHA=$(cat sha256-linux-amd64.txt)
+          ARM64_LIN_SHA=$(cat sha256-linux-arm64.txt)
 
           FORMULA="homebrew-tap/Formula/muninn.rb"
 
@@ -223,6 +234,7 @@ jobs:
           sed -i 's|sha256 "[^"]*"  # darwin-arm64|sha256 "'"${ARM64_SHA}"'"  # darwin-arm64|' "${FORMULA}"
           sed -i 's|sha256 "[^"]*"  # darwin-amd64|sha256 "'"${AMD64_MAC_SHA}"'"  # darwin-amd64|' "${FORMULA}"
           sed -i 's|sha256 "[^"]*"  # linux-amd64|sha256 "'"${AMD64_LIN_SHA}"'"  # linux-amd64|'  "${FORMULA}"
+          sed -i 's|sha256 "[^"]*"  # linux-arm64|sha256 "'"${ARM64_LIN_SHA}"'"  # linux-arm64|'  "${FORMULA}"
 
       - name: Commit and push
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.24-bookworm AS builder
 
 WORKDIR /src
 
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl make ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM golang:1.24-bookworm AS builder
 
 WORKDIR /src
 
+ARG TARGETARCH=amd64
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl make ca-certificates \
     && rm -rf /var/lib/apt/lists/*
@@ -15,10 +17,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
 
 COPY . .
 
-# Fetch only what linux/amd64 needs (skips darwin libs to speed up the build).
+# Fetch model + platform-specific ORT native library.
+# TARGETARCH is injected by Docker Buildx (amd64 or arm64).
 # - model_int8.onnx + tokenizer.json: required by local_assets_common.go go:embed
-# - libonnxruntime_linux_amd64.so:    required by local_assets_linux_amd64.go go:embed
-RUN make fetch-model _ort-linux-amd64
+# - libonnxruntime_linux_{arch}.so:   required by local_assets_linux_{arch}.go go:embed
+RUN make fetch-model _ort-linux-${TARGETARCH}
 
 # Build web assets (Tailwind CSS via Vite)
 RUN cd web && npm ci --ignore-scripts && npm run build

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ HF_BASE     := https://huggingface.co/$(MODEL_REPO)/resolve/main
 ORT_BASE    := https://github.com/microsoft/onnxruntime/releases/download/v$(ORT_VERSION)
 
 .PHONY: fetch-assets fetch-model fetch-ort-libs clean-assets web build test bench test-integration \
-        eval-bible-setup eval-bible eval-bible-full eval-bible-quick eval-bible-export eval-bible-fast
+        eval-bible-setup eval-bible eval-bible-full eval-bible-quick eval-bible-export eval-bible-fast \
+        _ort-darwin-arm64 _ort-darwin-amd64 _ort-linux-amd64 _ort-linux-arm64 _ort-windows-amd64
 
 ## fetch-assets: download the model, tokenizer, and all platform ORT libraries.
 fetch-assets: fetch-model fetch-ort-libs
@@ -34,6 +35,7 @@ fetch-ort-libs:
 	@$(MAKE) -s _ort-darwin-arm64
 	@$(MAKE) -s _ort-darwin-amd64
 	@$(MAKE) -s _ort-linux-amd64
+	@$(MAKE) -s _ort-linux-arm64
 	@$(MAKE) -s _ort-windows-amd64
 	@echo "==> ORT native libraries ready."
 
@@ -68,6 +70,17 @@ _ort-linux-amd64:
 	@cp /tmp/onnxruntime-linux-x64-$(ORT_VERSION)/lib/libonnxruntime.so.$(ORT_VERSION) $(ASSETS_DIR)/libonnxruntime_linux_amd64.so 2>/dev/null || \
 		find /tmp -name 'libonnxruntime.so.*' | head -1 | xargs -I{} cp {} $(ASSETS_DIR)/libonnxruntime_linux_amd64.so
 	@echo "    linux/amd64: $$(du -sh $(ASSETS_DIR)/libonnxruntime_linux_amd64.so | cut -f1)"
+
+_ort-linux-arm64:
+	@echo "    Fetching linux/arm64..."
+	@curl -fL --progress-bar \
+		"$(ORT_BASE)/onnxruntime-linux-aarch64-$(ORT_VERSION).tgz" \
+		-o "/tmp/ort-linux-arm64.tgz"
+	@tar -xzf /tmp/ort-linux-arm64.tgz -C /tmp onnxruntime-linux-aarch64-$(ORT_VERSION)/lib/libonnxruntime.so.$(ORT_VERSION) 2>/dev/null || \
+		tar -xzf /tmp/ort-linux-arm64.tgz -C /tmp --strip-components=2 --wildcards '*/lib/libonnxruntime.so.*'
+	@cp /tmp/onnxruntime-linux-aarch64-$(ORT_VERSION)/lib/libonnxruntime.so.$(ORT_VERSION) $(ASSETS_DIR)/libonnxruntime_linux_arm64.so 2>/dev/null || \
+		find /tmp -name 'libonnxruntime.so.*' | head -1 | xargs -I{} cp {} $(ASSETS_DIR)/libonnxruntime_linux_arm64.so
+	@echo "    linux/arm64: $$(du -sh $(ASSETS_DIR)/libonnxruntime_linux_arm64.so | cut -f1)"
 
 _ort-windows-amd64:
 	@echo "    Fetching windows/amd64..."

--- a/internal/plugin/embed/local_assets_linux_arm64.go
+++ b/internal/plugin/embed/local_assets_linux_arm64.go
@@ -1,0 +1,14 @@
+//go:build linux && arm64 && localassets
+
+package embed
+
+import _ "embed"
+
+// nativeLibFilename is the extracted filename for the ORT shared library on this platform.
+const nativeLibFilename = "libonnxruntime.so"
+
+// embeddedNativeLib is the ORT 1.24.2 shared library for linux/arm64.
+// Populated by `make fetch-assets`.
+//
+//go:embed assets/libonnxruntime_linux_arm64.so
+var embeddedNativeLib []byte

--- a/internal/plugin/embed/local_assets_unsupported.go
+++ b/internal/plugin/embed/local_assets_unsupported.go
@@ -1,4 +1,4 @@
-//go:build localassets && !(darwin && arm64) && !(darwin && amd64) && !(linux && amd64) && !(windows && amd64)
+//go:build localassets && !(darwin && arm64) && !(darwin && amd64) && !(linux && amd64) && !(linux && arm64) && !(windows && amd64)
 
 package embed
 


### PR DESCRIPTION
## Summary

- Adds native `linux/arm64` build to release matrix using the `ubuntu-24.04-arm` GitHub-hosted runner
- New `_ort-linux-arm64` Makefile target fetches `onnxruntime-linux-aarch64-1.24.2.tgz` from the ORT release
- New `internal/plugin/embed/local_assets_linux_arm64.go` wires the `go:embed` for the arm64 `.so`
- Docker multi-platform build split into native per-arch jobs + manifest merge (no QEMU emulation)
- Homebrew formula updater extended to compute and patch linux/arm64 SHA256
- Adds explanatory comment to the darwin/amd64 matrix entry: ORT 1.23.2 pin is intentional (last release with Intel Mac support)

Closes #39

## Test Plan

- [ ] CI passes for linux/arm64 build job on release tag
- [ ] `ghcr.io/scrypster/muninndb:latest` manifest contains both `linux/amd64` and `linux/arm64` digests
- [ ] Homebrew formula `linux-arm64` SHA256 anchor present before first release using this workflow