### PR TITLE
fix(installer): show URL and HTTP code on download failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,17 @@ jobs:
             kill $SERVER_PID 2>/dev/null || true
           fi
 
+  # ── Shell script linting ─────────────────────────────────────────────
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run shellcheck
+        run: shellcheck install.sh
+
   # ── API spec validation — catches drift before it ships ───────────────
   api-spec-validation:
     name: API spec validation

--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,17 @@ URL="https://github.com/${REPO}/releases/download/${TAG}/${BIN_NAME}-${PLATFORM}
 TMP=$(mktemp)
 
 echo "  Downloading muninn ${TAG} for ${OS}/${ARCH}..."
-curl -fsSL --progress-bar "${URL}" -o "${TMP}"
+HTTP_CODE=$(curl -sSL --progress-bar -w "%{http_code}" -o "${TMP}" "${URL}")
+if [ "${HTTP_CODE}" != "200" ]; then
+  rm -f "${TMP}"
+  echo "" >&2
+  echo "muninn: download failed (HTTP ${HTTP_CODE})" >&2
+  echo "  URL: ${URL}" >&2
+  echo "" >&2
+  echo "  This may mean the release asset for ${PLATFORM} is not yet available." >&2
+  echo "  Download manually: https://github.com/${REPO}/releases/tag/${TAG}" >&2
+  exit 1
+fi
 chmod +x "${TMP}"
 
 # ── Install ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replaces `curl -f` (silent fail) with HTTP status code capture via `-w "%{http_code}"`
- On non-200 response, prints the exact URL attempted + HTTP code + manual download link
- Makes install failures actionable instead of cryptic

## Root cause (issue #58)

The user's error output referenced an API URL format (`https://api.github.com/repos/.../releases/293247273`) which doesn't match the current `install.sh`. This indicates `muninndb.com` was serving an older version of the installer script. The current release assets (`muninn-darwin-arm64` etc.) are correctly named and present in v0.3.4-alpha.

This fix ensures that even if an asset is missing or the script is stale, the user sees exactly which URL failed and how to download manually.

## Test Plan

- [ ] Simulate a 404 by pointing at a non-existent tag — confirm error shows URL and HTTP 404
- [ ] Normal install on darwin/arm64 still works end-to-end