### PR TITLE
feat(vault): markdown export (muninn vault export-markdown)

### DIFF
--- a/cmd/muninn/coverage_hardening_test.go
+++ b/cmd/muninn/coverage_hardening_test.go
@@ -454,6 +454,62 @@ func TestRunVaultExport_ResetMetadata(t *testing.T) {
 	}
 }
 
+func TestRunVaultExportMarkdown_Success(t *testing.T) {
+	cleanup := withMockVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && strings.Contains(r.URL.Path, "/export-markdown") {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("md-archive"))
+			return
+		}
+	})
+	defer cleanup()
+
+	outFile := filepath.Join(t.TempDir(), "notes.tgz")
+	out := captureStdout(func() {
+		runVaultExportMarkdown([]string{"--vault", "default", "--output", outFile})
+	})
+	if !strings.Contains(out, "Exported") {
+		t.Errorf("expected 'Exported' in output: %s", out)
+	}
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("markdown export file not written: %v", err)
+	}
+	if string(data) != "md-archive" {
+		t.Errorf("unexpected markdown export file content: %q", string(data))
+	}
+}
+
+func TestRunVaultExportMarkdown_AllVaults(t *testing.T) {
+	cleanup := withMockVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/api/vaults":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]string{"default", "team"})
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/export-markdown"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("archive"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer cleanup()
+
+	outDir := t.TempDir()
+	out := captureStdout(func() {
+		runVaultExportMarkdown([]string{"--all-vaults", "--output", outDir})
+	})
+	if !strings.Contains(out, "Exporting vault") {
+		t.Errorf("expected export progress output, got: %s", out)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "default.markdown.tgz")); err != nil {
+		t.Fatalf("missing default export file: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "team.markdown.tgz")); err != nil {
+		t.Fatalf("missing team export file: %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // vault.go: runVaultImport with httptest
 // ---------------------------------------------------------------------------

--- a/cmd/muninn/help.go
+++ b/cmd/muninn/help.go
@@ -165,6 +165,7 @@ var subcommandHelp = map[string]func(){
 				{"clone <source> <new-name>", "Clone a vault into a new vault"},
 				{"merge <source> <target>", "Merge source vault into target"},
 				{"export --vault <name>", "Export vault to .muninn archive"},
+				{"export-markdown --vault <name>", "Export vault notes as markdown .tgz"},
 				{"import <file> --vault <name>", "Import .muninn archive"},
 				{"reindex-fts <name>", "Rebuild FTS index"},
 				{"", ""},
@@ -181,6 +182,7 @@ var subcommandHelp = map[string]func(){
 				"muninn vault delete old-project --yes",
 				"muninn vault clone production staging",
 				"muninn vault export --vault mydata -o backup.muninn",
+				"muninn vault export-markdown --vault mydata -o notes.tgz",
 				"muninn vault delete prod-vault -u admin -p",
 			})
 	},

--- a/cmd/muninn/vault.go
+++ b/cmd/muninn/vault.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"sort"
 	"strings"
 	"time"
 )
@@ -25,6 +26,7 @@ func printVaultUsage() {
 	fmt.Println("  clone       <source> <new-name>                  Clone a vault into a new vault")
 	fmt.Println("  merge       <source> <target> [--delete-source] [--yes]  Merge source into target vault")
 	fmt.Println("  export      --vault <name> [--output <file>] [--reset-metadata]  Export vault to .muninn archive")
+	fmt.Println("  export-markdown --vault <name> [--output <file>] [--all-vaults]  Export vault notes to markdown .tgz")
 	fmt.Println("  import      <file> --vault <name> [--reset-metadata]             Import .muninn archive into new vault")
 	fmt.Println("  reindex-fts <name>                               Rebuild FTS index with Porter2 stemming")
 	fmt.Println("  rename      <old-name> <new-name>                  Rename a vault (metadata only)")
@@ -62,7 +64,7 @@ func runVault(args []string) {
 
 	// Validate the subcommand before authenticating so typos get fast feedback.
 	switch sub {
-	case "create", "delete", "clear", "clone", "merge", "rename", "export", "import", "reindex-fts", "reembed", "recall-mode":
+	case "create", "delete", "clear", "clone", "merge", "rename", "export", "export-markdown", "import", "reindex-fts", "reembed", "recall-mode":
 	default:
 		fmt.Printf("Unknown vault command: %q\n", sub)
 		printVaultUsage()
@@ -92,6 +94,8 @@ func runVault(args []string) {
 		runVaultMerge(subArgs)
 	case "export":
 		runVaultExport(subArgs)
+	case "export-markdown":
+		runVaultExportMarkdown(subArgs)
 	case "import":
 		runVaultImport(subArgs)
 	case "reindex-fts":
@@ -850,6 +854,124 @@ func runVaultExport(args []string) {
 		return
 	}
 	fmt.Printf("  Exported %d bytes to %q\n", n, outputFile)
+}
+
+// ---------------------------------------------------------------------------
+// vault export-markdown
+// ---------------------------------------------------------------------------
+
+func runVaultExportMarkdown(args []string) {
+	var vaultName, outputFile string
+	var allVaults bool
+
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--vault" || a == "-v":
+			if i+1 < len(args) {
+				i++
+				vaultName = args[i]
+			}
+		case strings.HasPrefix(a, "--vault="):
+			vaultName = strings.TrimPrefix(a, "--vault=")
+		case a == "--output" || a == "-o":
+			if i+1 < len(args) {
+				i++
+				outputFile = args[i]
+			}
+		case strings.HasPrefix(a, "--output="):
+			outputFile = strings.TrimPrefix(a, "--output=")
+		case a == "--all-vaults":
+			allVaults = true
+		case !strings.HasPrefix(a, "-") && vaultName == "":
+			vaultName = a
+		}
+	}
+
+	if allVaults {
+		names, err := listVaultNamesAdmin()
+		if err != nil {
+			fmt.Printf("Error listing vaults: %v\n", err)
+			return
+		}
+		outDir := outputFile
+		if outDir == "" {
+			outDir = "."
+		}
+		for _, name := range names {
+			fmt.Printf("Exporting vault %q...\n", name)
+			dest := fmt.Sprintf("%s/%s.markdown.tgz", outDir, name)
+			if err := exportVaultMarkdownOne(name, dest); err != nil {
+				fmt.Printf("  Error exporting %q: %v\n", name, err)
+			}
+		}
+		return
+	}
+
+	if vaultName == "" {
+		fmt.Println("Usage: muninn vault export-markdown --vault <name> [--output <file>] [--all-vaults]")
+		return
+	}
+
+	if outputFile == "" {
+		outputFile = vaultName + ".markdown.tgz"
+	}
+
+	if err := exportVaultMarkdownOne(vaultName, outputFile); err != nil {
+		fmt.Printf("Error: %v\n", err)
+	}
+}
+
+func exportVaultMarkdownOne(vaultName, outputFile string) error {
+	exportURL := fmt.Sprintf("%s/api/admin/vaults/%s/export-markdown", vaultAdminBase, url.PathEscape(vaultName))
+
+	client := &http.Client{Timeout: 30 * time.Minute}
+	req, err := http.NewRequest("GET", exportURL, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	addSessionCookie(req)
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("connect to MuninnDB: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(outputFile)
+	if err != nil {
+		return fmt.Errorf("create output file: %w", err)
+	}
+	defer f.Close()
+
+	n, err := io.Copy(f, resp.Body)
+	if err != nil {
+		return fmt.Errorf("write archive: %w", err)
+	}
+	fmt.Printf("  Exported %d bytes to %q\n", n, outputFile)
+	return nil
+}
+
+func listVaultNamesAdmin() ([]string, error) {
+	resp, err := http.Get(vaultAdminBase + "/api/vaults")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	var names []string
+	if err := json.NewDecoder(resp.Body).Decode(&names); err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -910,6 +910,41 @@ func (s *Server) handleReembedVault(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{"job_id": job.ID})
 }
 
+// handleExportVaultMarkdown exports a vault as a markdown .tgz archive.
+// GET /api/admin/vaults/{name}/export-markdown
+// Response: application/gzip stream with Content-Disposition attachment.
+func (s *Server) handleExportVaultMarkdown(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "vault name required")
+		return
+	}
+	if !isValidVaultName(name) {
+		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "vault name contains invalid characters")
+		return
+	}
+
+	// Check vault exists by listing engrams (limit 1).
+	_, err := s.engine.ListEngrams(r.Context(), &ListEngramsRequest{Vault: name, Limit: 1})
+	if err != nil {
+		if errors.Is(err, engine.ErrVaultNotFound) {
+			s.sendError(r, w, http.StatusNotFound, ErrVaultNotFound, fmt.Sprintf("vault %q not found", name))
+			return
+		}
+		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, "failed to access vault")
+		return
+	}
+
+	filename := name + ".markdown.tgz"
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+
+	if err := writeVaultMarkdownExport(r.Context(), s.engine, name, w); err != nil {
+		slog.Error("rest: markdown export failed", "vault", name, "err", err)
+		// Headers already committed; nothing to do but log.
+	}
+}
+
 // handleVaultJobStatus returns the current status of a vault clone/merge job.
 // GET /api/admin/vaults/{name}/job-status?job_id=...
 // Response 200: StatusSnapshot JSON

--- a/internal/transport/rest/admin_vault_handlers_test.go
+++ b/internal/transport/rest/admin_vault_handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/scrypster/muninndb/internal/engine"
@@ -402,4 +403,38 @@ func TestHandleImportVault_MissingVaultName(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for missing vault name, got %d", w.Code)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// handleExportVaultMarkdown
+// ---------------------------------------------------------------------------
+
+func TestHandleExportVaultMarkdown_Success(t *testing.T) {
+	srv := newVaultTestServer(&MockEngine{})
+	w := serveVault(srv, "GET", "/api/admin/vaults/testvault/export-markdown", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	cd := w.Header().Get("Content-Disposition")
+	if !strings.Contains(cd, "testvault.markdown.tgz") {
+		t.Errorf("expected Content-Disposition with testvault.markdown.tgz, got %q", cd)
+	}
+}
+
+func TestHandleExportVaultMarkdown_NotFound(t *testing.T) {
+	eng := &markdownExportNotFoundEngine{}
+	srv := newVaultTestServer(eng)
+	w := serveVault(srv, "GET", "/api/admin/vaults/missing/export-markdown", nil, nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// markdownExportNotFoundEngine returns ErrVaultNotFound for ListEngrams.
+type markdownExportNotFoundEngine struct {
+	MockEngine
+}
+
+func (e *markdownExportNotFoundEngine) ListEngrams(_ context.Context, req *ListEngramsRequest) (*ListEngramsResponse, error) {
+	return nil, fmt.Errorf("vault %q: %w", req.Vault, engine.ErrVaultNotFound)
 }

--- a/internal/transport/rest/markdown_export.go
+++ b/internal/transport/rest/markdown_export.go
@@ -1,0 +1,357 @@
+package rest
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// writeVaultMarkdownExport streams a .tgz archive to w containing:
+//   - index.md  — vault summary
+//   - tags.md   — all tags with engram counts
+//   - notes/<slug>-<id>.md — one file per engram (soft-deleted excluded)
+func writeVaultMarkdownExport(ctx context.Context, eng EngineAPI, vault string, w io.Writer) error {
+	gz := gzip.NewWriter(w)
+	tw := tar.NewWriter(gz)
+
+	notes, err := collectMarkdownNotes(ctx, eng, vault)
+	if err != nil {
+		return fmt.Errorf("markdown export: collect notes: %w", err)
+	}
+
+	// Build tag → engram-count index.
+	tagCounts := make(map[string]int)
+	for _, n := range notes {
+		for _, tag := range n.tags {
+			tagCounts[tag]++
+		}
+	}
+
+	// Write index.md
+	indexMD := renderIndexMD(vault, notes)
+	if err := writeTarEntry(tw, "index.md", indexMD); err != nil {
+		return err
+	}
+
+	// Write tags.md
+	tagsMD := renderTagsMD(tagCounts)
+	if err := writeTarEntry(tw, "tags.md", tagsMD); err != nil {
+		return err
+	}
+
+	// Write one file per engram.
+	for _, n := range notes {
+		filename := "notes/" + noteFileName(n)
+		body := renderNoteMD(n)
+		if err := writeTarEntry(tw, filename, body); err != nil {
+			return err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("markdown export: tar close: %w", err)
+	}
+	return gz.Close()
+}
+
+// markdownNote holds all data needed to render a single engram as markdown.
+type markdownNote struct {
+	id         string
+	concept    string
+	content    string
+	summary    string
+	tags       []string
+	memType    uint8
+	state      uint8
+	confidence float32
+	createdAt  int64
+	updatedAt  int64
+	links      []AssociationItem
+}
+
+// collectMarkdownNotes pages through all engrams in vault and returns non-deleted notes.
+func collectMarkdownNotes(ctx context.Context, eng EngineAPI, vault string) ([]markdownNote, error) {
+	const pageSize = 100
+	var notes []markdownNote
+	offset := 0
+
+	for {
+		resp, err := eng.ListEngrams(ctx, &ListEngramsRequest{
+			Vault:  vault,
+			Limit:  pageSize,
+			Offset: offset,
+			Sort:   "created",
+		})
+		if err != nil {
+			return nil, fmt.Errorf("markdown export: list engrams: %w", err)
+		}
+		if len(resp.Engrams) == 0 {
+			break
+		}
+
+		for _, item := range resp.Engrams {
+			read, err := eng.Read(ctx, &ReadRequest{ID: item.ID, Vault: vault})
+			if err != nil {
+				return nil, fmt.Errorf("markdown export: read engram %s: %w", item.ID, err)
+			}
+			// Skip soft-deleted engrams — state 127 = StateSoftDeleted.
+			if read.State == 127 {
+				continue
+			}
+
+			linksResp, _ := eng.GetEngramLinks(ctx, &GetEngramLinksRequest{ID: item.ID, Vault: vault})
+			var links []AssociationItem
+			if linksResp != nil {
+				links = linksResp.Links
+			}
+
+			notes = append(notes, markdownNote{
+				id:         read.ID,
+				concept:    read.Concept,
+				content:    read.Content,
+				summary:    read.Summary,
+				tags:       read.Tags,
+				memType:    read.MemoryType,
+				state:      read.State,
+				confidence: read.Confidence,
+				createdAt:  read.CreatedAt,
+				updatedAt:  read.UpdatedAt,
+				links:      links,
+			})
+		}
+
+		offset += len(resp.Engrams)
+		if offset >= resp.Total {
+			break
+		}
+	}
+
+	return notes, nil
+}
+
+// writeTarEntry writes content as a tar file entry.
+func writeTarEntry(tw *tar.Writer, name, content string) error {
+	data := []byte(content)
+	hdr := &tar.Header{
+		Name:    name,
+		Mode:    0644,
+		Size:    int64(len(data)),
+		ModTime: time.Now(),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("markdown export: write tar header %s: %w", name, err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		return fmt.Errorf("markdown export: write tar data %s: %w", name, err)
+	}
+	return nil
+}
+
+// renderIndexMD builds the index.md summary document.
+func renderIndexMD(vault string, notes []markdownNote) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# Vault: %s\n\n", vault)
+	fmt.Fprintf(&sb, "Exported: %s\n\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Fprintf(&sb, "Total engrams: %d\n\n", len(notes))
+	sb.WriteString("## Engrams\n\n")
+	for _, n := range notes {
+		fname := noteFileName(n)
+		fmt.Fprintf(&sb, "- [%s](notes/%s) — %s\n",
+			n.concept, fname, lifecycleStateLabelFromCode(n.state))
+	}
+	return sb.String()
+}
+
+// renderTagsMD builds the tags.md index document.
+func renderTagsMD(tagCounts map[string]int) string {
+	var sb strings.Builder
+	sb.WriteString("# Tags\n\n")
+	if len(tagCounts) == 0 {
+		sb.WriteString("No tags in this vault.\n")
+		return sb.String()
+	}
+	for tag, count := range tagCounts {
+		fmt.Fprintf(&sb, "- **%s** (%d)\n", tag, count)
+	}
+	return sb.String()
+}
+
+// renderNoteMD builds the full markdown document for a single engram.
+func renderNoteMD(n markdownNote) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# %s\n\n", n.concept)
+
+	// Front-matter block
+	sb.WriteString("---\n")
+	fmt.Fprintf(&sb, "id: %s\n", n.id)
+	fmt.Fprintf(&sb, "type: %s\n", memoryTypeLabelFromCode(n.memType))
+	fmt.Fprintf(&sb, "state: %s\n", lifecycleStateLabelFromCode(n.state))
+	fmt.Fprintf(&sb, "confidence: %.2f\n", n.confidence)
+	if len(n.tags) > 0 {
+		fmt.Fprintf(&sb, "tags: [%s]\n", strings.Join(n.tags, ", "))
+	}
+	fmt.Fprintf(&sb, "created: %s\n", time.Unix(n.createdAt, 0).UTC().Format(time.RFC3339))
+	if n.updatedAt > 0 && n.updatedAt != n.createdAt {
+		fmt.Fprintf(&sb, "updated: %s\n", time.Unix(n.updatedAt, 0).UTC().Format(time.RFC3339))
+	}
+	sb.WriteString("---\n\n")
+
+	// Content
+	sb.WriteString(n.content)
+	sb.WriteString("\n")
+
+	// Summary (if present)
+	if n.summary != "" {
+		sb.WriteString("\n## Summary\n\n")
+		sb.WriteString(n.summary)
+		sb.WriteString("\n")
+	}
+
+	// Links/associations
+	if len(n.links) > 0 {
+		sb.WriteString("\n## Links\n\n")
+		for _, lnk := range n.links {
+			fmt.Fprintf(&sb, "- [%s](../%s) — %s (weight: %.2f)\n",
+				lnk.TargetID, lnk.TargetID, relTypeLabelFromCode(lnk.RelType), lnk.Weight)
+		}
+	}
+
+	return sb.String()
+}
+
+// slugify converts a string into a URL-safe filename slug using ASCII characters only.
+func slugify(s string) string {
+	// Lowercase and replace non-ASCII-alphanumeric with hyphens.
+	var sb strings.Builder
+	prev := '-'
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			sb.WriteRune(r)
+			prev = r
+		} else if prev != '-' {
+			sb.WriteRune('-')
+			prev = '-'
+		}
+	}
+	result := strings.Trim(sb.String(), "-")
+	if result == "" {
+		return "engram"
+	}
+	return result
+}
+
+var reSlugTrim = regexp.MustCompile(`-+`)
+
+// noteFileName builds the filename for an engram note file.
+func noteFileName(n markdownNote) string {
+	slug := reSlugTrim.ReplaceAllString(slugify(n.concept), "-")
+	// Use last 8 chars of ID to keep filenames short but unique.
+	suffix := n.id
+	if len(suffix) > 8 {
+		suffix = suffix[len(suffix)-8:]
+	}
+	return fmt.Sprintf("%s-%s.md", slug, suffix)
+}
+
+// lifecycleStateLabelFromCode returns a human-readable label for a lifecycle state code.
+func lifecycleStateLabelFromCode(code uint8) string {
+	switch code {
+	case 0:
+		return "planning"
+	case 1:
+		return "active"
+	case 2:
+		return "paused"
+	case 3:
+		return "blocked"
+	case 4:
+		return "completed"
+	case 5:
+		return "cancelled"
+	case 6:
+		return "archived"
+	case 127:
+		return "soft_deleted"
+	default:
+		return fmt.Sprintf("unknown(%d)", code)
+	}
+}
+
+// memoryTypeLabelFromCode returns a human-readable label for a memory type code.
+func memoryTypeLabelFromCode(code uint8) string {
+	switch code {
+	case 0:
+		return "fact"
+	case 1:
+		return "decision"
+	case 2:
+		return "observation"
+	case 3:
+		return "preference"
+	case 4:
+		return "issue"
+	case 5:
+		return "task"
+	case 6:
+		return "procedure"
+	case 7:
+		return "event"
+	case 8:
+		return "goal"
+	case 9:
+		return "constraint"
+	case 10:
+		return "identity"
+	case 11:
+		return "reference"
+	default:
+		return fmt.Sprintf("unknown(%d)", code)
+	}
+}
+
+// NOTE: mirrors storage.RelType constants; update both if new RelType values are added.
+func relTypeLabelFromCode(code uint16) string {
+	switch code {
+	case 0x0001:
+		return "supports"
+	case 0x0002:
+		return "contradicts"
+	case 0x0003:
+		return "depends_on"
+	case 0x0004:
+		return "supersedes"
+	case 0x0005:
+		return "relates_to"
+	case 0x0006:
+		return "is_part_of"
+	case 0x0007:
+		return "causes"
+	case 0x0008:
+		return "preceded_by"
+	case 0x0009:
+		return "followed_by"
+	case 0x000A:
+		return "created_by_person"
+	case 0x000B:
+		return "belongs_to_project"
+	case 0x000C:
+		return "references"
+	case 0x000D:
+		return "implements"
+	case 0x000E:
+		return "blocks"
+	case 0x000F:
+		return "resolves"
+	case 0x0010:
+		return "refines"
+	case 0x8000:
+		return "user_defined"
+	default:
+		return fmt.Sprintf("rel(%d)", code)
+	}
+}

--- a/internal/transport/rest/markdown_export_test.go
+++ b/internal/transport/rest/markdown_export_test.go
@@ -1,0 +1,341 @@
+package rest
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"io"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// markdownExportEngine is an EngineAPI that returns a fixed set of engrams
+// for markdown export tests. Soft-deleted engrams (state=127) are included
+// in the list to verify they are filtered out.
+type markdownExportEngine struct {
+	MockEngine
+}
+
+func (e *markdownExportEngine) ListEngrams(_ context.Context, req *ListEngramsRequest) (*ListEngramsResponse, error) {
+	if req.Offset > 0 {
+		return &ListEngramsResponse{Engrams: nil, Total: 2}, nil
+	}
+	return &ListEngramsResponse{
+		Engrams: []EngramItem{
+			{ID: "01ABCDEF01234567", Concept: "Active Note", Vault: req.Vault},
+			{ID: "01ABCDEF89ABCDEF", Concept: "Deleted Note", Vault: req.Vault},
+		},
+		Total: 2,
+	}, nil
+}
+
+func (e *markdownExportEngine) Read(_ context.Context, req *ReadRequest) (*ReadResponse, error) {
+	switch req.ID {
+	case "01ABCDEF01234567":
+		return &ReadResponse{
+			ID:         "01ABCDEF01234567",
+			Concept:    "Active Note",
+			Content:    "This is active content.",
+			Tags:       []string{"go", "test"},
+			MemoryType: 0, // fact
+			State:      1, // active
+			Confidence: 0.9,
+			CreatedAt:  1700000000,
+		}, nil
+	case "01ABCDEF89ABCDEF":
+		return &ReadResponse{
+			ID:      "01ABCDEF89ABCDEF",
+			Concept: "Deleted Note",
+			Content: "This should not appear.",
+			State:   127, // soft-deleted
+		}, nil
+	}
+	return &ReadResponse{}, nil
+}
+
+func (e *markdownExportEngine) GetEngramLinks(_ context.Context, req *GetEngramLinksRequest) (*GetEngramLinksResponse, error) {
+	if req.ID == "01ABCDEF01234567" {
+		return &GetEngramLinksResponse{
+			Links: []AssociationItem{
+				{TargetID: "01ABCDEF89ABCDEF", RelType: 0x0001, Weight: 0.7},
+			},
+		}, nil
+	}
+	return &GetEngramLinksResponse{}, nil
+}
+
+// ---------------------------------------------------------------------------
+// writeVaultMarkdownExport
+// ---------------------------------------------------------------------------
+
+func TestWriteVaultMarkdownExport_ContainsExpectedFiles(t *testing.T) {
+	eng := &markdownExportEngine{}
+	var buf strings.Builder
+	w := &nopWriteCloser{&buf}
+	_ = w
+
+	var rawBuf strings.Builder
+	err := writeVaultMarkdownExport(context.Background(), eng, "default", &rawBuf)
+	if err != nil {
+		t.Fatalf("writeVaultMarkdownExport: %v", err)
+	}
+
+	// Decompress and list tar entries.
+	gr, err := gzip.NewReader(strings.NewReader(rawBuf.String()))
+	if err != nil {
+		t.Fatalf("gzip open: %v", err)
+	}
+	defer gr.Close()
+	tr := tar.NewReader(gr)
+
+	var files []string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar next: %v", err)
+		}
+		files = append(files, hdr.Name)
+	}
+
+	want := map[string]bool{
+		"index.md": false,
+		"tags.md":  false,
+	}
+	notesSeen := 0
+	for _, f := range files {
+		if f == "index.md" || f == "tags.md" {
+			want[f] = true
+		}
+		if strings.HasPrefix(f, "notes/") && strings.HasSuffix(f, ".md") {
+			notesSeen++
+		}
+	}
+	for k, v := range want {
+		if !v {
+			t.Errorf("expected file %q in archive, not found; got: %v", k, files)
+		}
+	}
+	// Only 1 active engram; the soft-deleted one must be excluded.
+	if notesSeen != 1 {
+		t.Errorf("expected 1 note file (soft-deleted excluded), got %d; files: %v", notesSeen, files)
+	}
+}
+
+// nopWriteCloser is a strings.Builder + io.WriteCloser for use in tests.
+type nopWriteCloser struct{ *strings.Builder }
+
+func (n *nopWriteCloser) Close() error { return nil }
+
+// ---------------------------------------------------------------------------
+// slugify
+// ---------------------------------------------------------------------------
+
+func TestSlugify(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"Hello World", "hello-world"},
+		{"foo--bar", "foo-bar"},
+		{"  spaces  ", "spaces"},
+		{"", "engram"},
+		{"123 facts!", "123-facts"},
+		{"café au lait", "caf-au-lait"},
+	}
+	for _, tc := range cases {
+		got := slugify(tc.input)
+		if got != tc.want {
+			t.Errorf("slugify(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// lifecycleStateLabelFromCode
+// ---------------------------------------------------------------------------
+
+func TestLifecycleStateLabelFromCode(t *testing.T) {
+	cases := []struct {
+		code uint8
+		want string
+	}{
+		{0, "planning"},
+		{1, "active"},
+		{2, "paused"},
+		{3, "blocked"},
+		{4, "completed"},
+		{5, "cancelled"},
+		{6, "archived"},
+		{127, "soft_deleted"},
+		{99, "unknown(99)"},
+	}
+	for _, tc := range cases {
+		got := lifecycleStateLabelFromCode(tc.code)
+		if got != tc.want {
+			t.Errorf("lifecycleStateLabelFromCode(%d) = %q, want %q", tc.code, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// memoryTypeLabelFromCode
+// ---------------------------------------------------------------------------
+
+func TestMemoryTypeLabelFromCode(t *testing.T) {
+	cases := []struct {
+		code uint8
+		want string
+	}{
+		{0, "fact"},
+		{1, "decision"},
+		{2, "observation"},
+		{3, "preference"},
+		{4, "issue"},
+		{5, "task"},
+		{6, "procedure"},
+		{7, "event"},
+		{8, "goal"},
+		{9, "constraint"},
+		{10, "identity"},
+		{11, "reference"},
+		{99, "unknown(99)"},
+	}
+	for _, tc := range cases {
+		got := memoryTypeLabelFromCode(tc.code)
+		if got != tc.want {
+			t.Errorf("memoryTypeLabelFromCode(%d) = %q, want %q", tc.code, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// relTypeLabelFromCode
+// ---------------------------------------------------------------------------
+
+func TestRelTypeLabelFromCode(t *testing.T) {
+	cases := []struct {
+		code uint16
+		want string
+	}{
+		{0x0001, "supports"},
+		{0x0002, "contradicts"},
+		{0x0003, "depends_on"},
+		{0x0004, "supersedes"},
+		{0x0005, "relates_to"},
+		{0x0006, "is_part_of"},
+		{0x0007, "causes"},
+		{0x0008, "preceded_by"},
+		{0x0009, "followed_by"},
+		{0x000A, "created_by_person"},
+		{0x000B, "belongs_to_project"},
+		{0x000C, "references"},
+		{0x000D, "implements"},
+		{0x000E, "blocks"},
+		{0x000F, "resolves"},
+		{0x0010, "refines"},
+		{0x8000, "user_defined"},
+		{0x9999, "rel(39321)"},
+	}
+	for _, tc := range cases {
+		got := relTypeLabelFromCode(tc.code)
+		if got != tc.want {
+			t.Errorf("relTypeLabelFromCode(0x%04X) = %q, want %q", tc.code, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// noteFileName
+// ---------------------------------------------------------------------------
+
+func TestNoteFileName(t *testing.T) {
+	n := markdownNote{
+		id:      "01HZ0000000000ABCDEF",
+		concept: "My Test Concept",
+	}
+	got := noteFileName(n)
+	if !strings.HasPrefix(got, "my-test-concept-") {
+		t.Errorf("expected prefix 'my-test-concept-', got %q", got)
+	}
+	if !strings.HasSuffix(got, ".md") {
+		t.Errorf("expected .md suffix, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// renderIndexMD / renderTagsMD / renderNoteMD
+// ---------------------------------------------------------------------------
+
+func TestRenderIndexMD(t *testing.T) {
+	notes := []markdownNote{
+		{id: "abc", concept: "First Note", state: 1},
+		{id: "def", concept: "Second Note", state: 4},
+	}
+	out := renderIndexMD("testvault", notes)
+	if !strings.Contains(out, "# Vault: testvault") {
+		t.Errorf("missing vault heading: %q", out)
+	}
+	if !strings.Contains(out, "First Note") {
+		t.Errorf("missing first note: %q", out)
+	}
+	if !strings.Contains(out, "Total engrams: 2") {
+		t.Errorf("missing engram count: %q", out)
+	}
+}
+
+func TestRenderTagsMD_Empty(t *testing.T) {
+	out := renderTagsMD(map[string]int{})
+	if !strings.Contains(out, "No tags") {
+		t.Errorf("expected no-tags message: %q", out)
+	}
+}
+
+func TestRenderTagsMD_WithTags(t *testing.T) {
+	out := renderTagsMD(map[string]int{"go": 3, "test": 1})
+	if !strings.Contains(out, "go") {
+		t.Errorf("expected tag 'go': %q", out)
+	}
+}
+
+func TestRenderNoteMD(t *testing.T) {
+	n := markdownNote{
+		id:         "abc123",
+		concept:    "Test Concept",
+		content:    "Some content here.",
+		summary:    "A brief summary.",
+		tags:       []string{"alpha", "beta"},
+		memType:    1,
+		state:      1,
+		confidence: 0.85,
+		createdAt:  1700000000,
+		links: []AssociationItem{
+			{TargetID: "xyz999", RelType: 0x0001, Weight: 0.6},
+		},
+	}
+	out := renderNoteMD(n)
+	if !strings.Contains(out, "# Test Concept") {
+		t.Errorf("missing heading: %q", out)
+	}
+	if !strings.Contains(out, "type: decision") {
+		t.Errorf("missing type: %q", out)
+	}
+	if !strings.Contains(out, "state: active") {
+		t.Errorf("missing state: %q", out)
+	}
+	if !strings.Contains(out, "Some content here.") {
+		t.Errorf("missing content: %q", out)
+	}
+	if !strings.Contains(out, "A brief summary.") {
+		t.Errorf("missing summary: %q", out)
+	}
+	if !strings.Contains(out, "supports") {
+		t.Errorf("missing link rel type: %q", out)
+	}
+}

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -201,6 +201,7 @@ func NewServer(addr string, engine EngineAPI, authStore *auth.Store, sessionSecr
 	mux.HandleFunc("POST /api/admin/vaults/{name}/merge-into", s.withAdminMiddleware(s.handleMergeVault))
 	mux.HandleFunc("GET /api/admin/vaults/{name}/job-status", s.withAdminMiddleware(s.handleVaultJobStatus))
 	mux.HandleFunc("GET /api/admin/vaults/{name}/export", s.withAdminMiddleware(s.handleExportVault))
+	mux.HandleFunc("GET /api/admin/vaults/{name}/export-markdown", s.withAdminMiddleware(s.handleExportVaultMarkdown))
 	mux.HandleFunc("POST /api/admin/vaults/import", s.withAdminMiddleware(s.withLargeBody(s.handleImportVault)))
 	mux.HandleFunc("POST /api/admin/vaults/{name}/reindex-fts", s.withAdminMiddleware(s.handleReindexFTSVault))
 	mux.HandleFunc("POST /api/admin/vaults/{name}/reembed", s.withAdminMiddleware(s.handleReembedVault))


### PR DESCRIPTION
## Summary

- Adds `muninn vault export-markdown --vault <name>` subcommand and `GET /api/admin/vaults/{name}/export-markdown` REST endpoint
- Streams a `.tgz` archive containing `index.md`, `tags.md`, and one `.md` file per engram
- Soft-deleted engrams (state=127) are excluded from the export
- Supports `--all-vaults` flag to export every vault into a directory

## Credit

Original implementation by @rsubr (PR #42). Applied directly per their request, with the soft-delete filter added.

## Test Plan

- [ ] `go test ./internal/transport/rest/... -run Markdown` — unit tests pass
- [ ] `go test ./cmd/muninn/... -run ExportMarkdown` — CLI tests pass
- [ ] `go test ./...` — all packages pass

Closes #42