### PR TITLE
feat(storage/cognitive/api): co-activation count for association pairs

### DIFF
--- a/cmd/bench/adapters.go
+++ b/cmd/bench/adapters.go
@@ -14,7 +14,7 @@ func (a *benchHebbianAdapter) GetAssocWeight(ctx context.Context, ws [8]byte, sr
 	return a.store.GetAssocWeight(ctx, ws, storage.ULID(src), storage.ULID(dst))
 }
 func (a *benchHebbianAdapter) UpdateAssocWeight(ctx context.Context, ws [8]byte, src, dst [16]byte, w float32) error {
-	return a.store.UpdateAssocWeight(ctx, ws, storage.ULID(src), storage.ULID(dst), w)
+	return a.store.UpdateAssocWeight(ctx, ws, storage.ULID(src), storage.ULID(dst), w, 0)
 }
 func (a *benchHebbianAdapter) DecayAssocWeights(ctx context.Context, ws [8]byte, factor float64, min float32) (int, error) {
 	return a.store.DecayAssocWeights(ctx, ws, factor, min)

--- a/cmd/bench/adapters.go
+++ b/cmd/bench/adapters.go
@@ -23,10 +23,11 @@ func (a *benchHebbianAdapter) UpdateAssocWeightBatch(ctx context.Context, update
 	storageUpdates := make([]storage.AssocWeightUpdate, len(updates))
 	for i, u := range updates {
 		storageUpdates[i] = storage.AssocWeightUpdate{
-			WS:     u.WS,
-			Src:    storage.ULID(u.Src),
-			Dst:    storage.ULID(u.Dst),
-			Weight: u.Weight,
+			WS:         u.WS,
+			Src:        storage.ULID(u.Src),
+			Dst:        storage.ULID(u.Dst),
+			Weight:     u.Weight,
+			CountDelta: u.CountDelta,
 		}
 	}
 	return a.store.UpdateAssocWeightBatch(ctx, storageUpdates)

--- a/cmd/bench/adapters.go
+++ b/cmd/bench/adapters.go
@@ -14,6 +14,9 @@ func (a *benchHebbianAdapter) GetAssocWeight(ctx context.Context, ws [8]byte, sr
 	return a.store.GetAssocWeight(ctx, ws, storage.ULID(src), storage.ULID(dst))
 }
 func (a *benchHebbianAdapter) UpdateAssocWeight(ctx context.Context, ws [8]byte, src, dst [16]byte, w float32) error {
+	// This path is only used outside of processBatch (e.g., tests, manual adjustments).
+	// CountDelta is 0 because this is a weight-only update — co-activation count
+	// is accumulated exclusively through UpdateAssocWeightBatch in processBatch.
 	return a.store.UpdateAssocWeight(ctx, ws, storage.ULID(src), storage.ULID(dst), w, 0)
 }
 func (a *benchHebbianAdapter) DecayAssocWeights(ctx context.Context, ws [8]byte, factor float64, min float32) (int, error) {

--- a/docs/adr/2026-03-04-coactivation-count.md
+++ b/docs/adr/2026-03-04-coactivation-count.md
@@ -1,0 +1,58 @@
+# ADR: Lifetime Co-Activation Count per Association Pair
+
+**Date:** 2026-03-04
+**Status:** Implemented
+
+## Context
+
+MuninnDB's Hebbian engine tracked per-batch co-activation count transiently
+in `pairStats.count` but discarded it after each consolidation pass. This lost
+a fundamental cognitive signal: how many times have two engrams fired together
+over their lifetime?
+
+Without a persistent count, MuninnDB cannot distinguish:
+- An association that fired once at high weight (episodic trace)
+- An association that fired 500 times at moderate weight (habitual/semantic)
+
+These represent very different memory types, with different durability
+and reactivation expectations.
+
+## Decision
+
+Extend the association Pebble value from 22→26 bytes by appending a `uint32`
+co-activation count at bytes 22-25. Thread the count through all write paths
+(WriteAssociation, UpdateAssocWeight, UpdateAssocWeightBatch) and expose it
+in the REST API via `GET /engrams/{id}/links`.
+
+## Value Layout (26 bytes)
+
+| Offset | Size | Field              | Encoding              |
+|--------|------|--------------------|-----------------------|
+| 0      | 2    | relType            | uint16 big-endian     |
+| 2      | 4    | confidence         | float32 big-endian    |
+| 6      | 8    | createdAt          | int64 UnixNano BE     |
+| 14     | 4    | lastActivated      | uint32 Unix seconds BE|
+| 18     | 4    | peakWeight         | float32 big-endian    |
+| 22     | 4    | coActivationCount  | uint32 big-endian     |
+
+## Backward Compatibility
+
+- Old 22-byte values decode with `coActivationCount=0` ("pre-feature/unknown")
+- Old binaries reading new 26-byte values ignore bytes 22-25 safely (progressive-length decoder)
+- New associations created after this release start with `count=1` (creation is itself a co-activation)
+- `count=0` means "unknown/pre-feature", not "never fired" — downstream logic must handle this distinction
+- Count saturates at `math.MaxUint32` to prevent overflow
+
+## What This Enables
+
+- **Archiving decisions**: high count = preserve even at low weight (episodic vs semantic distinction)
+- **Recall ranking**: count signals relationship stability independent of current weight
+- **DeCue long-dormancy**: distinguish "decayed after one firing" from "decayed despite 500 firings"
+- **API consumers**: `co_activation_count` available in `GET /engrams/{id}/links` with no additional work
+
+## What Was Deferred
+
+- **erf export format**: The erf package has its own 40-byte AssocRecordSize with exact-length checks. Adding count to erf requires a version bump and is a separate concern — left for a follow-up PR.
+- **Structured record format (flatbuffers/protobuf)**: The progressive-length decoder pattern handles this extension cleanly. Trigger to revisit: when value exceeds ~30 bytes OR when optional/conditional fields are needed.
+- **Archiving (0x25 prefix)**: Requires count as a prerequisite (now done) plus operational experience with the count signal before designing archiving policy.
+- **Phase 1 replay composite scoring**: Deferred — Phase 1 replay is currently a stub and scoring improvements are premature until replay is wired.

--- a/internal/cognitive/hebbian.go
+++ b/internal/cognitive/hebbian.go
@@ -32,10 +32,11 @@ type HebbianStore interface {
 
 // AssocWeightUpdate represents a single weight update for batching.
 type AssocWeightUpdate struct {
-	WS  [8]byte
-	Src [16]byte
-	Dst [16]byte
-	Weight float32
+	WS         [8]byte
+	Src        [16]byte
+	Dst        [16]byte
+	Weight     float32
+	CountDelta uint32 // number of co-activations observed for this pair in the batch
 }
 
 // CoActivationEvent records a set of engrams that were retrieved together.
@@ -228,11 +229,17 @@ func (hw *HebbianWorker) processBatch(ctx context.Context, batch []CoActivationE
 		logNew := math.Log(float64(current)) + effectiveSignal*math.Log(1.0+HebbianLearningRate)
 		newWeight := float32(math.Min(1.0, math.Exp(logNew)))
 
+		countDelta := uint32(stats.count)
+		if stats.count > math.MaxUint32 {
+			countDelta = math.MaxUint32
+		}
+
 		updates = append(updates, AssocWeightUpdate{
-			WS:     stats.ws,
-			Src:    pair.a,
-			Dst:    pair.b,
-			Weight: newWeight,
+			WS:         stats.ws,
+			Src:        pair.a,
+			Dst:        pair.b,
+			Weight:     newWeight,
+			CountDelta: countDelta,
 		})
 
 		if hw.OnWeightUpdate != nil {

--- a/internal/cognitive/hebbian.go
+++ b/internal/cognitive/hebbian.go
@@ -229,9 +229,11 @@ func (hw *HebbianWorker) processBatch(ctx context.Context, batch []CoActivationE
 		logNew := math.Log(float64(current)) + effectiveSignal*math.Log(1.0+HebbianLearningRate)
 		newWeight := float32(math.Min(1.0, math.Exp(logNew)))
 
-		countDelta := uint32(stats.count)
+		var countDelta uint32
 		if stats.count > math.MaxUint32 {
 			countDelta = math.MaxUint32
+		} else {
+			countDelta = uint32(stats.count)
 		}
 
 		updates = append(updates, AssocWeightUpdate{

--- a/internal/cognitive/store_adapters.go
+++ b/internal/cognitive/store_adapters.go
@@ -32,10 +32,11 @@ func (a *hebbianStoreAdapter) UpdateAssocWeightBatch(ctx context.Context, update
 	storageUpdates := make([]storage.AssocWeightUpdate, len(updates))
 	for i, u := range updates {
 		storageUpdates[i] = storage.AssocWeightUpdate{
-			WS:     u.WS,
-			Src:    storage.ULID(u.Src),
-			Dst:    storage.ULID(u.Dst),
-			Weight: u.Weight,
+			WS:         u.WS,
+			Src:        storage.ULID(u.Src),
+			Dst:        storage.ULID(u.Dst),
+			Weight:     u.Weight,
+			CountDelta: u.CountDelta,
 		}
 	}
 	return a.store.UpdateAssocWeightBatch(ctx, storageUpdates)

--- a/internal/cognitive/store_adapters.go
+++ b/internal/cognitive/store_adapters.go
@@ -21,7 +21,7 @@ func (a *hebbianStoreAdapter) GetAssocWeight(ctx context.Context, ws [8]byte, sr
 }
 
 func (a *hebbianStoreAdapter) UpdateAssocWeight(ctx context.Context, ws [8]byte, src, dst [16]byte, weight float32) error {
-	return a.store.UpdateAssocWeight(ctx, ws, storage.ULID(src), storage.ULID(dst), weight)
+	return a.store.UpdateAssocWeight(ctx, ws, storage.ULID(src), storage.ULID(dst), weight, 0)
 }
 
 func (a *hebbianStoreAdapter) DecayAssocWeights(ctx context.Context, ws [8]byte, decayFactor float64, minWeight float32) (int, error) {

--- a/internal/cognitive/store_adapters.go
+++ b/internal/cognitive/store_adapters.go
@@ -21,6 +21,9 @@ func (a *hebbianStoreAdapter) GetAssocWeight(ctx context.Context, ws [8]byte, sr
 }
 
 func (a *hebbianStoreAdapter) UpdateAssocWeight(ctx context.Context, ws [8]byte, src, dst [16]byte, weight float32) error {
+	// This path is only used outside of processBatch (e.g., tests, manual adjustments).
+	// CountDelta is 0 because this is a weight-only update — co-activation count
+	// is accumulated exclusively through UpdateAssocWeightBatch in processBatch.
 	return a.store.UpdateAssocWeight(ctx, ws, storage.ULID(src), storage.ULID(dst), weight, 0)
 }
 

--- a/internal/consolidation/transitive.go
+++ b/internal/consolidation/transitive.go
@@ -103,7 +103,7 @@ func (w *Worker) runPhase5TransitiveInference(ctx context.Context, store *storag
 				}
 
 				if !w.DryRun {
-					if err := store.UpdateAssocWeight(ctx, wsPrefix, a, c, inferredWeight); err != nil {
+					if err := store.UpdateAssocWeight(ctx, wsPrefix, a, c, inferredWeight, 0); err != nil {
 						slog.Warn("consolidation phase 5: failed to infer association", "a", a, "c", c, "error", err)
 						continue
 					}

--- a/internal/consolidation/transitive_peak_test.go
+++ b/internal/consolidation/transitive_peak_test.go
@@ -44,7 +44,7 @@ func TestTransitiveInference_PeakWeightFallback(t *testing.T) {
 		t.Fatalf("WriteAssociation A→B: %v", err)
 	}
 	// Decay A→B to 0.5 — UpdateAssocWeight preserves PeakWeight monotonically (stays 0.8).
-	if err := store.UpdateAssocWeight(ctx, wsPrefix, idA, idB, 0.5); err != nil {
+	if err := store.UpdateAssocWeight(ctx, wsPrefix, idA, idB, 0.5, 0); err != nil {
 		t.Fatalf("UpdateAssocWeight A→B to 0.5: %v", err)
 	}
 
@@ -54,7 +54,7 @@ func TestTransitiveInference_PeakWeightFallback(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("WriteAssociation B→C: %v", err)
 	}
-	if err := store.UpdateAssocWeight(ctx, wsPrefix, idB, idC, 0.5); err != nil {
+	if err := store.UpdateAssocWeight(ctx, wsPrefix, idB, idC, 0.5, 0); err != nil {
 		t.Fatalf("UpdateAssocWeight B→C to 0.5: %v", err)
 	}
 

--- a/internal/storage/assoc_weight_index_test.go
+++ b/internal/storage/assoc_weight_index_test.go
@@ -95,7 +95,7 @@ func TestAssocWeightIndex_UpdateWeight(t *testing.T) {
 	}
 
 	// Update weight
-	if err := store.UpdateAssocWeight(ctx, ws, a, b, 0.9); err != nil {
+	if err := store.UpdateAssocWeight(ctx, ws, a, b, 0.9, 0); err != nil {
 		t.Fatalf("UpdateAssocWeight: %v", err)
 	}
 

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -13,12 +13,12 @@ import (
 	"github.com/scrypster/muninndb/internal/storage/keys"
 )
 
-// encodeAssocValue serializes association metadata into the 22-byte value
+// encodeAssocValue serializes association metadata into the 26-byte value
 // stored under 0x03/0x04 Pebble keys.
-// Layout: relType(2) | confidence(4) | createdAt(8) | lastActivated(4) | peakWeight(4) = 22 bytes
-// Old readers that only consume 18 bytes continue to work; peakWeight is at the tail.
-func encodeAssocValue(relType RelType, confidence float32, createdAt time.Time, lastActivated int32, peakWeight float32) [22]byte {
-	var val [22]byte
+// Layout: relType(2) | confidence(4) | createdAt(8) | lastActivated(4) | peakWeight(4) | coActivationCount(4) = 26 bytes
+// Old readers that only consume 18 or 22 bytes continue to work; new fields are at the tail.
+func encodeAssocValue(relType RelType, confidence float32, createdAt time.Time, lastActivated int32, peakWeight float32, coActivationCount uint32) [26]byte {
+	var val [26]byte
 	binary.BigEndian.PutUint16(val[0:2], uint16(relType))
 	binary.BigEndian.PutUint32(val[2:6], math.Float32bits(confidence))
 	var nanos int64
@@ -28,18 +28,19 @@ func encodeAssocValue(relType RelType, confidence float32, createdAt time.Time, 
 	binary.BigEndian.PutUint64(val[6:14], uint64(nanos))
 	binary.BigEndian.PutUint32(val[14:18], uint32(lastActivated))
 	binary.BigEndian.PutUint32(val[18:22], math.Float32bits(peakWeight))
+	binary.BigEndian.PutUint32(val[22:26], coActivationCount)
 	return val
 }
 
-// decodeAssocValue decodes a 18-byte (legacy) or 22-byte association value.
-// Returns peakWeight=0 for legacy 18-byte values.
+// decodeAssocValue decodes an 18-byte (legacy), 22-byte, or 26-byte association value.
+// Returns peakWeight=0 for legacy 18-byte values, coActivationCount=0 for pre-26-byte values.
 // All-zero 18-byte values treated as pre-fix legacy: confidence=1.0, rest zero.
-func decodeAssocValue(val []byte) (relType RelType, confidence float32, createdAt time.Time, lastActivated int32, peakWeight float32) {
+func decodeAssocValue(val []byte) (relType RelType, confidence float32, createdAt time.Time, lastActivated int32, peakWeight float32, coActivationCount uint32) {
 	if len(val) < 18 {
-		return 0, 1.0, time.Time{}, 0, 0
+		return 0, 1.0, time.Time{}, 0, 0, 0
 	}
 	// All-zero 18-byte values are pre-fix legacy (old encoder wrote blank values).
-	// 22-byte values are from the new encoder and always carry real metadata.
+	// 22-byte and 26-byte values are from newer encoders and always carry real metadata.
 	if len(val) == 18 {
 		allZero := true
 		for _, b := range val {
@@ -49,7 +50,7 @@ func decodeAssocValue(val []byte) (relType RelType, confidence float32, createdA
 			}
 		}
 		if allZero {
-			return 0, 1.0, time.Time{}, 0, 0
+			return 0, 1.0, time.Time{}, 0, 0, 0
 		}
 	}
 	relType = RelType(binary.BigEndian.Uint16(val[0:2]))
@@ -61,6 +62,9 @@ func decodeAssocValue(val []byte) (relType RelType, confidence float32, createdA
 	lastActivated = int32(binary.BigEndian.Uint32(val[14:18]))
 	if len(val) >= 22 {
 		peakWeight = math.Float32frombits(binary.BigEndian.Uint32(val[18:22]))
+	}
+	if len(val) >= 26 {
+		coActivationCount = binary.BigEndian.Uint32(val[22:26])
 	}
 	return
 }
@@ -81,7 +85,7 @@ func (ps *PebbleStore) WriteAssociation(ctx context.Context, wsPrefix [8]byte, s
 	// Forward association (0x03 key)
 	// PeakWeight is seeded to Weight on initial write — this is the association's first peak.
 	fwdKey := keys.AssocFwdKey(wsPrefix, [16]byte(src), assoc.Weight, [16]byte(dst))
-	assocValue := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, assoc.Weight)
+	assocValue := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, assoc.Weight, assoc.CoActivationCount)
 	batch.Set(fwdKey, assocValue[:], nil)
 
 	// Reverse association (0x04 key)
@@ -175,15 +179,16 @@ func (ps *PebbleStore) GetAssociations(ctx context.Context, wsPrefix [8]byte, id
 			var wc [4]byte
 			copy(wc[:], k[25:29])
 			weight := keys.WeightFromComplement(wc)
-			relType, confidence, createdAt, lastActivated, peakWeight := decodeAssocValue(iter.Value())
+			relType, confidence, createdAt, lastActivated, peakWeight, coActivationCount := decodeAssocValue(iter.Value())
 			assocs = append(assocs, Association{
-				TargetID:      targetID,
-				Weight:        weight,
-				RelType:       relType,
-				Confidence:    confidence,
-				CreatedAt:     createdAt,
-				LastActivated: lastActivated,
-				PeakWeight:    peakWeight,
+				TargetID:          targetID,
+				Weight:            weight,
+				RelType:           relType,
+				Confidence:        confidence,
+				CreatedAt:         createdAt,
+				LastActivated:     lastActivated,
+				PeakWeight:        peakWeight,
+				CoActivationCount: coActivationCount,
 			})
 		}
 
@@ -241,16 +246,17 @@ func (ps *PebbleStore) associationsForOne(wsPrefix [8]byte, id ULID, maxPerNode 
 
 		// Decode value bytes: rel_type, confidence, timestamps, peakWeight
 		val := iter.Value()
-		relType, confidence, createdAt, lastActivated, peakWeight := decodeAssocValue(val)
+		relType, confidence, createdAt, lastActivated, peakWeight, coActivationCount := decodeAssocValue(val)
 
 		assocs = append(assocs, Association{
-			TargetID:      targetID,
-			Weight:        weight,
-			RelType:       relType,
-			Confidence:    confidence,
-			CreatedAt:     createdAt,
-			LastActivated: lastActivated,
-			PeakWeight:    peakWeight,
+			TargetID:          targetID,
+			Weight:            weight,
+			RelType:           relType,
+			Confidence:        confidence,
+			CreatedAt:         createdAt,
+			LastActivated:     lastActivated,
+			PeakWeight:        peakWeight,
+			CoActivationCount: coActivationCount,
 		})
 	}
 	// Populate cache — expirable.LRU enforces the TTL automatically.
@@ -273,14 +279,14 @@ func (ps *PebbleStore) GetAssocWeight(ctx context.Context, wsPrefix [8]byte, a, 
 // getAssocValue reads the decoded association metadata for pair (a→b).
 // Uses knownWeight to construct the 0x03 key. Returns zero values if no
 // association exists or the key cannot be read.
-func (ps *PebbleStore) getAssocValue(wsPrefix [8]byte, a, b ULID, knownWeight float32) (relType RelType, confidence float32, createdAt time.Time, lastActivated int32, peakWeight float32) {
+func (ps *PebbleStore) getAssocValue(wsPrefix [8]byte, a, b ULID, knownWeight float32) (relType RelType, confidence float32, createdAt time.Time, lastActivated int32, peakWeight float32, coActivationCount uint32) {
 	if knownWeight <= 0 {
-		return 0, 1.0, time.Time{}, 0, 0
+		return 0, 1.0, time.Time{}, 0, 0, 0
 	}
 	fwdKey := keys.AssocFwdKey(wsPrefix, [16]byte(a), knownWeight, [16]byte(b))
 	val, err := Get(ps.db, fwdKey)
 	if err != nil || val == nil {
-		return 0, 1.0, time.Time{}, 0, 0
+		return 0, 1.0, time.Time{}, 0, 0, 0
 	}
 	return decodeAssocValue(val)
 }
@@ -290,13 +296,14 @@ func (ps *PebbleStore) getAssocValue(wsPrefix [8]byte, a, b ULID, knownWeight fl
 // ones, preventing stale duplicate entries from accumulating in the key space.
 // Existing metadata (relType, confidence, createdAt) is preserved; lastActivated
 // is set to now (Hebbian update = activation).
-func (ps *PebbleStore) UpdateAssocWeight(ctx context.Context, wsPrefix [8]byte, a, b ULID, weight float32) error {
+// countDelta is added to the existing CoActivationCount (saturating at MaxUint32).
+func (ps *PebbleStore) UpdateAssocWeight(ctx context.Context, wsPrefix [8]byte, a, b ULID, weight float32, countDelta uint32) error {
 	batch := ps.db.NewBatch()
 	defer batch.Close()
 
 	// Read existing metadata before deleting old keys.
 	oldWeight, _ := ps.GetAssocWeight(ctx, wsPrefix, a, b)
-	relType, confidence, createdAt, _, existingPeak := ps.getAssocValue(wsPrefix, a, b, oldWeight)
+	relType, confidence, createdAt, _, existingPeak, existingCoAct := ps.getAssocValue(wsPrefix, a, b, oldWeight)
 
 	if oldWeight > 0 {
 		batch.Delete(keys.AssocFwdKey(wsPrefix, [16]byte(a), oldWeight, [16]byte(b)), nil)
@@ -310,7 +317,16 @@ func (ps *PebbleStore) UpdateAssocWeight(ctx context.Context, wsPrefix [8]byte, 
 	if weight > newPeak {
 		newPeak = weight
 	}
-	assocValue := encodeAssocValue(relType, confidence, createdAt, now, newPeak)
+	// Accumulate CoActivationCount with saturation at MaxUint32.
+	newCoAct := existingCoAct
+	if countDelta > 0 {
+		if newCoAct+countDelta < newCoAct {
+			newCoAct = ^uint32(0) // saturate at MaxUint32
+		} else {
+			newCoAct += countDelta
+		}
+	}
+	assocValue := encodeAssocValue(relType, confidence, createdAt, now, newPeak, newCoAct)
 	batch.Set(keys.AssocFwdKey(wsPrefix, [16]byte(a), weight, [16]byte(b)), assocValue[:], nil)
 	batch.Set(keys.AssocRevKey(wsPrefix, [16]byte(b), weight, [16]byte(a)), assocValue[:], nil)
 
@@ -339,7 +355,7 @@ func (ps *PebbleStore) UpdateAssocWeightBatch(ctx context.Context, updates []Ass
 
 	for _, update := range updates {
 		oldWeight, _ := ps.GetAssocWeight(ctx, update.WS, update.Src, update.Dst)
-		relType, confidence, createdAt, _, existingPeak := ps.getAssocValue(update.WS, ULID(update.Src), ULID(update.Dst), oldWeight)
+		relType, confidence, createdAt, _, existingPeak, existingCoAct := ps.getAssocValue(update.WS, ULID(update.Src), ULID(update.Dst), oldWeight)
 
 		if oldWeight > 0 {
 			batch.Delete(keys.AssocFwdKey(update.WS, update.Src, oldWeight, update.Dst), nil)
@@ -351,7 +367,16 @@ func (ps *PebbleStore) UpdateAssocWeightBatch(ctx context.Context, updates []Ass
 		if update.Weight > newPeak {
 			newPeak = update.Weight
 		}
-		assocValue := encodeAssocValue(relType, confidence, createdAt, now, newPeak)
+		// Accumulate CoActivationCount with saturation at MaxUint32.
+		newCoAct := existingCoAct
+		if update.CountDelta > 0 {
+			if newCoAct+update.CountDelta < newCoAct {
+				newCoAct = ^uint32(0) // saturate at MaxUint32
+			} else {
+				newCoAct += update.CountDelta
+			}
+		}
+		assocValue := encodeAssocValue(relType, confidence, createdAt, now, newPeak, newCoAct)
 		batch.Set(keys.AssocFwdKey(update.WS, update.Src, update.Weight, update.Dst), assocValue[:], nil)
 		batch.Set(keys.AssocRevKey(update.WS, update.Dst, update.Weight, update.Src), assocValue[:], nil)
 
@@ -414,11 +439,12 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 		newW   float32
 		remove bool
 		// Preserved from existing Pebble value:
-		relType       RelType
-		confidence    float32
-		createdAt     time.Time
-		lastActivated int32
-		peakWeight    float32 // historical max Weight
+		relType           RelType
+		confidence        float32
+		createdAt         time.Time
+		lastActivated     int32
+		peakWeight        float32 // historical max Weight
+		coActivationCount uint32
 	}
 
 	removed := 0
@@ -441,7 +467,7 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 				if e.newW > peak {
 					peak = e.newW
 				}
-				val := encodeAssocValue(e.relType, e.confidence, e.createdAt, e.lastActivated, peak)
+				val := encodeAssocValue(e.relType, e.confidence, e.createdAt, e.lastActivated, peak, e.coActivationCount)
 				_ = batch.Set(keys.AssocFwdKey(wsPrefix, e.src, e.newW, e.dst), val[:], nil)
 				_ = batch.Set(keys.AssocRevKey(wsPrefix, e.dst, e.newW, e.src), val[:], nil)
 				var wiBuf [4]byte
@@ -465,7 +491,7 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 		}
 
 		// Decode existing metadata from the value bytes before extracting key fields.
-		relType, confidence, createdAt, lastActivated, peakWeight := decodeAssocValue(iter.Value())
+		relType, confidence, createdAt, lastActivated, peakWeight, coActivationCount := decodeAssocValue(iter.Value())
 
 		// Recency skip: associations activated within the grace window are not decayed.
 		// Window must be > a few seconds (to protect edges just activated) but
@@ -496,7 +522,7 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 			src: src, dst: dst, oldW: oldW, newW: newW,
 			relType: relType, confidence: confidence,
 			createdAt: createdAt, lastActivated: lastActivated,
-			peakWeight: peakWeight,
+			peakWeight: peakWeight, coActivationCount: coActivationCount,
 		}
 		if newW < minWeight {
 			dynamicFloor := peakWeight * 0.05
@@ -579,7 +605,7 @@ func (ps *PebbleStore) GetChildrenByParent(ctx context.Context, wsPrefix [8]byte
 			continue
 		}
 		val := iter.Value()
-		relType, _, _, _, _ := decodeAssocValue(val)
+		relType, _, _, _, _, _ := decodeAssocValue(val)
 		if relType != RelIsPartOf {
 			continue
 		}

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -84,8 +84,13 @@ func (ps *PebbleStore) WriteAssociation(ctx context.Context, wsPrefix [8]byte, s
 
 	// Forward association (0x03 key)
 	// PeakWeight is seeded to Weight on initial write — this is the association's first peak.
+	// CoActivationCount is seeded to 1: creation itself counts as the first co-activation event.
+	seedCount := assoc.CoActivationCount
+	if seedCount == 0 {
+		seedCount = 1
+	}
 	fwdKey := keys.AssocFwdKey(wsPrefix, [16]byte(src), assoc.Weight, [16]byte(dst))
-	assocValue := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, assoc.Weight, assoc.CoActivationCount)
+	assocValue := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, assoc.Weight, seedCount)
 	batch.Set(fwdKey, assocValue[:], nil)
 
 	// Reverse association (0x04 key)

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -84,11 +84,9 @@ func (ps *PebbleStore) WriteAssociation(ctx context.Context, wsPrefix [8]byte, s
 
 	// Forward association (0x03 key)
 	// PeakWeight is seeded to Weight on initial write — this is the association's first peak.
-	// CoActivationCount is seeded to 1: creation itself counts as the first co-activation event.
-	seedCount := assoc.CoActivationCount
-	if seedCount == 0 {
-		seedCount = 1
-	}
+	// Creation is itself a co-activation event; always seed at 1.
+	// Callers should not set CoActivationCount on new associations.
+	const seedCount uint32 = 1
 	fwdKey := keys.AssocFwdKey(wsPrefix, [16]byte(src), assoc.Weight, [16]byte(dst))
 	assocValue := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, assoc.Weight, seedCount)
 	batch.Set(fwdKey, assocValue[:], nil)

--- a/internal/storage/association_durability_test.go
+++ b/internal/storage/association_durability_test.go
@@ -35,7 +35,7 @@ func TestAssocMetadata_LastActivated_PreservedOnUpdate(t *testing.T) {
 	}
 
 	// Update only the weight — all other metadata should be preserved.
-	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.7); err != nil {
+	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.7, 0); err != nil {
 		t.Fatalf("UpdateAssocWeight: %v", err)
 	}
 
@@ -153,12 +153,12 @@ func TestAssocPeakWeight_TrackedAcrossUpdates(t *testing.T) {
 	}
 
 	// Boost to 0.8 — peak becomes 0.8
-	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.8); err != nil {
+	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.8, 0); err != nil {
 		t.Fatalf("UpdateAssocWeight to 0.8: %v", err)
 	}
 
 	// Drop to 0.3 — peak should remain 0.8
-	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.3); err != nil {
+	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.3, 0); err != nil {
 		t.Fatalf("UpdateAssocWeight to 0.3: %v", err)
 	}
 

--- a/internal/storage/association_test.go
+++ b/internal/storage/association_test.go
@@ -421,7 +421,7 @@ func TestUpdateAssocWeightPersistsCorrectly(t *testing.T) {
 	}
 
 	// Update weight.
-	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.85); err != nil {
+	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.85, 0); err != nil {
 		t.Fatalf("UpdateAssocWeight: %v", err)
 	}
 

--- a/internal/storage/batch.go
+++ b/internal/storage/batch.go
@@ -113,7 +113,7 @@ func (b *pebbleStoreBatch) WriteEngram(ctx context.Context, wsPrefix [8]byte, en
 		if peak == 0 {
 			peak = assoc.Weight
 		}
-		av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, peak)
+		av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, peak, assoc.CoActivationCount)
 		b.batch.Set(keys.AssocFwdKey(wsPrefix, id16, assoc.Weight, [16]byte(assoc.TargetID)), av[:], nil)
 		b.batch.Set(keys.AssocRevKey(wsPrefix, [16]byte(assoc.TargetID), assoc.Weight, id16), av[:], nil)
 		var wiBuf [4]byte
@@ -153,7 +153,7 @@ func (b *pebbleStoreBatch) WriteAssociation(ctx context.Context, ws [8]byte, src
 	if peak == 0 {
 		peak = assoc.Weight
 	}
-	av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, peak)
+	av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, peak, assoc.CoActivationCount)
 	b.batch.Set(keys.AssocFwdKey(ws, [16]byte(src), assoc.Weight, [16]byte(dst)), av[:], nil)
 	b.batch.Set(keys.AssocRevKey(ws, [16]byte(dst), assoc.Weight, [16]byte(src)), av[:], nil)
 	var weightBuf [4]byte

--- a/internal/storage/coactivation_count_test.go
+++ b/internal/storage/coactivation_count_test.go
@@ -1,0 +1,226 @@
+package storage
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// TestCoActivationCount_NewAssocStartsAtOne verifies that WriteAssociation seeds
+// CoActivationCount=1 (creation is itself a co-activation event).
+func TestCoActivationCount_NewAssocStartsAtOne(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("coact-new-starts-at-one")
+
+	src := NewULID()
+	dst := NewULID()
+
+	if err := store.WriteAssociation(ctx, ws, src, dst, &Association{
+		TargetID: dst,
+		Weight:   0.5,
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	results, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+
+	got, ok := results[src]
+	if !ok || len(got) != 1 {
+		t.Fatalf("expected 1 association for src, got %d", len(got))
+	}
+
+	if got[0].CoActivationCount != 1 {
+		t.Errorf("CoActivationCount on new association: got %d, want 1", got[0].CoActivationCount)
+	}
+}
+
+// TestCoActivationCount_IncrementOnUpdate verifies that UpdateAssocWeight accumulates
+// the countDelta into CoActivationCount.
+func TestCoActivationCount_IncrementOnUpdate(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("coact-increment-on-update")
+
+	src := NewULID()
+	dst := NewULID()
+
+	if err := store.WriteAssociation(ctx, ws, src, dst, &Association{
+		TargetID: dst,
+		Weight:   0.5,
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	// After write: count=1. Add delta=3 → expect count=4.
+	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.6, 3); err != nil {
+		t.Fatalf("UpdateAssocWeight (delta=3): %v", err)
+	}
+
+	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	results, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations after first update: %v", err)
+	}
+	got := results[src]
+	if len(got) != 1 {
+		t.Fatalf("expected 1 association, got %d", len(got))
+	}
+	if got[0].CoActivationCount != 4 {
+		t.Errorf("CoActivationCount after delta=3: got %d, want 4", got[0].CoActivationCount)
+	}
+
+	// Add delta=10 → expect count=14.
+	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.7, 10); err != nil {
+		t.Fatalf("UpdateAssocWeight (delta=10): %v", err)
+	}
+
+	fresh2 := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	results2, err := fresh2.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations after second update: %v", err)
+	}
+	got2 := results2[src]
+	if len(got2) != 1 {
+		t.Fatalf("expected 1 association, got %d", len(got2))
+	}
+	if got2[0].CoActivationCount != 14 {
+		t.Errorf("CoActivationCount after delta=10: got %d, want 14", got2[0].CoActivationCount)
+	}
+}
+
+// TestCoActivationCount_BatchUpdate verifies that UpdateAssocWeightBatch accumulates
+// CountDelta per pair.
+func TestCoActivationCount_BatchUpdate(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("coact-batch-update")
+
+	src1, dst1 := NewULID(), NewULID()
+	src2, dst2 := NewULID(), NewULID()
+
+	// Write both associations — each starts at count=1.
+	if err := store.WriteAssociation(ctx, ws, src1, dst1, &Association{
+		TargetID: dst1, Weight: 0.4,
+	}); err != nil {
+		t.Fatalf("WriteAssociation pair1: %v", err)
+	}
+	if err := store.WriteAssociation(ctx, ws, src2, dst2, &Association{
+		TargetID: dst2, Weight: 0.4,
+	}); err != nil {
+		t.Fatalf("WriteAssociation pair2: %v", err)
+	}
+
+	// Batch update: pair1 delta=5 (expect 1+5=6), pair2 delta=2 (expect 1+2=3).
+	updates := []AssocWeightUpdate{
+		{WS: ws, Src: src1, Dst: dst1, Weight: 0.6, CountDelta: 5},
+		{WS: ws, Src: src2, Dst: dst2, Weight: 0.5, CountDelta: 2},
+	}
+	if err := store.UpdateAssocWeightBatch(ctx, updates); err != nil {
+		t.Fatalf("UpdateAssocWeightBatch: %v", err)
+	}
+
+	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	results, err := fresh.GetAssociations(ctx, ws, []ULID{src1, src2}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+
+	pair1 := results[src1]
+	if len(pair1) != 1 {
+		t.Fatalf("expected 1 association for src1, got %d", len(pair1))
+	}
+	if pair1[0].CoActivationCount != 6 {
+		t.Errorf("pair1 CoActivationCount: got %d, want 6", pair1[0].CoActivationCount)
+	}
+
+	pair2 := results[src2]
+	if len(pair2) != 1 {
+		t.Fatalf("expected 1 association for src2, got %d", len(pair2))
+	}
+	if pair2[0].CoActivationCount != 3 {
+		t.Errorf("pair2 CoActivationCount: got %d, want 3", pair2[0].CoActivationCount)
+	}
+}
+
+// TestCoActivationCount_LegacyValueDecodesAsZero verifies that a 22-byte legacy
+// association value (without the CoActivationCount field) decodes with count=0.
+func TestCoActivationCount_LegacyValueDecodesAsZero(t *testing.T) {
+	// Construct a 22-byte legacy value by hand (the old format).
+	// relType=1, confidence=0.9, createdAt nanos=0, lastActivated=0, peakWeight=0.5
+	var legacy [22]byte
+	// relType (bytes 0-1): RelSupports = 1
+	binary.BigEndian.PutUint16(legacy[0:2], uint16(RelSupports))
+	// confidence (bytes 2-5): 0.9 as float32 bits big-endian
+	binary.BigEndian.PutUint32(legacy[2:6], math.Float32bits(0.9))
+	// createdAt nanos (bytes 6-13): 0 (zero time)
+	binary.BigEndian.PutUint64(legacy[6:14], 0)
+	// lastActivated (bytes 14-17): 0
+	binary.BigEndian.PutUint32(legacy[14:18], 0)
+	// peakWeight (bytes 18-21): 0.5 as float32 bits big-endian
+	binary.BigEndian.PutUint32(legacy[18:22], math.Float32bits(0.5))
+
+	_, _, _, _, _, coActivationCount := decodeAssocValue(legacy[:])
+	if coActivationCount != 0 {
+		t.Errorf("legacy 22-byte value: CoActivationCount got %d, want 0", coActivationCount)
+	}
+}
+
+// TestCoActivationCount_SaturatesAtMaxUint32 verifies that CoActivationCount saturates
+// at math.MaxUint32 rather than wrapping around on overflow.
+func TestCoActivationCount_SaturatesAtMaxUint32(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("coact-saturate")
+
+	src := NewULID()
+	dst := NewULID()
+
+	// Write: count starts at 1.
+	if err := store.WriteAssociation(ctx, ws, src, dst, &Association{
+		TargetID: dst, Weight: 0.5,
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	// Add delta = MaxUint32 - 1 → count should be 1 + (MaxUint32-1) = MaxUint32.
+	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.6, math.MaxUint32-1); err != nil {
+		t.Fatalf("UpdateAssocWeight (delta=MaxUint32-1): %v", err)
+	}
+
+	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	results, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations after saturation update: %v", err)
+	}
+	got := results[src]
+	if len(got) != 1 {
+		t.Fatalf("expected 1 association, got %d", len(got))
+	}
+	if got[0].CoActivationCount != math.MaxUint32 {
+		t.Errorf("CoActivationCount after saturation: got %d, want %d", got[0].CoActivationCount, uint32(math.MaxUint32))
+	}
+
+	// Another update — count must remain at MaxUint32 (no overflow).
+	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.7, 1); err != nil {
+		t.Fatalf("UpdateAssocWeight (delta=1, post-saturation): %v", err)
+	}
+
+	fresh2 := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	results2, err := fresh2.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations after post-saturation update: %v", err)
+	}
+	got2 := results2[src]
+	if len(got2) != 1 {
+		t.Fatalf("expected 1 association, got %d", len(got2))
+	}
+	if got2[0].CoActivationCount != math.MaxUint32 {
+		t.Errorf("CoActivationCount post-saturation: got %d, want %d (must not overflow)", got2[0].CoActivationCount, uint32(math.MaxUint32))
+	}
+}

--- a/internal/storage/coactivation_count_test.go
+++ b/internal/storage/coactivation_count_test.go
@@ -148,6 +148,57 @@ func TestCoActivationCount_BatchUpdate(t *testing.T) {
 	}
 }
 
+// TestCoActivationCount_ZeroDeltaDoesNotChange verifies that UpdateAssocWeight
+// with countDelta=0 does not modify CoActivationCount (weight-only update).
+func TestCoActivationCount_ZeroDeltaDoesNotChange(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("coact-zero-delta")
+
+	src := NewULID()
+	dst := NewULID()
+
+	// Write: count starts at 1.
+	if err := store.WriteAssociation(ctx, ws, src, dst, &Association{
+		TargetID: dst,
+		Weight:   0.5,
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	// Verify initial count is 1.
+	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	results, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations after write: %v", err)
+	}
+	got := results[src]
+	if len(got) != 1 {
+		t.Fatalf("expected 1 association, got %d", len(got))
+	}
+	if got[0].CoActivationCount != 1 {
+		t.Errorf("CoActivationCount after write: got %d, want 1", got[0].CoActivationCount)
+	}
+
+	// Update weight only (countDelta=0) — count must remain at 1.
+	if err := store.UpdateAssocWeight(ctx, ws, src, dst, 0.7, 0); err != nil {
+		t.Fatalf("UpdateAssocWeight (delta=0): %v", err)
+	}
+
+	fresh2 := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	results2, err := fresh2.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations after zero-delta update: %v", err)
+	}
+	got2 := results2[src]
+	if len(got2) != 1 {
+		t.Fatalf("expected 1 association, got %d", len(got2))
+	}
+	if got2[0].CoActivationCount != 1 {
+		t.Errorf("CoActivationCount after delta=0: got %d, want 1 (must not change)", got2[0].CoActivationCount)
+	}
+}
+
 // TestCoActivationCount_LegacyValueDecodesAsZero verifies that a 22-byte legacy
 // association value (without the CoActivationCount field) decodes with count=0.
 func TestCoActivationCount_LegacyValueDecodesAsZero(t *testing.T) {

--- a/internal/storage/impl.go
+++ b/internal/storage/impl.go
@@ -262,7 +262,7 @@ func (ps *PebbleStore) WriteEngram(ctx context.Context, wsPrefix [8]byte, eng *E
 		if peak == 0 {
 			peak = assoc.Weight
 		}
-		av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, peak)
+		av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, peak, assoc.CoActivationCount)
 		batch.Set(keys.AssocFwdKey(wsPrefix, [16]byte(eng.ID), assoc.Weight, [16]byte(assoc.TargetID)), av[:], nil)
 		batch.Set(keys.AssocRevKey(wsPrefix, [16]byte(assoc.TargetID), assoc.Weight, [16]byte(eng.ID)), av[:], nil)
 		var wiBuf [4]byte
@@ -428,7 +428,7 @@ func (ps *PebbleStore) WriteEngramBatch(ctx context.Context, items []EngramBatch
 			if peak == 0 {
 				peak = assoc.Weight
 			}
-			av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, peak)
+			av := encodeAssocValue(assoc.RelType, assoc.Confidence, assoc.CreatedAt, assoc.LastActivated, peak, assoc.CoActivationCount)
 			batch.Set(keys.AssocFwdKey(ws, id16, assoc.Weight, [16]byte(assoc.TargetID)), av[:], nil)
 			batch.Set(keys.AssocRevKey(ws, [16]byte(assoc.TargetID), assoc.Weight, id16), av[:], nil)
 			var wiBuf [4]byte

--- a/internal/storage/impl_test.go
+++ b/internal/storage/impl_test.go
@@ -431,7 +431,7 @@ func TestUpdateAssocWeight(t *testing.T) {
 	}
 
 	// Update weight to 0.9
-	err = store.UpdateAssocWeight(ctx, ws, id1, id2, 0.9)
+	err = store.UpdateAssocWeight(ctx, ws, id1, id2, 0.9, 0)
 	if err != nil {
 		t.Fatalf("UpdateAssocWeight: %v", err)
 	}
@@ -701,9 +701,9 @@ func TestUpdateAssocWeightNoDuplicateEdges(t *testing.T) {
 
 	// Write initial association then update weight three times
 	_ = store.WriteAssociation(ctx, ws, id1, id2, &Association{TargetID: id2, Weight: 0.3})
-	_ = store.UpdateAssocWeight(ctx, ws, id1, id2, 0.5)
-	_ = store.UpdateAssocWeight(ctx, ws, id1, id2, 0.7)
-	_ = store.UpdateAssocWeight(ctx, ws, id1, id2, 0.9)
+	_ = store.UpdateAssocWeight(ctx, ws, id1, id2, 0.5, 0)
+	_ = store.UpdateAssocWeight(ctx, ws, id1, id2, 0.7, 0)
+	_ = store.UpdateAssocWeight(ctx, ws, id1, id2, 0.9, 0)
 
 	// Scan all forward-assoc keys for the pair and count distinct weight-encoded entries.
 	// There must be exactly 1 — if old keys weren't deleted, there'd be multiple.

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -7,10 +7,11 @@ import (
 
 // AssocWeightUpdate represents a single association weight update for batching.
 type AssocWeightUpdate struct {
-	WS     [8]byte
-	Src    ULID
-	Dst    ULID
-	Weight float32
+	WS         [8]byte
+	Src        ULID
+	Dst        ULID
+	Weight     float32
+	CountDelta uint32 // Hebbian co-activation increment to add to CoActivationCount
 }
 
 // OrdinalEntry is a (childID, ordinal) pair returned by ListChildOrdinals.
@@ -93,7 +94,8 @@ type EngineStore interface {
 	GetAssocWeight(ctx context.Context, wsPrefix [8]byte, a, b ULID) (float32, error)
 
 	// UpdateAssocWeight writes/updates the 0x03 and 0x04 association keys for pair (a,b).
-	UpdateAssocWeight(ctx context.Context, wsPrefix [8]byte, a, b ULID, weight float32) error
+	// countDelta is added to the existing CoActivationCount (saturating at MaxUint32).
+	UpdateAssocWeight(ctx context.Context, wsPrefix [8]byte, a, b ULID, weight float32, countDelta uint32) error
 
 	// DecayAssocWeights multiplies all association weights for wsPrefix by decayFactor,
 	// deleting entries that fall below minWeight. Returns count deleted.

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -100,13 +100,14 @@ type EngramMeta struct {
 // Association represents a directed, weighted link between two engrams.
 // Fixed-size: 40 bytes on disk.
 type Association struct {
-	TargetID      ULID
-	RelType       RelType
-	Weight        float32 // 0.0-1.0, Hebbian-adjustable
-	Confidence    float32 // 0.0-1.0
-	CreatedAt     time.Time
-	LastActivated int32   // Unix seconds (not nanoseconds; int32 is sufficient)
-	PeakWeight    float32 // historical max Weight; 0 = untracked (legacy pre-upgrade)
+	TargetID          ULID
+	RelType           RelType
+	Weight            float32 // 0.0-1.0, Hebbian-adjustable
+	Confidence        float32 // 0.0-1.0
+	CreatedAt         time.Time
+	LastActivated     int32   // Unix seconds (not nanoseconds; int32 is sufficient)
+	PeakWeight        float32 // historical max Weight; 0 = untracked (legacy pre-upgrade)
+	CoActivationCount uint32  // lifetime Hebbian co-activation count; 0 = pre-feature/unknown
 }
 
 // LifecycleState is the engram state machine (uint8 on disk).

--- a/internal/transport/mbp/types.go
+++ b/internal/transport/mbp/types.go
@@ -16,12 +16,13 @@ type RelType uint16
 
 // Association represents a directed link between two engrams
 type Association struct {
-	TargetID      string  `msgpack:"target_id" json:"target_id"`
-	RelType       uint16  `msgpack:"rel_type" json:"rel_type"`
-	Weight        float32 `msgpack:"weight" json:"weight"`
-	Confidence    float32 `msgpack:"confidence" json:"confidence"`
-	CreatedAt     int64   `msgpack:"created_at" json:"created_at"`
-	LastActivated int32   `msgpack:"last_activated" json:"last_activated"`
+	TargetID          string  `msgpack:"target_id" json:"target_id"`
+	RelType           uint16  `msgpack:"rel_type" json:"rel_type"`
+	Weight            float32 `msgpack:"weight" json:"weight"`
+	Confidence        float32 `msgpack:"confidence" json:"confidence"`
+	CreatedAt         int64   `msgpack:"created_at" json:"created_at"`
+	LastActivated     int32   `msgpack:"last_activated" json:"last_activated"`
+	CoActivationCount uint32  `msgpack:"co_activation_count,omitempty" json:"co_activation_count,omitempty"`
 }
 
 // HelloRequest is the HELLO handshake payload.

--- a/internal/transport/rest/engine_adapter.go
+++ b/internal/transport/rest/engine_adapter.go
@@ -175,9 +175,10 @@ func (w *RESTEngineWrapper) GetEngramLinks(ctx context.Context, req *GetEngramLi
 	links := make([]AssociationItem, len(assocs))
 	for i, a := range assocs {
 		links[i] = AssociationItem{
-			TargetID: a.TargetID.String(),
-			RelType:  uint16(a.RelType),
-			Weight:   a.Weight,
+			TargetID:          a.TargetID.String(),
+			RelType:           uint16(a.RelType),
+			Weight:            a.Weight,
+			CoActivationCount: a.CoActivationCount,
 		}
 	}
 	return &GetEngramLinksResponse{Links: links}, nil

--- a/internal/transport/rest/types.go
+++ b/internal/transport/rest/types.go
@@ -174,9 +174,10 @@ type ListEngramsResponse struct {
 
 // AssociationItem is a graph edge for the UI.
 type AssociationItem struct {
-	TargetID string  `json:"target_id"`
-	RelType  uint16  `json:"rel_type"`
-	Weight   float32 `json:"weight"`
+	TargetID          string  `json:"target_id"`
+	RelType           uint16  `json:"rel_type"`
+	Weight            float32 `json:"weight"`
+	CoActivationCount uint32  `json:"co_activation_count"`
 }
 
 // GetEngramLinksRequest requests associations for an engram.


### PR DESCRIPTION
## Summary

- Extends association binary format 22→26 bytes, adding a `CoActivationCount uint32` field that tracks the lifetime number of Hebbian co-firings per pair
- Seeds count at `1` on `WriteAssociation` (the act of creating the link is itself a co-firing event)
- Forwards per-batch co-activation increments through the Hebbian engine to the storage layer with saturation at `MaxUint32`
- Exposes `co_activation_count` in the REST and MBP transport layers
- Fully backward-compatible: legacy 22-byte values decode as `count=0` ("pre-feature/unknown"); old binaries reading 26-byte values safely ignore bytes 22–25

## 26-byte layout

```
0-1:   relType (uint16)
2-5:   confidence (float32)
6-13:  createdAt (int64 UnixNano)
14-17: lastActivated (uint32)
18-21: peakWeight (float32)
22-25: coActivationCount (uint32)  ← new
```

## Test Plan

- [ ] `go test ./internal/storage/... -run CoActivation` — 6 new targeted tests pass
- [ ] `go test ./...` — all 45 packages pass
- [ ] ADR saved to `docs/adr/2026-03-04-coactivation-count.md`

Closes #N/A (tracking co-activation count roadmap item)