### PR TITLE
fix(installer): pause on error so window stays open when piped via iex

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -6,23 +6,32 @@ $ErrorActionPreference = "Stop"
 $repo = "scrypster/muninndb"
 $installDir = "$env:LOCALAPPDATA\muninn"
 
+# When piped through iex, exit closes the PowerShell session and the window
+# disappears before the user can read the error.  This helper prints the error
+# and waits for a keypress so the message is always visible.
+function Abort($msg) {
+    Write-Host ""
+    Write-Host "  Error: $msg" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "  Press any key to close..." -ForegroundColor DarkGray
+    $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+    exit 1
+}
+
 Write-Host ""
 Write-Host "  Installing MuninnDB..." -ForegroundColor Cyan
 Write-Host ""
 
 # Detect architecture
 $arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else {
-    Write-Host "  Error: MuninnDB requires a 64-bit Windows system." -ForegroundColor Red
-    exit 1
+    Abort "MuninnDB requires a 64-bit Windows system."
 }
 
 # Query GitHub API for the latest release
 try {
     $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$repo/releases/latest" -Headers @{ "User-Agent" = "muninn-installer" }
 } catch {
-    Write-Host "  Error: Could not reach GitHub API. Check your internet connection." -ForegroundColor Red
-    Write-Host "  $_" -ForegroundColor DarkGray
-    exit 1
+    Abort "Could not reach GitHub API. Check your internet connection.`n  $_"
 }
 
 $version = $release.tag_name -replace '^v', ''
@@ -30,10 +39,8 @@ $assetName = "muninn_${version}_windows_${arch}.zip"
 $asset = $release.assets | Where-Object { $_.name -eq $assetName }
 
 if (-not $asset) {
-    Write-Host "  Error: Could not find $assetName in release $($release.tag_name)." -ForegroundColor Red
-    Write-Host "  Available assets:" -ForegroundColor DarkGray
-    $release.assets | ForEach-Object { Write-Host "    $($_.name)" -ForegroundColor DarkGray }
-    exit 1
+    $available = ($release.assets | ForEach-Object { $_.name }) -join "`n    "
+    Abort "Could not find $assetName in release $($release.tag_name).`n  Available assets:`n    $available"
 }
 
 $downloadUrl = $asset.browser_download_url
@@ -50,8 +57,7 @@ try {
     Write-Host " done" -ForegroundColor Green
 } catch {
     Write-Host " failed" -ForegroundColor Red
-    Write-Host "  $_" -ForegroundColor DarkGray
-    exit 1
+    Abort "Download failed: $_"
 }
 
 # Extract
@@ -67,10 +73,8 @@ Write-Host " done" -ForegroundColor Green
 # Verify binary
 $binary = "$installDir\muninn.exe"
 if (-not (Test-Path $binary)) {
-    Write-Host "  Error: muninn.exe not found after extraction." -ForegroundColor Red
-    Write-Host "  Contents of ${installDir}:" -ForegroundColor DarkGray
-    Get-ChildItem $installDir | ForEach-Object { Write-Host "    $($_.Name)" -ForegroundColor DarkGray }
-    exit 1
+    $contents = (Get-ChildItem $installDir | ForEach-Object { $_.Name }) -join "`n    "
+    Abort "muninn.exe not found after extraction.`n  Contents of ${installDir}:`n    $contents"
 }
 
 # Add to PATH if not already there


### PR DESCRIPTION
## Summary

- Fixes #45 — PowerShell window closed immediately with no visible error when running `irm https://muninndb.com/install.ps1 | iex`
- Root cause: `exit 1` inside a script piped through `iex` terminates the entire PowerShell session, closing the window before the user can read the error
- Adds an `Abort` helper that prints the error in red and waits for a keypress before exiting — every failure path is now readable

## Test Plan

- [ ] Verify `Abort` is called in place of all bare `exit 1` paths (32-bit check, GitHub API failure, asset not found, download failure, binary not found)
- [ ] Confirm successful install still exits cleanly with no keypress prompt