### PR TITLE
fix(init): remove type:http from MCP entry to prevent Claude Desktop crash

### DIFF
--- a/cmd/muninn/setup_ai.go
+++ b/cmd/muninn/setup_ai.go
@@ -165,10 +165,12 @@ func writeAIToolConfig(path string, mergeFn func(cfg map[string]any)) (string, e
 }
 
 // mcpServerEntry returns the JSON map for muninn's MCP server entry.
+// Note: "type" is intentionally omitted. Claude Desktop v1.1.4010+ crashes
+// on startup with a TypeError if "type":"http" is present in any mcpServers
+// entry. The MCP client infers transport from the URL schema.
 func mcpServerEntry(mcpURL, token string) map[string]any {
 	entry := map[string]any{
-		"type": "http",
-		"url":  mcpURL,
+		"url": mcpURL,
 	}
 	if token != "" {
 		entry["headers"] = map[string]any{

--- a/cmd/muninn/setup_ai_test.go
+++ b/cmd/muninn/setup_ai_test.go
@@ -231,8 +231,8 @@ func TestMCPServerEntry_WithToken(t *testing.T) {
 	if entry["url"] != "http://localhost:8750/mcp" {
 		t.Errorf("unexpected url: %v", entry["url"])
 	}
-	if entry["type"] != "http" {
-		t.Errorf("type = %v, want \"http\" (SSE is deprecated)", entry["type"])
+	if _, ok := entry["type"]; ok {
+		t.Errorf("type field must not be present (causes Claude Desktop crash on startup)")
 	}
 	headers, ok := entry["headers"].(map[string]any)
 	if !ok {
@@ -249,8 +249,8 @@ func TestMCPServerEntry_NoToken(t *testing.T) {
 	if _, ok := entry["headers"]; ok {
 		t.Error("headers should not be present when token is empty")
 	}
-	if entry["type"] != "http" {
-		t.Errorf("type = %v, want \"http\" (SSE is deprecated)", entry["type"])
+	if _, ok := entry["type"]; ok {
+		t.Errorf("type field must not be present (causes Claude Desktop crash on startup)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Removes `"type": "http"` from `mcpServerEntry()` which is used for all Claude Desktop, Cursor, Windsurf, etc. configs
- Claude Desktop infers transport from the URL — the `type` field is redundant and actively harmful
- Cursor, Windsurf, and other tools are unaffected by this change

## Root cause

Claude Desktop v1.1.4010+ (still broken as of March 2026) has a known bug ([anthropics/claude-code#28713](https://github.com/anthropics/claude-code/issues/28713)) where **any** `"type": "http"` entry in `claude_desktop_config.json` causes the app to crash on startup with:
```
TypeError: Cannot read properties of undefined (reading 'value')
```
in its internal logger/splat formatter. The app shows a "failed to launch" screen.

This is exactly what maxmcorp experienced in #60: `muninn init` wrote the entry, Claude Desktop crashed, restoring the backup (which removed the entry) fixed it.

## Test Plan

- [x] Existing `TestMCPServerEntry_WithToken` and `TestMCPServerEntry_NoToken` updated to assert `type` is absent
- [x] Full test suite passes (`ok cmd/muninn 8.050s`)
- [ ] Manually verify on a Windows machine that Claude Desktop starts after `muninn init`