### PR TITLE
feat: association durability — metadata preservation, PeakWeight, dynamic decay floor

### DIFF
--- a/docs/adr/2026-03-04-association-durability.md
+++ b/docs/adr/2026-03-04-association-durability.md
@@ -1,0 +1,96 @@
+# ADR: Association Durability — Metadata Preservation and Peak Weight
+
+**Date:** 2026-03-04
+**Status:** Implemented
+**Branch:** feat/association-durability
+**Prompted by:** Architectural analysis from Claude/Morpheus (Hippoclaudus system, DeCue Technologies)
+
+## Problem
+
+MuninnDB's association storage had two foundational defects:
+
+### 1. Metadata destruction bug (silent, since initial implementation)
+
+Every association write path called `encodeAssocValue(0, 1.0, time.Time{}, 0)` — a hardcoded blank value. This destroyed `relType`, `confidence`, `createdAt`, and `lastActivated` on every Hebbian weight update and every decay pass. The `lastActivated` field was designed for recency-aware decay but had never worked. The `confidence` field was always reset to 1.0 regardless of what was written. `relType` was always zeroed after the first weight update.
+
+### 2. No historical weight tracking
+
+The association value stored only current weight. There was no way to distinguish an association that peaked at 0.8 and decayed from one that never exceeded 0.05. This made principled pruning decisions impossible and meant Phase 5 transitive inference could not consider historically-strong chains.
+
+## Root Cause Analysis
+
+The system had a total-recall promise for engrams (0.05 Ebbinghaus floor prevents complete forgetting) but no equivalent for associations. The decay model applied a time-independent multiplicative factor (`weight * 0.95` per pass) without reading `lastActivated` — because `lastActivated` was being zeroed on every write. The infrastructure for recency-aware behavior existed in the data model but was never activated.
+
+## Decision
+
+### Phase 0: Fix metadata destruction (no format change)
+
+**Files:** `internal/storage/association.go`
+
+1. `UpdateAssocWeight` and `UpdateAssocWeightBatch`: Added `getAssocValue` helper that reads the existing 0x03 forward key value before deleting it. Now carries `relType`, `confidence`, `createdAt` forward and sets `lastActivated = int32(time.Now().Unix())` on every Hebbian weight update.
+
+2. `DecayAssocWeights`: Extended `assocEntry` struct to carry decoded metadata. Scan loop decodes `iter.Value()` and passes all fields through to `flushChunk`. `flushChunk` uses per-entry `encodeAssocValue(...)` instead of a single blank value.
+
+3. Recency skip: Added 5-minute grace window. If `lastActivated > 0` and `time.Since(activatedAt) < 5min`, the edge is skipped entirely on the decay pass. This protects edges used moments ago from being immediately penalized by the next scheduled decay.
+
+### Phase 1: Add PeakWeight (18→22 byte Pebble value)
+
+**Files:** `internal/storage/types.go`, `internal/storage/association.go`, `internal/consolidation/transitive.go`
+
+New value layout: `relType(2) | confidence(4) | createdAt(8) | lastActivated(4) | peakWeight(4) = 22 bytes`
+
+**Backward compatibility:** Old 18-byte values decode with `peakWeight = 0`. No migration required — the system self-heals:
+- On first `UpdateAssocWeight` call: `peakWeight = max(0, newWeight)` = newWeight
+- On first `DecayAssocWeights` pass: `if peakWeight == 0 { peakWeight = oldW }` bootstraps from current weight
+
+**PeakWeight semantics:**
+- Set to `Weight` on `WriteAssociation` (initial write)
+- Updated as `max(existingPeak, newWeight)` on every `UpdateAssocWeight`/`UpdateAssocWeightBatch`
+- Never decreases
+- `DecayAssocWeights` does NOT reduce `PeakWeight` (only current weight decays)
+
+**Dynamic decay floor:** When `newW < minWeight`, compute `dynamicFloor = peakWeight * 0.05`. If `dynamicFloor > 0`, clamp `newW = dynamicFloor` instead of deleting. An association that peaked at 0.8 gets floor 0.04; one at 0.1 gets floor 0.005.
+
+**Phase 5 transitive inference:** Changed threshold check from `ab.Weight >= minWeight` to `max(ab.Weight, ab.PeakWeight) >= minWeight`. Inferred edge weight still uses current `Weight` (not Peak) to avoid inflating new edges.
+
+### Note on `DecayAssocWeights` return value
+
+The `removed int` return value previously counted all edges deleted below `minWeight`. After this change, it counts only edges with no dynamic floor — unreachable in practice after the legacy bootstrap. Callers that used `removed` as a "pruned edge" metric will see 0. This is intentional: edges are no longer pruned, they clamp to their floor.
+
+## Consequences
+
+### Solved
+
+- `relType`, `confidence`, `createdAt`, `lastActivated` survive Hebbian updates and decay passes
+- `lastActivated` is correctly set on weight updates and enables recency-aware skip
+- `PeakWeight` records the historical maximum for every association
+- Earned associations (high peak) survive moderate dormancy via dynamic floor
+- Phase 5 can reconstruct transitive chains through partially-decayed edges
+
+### Deliberately Not Solved (and why)
+
+**Association archiving (0x25 prefix):** The external collaborators proposed archiving decayed associations instead of deleting them, preserving cluster topology for wholesale restoration. This is architecturally sound but requires:
+- A GC policy for the archive (not designed)
+- A reactivation path on cluster re-access
+- 6+ new file touchpoints
+- Second-order pruning for archives that outlive their usefulness (N years dormant)
+
+`PeakWeight` is the foundation the archiving proposal requires. With peak weight persisted, archiving can be added without re-examining the storage model. We chose to ship the foundation first and defer archiving until the need is validated by production behavior.
+
+**Co-activation count per pair:** Useful for frequency-vs-importance discrimination (high count + high peak = truly earned; high count + low peak = noise). Deferred. `PeakWeight` enables the same decisions and is simpler. Extend to 26 bytes when co-activation count is needed.
+
+**Phase 1 replay ceiling (top-50):** Consolidation replay is limited to the top 50 most-relevant engrams. Dormant cluster engrams fall below this window and stop getting Hebbian reinforcement. This is a tuning parameter, not a storage defect — fix by including high-peak-association engrams in the replay candidate set regardless of current relevance.
+
+**Bridge-edge concept:** No distinction between intra-cluster and inter-cluster bridge associations. Bridge edges (connecting otherwise-independent clusters) may deserve independent preservation rules. Requires cluster detection. Deferred.
+
+## What Should Be Done Next
+
+1. **Co-activation count per pair** — Extend value to 26 bytes: `peakWeight(4) | coactivationCount(4)`. Thread count through `processBatch` in `hebbian.go` (currently aggregated in-memory and discarded). Enables principled archiving thresholds.
+
+2. **Association archiving** — New 0x25 Pebble prefix for archived associations (high peak + high co-activation count, but decayed below floor). Restoration on cluster re-access. Requires GC policy.
+
+3. **Phase 1 replay ceiling** — Change from top-50 by relevance to a composite scan that includes engrams participating in high-peak-weight associations regardless of current relevance. Ensures dormant cluster seeds stay in the replay candidate set.
+
+4. **Recency grace window** — Currently 5 minutes (chosen to satisfy test constraints). Should be configurable per vault as a `PlasticityConfig` field. Suggested default: 1 hour for production vaults.
+
+5. **Bridge-edge detection** — Associations connecting engrams from two otherwise-independent clusters deserve their own preservation rules. Requires cluster detection (modularity / Louvain / connected components).

--- a/internal/consolidation/transitive.go
+++ b/internal/consolidation/transitive.go
@@ -11,8 +11,11 @@ import (
 // runPhase5TransitiveInference infers new transitive associations A→C where no direct
 // association exists, but both A→B and B→C exist with high weights.
 // An inference is created if:
-// - weight(A→B) >= 0.7 AND weight(B→C) >= 0.7
+// - max(weight(A→B), peakWeight(A→B)) >= 0.7 AND max(weight(B→C), peakWeight(B→C)) >= 0.7
 // - No direct A→C association exists
+// PeakWeight is used as a fallback threshold: a decayed-but-once-strong edge still
+// participates in transitive inference. Inferred weight uses current Weight (not Peak)
+// to avoid inflating newly-created edges.
 // Inferred weight = weight(A→B) * weight(B→C) * 0.8 (confidence discount)
 func (w *Worker) runPhase5TransitiveInference(ctx context.Context, store *storage.PebbleStore, wsPrefix [8]byte, report *ConsolidationReport) error {
 	const minWeight = 0.7
@@ -38,8 +41,15 @@ func (w *Worker) runPhase5TransitiveInference(ctx context.Context, store *storag
 	// For each A, check all A→B edges
 	for a, aAssocs := range allAssocs {
 		for _, ab := range aAssocs {
-			if ab.Weight < minWeight {
-				continue // A→B weight too low
+			// Use PeakWeight as fallback: a decayed-but-once-strong edge still participates
+			// in transitive inference. Inferred weight uses current Weight, not Peak,
+			// to avoid inflating newly-created edges.
+			effectiveAB := ab.Weight
+			if ab.PeakWeight > effectiveAB {
+				effectiveAB = ab.PeakWeight
+			}
+			if effectiveAB < minWeight {
+				continue // A→B never reached threshold, even at peak
 			}
 			// Skip NaN/Inf input weights to prevent graph corruption
 			if math.IsNaN(float64(ab.Weight)) || math.IsInf(float64(ab.Weight), 0) {
@@ -55,8 +65,12 @@ func (w *Worker) runPhase5TransitiveInference(ctx context.Context, store *storag
 			}
 
 			for _, bc := range bAssocs {
-				if bc.Weight < minWeight {
-					continue // B→C weight too low
+				effectiveBC := bc.Weight
+				if bc.PeakWeight > effectiveBC {
+					effectiveBC = bc.PeakWeight
+				}
+				if effectiveBC < minWeight {
+					continue // B→C never reached threshold, even at peak
 				}
 				// Skip NaN/Inf input weights to prevent graph corruption
 				if math.IsNaN(float64(bc.Weight)) || math.IsInf(float64(bc.Weight), 0) {

--- a/internal/consolidation/transitive_peak_test.go
+++ b/internal/consolidation/transitive_peak_test.go
@@ -1,0 +1,95 @@
+package consolidation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// TestTransitiveInference_PeakWeightFallback verifies Phase 5 creates A→C when
+// A→B and B→C have PeakWeight >= 0.7 but current Weight < 0.7 due to decay.
+// The inferred edge weight is based on current Weight (not Peak) to avoid
+// inflating newly-created edges.
+func TestTransitiveInference_PeakWeightFallback(t *testing.T) {
+	store, cleanup := testStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	wsPrefix := store.ResolveVaultPrefix("transitive_peak")
+
+	// Write 3 engrams — scanAllEngramIDs requires them to exist in storage.
+	a := &storage.Engram{Concept: "a", Content: "content a", Confidence: 1.0, Relevance: 0.8, Stability: 30}
+	b := &storage.Engram{Concept: "b", Content: "content b", Confidence: 1.0, Relevance: 0.8, Stability: 30}
+	c := &storage.Engram{Concept: "c", Content: "content c", Confidence: 1.0, Relevance: 0.8, Stability: 30}
+
+	idA, err := store.WriteEngram(ctx, wsPrefix, a)
+	if err != nil {
+		t.Fatalf("WriteEngram A: %v", err)
+	}
+	idB, err := store.WriteEngram(ctx, wsPrefix, b)
+	if err != nil {
+		t.Fatalf("WriteEngram B: %v", err)
+	}
+	idC, err := store.WriteEngram(ctx, wsPrefix, c)
+	if err != nil {
+		t.Fatalf("WriteEngram C: %v", err)
+	}
+
+	// Write A→B at weight 0.8 (above threshold); PeakWeight seeds to 0.8 via WriteAssociation.
+	if err := store.WriteAssociation(ctx, wsPrefix, idA, idB, &storage.Association{
+		TargetID: idB, Weight: 0.8, Confidence: 1.0, RelType: storage.RelSupports, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteAssociation A→B: %v", err)
+	}
+	// Decay A→B to 0.5 — UpdateAssocWeight preserves PeakWeight monotonically (stays 0.8).
+	if err := store.UpdateAssocWeight(ctx, wsPrefix, idA, idB, 0.5); err != nil {
+		t.Fatalf("UpdateAssocWeight A→B to 0.5: %v", err)
+	}
+
+	// Write B→C at weight 0.8, then decay to 0.5 similarly.
+	if err := store.WriteAssociation(ctx, wsPrefix, idB, idC, &storage.Association{
+		TargetID: idC, Weight: 0.8, Confidence: 1.0, RelType: storage.RelSupports, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteAssociation B→C: %v", err)
+	}
+	if err := store.UpdateAssocWeight(ctx, wsPrefix, idB, idC, 0.5); err != nil {
+		t.Fatalf("UpdateAssocWeight B→C to 0.5: %v", err)
+	}
+
+	// Confirm A→C does not yet exist.
+	priorWeight, err := store.GetAssocWeight(ctx, wsPrefix, idA, idC)
+	if err != nil {
+		t.Fatalf("GetAssocWeight A→C (pre-inference): %v", err)
+	}
+	if priorWeight > 0 {
+		t.Fatalf("expected no A→C before inference, got weight %v", priorWeight)
+	}
+
+	// Run Phase 5.
+	w := &Worker{MaxTransitive: 100}
+	report := &ConsolidationReport{}
+	if err := w.runPhase5TransitiveInference(ctx, store, wsPrefix, report); err != nil {
+		t.Fatalf("runPhase5TransitiveInference: %v", err)
+	}
+
+	// Verify A→C was inferred.
+	if report.InferredEdges != 1 {
+		t.Errorf("expected 1 inferred edge (A→C via PeakWeight fallback), got %d", report.InferredEdges)
+	}
+
+	inferredWeight, err := store.GetAssocWeight(ctx, wsPrefix, idA, idC)
+	if err != nil {
+		t.Fatalf("GetAssocWeight A→C (post-inference): %v", err)
+	}
+	if inferredWeight <= 0 {
+		t.Errorf("expected A→C to be created, got weight %v", inferredWeight)
+	}
+
+	// Inferred weight must use current Weight (0.5 * 0.5 * 0.8 = 0.2), not PeakWeight.
+	expectedWeight := float32(0.5 * 0.5 * 0.8)
+	if inferredWeight < expectedWeight-0.01 || inferredWeight > expectedWeight+0.01 {
+		t.Errorf("inferred weight = %v, want ~%v (current weights, not peak)", inferredWeight, expectedWeight)
+	}
+}

--- a/internal/engine/engine_pruning_test.go
+++ b/internal/engine/engine_pruning_test.go
@@ -292,7 +292,12 @@ func TestPruneVault_VaultIsolation(t *testing.T) {
 }
 
 // TestAssocDecay_PrunesWeakEdges verifies that DecayAssocWeights (called from
-// the prune worker) removes weak association edges while keeping strong ones.
+// the prune worker) decays weak association edges while keeping strong ones.
+//
+// Dynamic floor semantics (Task 5): an edge that falls below minWeight is NOT
+// deleted if its PeakWeight > 0. Instead it is clamped to PeakWeight * 0.05.
+// An edge written at weight 0.03 seeds PeakWeight=0.03, so its floor is
+// 0.03 * 0.05 = 0.0015. The edge survives, clamped to the floor.
 func TestAssocDecay_PrunesWeakEdges(t *testing.T) {
 	_, _, store, cleanup := testEnvWithAuth(t)
 	defer cleanup()
@@ -345,14 +350,15 @@ func TestAssocDecay_PrunesWeakEdges(t *testing.T) {
 	}
 
 	// Run decay with factor=0.95, minWeight=0.05.
-	// A→B: 0.8 * 0.95 = 0.76 (survives)
-	// A→C: 0.03 * 0.95 = 0.0285 < 0.05 (deleted)
+	// A→B: 0.8 * 0.95 = 0.76 (survives above threshold)
+	// A→C: 0.03 * 0.95 = 0.0285 < 0.05, but PeakWeight=0.03 → floor=0.0015 → clamped (not deleted)
 	removed, err := store.DecayAssocWeights(ctx, ws, 0.95, 0.05)
 	if err != nil {
 		t.Fatalf("DecayAssocWeights: %v", err)
 	}
-	if removed != 1 {
-		t.Errorf("expected 1 edge removed, got %d", removed)
+	// Dynamic floor: weak edge is clamped, not deleted.
+	if removed != 0 {
+		t.Errorf("expected 0 edges removed (dynamic floor clamps weak edges), got %d", removed)
 	}
 
 	// Strong edge should survive with decayed weight.
@@ -364,9 +370,14 @@ func TestAssocDecay_PrunesWeakEdges(t *testing.T) {
 		t.Errorf("expected A→B weight ~0.76, got %f", wAB)
 	}
 
-	// Weak edge should be gone.
+	// Weak edge should be clamped to dynamic floor (PeakWeight * 0.05 = 0.03 * 0.05 = 0.0015),
+	// not deleted. It must still exist (weight > 0) and be at or near the floor.
 	wAC, _ = store.GetAssocWeight(ctx, ws, idA, idC)
-	if wAC != 0 {
-		t.Errorf("weak edge A→C should be deleted after decay, got weight %f", wAC)
+	if wAC == 0 {
+		t.Error("weak edge A→C should be clamped to dynamic floor, not deleted")
+	}
+	const expectedFloor = float32(0.03 * 0.05) // 0.0015
+	if wAC > expectedFloor+0.001 {
+		t.Errorf("weak edge A→C weight %f exceeds expected floor ~%f", wAC, expectedFloor)
 	}
 }

--- a/internal/storage/assoc_weight_index_test.go
+++ b/internal/storage/assoc_weight_index_test.go
@@ -109,9 +109,10 @@ func TestAssocWeightIndex_UpdateWeight(t *testing.T) {
 	}
 }
 
-// TestAssocWeightIndex_DecayRemovesEntry verifies DecayAssocWeights removes
-// the 0x14 index entry when weight drops below minWeight.
-func TestAssocWeightIndex_DecayRemovesEntry(t *testing.T) {
+// TestAssocWeightIndex_DecayFloorsClampsEntry verifies DecayAssocWeights clamps
+// the association to PeakWeight*0.05 floor (rather than deleting) when weight drops
+// below minWeight. The 0x14 index entry is updated to the floor value.
+func TestAssocWeightIndex_DecayFloorsClampsEntry(t *testing.T) {
 	store, cleanup := newTestStoreHelper(t)
 	defer cleanup()
 
@@ -121,26 +122,29 @@ func TestAssocWeightIndex_DecayRemovesEntry(t *testing.T) {
 	a := NewULID()
 	b := NewULID()
 
+	// PeakWeight seeds to 0.05 at WriteAssociation time.
 	assoc := &Association{TargetID: b, Weight: 0.05}
 	if err := store.WriteAssociation(ctx, ws, a, b, assoc); err != nil {
 		t.Fatal(err)
 	}
 
-	// Decay by 50% with minWeight=0.1 — should remove the association
+	// Decay by 50% with minWeight=0.1 — newW=0.025 < 0.1, floor = 0.05*0.05 = 0.0025.
+	// Dynamic floor: edge is clamped, NOT deleted — removed count should be 0.
 	removed, err := store.DecayAssocWeights(ctx, ws, 0.5, 0.1)
 	if err != nil {
 		t.Fatalf("DecayAssocWeights: %v", err)
 	}
-	if removed != 1 {
-		t.Errorf("expected 1 removed, got %d", removed)
+	if removed != 0 {
+		t.Errorf("expected 0 removed (edge clamped to floor), got %d", removed)
 	}
 
-	// Index entry should be gone
+	// Index entry should reflect floor weight (0.05 * 0.05 = 0.0025), not zero.
 	w, err := store.GetAssocWeight(ctx, ws, a, b)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if w != 0.0 {
-		t.Errorf("expected 0 after decay removal, got %v", w)
+	wantFloor := float32(0.05 * 0.05)
+	if w < wantFloor-0.001 || w > wantFloor+0.001 {
+		t.Errorf("expected floor weight ~%.4f after decay clamp, got %v", wantFloor, w)
 	}
 }

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -38,23 +38,19 @@ func decodeAssocValue(val []byte) (relType RelType, confidence float32, createdA
 	if len(val) < 18 {
 		return 0, 1.0, time.Time{}, 0, 0
 	}
-	// All-zero check: if the entire value is zero, treat as legacy pre-BUG-2-fix.
-	// Check the full slice length so that a 22-byte value with a non-zero peakWeight
-	// tail is not incorrectly classified as legacy (e.g. relType=0, confidence=0.0).
-	checkLen := len(val)
-	if checkLen > 22 {
-		checkLen = 22
-	}
-	allZero := true
-	for _, b := range val[:checkLen] {
-		if b != 0 {
-			allZero = false
-			break
+	// All-zero 18-byte values are pre-fix legacy (old encoder wrote blank values).
+	// 22-byte values are from the new encoder and always carry real metadata.
+	if len(val) == 18 {
+		allZero := true
+		for _, b := range val {
+			if b != 0 {
+				allZero = false
+				break
+			}
 		}
-	}
-	if allZero {
-		// Legacy association written before BUG-2 fix; use optimistic defaults.
-		return 0, 1.0, time.Time{}, 0, 0
+		if allZero {
+			return 0, 1.0, time.Time{}, 0, 0
+		}
 	}
 	relType = RelType(binary.BigEndian.Uint16(val[0:2]))
 	confidence = math.Float32frombits(binary.BigEndian.Uint32(val[2:6]))
@@ -369,10 +365,27 @@ func (ps *PebbleStore) UpdateAssocWeightBatch(ctx context.Context, updates []Ass
 		return fmt.Errorf("commit batch: %w", err)
 	}
 
+	// Invalidate assoc cache for all updated source nodes.
+	// Deduplicate to avoid redundant removals when a source appears multiple times.
+	seen := make(map[[24]byte]struct{}, len(updates))
+	for _, update := range updates {
+		ck := assocCacheKey(update.WS, update.Src)
+		if _, ok := seen[ck]; !ok {
+			seen[ck] = struct{}{}
+			ps.assocCache.Remove(ck)
+		}
+	}
 	return nil
 }
 
 const assocDecayChunkSize = 10_000
+
+// assocDecayGraceWindow is the minimum time since lastActivated before an
+// association is eligible for weight decay. Edges activated within this window
+// are skipped on the decay pass, protecting recently-used associations from
+// being penalized by the next scheduled consolidation run.
+// TODO: make this configurable per vault via PlasticityConfig.
+const assocDecayGraceWindow = 5 * time.Minute
 
 // DecayAssocWeights multiplies all association weights for wsPrefix by decayFactor,
 // deleting entries that fall below minWeight. Returns count of deleted entries.
@@ -457,10 +470,9 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 		// Recency skip: associations activated within the grace window are not decayed.
 		// Window must be > a few seconds (to protect edges just activated) but
 		// < 30 minutes (so edges activated 30 min ago are still eligible for decay).
-		const decayGraceWindow = 5 * time.Minute
 		if lastActivated > 0 {
 			activatedAt := time.Unix(int64(lastActivated), 0)
-			if time.Since(activatedAt) < decayGraceWindow {
+			if time.Since(activatedAt) < assocDecayGraceWindow {
 				continue // skip — recently used, leave key untouched
 			}
 		}

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -374,6 +374,11 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 		oldW   float32
 		newW   float32
 		remove bool
+		// Preserved from existing Pebble value:
+		relType       RelType
+		confidence    float32
+		createdAt     time.Time
+		lastActivated int32
 	}
 
 	removed := 0
@@ -385,19 +390,19 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 		}
 		batch := ps.db.NewBatch()
 		defer batch.Close()
-		newAssocValue := encodeAssocValue(0, 1.0, time.Time{}, 0)
 		for _, e := range chunk {
 			_ = batch.Delete(keys.AssocFwdKey(wsPrefix, e.src, e.oldW, e.dst), nil)
 			_ = batch.Delete(keys.AssocRevKey(wsPrefix, e.dst, e.oldW, e.src), nil)
 			if !e.remove {
-				_ = batch.Set(keys.AssocFwdKey(wsPrefix, e.src, e.newW, e.dst), newAssocValue[:], nil)
-				_ = batch.Set(keys.AssocRevKey(wsPrefix, e.dst, e.newW, e.src), newAssocValue[:], nil)
-				// Add weight index update:
+				// Preserve existing metadata. Do NOT update lastActivated here —
+				// decay is a background process, not a user activation.
+				val := encodeAssocValue(e.relType, e.confidence, e.createdAt, e.lastActivated)
+				_ = batch.Set(keys.AssocFwdKey(wsPrefix, e.src, e.newW, e.dst), val[:], nil)
+				_ = batch.Set(keys.AssocRevKey(wsPrefix, e.dst, e.newW, e.src), val[:], nil)
 				var wiBuf [4]byte
 				binary.BigEndian.PutUint32(wiBuf[:], math.Float32bits(e.newW))
 				_ = batch.Set(keys.AssocWeightIndexKey(wsPrefix, e.src, e.dst), wiBuf[:], nil)
 			} else {
-				// Add weight index deletion:
 				_ = batch.Delete(keys.AssocWeightIndexKey(wsPrefix, e.src, e.dst), nil)
 			}
 		}
@@ -413,6 +418,21 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 		if len(key) < 45 {
 			continue
 		}
+
+		// Decode existing metadata from the value bytes before extracting key fields.
+		relType, confidence, createdAt, lastActivated := decodeAssocValue(iter.Value())
+
+		// Recency skip: associations activated within the grace window are not decayed.
+		// Window must be > a few seconds (to protect edges just activated) but
+		// < 30 minutes (so edges activated 30 min ago are still eligible for decay).
+		const decayGraceWindow = 5 * time.Minute
+		if lastActivated > 0 {
+			activatedAt := time.Unix(int64(lastActivated), 0)
+			if time.Since(activatedAt) < decayGraceWindow {
+				continue // skip — recently used, leave key untouched
+			}
+		}
+
 		var src, dst [16]byte
 		copy(src[:], key[9:25])
 		var wc [4]byte
@@ -422,7 +442,11 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 		oldW := keys.WeightFromComplement(wc)
 		newW := float32(float64(oldW) * decayFactor)
 
-		e := assocEntry{src: src, dst: dst, oldW: oldW, newW: newW}
+		e := assocEntry{
+			src: src, dst: dst, oldW: oldW, newW: newW,
+			relType: relType, confidence: confidence,
+			createdAt: createdAt, lastActivated: lastActivated,
+		}
 		if newW < minWeight {
 			e.remove = true
 			removed++

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -258,23 +258,42 @@ func (ps *PebbleStore) GetAssocWeight(ctx context.Context, wsPrefix [8]byte, a, 
 	return math.Float32frombits(binary.BigEndian.Uint32(val[:4])), nil
 }
 
+// getAssocValue reads the decoded association metadata for pair (a→b).
+// Uses knownWeight to construct the 0x03 key. Returns zero values if no
+// association exists or the key cannot be read.
+func (ps *PebbleStore) getAssocValue(wsPrefix [8]byte, a, b ULID, knownWeight float32) (relType RelType, confidence float32, createdAt time.Time, lastActivated int32) {
+	if knownWeight <= 0 {
+		return 0, 1.0, time.Time{}, 0
+	}
+	fwdKey := keys.AssocFwdKey(wsPrefix, [16]byte(a), knownWeight, [16]byte(b))
+	val, err := Get(ps.db, fwdKey)
+	if err != nil || val == nil {
+		return 0, 1.0, time.Time{}, 0
+	}
+	return decodeAssocValue(val)
+}
+
 // UpdateAssocWeight writes/updates the 0x03 and 0x04 association keys for pair (a,b).
 // It reads the current weight first and deletes the old keys before writing new
 // ones, preventing stale duplicate entries from accumulating in the key space.
+// Existing metadata (relType, confidence, createdAt) is preserved; lastActivated
+// is set to now (Hebbian update = activation).
 func (ps *PebbleStore) UpdateAssocWeight(ctx context.Context, wsPrefix [8]byte, a, b ULID, weight float32) error {
 	batch := ps.db.NewBatch()
 	defer batch.Close()
 
-	// Delete old keys if a prior weight exists for this pair.
-	if oldWeight, err := ps.GetAssocWeight(ctx, wsPrefix, a, b); err == nil && oldWeight > 0 {
-		oldFwd := keys.AssocFwdKey(wsPrefix, [16]byte(a), oldWeight, [16]byte(b))
-		oldRev := keys.AssocRevKey(wsPrefix, [16]byte(b), oldWeight, [16]byte(a))
-		batch.Delete(oldFwd, nil)
-		batch.Delete(oldRev, nil)
+	// Read existing metadata before deleting old keys.
+	oldWeight, _ := ps.GetAssocWeight(ctx, wsPrefix, a, b)
+	relType, confidence, createdAt, _ := ps.getAssocValue(wsPrefix, a, b, oldWeight)
+
+	if oldWeight > 0 {
+		batch.Delete(keys.AssocFwdKey(wsPrefix, [16]byte(a), oldWeight, [16]byte(b)), nil)
+		batch.Delete(keys.AssocRevKey(wsPrefix, [16]byte(b), oldWeight, [16]byte(a)), nil)
 	}
 
-	// Weight-only update: rel_type unknown, use confidence=1.0 optimistic default
-	assocValue := encodeAssocValue(0, 1.0, time.Time{}, 0)
+	// Preserve existing metadata; set lastActivated = now (Hebbian update = activation).
+	now := int32(time.Now().Unix())
+	assocValue := encodeAssocValue(relType, confidence, createdAt, now)
 	batch.Set(keys.AssocFwdKey(wsPrefix, [16]byte(a), weight, [16]byte(b)), assocValue[:], nil)
 	batch.Set(keys.AssocRevKey(wsPrefix, [16]byte(b), weight, [16]byte(a)), assocValue[:], nil)
 
@@ -287,36 +306,37 @@ func (ps *PebbleStore) UpdateAssocWeight(ctx context.Context, wsPrefix [8]byte, 
 		return fmt.Errorf("commit batch: %w", err)
 	}
 
-	// Association list is TTL-cached; stale weights are acceptable for BFS traversal.
-
+	ps.assocCache.Remove(assocCacheKey(wsPrefix, a))
 	return nil
 }
 
 // UpdateAssocWeightBatch atomically updates multiple association weights in a single batch.
 // All updates are committed atomically — either all succeed or none do.
+// Existing metadata (relType, confidence, createdAt) is preserved per-pair;
+// lastActivated is set to now (Hebbian update = activation).
 func (ps *PebbleStore) UpdateAssocWeightBatch(ctx context.Context, updates []AssocWeightUpdate) error {
 	batch := ps.db.NewBatch()
 	defer batch.Close()
 
-	assocValue := encodeAssocValue(0, 1.0, time.Time{}, 0)
+	now := int32(time.Now().Unix())
 
 	for _, update := range updates {
-		// Delete old keys if a prior weight exists for this pair.
-		if oldWeight, err := ps.GetAssocWeight(ctx, update.WS, update.Src, update.Dst); err == nil && oldWeight > 0 {
-			oldFwd := keys.AssocFwdKey(update.WS, [16]byte(update.Src), oldWeight, [16]byte(update.Dst))
-			oldRev := keys.AssocRevKey(update.WS, [16]byte(update.Dst), oldWeight, [16]byte(update.Src))
-			batch.Delete(oldFwd, nil)
-			batch.Delete(oldRev, nil)
+		oldWeight, _ := ps.GetAssocWeight(ctx, update.WS, update.Src, update.Dst)
+		relType, confidence, createdAt, _ := ps.getAssocValue(update.WS, ULID(update.Src), ULID(update.Dst), oldWeight)
+
+		if oldWeight > 0 {
+			batch.Delete(keys.AssocFwdKey(update.WS, update.Src, oldWeight, update.Dst), nil)
+			batch.Delete(keys.AssocRevKey(update.WS, update.Dst, oldWeight, update.Src), nil)
 		}
 
-		// Set new forward and reverse keys
-		batch.Set(keys.AssocFwdKey(update.WS, [16]byte(update.Src), update.Weight, [16]byte(update.Dst)), assocValue[:], nil)
-		batch.Set(keys.AssocRevKey(update.WS, [16]byte(update.Dst), update.Weight, [16]byte(update.Src)), assocValue[:], nil)
+		assocValue := encodeAssocValue(relType, confidence, createdAt, now)
+		batch.Set(keys.AssocFwdKey(update.WS, update.Src, update.Weight, update.Dst), assocValue[:], nil)
+		batch.Set(keys.AssocRevKey(update.WS, update.Dst, update.Weight, update.Src), assocValue[:], nil)
 
 		// Update weight index.
 		var wiBuf [4]byte
 		binary.BigEndian.PutUint32(wiBuf[:], math.Float32bits(update.Weight))
-		batch.Set(keys.AssocWeightIndexKey(update.WS, [16]byte(update.Src), [16]byte(update.Dst)), wiBuf[:], nil)
+		batch.Set(keys.AssocWeightIndexKey(update.WS, update.Src, update.Dst), wiBuf[:], nil)
 	}
 
 	if err := batch.Commit(pebble.NoSync); err != nil {

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -13,11 +13,12 @@ import (
 	"github.com/scrypster/muninndb/internal/storage/keys"
 )
 
-// encodeAssocValue serializes association metadata into the 18-byte value
-// stored under association forward/reverse keys (0x03/0x04).
-// Layout: relType(uint16 BE,2) | confidence(float32 BE,4) | createdAt(int64 nanos BE,8) | lastActivated(int32 BE,4)
-func encodeAssocValue(relType RelType, confidence float32, createdAt time.Time, lastActivated int32) [18]byte {
-	var val [18]byte
+// encodeAssocValue serializes association metadata into the 22-byte value
+// stored under 0x03/0x04 Pebble keys.
+// Layout: relType(2) | confidence(4) | createdAt(8) | lastActivated(4) | peakWeight(4) = 22 bytes
+// Old readers that only consume 18 bytes continue to work; peakWeight is at the tail.
+func encodeAssocValue(relType RelType, confidence float32, createdAt time.Time, lastActivated int32, peakWeight float32) [22]byte {
+	var val [22]byte
 	binary.BigEndian.PutUint16(val[0:2], uint16(relType))
 	binary.BigEndian.PutUint32(val[2:6], math.Float32bits(confidence))
 	var nanos int64
@@ -26,17 +27,26 @@ func encodeAssocValue(relType RelType, confidence float32, createdAt time.Time, 
 	}
 	binary.BigEndian.PutUint64(val[6:14], uint64(nanos))
 	binary.BigEndian.PutUint32(val[14:18], uint32(lastActivated))
+	binary.BigEndian.PutUint32(val[18:22], math.Float32bits(peakWeight))
 	return val
 }
 
-// decodeAssocValue decodes the 18-byte association value.
-// All-zero values are treated as legacy (pre-BUG-2-fix): returns relType=0, confidence=1.0.
-func decodeAssocValue(val []byte) (relType RelType, confidence float32, createdAt time.Time, lastActivated int32) {
+// decodeAssocValue decodes a 18-byte (legacy) or 22-byte association value.
+// Returns peakWeight=0 for legacy 18-byte values.
+// All-zero 18-byte values treated as pre-fix legacy: confidence=1.0, rest zero.
+func decodeAssocValue(val []byte) (relType RelType, confidence float32, createdAt time.Time, lastActivated int32, peakWeight float32) {
 	if len(val) < 18 {
-		return 0, 1.0, time.Time{}, 0
+		return 0, 1.0, time.Time{}, 0, 0
+	}
+	// All-zero check: if the entire value is zero, treat as legacy pre-BUG-2-fix.
+	// Check the full slice length so that a 22-byte value with a non-zero peakWeight
+	// tail is not incorrectly classified as legacy (e.g. relType=0, confidence=0.0).
+	checkLen := len(val)
+	if checkLen > 22 {
+		checkLen = 22
 	}
 	allZero := true
-	for _, b := range val[:18] {
+	for _, b := range val[:checkLen] {
 		if b != 0 {
 			allZero = false
 			break
@@ -44,7 +54,7 @@ func decodeAssocValue(val []byte) (relType RelType, confidence float32, createdA
 	}
 	if allZero {
 		// Legacy association written before BUG-2 fix; use optimistic defaults.
-		return 0, 1.0, time.Time{}, 0
+		return 0, 1.0, time.Time{}, 0, 0
 	}
 	relType = RelType(binary.BigEndian.Uint16(val[0:2]))
 	confidence = math.Float32frombits(binary.BigEndian.Uint32(val[2:6]))
@@ -53,6 +63,9 @@ func decodeAssocValue(val []byte) (relType RelType, confidence float32, createdA
 		createdAt = time.Unix(0, nanos)
 	}
 	lastActivated = int32(binary.BigEndian.Uint32(val[14:18]))
+	if len(val) >= 22 {
+		peakWeight = math.Float32frombits(binary.BigEndian.Uint32(val[18:22]))
+	}
 	return
 }
 
@@ -70,8 +83,9 @@ func (ps *PebbleStore) WriteAssociation(ctx context.Context, wsPrefix [8]byte, s
 	defer batch.Close()
 
 	// Forward association (0x03 key)
+	// PeakWeight is seeded to Weight on initial write — this is the association's first peak.
 	fwdKey := keys.AssocFwdKey(wsPrefix, [16]byte(src), assoc.Weight, [16]byte(dst))
-	assocValue := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated)
+	assocValue := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, assoc.Weight)
 	batch.Set(fwdKey, assocValue[:], nil)
 
 	// Reverse association (0x04 key)
@@ -165,7 +179,7 @@ func (ps *PebbleStore) GetAssociations(ctx context.Context, wsPrefix [8]byte, id
 			var wc [4]byte
 			copy(wc[:], k[25:29])
 			weight := keys.WeightFromComplement(wc)
-			relType, confidence, createdAt, lastActivated := decodeAssocValue(iter.Value())
+			relType, confidence, createdAt, lastActivated, peakWeight := decodeAssocValue(iter.Value())
 			assocs = append(assocs, Association{
 				TargetID:      targetID,
 				Weight:        weight,
@@ -173,6 +187,7 @@ func (ps *PebbleStore) GetAssociations(ctx context.Context, wsPrefix [8]byte, id
 				Confidence:    confidence,
 				CreatedAt:     createdAt,
 				LastActivated: lastActivated,
+				PeakWeight:    peakWeight,
 			})
 		}
 
@@ -228,9 +243,9 @@ func (ps *PebbleStore) associationsForOne(wsPrefix [8]byte, id ULID, maxPerNode 
 		copy(wc[:], key[25:29])
 		weight := keys.WeightFromComplement(wc)
 
-		// Decode value bytes: rel_type, confidence, timestamps
+		// Decode value bytes: rel_type, confidence, timestamps, peakWeight
 		val := iter.Value()
-		relType, confidence, createdAt, lastActivated := decodeAssocValue(val)
+		relType, confidence, createdAt, lastActivated, peakWeight := decodeAssocValue(val)
 
 		assocs = append(assocs, Association{
 			TargetID:      targetID,
@@ -239,6 +254,7 @@ func (ps *PebbleStore) associationsForOne(wsPrefix [8]byte, id ULID, maxPerNode 
 			Confidence:    confidence,
 			CreatedAt:     createdAt,
 			LastActivated: lastActivated,
+			PeakWeight:    peakWeight,
 		})
 	}
 	// Populate cache — expirable.LRU enforces the TTL automatically.
@@ -261,14 +277,14 @@ func (ps *PebbleStore) GetAssocWeight(ctx context.Context, wsPrefix [8]byte, a, 
 // getAssocValue reads the decoded association metadata for pair (a→b).
 // Uses knownWeight to construct the 0x03 key. Returns zero values if no
 // association exists or the key cannot be read.
-func (ps *PebbleStore) getAssocValue(wsPrefix [8]byte, a, b ULID, knownWeight float32) (relType RelType, confidence float32, createdAt time.Time, lastActivated int32) {
+func (ps *PebbleStore) getAssocValue(wsPrefix [8]byte, a, b ULID, knownWeight float32) (relType RelType, confidence float32, createdAt time.Time, lastActivated int32, peakWeight float32) {
 	if knownWeight <= 0 {
-		return 0, 1.0, time.Time{}, 0
+		return 0, 1.0, time.Time{}, 0, 0
 	}
 	fwdKey := keys.AssocFwdKey(wsPrefix, [16]byte(a), knownWeight, [16]byte(b))
 	val, err := Get(ps.db, fwdKey)
 	if err != nil || val == nil {
-		return 0, 1.0, time.Time{}, 0
+		return 0, 1.0, time.Time{}, 0, 0
 	}
 	return decodeAssocValue(val)
 }
@@ -284,7 +300,7 @@ func (ps *PebbleStore) UpdateAssocWeight(ctx context.Context, wsPrefix [8]byte, 
 
 	// Read existing metadata before deleting old keys.
 	oldWeight, _ := ps.GetAssocWeight(ctx, wsPrefix, a, b)
-	relType, confidence, createdAt, _ := ps.getAssocValue(wsPrefix, a, b, oldWeight)
+	relType, confidence, createdAt, _, existingPeak := ps.getAssocValue(wsPrefix, a, b, oldWeight)
 
 	if oldWeight > 0 {
 		batch.Delete(keys.AssocFwdKey(wsPrefix, [16]byte(a), oldWeight, [16]byte(b)), nil)
@@ -292,8 +308,13 @@ func (ps *PebbleStore) UpdateAssocWeight(ctx context.Context, wsPrefix [8]byte, 
 	}
 
 	// Preserve existing metadata; set lastActivated = now (Hebbian update = activation).
+	// PeakWeight is monotonically non-decreasing: max(existingPeak, newWeight).
 	now := int32(time.Now().Unix())
-	assocValue := encodeAssocValue(relType, confidence, createdAt, now)
+	newPeak := existingPeak
+	if weight > newPeak {
+		newPeak = weight
+	}
+	assocValue := encodeAssocValue(relType, confidence, createdAt, now, newPeak)
 	batch.Set(keys.AssocFwdKey(wsPrefix, [16]byte(a), weight, [16]byte(b)), assocValue[:], nil)
 	batch.Set(keys.AssocRevKey(wsPrefix, [16]byte(b), weight, [16]byte(a)), assocValue[:], nil)
 
@@ -322,14 +343,19 @@ func (ps *PebbleStore) UpdateAssocWeightBatch(ctx context.Context, updates []Ass
 
 	for _, update := range updates {
 		oldWeight, _ := ps.GetAssocWeight(ctx, update.WS, update.Src, update.Dst)
-		relType, confidence, createdAt, _ := ps.getAssocValue(update.WS, ULID(update.Src), ULID(update.Dst), oldWeight)
+		relType, confidence, createdAt, _, existingPeak := ps.getAssocValue(update.WS, ULID(update.Src), ULID(update.Dst), oldWeight)
 
 		if oldWeight > 0 {
 			batch.Delete(keys.AssocFwdKey(update.WS, update.Src, oldWeight, update.Dst), nil)
 			batch.Delete(keys.AssocRevKey(update.WS, update.Dst, oldWeight, update.Src), nil)
 		}
 
-		assocValue := encodeAssocValue(relType, confidence, createdAt, now)
+		// PeakWeight is monotonically non-decreasing: max(existingPeak, newWeight).
+		newPeak := existingPeak
+		if update.Weight > newPeak {
+			newPeak = update.Weight
+		}
+		assocValue := encodeAssocValue(relType, confidence, createdAt, now, newPeak)
 		batch.Set(keys.AssocFwdKey(update.WS, update.Src, update.Weight, update.Dst), assocValue[:], nil)
 		batch.Set(keys.AssocRevKey(update.WS, update.Dst, update.Weight, update.Src), assocValue[:], nil)
 
@@ -379,6 +405,7 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 		confidence    float32
 		createdAt     time.Time
 		lastActivated int32
+		peakWeight    float32 // historical max Weight
 	}
 
 	removed := 0
@@ -396,7 +423,12 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 			if !e.remove {
 				// Preserve existing metadata. Do NOT update lastActivated here —
 				// decay is a background process, not a user activation.
-				val := encodeAssocValue(e.relType, e.confidence, e.createdAt, e.lastActivated)
+				// Keep peak up to date (shouldn't change during decay, but guard).
+				peak := e.peakWeight
+				if e.newW > peak {
+					peak = e.newW
+				}
+				val := encodeAssocValue(e.relType, e.confidence, e.createdAt, e.lastActivated, peak)
 				_ = batch.Set(keys.AssocFwdKey(wsPrefix, e.src, e.newW, e.dst), val[:], nil)
 				_ = batch.Set(keys.AssocRevKey(wsPrefix, e.dst, e.newW, e.src), val[:], nil)
 				var wiBuf [4]byte
@@ -420,7 +452,7 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 		}
 
 		// Decode existing metadata from the value bytes before extracting key fields.
-		relType, confidence, createdAt, lastActivated := decodeAssocValue(iter.Value())
+		relType, confidence, createdAt, lastActivated, peakWeight := decodeAssocValue(iter.Value())
 
 		// Recency skip: associations activated within the grace window are not decayed.
 		// Window must be > a few seconds (to protect edges just activated) but
@@ -446,6 +478,7 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 			src: src, dst: dst, oldW: oldW, newW: newW,
 			relType: relType, confidence: confidence,
 			createdAt: createdAt, lastActivated: lastActivated,
+			peakWeight: peakWeight,
 		}
 		if newW < minWeight {
 			e.remove = true
@@ -520,7 +553,7 @@ func (ps *PebbleStore) GetChildrenByParent(ctx context.Context, wsPrefix [8]byte
 			continue
 		}
 		val := iter.Value()
-		relType, _, _, _ := decodeAssocValue(val)
+		relType, _, _, _, _ := decodeAssocValue(val)
 		if relType != RelIsPartOf {
 			continue
 		}

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -474,6 +474,12 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 		oldW := keys.WeightFromComplement(wc)
 		newW := float32(float64(oldW) * decayFactor)
 
+		// Bootstrap legacy peakWeight from current weight (pre-upgrade associations have peakWeight=0).
+		// This runs before decay so oldW is the pre-decay weight — a good conservative peak estimate.
+		if peakWeight == 0 {
+			peakWeight = oldW
+		}
+
 		e := assocEntry{
 			src: src, dst: dst, oldW: oldW, newW: newW,
 			relType: relType, confidence: confidence,
@@ -481,9 +487,17 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 			peakWeight: peakWeight,
 		}
 		if newW < minWeight {
-			e.remove = true
-			removed++
-		}
+			dynamicFloor := peakWeight * 0.05
+			if dynamicFloor > 0 {
+				// Earned association: clamp to floor instead of deleting.
+				e.newW = dynamicFloor
+				// e.remove stays false
+			} else {
+				// No peak (guard; shouldn't reach here after bootstrap).
+				e.remove = true
+				removed++
+			}
+		} // else: newW >= minWeight, standard keep
 		chunk = append(chunk, e)
 
 		if len(chunk) >= assocDecayChunkSize {

--- a/internal/storage/association_durability_test.go
+++ b/internal/storage/association_durability_test.go
@@ -277,19 +277,61 @@ func TestAssocDecay_LowPeakEdgeClampsToVeryLowFloor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAssociations: %v", err)
 	}
-	// Edge may be present at floor (0.003) or absent — both are valid behaviors.
-	// The key assertion is that PeakWeight was recorded correctly.
-	if len(assocs[src]) == 1 {
-		got := assocs[src][0]
-		if got.PeakWeight < 0.06-0.001 {
-			t.Errorf("PeakWeight should be ~0.06, got %.4f", got.PeakWeight)
-		}
-		// Weight should be at the very low floor
-		if got.Weight > 0.01 {
-			t.Errorf("clamped weight should be very low (<0.01), got %.4f", got.Weight)
-		}
+	if len(assocs[src]) != 1 {
+		t.Fatalf("expected edge to survive at floor (PeakWeight=0.06 → floor=0.003), got %d edges", len(assocs[src]))
 	}
-	// Either 0 or 1 edges is fine; we just verified PeakWeight correctness above.
+	got := assocs[src][0]
+	if got.PeakWeight < 0.06-0.001 {
+		t.Errorf("PeakWeight should be ~0.06, got %.4f", got.PeakWeight)
+	}
+	if got.Weight > 0.01 {
+		t.Errorf("clamped weight should be very low (<0.01), got %.4f", got.Weight)
+	}
+}
+
+// TestAssocPeakWeight_BatchUpdatePreservesPeak verifies UpdateAssocWeightBatch
+// correctly tracks PeakWeight across batch weight updates.
+func TestAssocPeakWeight_BatchUpdatePreservesPeak(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("peak-batch")
+	src, dst := NewULID(), NewULID()
+
+	// Write initial association at 0.4
+	if err := store.WriteAssociation(ctx, ws, src, dst, &Association{
+		TargetID: dst, Weight: 0.4,
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	// Batch-update to 0.9 — peak becomes 0.9
+	updates := []AssocWeightUpdate{{WS: ws, Src: src, Dst: dst, Weight: 0.9}}
+	if err := store.UpdateAssocWeightBatch(ctx, updates); err != nil {
+		t.Fatalf("UpdateAssocWeightBatch to 0.9: %v", err)
+	}
+
+	// Batch-update back to 0.2 — peak should remain 0.9
+	updates[0].Weight = 0.2
+	if err := store.UpdateAssocWeightBatch(ctx, updates); err != nil {
+		t.Fatalf("UpdateAssocWeightBatch to 0.2: %v", err)
+	}
+
+	// Read via fresh store to bypass cache
+	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	assocs, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+	got := assocs[src]
+	if len(got) != 1 {
+		t.Fatalf("expected 1 association, got %d", len(got))
+	}
+	if got[0].PeakWeight != 0.9 {
+		t.Errorf("PeakWeight after batch update: want 0.9, got %.4f", got[0].PeakWeight)
+	}
+	if got[0].Weight != 0.2 {
+		t.Errorf("Weight after batch update: want 0.2, got %.4f", got[0].Weight)
+	}
 }
 
 // TestAssocDecay_RecencySkip verifies that an edge activated very recently

--- a/internal/storage/association_durability_test.go
+++ b/internal/storage/association_durability_test.go
@@ -1,0 +1,192 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestAssocMetadata_LastActivated_PreservedOnUpdate verifies that calling
+// UpdateAssocWeight to change only the weight does NOT destroy the
+// LastActivated field that was set on the original WriteAssociation.
+//
+// Currently FAILS because UpdateAssocWeight calls
+// encodeAssocValue(0, 1.0, time.Time{}, 0), zeroing LastActivated.
+func TestAssocMetadata_LastActivated_PreservedOnUpdate(t *testing.T) {
+	store := newTestStore(t)
+
+	ctx := context.Background()
+	ws := store.VaultPrefix("assoc-meta-lastact")
+
+	src := NewULID()
+	dst := NewULID()
+
+	lastAct := int32(time.Now().Add(-2 * time.Hour).Unix())
+
+	// Write association with a specific LastActivated value.
+	if err := store.WriteAssociation(ctx, ws, src, dst, &Association{
+		TargetID:      dst,
+		Weight:        0.5,
+		RelType:       RelSupports,
+		Confidence:    0.8,
+		LastActivated: lastAct,
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	// Update only the weight — all other metadata should be preserved.
+	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.7); err != nil {
+		t.Fatalf("UpdateAssocWeight: %v", err)
+	}
+
+	// Read back on a fresh (cold-cache) store.
+	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	results, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+
+	got, ok := results[src]
+	if !ok || len(got) != 1 {
+		t.Fatalf("expected 1 association for src, got %d", len(got))
+	}
+
+	a := got[0]
+
+	// The weight should have been updated.
+	if a.Weight < 0.69 || a.Weight > 0.71 {
+		t.Errorf("Weight: got %v, want ~0.7", a.Weight)
+	}
+
+	// LastActivated must NOT have been zeroed by UpdateAssocWeight.
+	// This is the core assertion that exposes the bug.
+	if a.LastActivated == 0 {
+		t.Errorf("LastActivated was zeroed by UpdateAssocWeight: got 0, want %d — metadata destruction bug", lastAct)
+	}
+}
+
+// TestAssocMetadata_PreservedThroughDecay verifies that DecayAssocWeights
+// preserves RelType, Confidence, and LastActivated on edges that survive decay.
+//
+// Currently FAILS because DecayAssocWeights calls
+// encodeAssocValue(0, 1.0, time.Time{}, 0) when re-writing surviving edges,
+// destroying all metadata fields.
+func TestAssocMetadata_PreservedThroughDecay(t *testing.T) {
+	store := newTestStore(t)
+
+	ctx := context.Background()
+	ws := store.VaultPrefix("assoc-meta-decay")
+
+	src := NewULID()
+	dst := NewULID()
+
+	lastAct := int32(time.Now().Add(-30 * time.Minute).Unix())
+
+	// Write association with rich metadata. Weight 0.8 * decay 0.9 = 0.72 > minWeight 0.05 → survives.
+	if err := store.WriteAssociation(ctx, ws, src, dst, &Association{
+		TargetID:      dst,
+		Weight:        0.8,
+		RelType:       RelType(5), // RelRelatesTo
+		Confidence:    0.75,
+		LastActivated: lastAct,
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	// Decay: factor 0.9, minWeight 0.05 — edge stays alive at 0.72.
+	removed, err := store.DecayAssocWeights(ctx, ws, 0.9, 0.05)
+	if err != nil {
+		t.Fatalf("DecayAssocWeights: %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("expected 0 removed, got %d (edge should survive)", removed)
+	}
+
+	// Read back on a fresh (cold-cache) store.
+	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	results, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+
+	got, ok := results[src]
+	if !ok || len(got) != 1 {
+		t.Fatalf("expected 1 surviving association, got %d", len(got))
+	}
+
+	a := got[0]
+
+	// Weight should be decayed to ~0.72.
+	if a.Weight < 0.70 || a.Weight > 0.74 {
+		t.Errorf("Weight after decay: got %v, want ~0.72", a.Weight)
+	}
+
+	// RelType must be preserved through decay rewrite.
+	if a.RelType != RelType(5) {
+		t.Errorf("RelType destroyed by DecayAssocWeights: got %v, want 5 — metadata destruction bug", a.RelType)
+	}
+
+	// Confidence must be preserved through decay rewrite.
+	if a.Confidence < 0.74 || a.Confidence > 0.76 {
+		t.Errorf("Confidence destroyed by DecayAssocWeights: got %v, want ~0.75 — metadata destruction bug", a.Confidence)
+	}
+
+	// LastActivated must be preserved through decay rewrite.
+	if a.LastActivated == 0 {
+		t.Errorf("LastActivated zeroed by DecayAssocWeights: got 0, want %d — metadata destruction bug", lastAct)
+	}
+}
+
+// TestAssocDecay_RecencySkip verifies that an edge activated very recently
+// (within the last few minutes) is NOT decayed, even with an aggressive factor.
+//
+// This is a recency-skip feature that does not yet exist. Currently FAILS
+// because DecayAssocWeights decays all edges unconditionally, including those
+// that were just activated.
+func TestAssocDecay_RecencySkip(t *testing.T) {
+	store := newTestStore(t)
+
+	ctx := context.Background()
+	ws := store.VaultPrefix("assoc-recency-skip")
+
+	src := NewULID()
+	dst := NewULID()
+
+	// LastActivated = right now — should be skipped by recency-aware decay.
+	recentlyActivated := int32(time.Now().Unix())
+
+	const initialWeight = float32(0.8)
+
+	if err := store.WriteAssociation(ctx, ws, src, dst, &Association{
+		TargetID:      dst,
+		Weight:        initialWeight,
+		RelType:       RelSupports,
+		Confidence:    1.0,
+		LastActivated: recentlyActivated,
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	// Aggressive decay factor 0.1 with minWeight 0.05.
+	// Without recency skip: 0.8 * 0.1 = 0.08 (survives but weight is massacred).
+	// With recency skip: weight must remain at 0.8 unchanged.
+	removed, err := store.DecayAssocWeights(ctx, ws, 0.1, 0.05)
+	if err != nil {
+		t.Fatalf("DecayAssocWeights: %v", err)
+	}
+
+	// Edge must not have been removed.
+	if removed != 0 {
+		t.Fatalf("recently-activated edge was removed by decay: removed=%d, want 0", removed)
+	}
+
+	// Read back the weight — it must be unchanged at ~0.8.
+	w, err := store.GetAssocWeight(ctx, ws, src, dst)
+	if err != nil {
+		t.Fatalf("GetAssocWeight: %v", err)
+	}
+
+	if w < 0.75 || w > 0.85 {
+		t.Errorf("recently-activated edge weight was decayed: got %v, want ~%.1f — recency skip not implemented", w, initialWeight)
+	}
+}

--- a/internal/storage/association_durability_test.go
+++ b/internal/storage/association_durability_test.go
@@ -137,6 +137,75 @@ func TestAssocMetadata_PreservedThroughDecay(t *testing.T) {
 	}
 }
 
+// TestAssocPeakWeight_TrackedAcrossUpdates verifies PeakWeight records
+// the historical maximum and is never reduced by subsequent lower updates.
+func TestAssocPeakWeight_TrackedAcrossUpdates(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("peak-tracking")
+	src, dst := NewULID(), NewULID()
+
+	// Write at 0.4
+	if err := store.WriteAssociation(ctx, ws, src, dst, &Association{
+		TargetID: dst, Weight: 0.4,
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	// Boost to 0.8 — peak becomes 0.8
+	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.8); err != nil {
+		t.Fatalf("UpdateAssocWeight to 0.8: %v", err)
+	}
+
+	// Drop to 0.3 — peak should remain 0.8
+	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.3); err != nil {
+		t.Fatalf("UpdateAssocWeight to 0.3: %v", err)
+	}
+
+	// Open fresh store (bypass cache) to read from Pebble directly
+	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	assocs, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+	got := assocs[src]
+	if len(got) != 1 {
+		t.Fatalf("expected 1 association, got %d", len(got))
+	}
+	if got[0].PeakWeight != 0.8 {
+		t.Errorf("PeakWeight: want 0.8, got %.4f (must not decrease)", got[0].PeakWeight)
+	}
+	if got[0].Weight != 0.3 {
+		t.Errorf("Weight: want 0.3, got %.4f", got[0].Weight)
+	}
+}
+
+// TestAssocPeakWeight_InitialWriteSetsPeak verifies WriteAssociation seeds PeakWeight = Weight.
+func TestAssocPeakWeight_InitialWriteSetsPeak(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("peak-initial")
+	src, dst := NewULID(), NewULID()
+
+	if err := store.WriteAssociation(ctx, ws, src, dst, &Association{
+		TargetID: dst, Weight: 0.7,
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	assocs, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+	if len(assocs[src]) != 1 {
+		t.Fatalf("expected 1 association, got %d", len(assocs[src]))
+	}
+	if assocs[src][0].PeakWeight != 0.7 {
+		t.Errorf("PeakWeight on initial write: want 0.7, got %.4f", assocs[src][0].PeakWeight)
+	}
+}
+
 // TestAssocDecay_RecencySkip verifies that an edge activated very recently
 // (within the last few minutes) is NOT decayed, even with an aggressive factor.
 //

--- a/internal/storage/association_durability_test.go
+++ b/internal/storage/association_durability_test.go
@@ -206,6 +206,92 @@ func TestAssocPeakWeight_InitialWriteSetsPeak(t *testing.T) {
 	}
 }
 
+// TestAssocDecay_DynamicFloor verifies associations with earned PeakWeight are
+// clamped to PeakWeight*0.05 floor rather than deleted when below minWeight.
+func TestAssocDecay_DynamicFloor(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("dynamic-floor")
+	src, dst := NewULID(), NewULID()
+
+	// Write at 0.8 — PeakWeight is seeded to 0.8 by WriteAssociation.
+	if err := store.WriteAssociation(ctx, ws, src, dst, &Association{
+		TargetID: dst, Weight: 0.8,
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	// Decay aggressively — 5 passes of 0.3 factor.
+	// 0.8 * 0.3^5 ≈ 0.002, well below minWeight=0.05.
+	for i := 0; i < 5; i++ {
+		if _, err := store.DecayAssocWeights(ctx, ws, 0.3, 0.05); err != nil {
+			t.Fatalf("DecayAssocWeights pass %d: %v", i, err)
+		}
+	}
+
+	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	assocs, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+	got := assocs[src]
+	if len(got) != 1 {
+		t.Fatalf("edge should survive via dynamic floor (PeakWeight=0.8 → floor=0.04), got %d edges", len(got))
+	}
+	// Floor = 0.8 * 0.05 = 0.04
+	wantFloor := float32(0.8 * 0.05)
+	tolerance := float32(0.001)
+	if got[0].Weight < wantFloor-tolerance || got[0].Weight > wantFloor+tolerance {
+		t.Errorf("weight should be clamped to floor ~%.4f, got %.4f", wantFloor, got[0].Weight)
+	}
+	if got[0].PeakWeight < 0.8-tolerance {
+		t.Errorf("PeakWeight should remain ~0.8, got %.4f", got[0].PeakWeight)
+	}
+}
+
+// TestAssocDecay_LowPeakEdgeClampsToVeryLowFloor verifies that an edge that never earned
+// a meaningful peak is clamped to its (very low) floor and
+// is NOT returned by GetAssociations (below practical threshold).
+// Note: After Task 5, all associations bootstrap peakWeight from oldW, so
+// the "no peak" scenario is only possible for legacy zero-weight entries.
+func TestAssocDecay_LowPeakEdgeClampsToVeryLowFloor(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("low-floor")
+	src, dst := NewULID(), NewULID()
+
+	// Write at just above minWeight — peak bootstraps to this value.
+	if err := store.WriteAssociation(ctx, ws, src, dst, &Association{
+		TargetID: dst, Weight: 0.06, // PeakWeight seeds to 0.06
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	// Decay below minWeight — floor = 0.06 * 0.05 = 0.003
+	if _, err := store.DecayAssocWeights(ctx, ws, 0.5, 0.05); err != nil {
+		t.Fatalf("DecayAssocWeights: %v", err)
+	}
+
+	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	assocs, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+	// Edge may be present at floor (0.003) or absent — both are valid behaviors.
+	// The key assertion is that PeakWeight was recorded correctly.
+	if len(assocs[src]) == 1 {
+		got := assocs[src][0]
+		if got.PeakWeight < 0.06-0.001 {
+			t.Errorf("PeakWeight should be ~0.06, got %.4f", got.PeakWeight)
+		}
+		// Weight should be at the very low floor
+		if got.Weight > 0.01 {
+			t.Errorf("clamped weight should be very low (<0.01), got %.4f", got.Weight)
+		}
+	}
+	// Either 0 or 1 edges is fine; we just verified PeakWeight correctness above.
+}
+
 // TestAssocDecay_RecencySkip verifies that an edge activated very recently
 // (within the last few minutes) is NOT decayed, even with an aggressive factor.
 //

--- a/internal/storage/association_test.go
+++ b/internal/storage/association_test.go
@@ -450,7 +450,8 @@ func TestUpdateAssocWeightPersistsCorrectly(t *testing.T) {
 }
 
 // TestDecayAssocWeightsReducesBelowThreshold verifies that DecayAssocWeights
-// removes associations whose weight falls below the minWeight threshold.
+// clamps associations to PeakWeight*0.05 floor (rather than deleting) when weight
+// falls below minWeight. The dynamic floor preserves earned associations.
 func TestDecayAssocWeightsReducesBelowThreshold(t *testing.T) {
 	store := newTestStore(t)
 
@@ -458,10 +459,11 @@ func TestDecayAssocWeightsReducesBelowThreshold(t *testing.T) {
 	ws := store.VaultPrefix("decay-roundtrip")
 
 	// Write three associations with different weights.
+	// PeakWeight is seeded from Weight at write time.
 	pairs := [][2]ULID{
-		{NewULID(), NewULID()}, // weight 0.8 — stays after 50% decay (0.4 > 0.3)
-		{NewULID(), NewULID()}, // weight 0.5 — stays after 50% decay (0.25 < 0.3, removed)
-		{NewULID(), NewULID()}, // weight 0.1 — removed after 50% decay (0.05 < 0.3)
+		{NewULID(), NewULID()}, // weight 0.8 — stays after 50% decay (0.4 > 0.3), no floor needed
+		{NewULID(), NewULID()}, // weight 0.5 — decays to 0.25 < 0.3, floor = 0.5*0.05 = 0.025
+		{NewULID(), NewULID()}, // weight 0.1 — decays to 0.05 < 0.3, floor = 0.1*0.05 = 0.005
 	}
 	weights := []float32{0.8, 0.5, 0.1}
 
@@ -474,16 +476,17 @@ func TestDecayAssocWeightsReducesBelowThreshold(t *testing.T) {
 		}
 	}
 
-	// Decay by 50% with minWeight=0.3 — should remove pairs[1] and pairs[2].
+	// Decay by 50% with minWeight=0.3.
+	// Dynamic floor: edges below minWeight are clamped, NOT deleted — removed=0.
 	removed, err := store.DecayAssocWeights(ctx, ws, 0.5, 0.3)
 	if err != nil {
 		t.Fatalf("DecayAssocWeights: %v", err)
 	}
-	if removed != 2 {
-		t.Errorf("expected 2 removed, got %d", removed)
+	if removed != 0 {
+		t.Errorf("expected 0 removed (edges clamped to floor), got %d", removed)
 	}
 
-	// pairs[0] should survive with weight ~0.4.
+	// pairs[0] should survive with weight ~0.4 (above minWeight, no clamping).
 	w0, err := store.GetAssocWeight(ctx, ws, pairs[0][0], pairs[0][1])
 	if err != nil {
 		t.Fatalf("GetAssocWeight[0]: %v", err)
@@ -492,22 +495,24 @@ func TestDecayAssocWeightsReducesBelowThreshold(t *testing.T) {
 		t.Errorf("surviving weight: got %v, want ~0.4", w0)
 	}
 
-	// pairs[1] should be gone.
+	// pairs[1] should be clamped to floor: 0.5 * 0.05 = 0.025.
 	w1, err := store.GetAssocWeight(ctx, ws, pairs[1][0], pairs[1][1])
 	if err != nil {
 		t.Fatalf("GetAssocWeight[1]: %v", err)
 	}
-	if w1 != 0.0 {
-		t.Errorf("decayed-below-min weight should be 0, got %v", w1)
+	wantFloor1 := float32(0.5 * 0.05)
+	if w1 < wantFloor1-0.001 || w1 > wantFloor1+0.001 {
+		t.Errorf("clamped weight for pairs[1]: got %v, want ~%.4f (floor)", w1, wantFloor1)
 	}
 
-	// pairs[2] should be gone.
+	// pairs[2] should be clamped to floor: 0.1 * 0.05 = 0.005.
 	w2, err := store.GetAssocWeight(ctx, ws, pairs[2][0], pairs[2][1])
 	if err != nil {
 		t.Fatalf("GetAssocWeight[2]: %v", err)
 	}
-	if w2 != 0.0 {
-		t.Errorf("decayed-below-min weight should be 0, got %v", w2)
+	wantFloor2 := float32(0.1 * 0.05)
+	if w2 < wantFloor2-0.001 || w2 > wantFloor2+0.001 {
+		t.Errorf("clamped weight for pairs[2]: got %v, want ~%.4f (floor)", w2, wantFloor2)
 	}
 }
 

--- a/internal/storage/batch.go
+++ b/internal/storage/batch.go
@@ -108,7 +108,12 @@ func (b *pebbleStoreBatch) WriteEngram(ctx context.Context, wsPrefix [8]byte, en
 
 	// 0x03/0x04/weight-index: association keys
 	for _, assoc := range eng.Associations {
-		av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated)
+		// Seed PeakWeight from Weight if not set (legacy or newly created associations).
+		peak := assoc.PeakWeight
+		if peak == 0 {
+			peak = assoc.Weight
+		}
+		av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, peak)
 		b.batch.Set(keys.AssocFwdKey(wsPrefix, id16, assoc.Weight, [16]byte(assoc.TargetID)), av[:], nil)
 		b.batch.Set(keys.AssocRevKey(wsPrefix, [16]byte(assoc.TargetID), assoc.Weight, id16), av[:], nil)
 		var wiBuf [4]byte
@@ -143,7 +148,12 @@ func (b *pebbleStoreBatch) WriteAssociation(ctx context.Context, ws [8]byte, src
 	if b.committed {
 		return fmt.Errorf("batch already committed")
 	}
-	av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated)
+	// Seed PeakWeight from Weight if not set (new association initial write).
+	peak := assoc.PeakWeight
+	if peak == 0 {
+		peak = assoc.Weight
+	}
+	av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, peak)
 	b.batch.Set(keys.AssocFwdKey(ws, [16]byte(src), assoc.Weight, [16]byte(dst)), av[:], nil)
 	b.batch.Set(keys.AssocRevKey(ws, [16]byte(dst), assoc.Weight, [16]byte(src)), av[:], nil)
 	var weightBuf [4]byte

--- a/internal/storage/impl.go
+++ b/internal/storage/impl.go
@@ -257,7 +257,12 @@ func (ps *PebbleStore) WriteEngram(ctx context.Context, wsPrefix [8]byte, eng *E
 
 	// 0x03/0x04/weight-index: association keys
 	for _, assoc := range eng.Associations {
-		av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated)
+		// Seed PeakWeight from Weight if not set (legacy or newly created associations).
+		peak := assoc.PeakWeight
+		if peak == 0 {
+			peak = assoc.Weight
+		}
+		av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, peak)
 		batch.Set(keys.AssocFwdKey(wsPrefix, [16]byte(eng.ID), assoc.Weight, [16]byte(assoc.TargetID)), av[:], nil)
 		batch.Set(keys.AssocRevKey(wsPrefix, [16]byte(assoc.TargetID), assoc.Weight, [16]byte(eng.ID)), av[:], nil)
 		var wiBuf [4]byte
@@ -418,7 +423,12 @@ func (ps *PebbleStore) WriteEngramBatch(ctx context.Context, items []EngramBatch
 		}
 
 		for _, assoc := range eng.Associations {
-			av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated)
+			// Seed PeakWeight from Weight if not set (legacy or newly created associations).
+			peak := assoc.PeakWeight
+			if peak == 0 {
+				peak = assoc.Weight
+			}
+			av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, peak)
 			batch.Set(keys.AssocFwdKey(ws, id16, assoc.Weight, [16]byte(assoc.TargetID)), av[:], nil)
 			batch.Set(keys.AssocRevKey(ws, [16]byte(assoc.TargetID), assoc.Weight, id16), av[:], nil)
 			var wiBuf [4]byte

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -105,7 +105,8 @@ type Association struct {
 	Weight        float32 // 0.0-1.0, Hebbian-adjustable
 	Confidence    float32 // 0.0-1.0
 	CreatedAt     time.Time
-	LastActivated int32 // Unix seconds (not nanoseconds; int32 is sufficient)
+	LastActivated int32   // Unix seconds (not nanoseconds; int32 is sufficient)
+	PeakWeight    float32 // historical max Weight; 0 = untracked (legacy pre-upgrade)
 }
 
 // LifecycleState is the engram state machine (uint8 on disk).


### PR DESCRIPTION
## Summary

- **Phase 0 (bug fix):** Every association write path was calling `encodeAssocValue(0, 1.0, time.Time{}, 0)` — a hardcoded blank that silently zeroed `relType`, `confidence`, `createdAt`, and `lastActivated` on every Hebbian update and decay pass. Fixed with read-modify-write in `UpdateAssocWeight`, `UpdateAssocWeightBatch`, and `DecayAssocWeights`. Also added a 5-minute recency skip in `DecayAssocWeights` and fixed missing cache invalidation in `UpdateAssocWeightBatch`.
- **Phase 1 (feature):** Extended Pebble association value from 18 → 22 bytes by appending `PeakWeight float32`. Tracks historical max weight per association, never decreases. Backward compatible — old 18-byte values bootstrap on first decay pass. Dynamic floor in `DecayAssocWeights`: edges clamp to `PeakWeight × 0.05` instead of being deleted at `minWeight`. Phase 5 transitive inference now uses `max(Weight, PeakWeight)` as the effective threshold.

## Motivation

Prompted by architectural analysis from the Hippoclaudus team (DeCue Technologies), who correctly identified that engrams survive dormancy (0.05 Ebbinghaus floor) but associations do not. The metadata destruction bug was discovered during investigation — `lastActivated` had never worked as designed.

## Test Plan
- [x] All 46 packages pass (`go test ./... -timeout 180s`)
- [x] New tests: `TestAssocMetadata_LastActivated_PreservedOnUpdate`, `TestAssocMetadata_PreservedThroughDecay`, `TestAssocDecay_RecencySkip`, `TestAssocPeakWeight_TrackedAcrossUpdates`, `TestAssocPeakWeight_InitialWriteSetsPeak`, `TestAssocPeakWeight_BatchUpdatePreservesPeak`, `TestAssocDecay_DynamicFloor`, `TestTransitiveInference_PeakWeightFallback`
- [x] Pre-existing test `TestAssocDecay_PrunesWeakEdges` updated to reflect correct dynamic floor behavior

## What's NOT in this PR (deferred)

- Association archiving (0x25 prefix) — needs co-activation count first
- Co-activation count per pair — next PR
- Phase 1 replay ceiling fix
- Bridge-edge detection
- Configurable recency grace window (currently hardcoded `assocDecayGraceWindow = 5min`)

See `docs/adr/2026-03-04-association-durability.md` for full rationale.