### PR TITLE
fix(installer): use full tag name (with v prefix) for Windows asset lookup

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -35,7 +35,7 @@ try {
 }
 
 $version = $release.tag_name -replace '^v', ''
-$assetName = "muninn_${version}_windows_${arch}.zip"
+$assetName = "muninn_$($release.tag_name)_windows_${arch}.zip"
 $asset = $release.assets | Where-Object { $_.name -eq $assetName }
 
 if (-not $asset) {


### PR DESCRIPTION
## Summary

- Fixes #45 (root cause) — Windows install always failed with `Could not find muninn_0.3.3-alpha_windows_amd64.zip`
- The script stripped the `v` prefix from the release tag (`v0.3.3-alpha` → `0.3.3-alpha`) and used that to construct the asset filename
- The actual release assets use the full tag name: `muninn_v0.3.3-alpha_windows_amd64.zip`
- Fix: use `$release.tag_name` directly for the asset filename while keeping the stripped `$version` for display output

Reported and confirmed by @maxmcorp.

## Test Plan

- [ ] Verify asset name constructed as `muninn_v0.3.3-alpha_windows_amd64.zip` (with `v`)
- [ ] Confirm `$version` (stripped) still used for the display line `Version: 0.3.3-alpha`