### PR TITLE
fix(docker): set GOTOOLCHAIN=auto to fix Docker build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Stage 1: Fetch assets and build
 # go:embed directives require the ORT native library and ONNX model to exist at compile time.
 FROM golang:1.24-bookworm AS builder
+ENV GOTOOLCHAIN=auto
 
 WORKDIR /src
 


### PR DESCRIPTION
The Dockerfile uses `golang:1.24-bookworm` but `go.mod` requires `go 1.25.0`. With `GOTOOLCHAIN=local` (the default), the build fails with `go.mod requires go >= 1.25.0 (running go 1.24.13)`. Adding `ENV GOTOOLCHAIN=auto` lets the builder download the required toolchain at build time, matching what `actions/setup-go` already does in CI. Fixes the Docker publish workflow failure on v0.3.5-alpha release.