### PR TITLE
fix(mcp): return 202 Accepted for notifications/ (MCP Streamable HTTP spec)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -159,7 +159,9 @@ func (s *MCPServer) handleRPC(w http.ResponseWriter, r *http.Request) {
 	case req.Method == "initialize":
 		s.handleInitialize(w, &req)
 	case strings.HasPrefix(req.Method, "notifications/"):
-		w.WriteHeader(http.StatusOK)
+		// MCP Streamable HTTP spec: notifications are fire-and-forget; respond
+		// with 202 Accepted and no body.  200 OK breaks strict clients (e.g. Codex).
+		w.WriteHeader(http.StatusAccepted)
 	case req.Method == "ping":
 		sendResult(w, req.ID, map[string]any{})
 	case req.Method == "tools/list":

--- a/internal/mcp/server_coverage_test.go
+++ b/internal/mcp/server_coverage_test.go
@@ -63,12 +63,12 @@ func TestHandleRPC_ToolsList(t *testing.T) {
 }
 
 func TestHandleRPC_Notifications(t *testing.T) {
-	// notifications/ prefix should return 200 with no body error.
+	// MCP Streamable HTTP: notifications/ must return 202 Accepted with no body.
 	srv := newTestServer()
 	body := `{"jsonrpc":"2.0","method":"notifications/initialized","id":1}`
 	w := postRPC(t, srv, body)
-	if w.Code != http.StatusOK {
-		t.Errorf("notifications should return 200, got %d", w.Code)
+	if w.Code != http.StatusAccepted {
+		t.Errorf("notifications should return 202, got %d", w.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes #43 — OpenAI Codex v0.107.0 fails to connect with `Transport channel closed, when send initialized notification`
- Root cause: `handleRPC` returned `200 OK` for `notifications/` methods; the MCP Streamable HTTP spec requires `202 Accepted` with no body for fire-and-forget notifications
- The SSE path (`processAndPushSSE`) already returned 202 correctly — this aligns the pure-POST path

Credit to @rsubr for diagnosing the root cause and supplying the patch in #43.

## Test Plan

- [ ] `TestHandleRPC_Notifications` updated to assert 202
- [ ] `go test ./internal/mcp/...` passes