### PR TITLE
feat(init): add OpenCode integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ That Q3 incident surfaces. You never mentioned it. MuninnDB connected the concep
 
 ## Connect Your AI Tools
 
-MuninnDB auto-detects and configures Claude Desktop, Cursor, OpenClaw, Windsurf, VS Code, and others:
+MuninnDB auto-detects and configures Claude Desktop, Cursor, OpenClaw, Windsurf, OpenCode, VS Code, and others:
 
 ```bash
 muninn init
@@ -166,6 +166,31 @@ Add to `.vscode/mcp.json` in your workspace:
   }
 }
 ```
+</details>
+
+<details>
+<summary>OpenCode</summary>
+
+Add to `~/.config/opencode/opencode.json` (macOS/Linux) or `%APPDATA%\opencode\opencode.json` (Windows):
+
+```json
+{
+  "mcp": {
+    "muninn": {
+      "type": "remote",
+      "url": "http://localhost:8750/mcp",
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer {file:~/.muninn/mcp.token}"
+      }
+    }
+  }
+}
+```
+
+Omit the `headers` block if you are running MuninnDB without token authentication.
+
+> **Note:** OpenCode tools are exposed as `muninn_muninn_remember`, `muninn_muninn_recall`, etc. (server key + tool name prefix). Users preferring shorter names can register the server under the key `memory` instead, which yields `memory_muninn_remember`, `memory_muninn_recall`, etc.
 </details>
 
 MuninnDB exposes **35 MCP tools** — store, activate, search, batch insert, get usage guidance, manage vaults, and more. On first connect, call `muninn_guide` for vault-aware instructions. No token required against the default vault. [Full MCP reference →](https://muninndb.com/docs)

--- a/cmd/muninn/init.go
+++ b/cmd/muninn/init.go
@@ -40,6 +40,7 @@ func detectInstalledTools() []toolChoice {
 		{key: "openclaw", displayName: "OpenClaw", configPath: openClawConfigPath()},
 		{key: "windsurf", displayName: "Windsurf", configPath: windsurfConfigPath()},
 		{key: "codex", displayName: "Codex", configPath: codexConfigPath()},
+		{key: "opencode", displayName: "OpenCode", configPath: openCodeConfigPath()},
 		{key: "vscode", displayName: "VS Code", configPath: ""},
 		{key: "manual", displayName: "Other / manual config", configPath: ""},
 	}
@@ -57,7 +58,7 @@ func detectInstalledTools() []toolChoice {
 // runInit runs the first-time onboarding wizard (or non-interactive setup via flags).
 func runInit() {
 	fs := flag.NewFlagSet("init", flag.ExitOnError)
-	toolFlag := fs.String("tool", "", "AI tools to configure, comma-separated: claude,claude-code,cursor,openclaw,windsurf,codex,vscode,manual")
+	toolFlag := fs.String("tool", "", "AI tools to configure, comma-separated: claude,claude-code,cursor,openclaw,windsurf,codex,opencode,vscode,manual")
 	tokenFlag := fs.String("token", "", "Use this specific token (skip generation)")
 	noToken := fs.Bool("no-token", false, "Disable token authentication (open MCP endpoint)")
 	noStart := fs.Bool("no-start", false, "Skip starting the server")
@@ -687,10 +688,15 @@ func configureNamedTools(tools []string, mcpURL, token string) []string {
 				errs = append(errs, fmt.Sprintf("Codex: %v", err))
 				fmt.Fprintf(os.Stderr, "  ✗ Codex: %v\n", err)
 			}
+		case "opencode":
+			if err := configureOpenCode(mcpURL, token); err != nil {
+				errs = append(errs, fmt.Sprintf("OpenCode: %v", err))
+				fmt.Fprintf(os.Stderr, "  ✗ OpenCode: %v\n", err)
+			}
 		case "manual", "other":
 			printManualInstructions(mcpURL, token)
 		default:
-			fmt.Fprintf(os.Stderr, "  unknown tool: %q (use: claude, claude-code, cursor, vscode, windsurf, openclaw, codex, manual)\n", t)
+			fmt.Fprintf(os.Stderr, "  unknown tool: %q (use: claude, claude-code, cursor, vscode, windsurf, openclaw, opencode, codex, manual)\n", t)
 		}
 	}
 	return errs

--- a/cmd/muninn/init_test.go
+++ b/cmd/muninn/init_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -165,6 +166,60 @@ func TestDetectTools(t *testing.T) {
 		if tool.displayName == "" {
 			t.Error("tool missing displayName")
 		}
+	}
+}
+
+func TestDetectInstalledTools_IncludesOpenCode(t *testing.T) {
+	tools := detectInstalledTools()
+	for _, tool := range tools {
+		if tool.key == "opencode" {
+			if tool.displayName != "OpenCode" {
+				t.Errorf("displayName = %q, want \"OpenCode\"", tool.displayName)
+			}
+			if tool.configPath == "" {
+				t.Error("configPath should not be empty")
+			}
+			return
+		}
+	}
+	t.Error("opencode not found in detectInstalledTools()")
+}
+
+func TestConfigureNamedTools_OpenCode(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+
+	out := captureStdout(func() {
+		errs := configureNamedTools([]string{"opencode"}, "http://localhost:8750/mcp", "tok123")
+		if len(errs) > 0 {
+			t.Errorf("unexpected errors: %v", errs)
+		}
+	})
+
+	if !strings.Contains(out, "✓") || !strings.Contains(out, "OpenCode") {
+		t.Errorf("expected success output, got: %s", out)
+	}
+
+	data, err := os.ReadFile(openCodeConfigPath())
+	if err != nil {
+		t.Fatalf("config not written: %v", err)
+	}
+	var cfg map[string]any
+	json.Unmarshal(data, &cfg)
+	muninn := cfg["mcp"].(map[string]any)["muninn"].(map[string]any)
+	if muninn["type"] != "remote" {
+		t.Errorf("type = %v, want \"remote\"", muninn["type"])
+	}
+}
+
+func TestUnknownToolMessage_IncludesOpenCode(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+	stderr := captureStderr(func() {
+		configureNamedTools([]string{"notarealtool"}, "http://localhost:8750/mcp", "")
+	})
+	if !strings.Contains(stderr, "opencode") {
+		t.Errorf("unknown-tool error should list 'opencode', got: %s", stderr)
 	}
 }
 

--- a/cmd/muninn/setup_ai.go
+++ b/cmd/muninn/setup_ai.go
@@ -288,7 +288,10 @@ func openCodeConfigPath() string {
 			appData = filepath.Join(home, "AppData", "Roaming")
 		}
 		return filepath.Join(appData, "opencode", "opencode.json")
-	default:
+	default: // macOS and Linux — OpenCode uses XDG conventions on both
+		if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+			return filepath.Join(xdg, "opencode", "opencode.json")
+		}
 		home, _ := os.UserHomeDir()
 		return filepath.Join(home, ".config", "opencode", "opencode.json")
 	}

--- a/cmd/muninn/setup_ai.go
+++ b/cmd/muninn/setup_ai.go
@@ -188,6 +188,34 @@ func mergeMCPServers(cfg map[string]any, mcpURL, token string) {
 	cfg["mcpServers"] = servers
 }
 
+// openCodeMCPEntry returns the JSON map for muninn's OpenCode MCP entry.
+// OpenCode requires type "remote", explicit oauth:false, and uses a
+// file-template for auth so the token is read from disk at startup.
+func openCodeMCPEntry(mcpURL, token string) map[string]any {
+	entry := map[string]any{
+		"type":  "remote",
+		"url":   mcpURL,
+		"oauth": false,
+	}
+	if token != "" {
+		entry["headers"] = map[string]any{
+			"Authorization": "Bearer {file:~/.muninn/mcp.token}",
+		}
+	}
+	return entry
+}
+
+// mergeOpenCodeMCP upserts muninn into cfg["mcp"]["muninn"],
+// preserving all other entries under the "mcp" top-level key.
+func mergeOpenCodeMCP(cfg map[string]any, mcpURL, token string) {
+	mcp, ok := cfg["mcp"].(map[string]any)
+	if !ok {
+		mcp = map[string]any{}
+	}
+	mcp["muninn"] = openCodeMCPEntry(mcpURL, token)
+	cfg["mcp"] = mcp
+}
+
 // claudeCodeConfigPath returns the path to Claude Code's (claude CLI) config file.
 // Claude Code reads ~/.claude.json for global MCP server configuration.
 func claudeCodeConfigPath() string {

--- a/cmd/muninn/setup_ai.go
+++ b/cmd/muninn/setup_ai.go
@@ -248,6 +248,24 @@ func openClawConfigPath() string {
 	return filepath.Join(home, ".openclaw", "mcp.json")
 }
 
+// openCodeConfigPath returns the path to OpenCode's config file.
+// macOS/Linux: ~/.config/opencode/opencode.json
+// Windows:     %APPDATA%\opencode\opencode.json
+func openCodeConfigPath() string {
+	switch runtime.GOOS {
+	case "windows":
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			home, _ := os.UserHomeDir()
+			appData = filepath.Join(home, "AppData", "Roaming")
+		}
+		return filepath.Join(appData, "opencode", "opencode.json")
+	default:
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, ".config", "opencode", "opencode.json")
+	}
+}
+
 // configureClaudeDesktop writes the muninn MCP entry into Claude Desktop's config.
 func configureClaudeDesktop(mcpURL, token string) error {
 	path := claudeDesktopConfigPath()

--- a/cmd/muninn/setup_ai.go
+++ b/cmd/muninn/setup_ai.go
@@ -350,6 +350,39 @@ func configureOpenClaw(mcpURL, token string) error {
 	return nil
 }
 
+// configureOpenCode writes the muninn MCP entry into OpenCode's opencode.json.
+func configureOpenCode(mcpURL, token string) error {
+	path := openCodeConfigPath()
+
+	// Capture whether "mcp" key exists before writeAIToolConfig runs,
+	// so we can print an accurate summary (writeAIToolConfig hardcodes "mcpServers").
+	hadMCP := false
+	if existing, err := os.ReadFile(path); err == nil {
+		var peek map[string]any
+		if json.Unmarshal(existing, &peek) == nil {
+			hadMCP = peek["mcp"] != nil
+		}
+	}
+
+	_, err := writeAIToolConfig(path, func(cfg map[string]any) {
+		mergeOpenCodeMCP(cfg, mcpURL, token)
+	})
+	if err != nil {
+		return err
+	}
+
+	var summary string
+	if hadMCP {
+		summary = "updated mcp.muninn in existing config (other servers preserved)"
+	} else {
+		summary = "added mcp.muninn to config"
+	}
+
+	fmt.Printf("  ✓ OpenCode: %s\n    %s\n", summary, path)
+	fmt.Println("  → Restart OpenCode to activate MuninnDB memory")
+	return nil
+}
+
 // codexConfigPath returns the path to OpenAI Codex CLI's config file.
 // Codex uses ~/.codex/config.toml for global MCP server configuration.
 func codexConfigPath() string {

--- a/cmd/muninn/setup_ai_test.go
+++ b/cmd/muninn/setup_ai_test.go
@@ -220,7 +220,7 @@ func TestWriteAIToolConfig_AtomicTempCleaned(t *testing.T) {
 	// No temp files should remain
 	entries, _ := os.ReadDir(dir)
 	for _, e := range entries {
-		if strings.Contains(e.Name(), ".tmp.") {
+		if strings.HasSuffix(e.Name(), ".tmp") {
 			t.Errorf("temp file not cleaned up: %s", e.Name())
 		}
 	}

--- a/cmd/muninn/setup_ai_test.go
+++ b/cmd/muninn/setup_ai_test.go
@@ -282,6 +282,20 @@ func TestParseToolNumbers(t *testing.T) {
 	}
 }
 
+// TestOpenCodeConfigPath verifies OpenCode config path is absolute and contains "opencode".
+func TestOpenCodeConfigPath(t *testing.T) {
+	path := openCodeConfigPath()
+	if !filepath.IsAbs(path) {
+		t.Errorf("path %q should be absolute", path)
+	}
+	if !strings.Contains(path, "opencode") {
+		t.Errorf("path %q should contain 'opencode'", path)
+	}
+	if !strings.HasSuffix(path, "opencode.json") {
+		t.Errorf("path %q should end with opencode.json", path)
+	}
+}
+
 // TestOpenClawConfigPath verifies OpenClaw config path is set correctly.
 func TestOpenClawConfigPath(t *testing.T) {
 	path := openClawConfigPath()

--- a/cmd/muninn/setup_ai_test.go
+++ b/cmd/muninn/setup_ai_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -305,6 +306,72 @@ func TestOpenClawConfigPath(t *testing.T) {
 	home, _ := os.UserHomeDir()
 	if !strings.HasPrefix(path, home) {
 		t.Errorf("path %q should start with home dir", path)
+	}
+}
+
+func TestOpenCodeMCPEntry_WithToken(t *testing.T) {
+	entry := openCodeMCPEntry("http://localhost:8750/mcp", "mdb_testtoken123")
+	if entry["type"] != "remote" {
+		t.Errorf("type = %v, want \"remote\"", entry["type"])
+	}
+	if entry["oauth"] != false {
+		t.Errorf("oauth = %v, want false", entry["oauth"])
+	}
+	headers, ok := entry["headers"].(map[string]any)
+	if !ok {
+		t.Fatal("headers not found when token supplied")
+	}
+	auth, _ := headers["Authorization"].(string)
+	if auth != "Bearer {file:~/.muninn/mcp.token}" {
+		t.Errorf("Authorization = %q, want file-template literal", auth)
+	}
+	if strings.Contains(fmt.Sprintf("%v", entry), "mdb_testtoken123") {
+		t.Error("raw token value should NOT appear in entry")
+	}
+}
+
+func TestOpenCodeMCPEntry_NoToken(t *testing.T) {
+	entry := openCodeMCPEntry("http://localhost:8750/mcp", "")
+	if entry["type"] != "remote" {
+		t.Errorf("type = %v, want \"remote\"", entry["type"])
+	}
+	if entry["oauth"] != false {
+		t.Errorf("oauth = %v, want false", entry["oauth"])
+	}
+	if _, ok := entry["headers"]; ok {
+		t.Error("headers should not be present when token is empty")
+	}
+}
+
+func TestMergeOpenCodeMCP_PreservesOtherEntries(t *testing.T) {
+	cfg := map[string]any{
+		"mcp": map[string]any{
+			"other-tool": map[string]any{"type": "remote", "url": "http://other:9999"},
+		},
+		"topKey": "preserved",
+	}
+	mergeOpenCodeMCP(cfg, "http://localhost:8750/mcp", "tok")
+	mcp := cfg["mcp"].(map[string]any)
+	if _, ok := mcp["other-tool"]; !ok {
+		t.Error("other-tool entry removed")
+	}
+	if _, ok := mcp["muninn"]; !ok {
+		t.Error("muninn not added")
+	}
+	if cfg["topKey"] != "preserved" {
+		t.Error("top-level key lost")
+	}
+}
+
+func TestMergeOpenCodeMCP_EmptyConfig(t *testing.T) {
+	cfg := map[string]any{}
+	mergeOpenCodeMCP(cfg, "http://localhost:8750/mcp", "tok")
+	mcp, ok := cfg["mcp"].(map[string]any)
+	if !ok {
+		t.Fatal("cfg[\"mcp\"] not a map")
+	}
+	if _, ok := mcp["muninn"]; !ok {
+		t.Error("muninn not added")
 	}
 }
 

--- a/cmd/muninn/setup_ai_test.go
+++ b/cmd/muninn/setup_ai_test.go
@@ -375,6 +375,109 @@ func TestMergeOpenCodeMCP_EmptyConfig(t *testing.T) {
 	}
 }
 
+func TestConfigureOpenCode_WritesCorrectSchema(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+
+	out := captureStdout(func() {
+		if err := configureOpenCode("http://localhost:8750/mcp", "mdb_testtoken"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	data, err := os.ReadFile(openCodeConfigPath())
+	if err != nil {
+		t.Fatalf("config file not written: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, data)
+	}
+	mcp := cfg["mcp"].(map[string]any)
+	muninn := mcp["muninn"].(map[string]any)
+
+	if muninn["type"] != "remote" {
+		t.Errorf("type = %v, want \"remote\"", muninn["type"])
+	}
+	if muninn["oauth"] != false {
+		t.Errorf("oauth = %v, want false", muninn["oauth"])
+	}
+	if !strings.Contains(out, "✓") || !strings.Contains(out, "OpenCode") {
+		t.Errorf("output missing success marker: %s", out)
+	}
+	if !strings.Contains(out, "Restart OpenCode") {
+		t.Errorf("output missing restart hint: %s", out)
+	}
+}
+
+func TestConfigureOpenCode_NoToken(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+
+	captureStdout(func() {
+		configureOpenCode("http://localhost:8750/mcp", "")
+	})
+
+	data, _ := os.ReadFile(openCodeConfigPath())
+	var cfg map[string]any
+	json.Unmarshal(data, &cfg)
+	muninn := cfg["mcp"].(map[string]any)["muninn"].(map[string]any)
+	if _, ok := muninn["headers"]; ok {
+		t.Error("headers should not be present without token")
+	}
+	if muninn["oauth"] != false {
+		t.Error("oauth must be false even without token")
+	}
+}
+
+func TestConfigureOpenCode_PreservesExistingEntries(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+
+	path := openCodeConfigPath()
+	os.MkdirAll(filepath.Dir(path), 0755)
+	os.WriteFile(path, []byte(`{"mcp":{"other":{"type":"remote","url":"http://x"}},"topKey":"kept"}`), 0644)
+
+	captureStdout(func() {
+		configureOpenCode("http://localhost:8750/mcp", "tok")
+	})
+
+	data, _ := os.ReadFile(path)
+	var cfg map[string]any
+	json.Unmarshal(data, &cfg)
+	if cfg["topKey"] != "kept" {
+		t.Error("top-level key lost")
+	}
+	mcp := cfg["mcp"].(map[string]any)
+	if _, ok := mcp["other"]; !ok {
+		t.Error("other tool removed")
+	}
+	if _, ok := mcp["muninn"]; !ok {
+		t.Error("muninn not added")
+	}
+}
+
+func TestConfigureOpenCode_SummaryAdded(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+	out := captureStdout(func() { configureOpenCode("http://localhost:8750/mcp", "tok") })
+	if !strings.Contains(out, "added") {
+		t.Errorf("expected 'added' in output for new config: %s", out)
+	}
+}
+
+func TestConfigureOpenCode_SummaryUpdated(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+	path := openCodeConfigPath()
+	os.MkdirAll(filepath.Dir(path), 0755)
+	os.WriteFile(path, []byte(`{"mcp":{"muninn":{"type":"remote","url":"http://localhost:8750/mcp","oauth":false}}}`), 0644)
+	out := captureStdout(func() { configureOpenCode("http://localhost:8750/mcp", "tok") })
+	if !strings.Contains(out, "updated") {
+		t.Errorf("expected 'updated' in output for existing mcp: %s", out)
+	}
+}
+
 // Helper to override HOME in tests
 func withTempHome(t *testing.T) (string, func()) {
 	t.Helper()


### PR DESCRIPTION
## Summary

Adds first-class `muninn init` support for OpenCode (anomalyco/opencode, 116K stars).

- `openCodeConfigPath()` — resolves to `~/.config/opencode/opencode.json` (respecting `XDG_CONFIG_HOME`) on macOS/Linux, `%APPDATA%\opencode\opencode.json` on Windows
- `openCodeMCPEntry()` + `mergeOpenCodeMCP()` — builds OpenCode-specific schema (`type: "remote"`, `oauth: false`, file-template auth header)
- `configureOpenCode()` — writes config, prints `✓ OpenCode: ...` + restart hint
- `detectInstalledTools()` — auto-detects OpenCode when config file exists
- `configureNamedTools()` — `muninn init --tool opencode` works
- README updated with OpenCode integration docs + manual config snippet

## Why OpenCode is different from every other tool

OpenCode uses a completely different MCP schema:

```json
{
  "mcp": {
    "muninn": {
      "type": "remote",
      "url": "http://localhost:8750/mcp",
      "oauth": false,
      "headers": { "Authorization": "Bearer {file:~/.muninn/mcp.token}" }
    }
  }
}
```

Key differences: `mcp` (not `mcpServers`), `type: "remote"`, explicit `oauth: false` required (without it OpenCode attempts OAuth discovery on 401s), auth uses a file-template literal read at OpenCode startup.

## Test Plan

- [x] `TestOpenCodeConfigPath` — path is absolute, contains "opencode", ends with "opencode.json"
- [x] `TestOpenCodeMCPEntry_WithToken` / `_NoToken` — correct schema, no raw token in output
- [x] `TestMergeOpenCodeMCP_*` — preserves sibling entries, works on empty config
- [x] `TestConfigureOpenCode_*` — correct JSON written, "added"/"updated" summary, restart hint
- [x] `TestDetectInstalledTools_IncludesOpenCode` — present in wizard
- [x] `TestConfigureNamedTools_OpenCode` — writes correct schema end-to-end
- [x] `TestUnknownToolMessage_IncludesOpenCode` — error message lists opencode
- [x] Full suite passes (`ok cmd/muninn 8.155s`)

Closes #56