### PR TITLE
fix(storage): UI always shows 'Not embedded' — patch EmbedDim in ERF on write + backfill migration

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -636,8 +636,11 @@ func runServer() {
 
 	// Run versioned schema migrations before the storage layer is built.
 	migRunner := migrate.NewRunner(db)
-	// Future migrations will be registered here:
-	// migRunner.Register(migrate.Migration{Version: 1, Description: "...", Up: func(db *pebble.DB) error { ... }})
+	migRunner.Register(migrate.Migration{
+		Version:     1,
+		Description: "backfill embed_dim in ERF records for existing embeddings",
+		Up:          migrate.BackfillEmbedDim,
+	})
 	if applied, err := migRunner.Run(); err != nil {
 		slog.Error("migration failed", "err", err)
 		db.Close()

--- a/internal/storage/embed_dim.go
+++ b/internal/storage/embed_dim.go
@@ -1,0 +1,25 @@
+package storage
+
+import "github.com/scrypster/muninndb/internal/types"
+
+// DimFromLen maps a vector length (number of float32 elements, or quantized byte count)
+// to an EmbedDimension enum value. Returns EmbedOther for any non-zero unknown length.
+func DimFromLen(n int) types.EmbedDimension {
+	switch n {
+	case 0:
+		return types.EmbedNone
+	case 384:
+		return types.Embed384
+	case 768:
+		return types.Embed768
+	case 1536:
+		return types.Embed1536
+	case 3072:
+		return types.Embed3072
+	default:
+		if n > 0 {
+			return types.EmbedOther
+		}
+		return types.EmbedNone
+	}
+}

--- a/internal/storage/erf/patch.go
+++ b/internal/storage/erf/patch.go
@@ -7,6 +7,19 @@ import (
 	"time"
 )
 
+// PatchEmbedDim updates the EmbedDim byte in a raw ERF record in-place and
+// recomputes the CRC32 trailer. Does NOT touch the CRC16 (covers bytes 0-5 only).
+// raw must be a mutable copy of the 0x01 record (Get() already returns a copy).
+func PatchEmbedDim(raw []byte, dim uint8) error {
+	if len(raw) < VariableDataStart+TrailerSize {
+		return errors.New("erf: record too short for PatchEmbedDim")
+	}
+	raw[OffsetEmbedDim] = dim
+	crc32val := ComputeCRC32(raw[:len(raw)-TrailerSize])
+	binary.BigEndian.PutUint32(raw[len(raw)-TrailerSize:], crc32val)
+	return nil
+}
+
 // PatchRelevance updates Relevance, Stability, and UpdatedAt fields in a raw ERF record
 // in-place. Recomputes the CRC32 trailer. Does NOT touch the CRC16 (covers bytes 0-5 only).
 // raw must be a mutable copy of the 0x01 record (Get() already returns a copy).

--- a/internal/storage/migrate/v1_embed_dim.go
+++ b/internal/storage/migrate/v1_embed_dim.go
@@ -5,31 +5,11 @@ import (
 	"log/slog"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/storage"
 	"github.com/scrypster/muninndb/internal/storage/erf"
 	"github.com/scrypster/muninndb/internal/storage/keys"
 	"github.com/scrypster/muninndb/internal/types"
 )
-
-// embedDimFromLen maps a quantized embedding value length (number of int8 vector bytes)
-// to an EmbedDimension constant. The embedding value format is:
-// [8 bytes quantize params] + [N bytes quantized int8], so N = len(val) - 8.
-func embedDimFromLen(n int) types.EmbedDimension {
-	switch n {
-	case 384:
-		return types.Embed384
-	case 768:
-		return types.Embed768
-	case 1536:
-		return types.Embed1536
-	case 3072:
-		return types.Embed3072
-	default:
-		if n > 0 {
-			return types.EmbedOther
-		}
-		return types.EmbedNone
-	}
-}
 
 // BackfillEmbedDim scans all embedding keys (0x18 prefix), derives the vector
 // dimension from the stored value length, and patches EmbedDim in the
@@ -63,7 +43,7 @@ func BackfillEmbedDim(db *pebble.DB) error {
 		}
 
 		vecLen := len(embedVal) - 8
-		dim := embedDimFromLen(vecLen)
+		dim := storage.DimFromLen(vecLen)
 		if dim == types.EmbedNone {
 			skipped++
 			continue

--- a/internal/storage/migrate/v1_embed_dim.go
+++ b/internal/storage/migrate/v1_embed_dim.go
@@ -1,0 +1,117 @@
+package migrate
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/storage/erf"
+	"github.com/scrypster/muninndb/internal/storage/keys"
+	"github.com/scrypster/muninndb/internal/types"
+)
+
+// embedDimFromLen maps a quantized embedding value length (number of int8 vector bytes)
+// to an EmbedDimension constant. The embedding value format is:
+// [8 bytes quantize params] + [N bytes quantized int8], so N = len(val) - 8.
+func embedDimFromLen(n int) types.EmbedDimension {
+	switch n {
+	case 384:
+		return types.Embed384
+	case 768:
+		return types.Embed768
+	case 1536:
+		return types.Embed1536
+	case 3072:
+		return types.Embed3072
+	default:
+		if n > 0 {
+			return types.EmbedOther
+		}
+		return types.EmbedNone
+	}
+}
+
+// BackfillEmbedDim scans all embedding keys (0x18 prefix), derives the vector
+// dimension from the stored value length, and patches EmbedDim in the
+// corresponding ERF record (0x01) and meta key (0x02).
+//
+// It is idempotent: records that already have EmbedDim != 0 are skipped.
+func BackfillEmbedDim(db *pebble.DB) error {
+	iter, err := db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte{0x18},
+		UpperBound: []byte{0x19},
+	})
+	if err != nil {
+		return fmt.Errorf("backfill embed dim: new iter: %w", err)
+	}
+	defer iter.Close()
+
+	patched, skipped := 0, 0
+
+	for valid := iter.First(); valid; valid = iter.Next() {
+		embedKey := iter.Key()
+		// Embedding key: 0x18 | wsPrefix(8) | ulid(16) = 25 bytes total.
+		if len(embedKey) != 25 {
+			skipped++
+			continue
+		}
+
+		embedVal, err := iter.ValueAndErr()
+		if err != nil || len(embedVal) <= 8 {
+			skipped++
+			continue
+		}
+
+		vecLen := len(embedVal) - 8
+		dim := embedDimFromLen(vecLen)
+		if dim == types.EmbedNone {
+			skipped++
+			continue
+		}
+
+		var wsPrefix [8]byte
+		var id [16]byte
+		copy(wsPrefix[:], embedKey[1:9])
+		copy(id[:], embedKey[9:25])
+
+		erfKey := keys.EngramKey(wsPrefix, id)
+		val, closer, err := db.Get(erfKey)
+		if err != nil {
+			// ERF record gone (deleted engram); nothing to patch.
+			skipped++
+			continue
+		}
+		buf := make([]byte, len(val))
+		copy(buf, val)
+		closer.Close()
+
+		// Skip if EmbedDim is already set (idempotent).
+		if len(buf) > erf.OffsetEmbedDim && buf[erf.OffsetEmbedDim] != 0 {
+			skipped++
+			continue
+		}
+
+		if err := erf.PatchEmbedDim(buf, uint8(dim)); err != nil {
+			return fmt.Errorf("backfill embed dim: patch ERF for %x/%x: %w", wsPrefix, id, err)
+		}
+
+		batch := db.NewBatch()
+		batch.Set(erfKey, buf, nil)
+		// Also patch the 0x02 meta key which holds a prefix of the ERF record.
+		metaKey := keys.MetaKey(wsPrefix, id)
+		batch.Set(metaKey, erf.MetaKeySlice(buf), nil)
+		if err := batch.Commit(pebble.Sync); err != nil {
+			batch.Close()
+			return fmt.Errorf("backfill embed dim: commit for %x/%x: %w", wsPrefix, id, err)
+		}
+		batch.Close()
+		patched++
+	}
+
+	if err := iter.Error(); err != nil {
+		return fmt.Errorf("backfill embed dim: iter: %w", err)
+	}
+
+	slog.Info("backfill embed dim complete", "patched", patched, "skipped", skipped)
+	return nil
+}

--- a/internal/storage/migrate/v1_embed_dim.go
+++ b/internal/storage/migrate/v1_embed_dim.go
@@ -26,7 +26,12 @@ func BackfillEmbedDim(db *pebble.DB) error {
 	}
 	defer iter.Close()
 
+	const batchSize = 100
+
 	patched, skipped := 0, 0
+
+	batch := db.NewBatch()
+	batchCount := 0
 
 	for valid := iter.First(); valid; valid = iter.Next() {
 		embedKey := iter.Key()
@@ -72,25 +77,40 @@ func BackfillEmbedDim(db *pebble.DB) error {
 		}
 
 		if err := erf.PatchEmbedDim(buf, uint8(dim)); err != nil {
+			batch.Close()
 			return fmt.Errorf("backfill embed dim: patch ERF for %x/%x: %w", wsPrefix, id, err)
 		}
 
-		batch := db.NewBatch()
-		batch.Set(erfKey, buf, nil)
 		// Also patch the 0x02 meta key which holds a prefix of the ERF record.
 		metaKey := keys.MetaKey(wsPrefix, id)
+		batch.Set(erfKey, buf, nil)
 		batch.Set(metaKey, erf.MetaKeySlice(buf), nil)
-		if err := batch.Commit(pebble.Sync); err != nil {
-			batch.Close()
-			return fmt.Errorf("backfill embed dim: commit for %x/%x: %w", wsPrefix, id, err)
-		}
-		batch.Close()
+		batchCount++
 		patched++
+
+		if batchCount >= batchSize {
+			if err := batch.Commit(pebble.Sync); err != nil {
+				batch.Close()
+				return fmt.Errorf("backfill embed dim: commit batch: %w", err)
+			}
+			batch.Close()
+			batch = db.NewBatch()
+			batchCount = 0
+		}
 	}
 
 	if err := iter.Error(); err != nil {
+		batch.Close()
 		return fmt.Errorf("backfill embed dim: iter: %w", err)
 	}
+
+	if batchCount > 0 {
+		if err := batch.Commit(pebble.Sync); err != nil {
+			batch.Close()
+			return fmt.Errorf("backfill embed dim: commit final batch: %w", err)
+		}
+	}
+	batch.Close()
 
 	slog.Info("backfill embed dim complete", "patched", patched, "skipped", skipped)
 	return nil

--- a/internal/storage/migrate/v1_embed_dim_test.go
+++ b/internal/storage/migrate/v1_embed_dim_test.go
@@ -11,6 +11,30 @@ import (
 	"github.com/scrypster/muninndb/internal/types"
 )
 
+// makeTestERFBytes encodes a minimal valid ERF record for the given id with
+// EmbedDim set to the given value. Used by migration tests.
+func makeTestERFBytes(t *testing.T, id [16]byte, embedDim uint8) []byte {
+	t.Helper()
+	eng := &erf.Engram{
+		Concept:    "test-concept",
+		Content:    "test content",
+		Confidence: 0.9,
+		Relevance:  0.5,
+		Stability:  30.0,
+		State:      0x01, // StateActive
+		EmbedDim:   embedDim,
+		CreatedAt:  time.Now().Truncate(time.Nanosecond),
+		UpdatedAt:  time.Now().Truncate(time.Nanosecond),
+		LastAccess: time.Now().Truncate(time.Nanosecond),
+	}
+	copy(eng.ID[:], id[:])
+	b, err := erf.Encode(eng)
+	if err != nil {
+		t.Fatalf("makeTestERFBytes: Encode: %v", err)
+	}
+	return b
+}
+
 func TestBackfillEmbedDim(t *testing.T) {
 	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
 	if err != nil {
@@ -144,5 +168,141 @@ func TestBackfillEmbedDim_Idempotent(t *testing.T) {
 	defer closer.Close()
 	if val[erf.OffsetEmbedDim] != uint8(types.Embed768) {
 		t.Errorf("EmbedDim = %d, want %d (Embed768, unchanged)", val[erf.OffsetEmbedDim], types.Embed768)
+	}
+}
+
+// TestBackfillEmbedDim_MetaKeyPatched verifies that BackfillEmbedDim patches
+// EmbedDim in both the 0x01 ERF key and the 0x02 meta key.
+func TestBackfillEmbedDim_MetaKeyPatched(t *testing.T) {
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	defer db.Close()
+
+	wsPrefix := [8]byte{0x10}
+	id := [16]byte{2}
+
+	erfBytes := makeTestERFBytes(t, id, 0 /* EmbedDim = 0, needs patching */)
+
+	erfKey := keys.EngramKey(wsPrefix, id)
+	if err := db.Set(erfKey, erfBytes, pebble.Sync); err != nil {
+		t.Fatalf("set ERF: %v", err)
+	}
+
+	metaKey := keys.MetaKey(wsPrefix, id)
+	if err := db.Set(metaKey, erf.MetaKeySlice(erfBytes), pebble.Sync); err != nil {
+		t.Fatalf("set meta: %v", err)
+	}
+
+	// 768-dim embedding: 8 bytes params + 768 bytes quantized.
+	embedVal := make([]byte, 8+768)
+	embedKey := keys.EmbeddingKey(wsPrefix, id)
+	if err := db.Set(embedKey, embedVal, pebble.Sync); err != nil {
+		t.Fatalf("set embedding: %v", err)
+	}
+
+	if err := BackfillEmbedDim(db); err != nil {
+		t.Fatalf("BackfillEmbedDim: %v", err)
+	}
+
+	// Verify the 0x02 meta key has EmbedDim = Embed768.
+	metaVal, metaCloser, err := db.Get(metaKey)
+	if err != nil {
+		t.Fatalf("get meta key after migration: %v", err)
+	}
+	defer metaCloser.Close()
+	if metaVal[erf.OffsetEmbedDim] != uint8(types.Embed768) {
+		t.Errorf("meta EmbedDim = %d, want %d (Embed768)", metaVal[erf.OffsetEmbedDim], types.Embed768)
+	}
+
+	// Also verify the 0x01 ERF key was patched.
+	erfVal, erfCloser, err := db.Get(erfKey)
+	if err != nil {
+		t.Fatalf("get ERF key after migration: %v", err)
+	}
+	defer erfCloser.Close()
+	if erfVal[erf.OffsetEmbedDim] != uint8(types.Embed768) {
+		t.Errorf("ERF EmbedDim = %d, want %d (Embed768)", erfVal[erf.OffsetEmbedDim], types.Embed768)
+	}
+}
+
+// TestBackfillEmbedDim_MultiRecord verifies BackfillEmbedDim across mixed states:
+// a record that needs patching, one that is already set (idempotent), and one whose
+// ERF is missing (orphaned embedding — should be skipped without error).
+func TestBackfillEmbedDim_MultiRecord(t *testing.T) {
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	defer db.Close()
+
+	wsPrefix := [8]byte{0x20}
+
+	// Record 1: needs patching (384-dim embedding, EmbedDim=0).
+	id1 := [16]byte{1}
+	erf1 := makeTestERFBytes(t, id1, 0 /* EmbedDim unset */)
+	if err := db.Set(keys.EngramKey(wsPrefix, id1), erf1, pebble.Sync); err != nil {
+		t.Fatalf("set ERF id1: %v", err)
+	}
+	if err := db.Set(keys.MetaKey(wsPrefix, id1), erf.MetaKeySlice(erf1), pebble.Sync); err != nil {
+		t.Fatalf("set meta id1: %v", err)
+	}
+	embedVal1 := make([]byte, 8+384) // 384-dim → Embed384
+	if err := db.Set(keys.EmbeddingKey(wsPrefix, id1), embedVal1, pebble.Sync); err != nil {
+		t.Fatalf("set embedding id1: %v", err)
+	}
+
+	// Record 2: already has EmbedDim set (Embed768 = 2) — should be skipped.
+	id2 := [16]byte{2}
+	erf2 := makeTestERFBytes(t, id2, uint8(types.Embed768))
+	if err := db.Set(keys.EngramKey(wsPrefix, id2), erf2, pebble.Sync); err != nil {
+		t.Fatalf("set ERF id2: %v", err)
+	}
+	// Write a 384-dim embedding for id2; migration must NOT overwrite EmbedDim.
+	embedVal2 := make([]byte, 8+384)
+	if err := db.Set(keys.EmbeddingKey(wsPrefix, id2), embedVal2, pebble.Sync); err != nil {
+		t.Fatalf("set embedding id2: %v", err)
+	}
+
+	// Record 3: embedding key exists but no ERF record (deleted engram — should skip).
+	id3 := [16]byte{3}
+	embedVal3 := make([]byte, 8+384)
+	if err := db.Set(keys.EmbeddingKey(wsPrefix, id3), embedVal3, pebble.Sync); err != nil {
+		t.Fatalf("set embedding id3: %v", err)
+	}
+	// No ERF record for id3 — BackfillEmbedDim must not error.
+
+	if err := BackfillEmbedDim(db); err != nil {
+		t.Fatalf("BackfillEmbedDim: %v", err)
+	}
+
+	// id1: should now have EmbedDim = Embed384.
+	val1, c1, err := db.Get(keys.EngramKey(wsPrefix, id1))
+	if err != nil {
+		t.Fatalf("get ERF id1 after migration: %v", err)
+	}
+	got1 := val1[erf.OffsetEmbedDim]
+	c1.Close()
+	if got1 != uint8(types.Embed384) {
+		t.Errorf("id1 ERF EmbedDim = %d, want %d (Embed384)", got1, types.Embed384)
+	}
+
+	// id2: should still have EmbedDim = Embed768 — not overwritten.
+	val2, c2, err := db.Get(keys.EngramKey(wsPrefix, id2))
+	if err != nil {
+		t.Fatalf("get ERF id2 after migration: %v", err)
+	}
+	got2 := val2[erf.OffsetEmbedDim]
+	c2.Close()
+	if got2 != uint8(types.Embed768) {
+		t.Errorf("id2 ERF EmbedDim = %d, want %d (Embed768, unchanged)", got2, types.Embed768)
+	}
+
+	// id3: no ERF written, migration must not have created one.
+	_, c3, err := db.Get(keys.EngramKey(wsPrefix, id3))
+	if err == nil {
+		c3.Close()
+		t.Error("id3 should have no ERF record — migration must skip orphaned embeddings")
 	}
 }

--- a/internal/storage/migrate/v1_embed_dim_test.go
+++ b/internal/storage/migrate/v1_embed_dim_test.go
@@ -1,0 +1,148 @@
+package migrate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/scrypster/muninndb/internal/storage/erf"
+	"github.com/scrypster/muninndb/internal/storage/keys"
+	"github.com/scrypster/muninndb/internal/types"
+)
+
+func TestBackfillEmbedDim(t *testing.T) {
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	defer db.Close()
+
+	wsPrefix := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	id := [16]byte{1}
+
+	// Encode a minimal valid ERF record with EmbedDim = 0 (not set).
+	eng := &erf.Engram{
+		Concept:    "test-concept",
+		Content:    "test content",
+		Confidence: 0.9,
+		Relevance:  0.5,
+		Stability:  30.0,
+		State:      0x01, // StateActive
+		CreatedAt:  time.Now().Truncate(time.Nanosecond),
+		UpdatedAt:  time.Now().Truncate(time.Nanosecond),
+		LastAccess: time.Now().Truncate(time.Nanosecond),
+		// EmbedDim intentionally left as zero (EmbedNone)
+	}
+	copy(eng.ID[:], id[:])
+
+	erfBytes, err := erf.Encode(eng)
+	if err != nil {
+		t.Fatalf("Encode ERF: %v", err)
+	}
+
+	// Verify EmbedDim is 0 before migration.
+	if erfBytes[erf.OffsetEmbedDim] != 0 {
+		t.Fatalf("precondition: EmbedDim = %d, want 0", erfBytes[erf.OffsetEmbedDim])
+	}
+
+	// Write the ERF record at the 0x01 engram key.
+	erfKey := keys.EngramKey(wsPrefix, id)
+	if err := db.Set(erfKey, erfBytes, pebble.Sync); err != nil {
+		t.Fatalf("set ERF: %v", err)
+	}
+
+	// Write the meta key at the 0x02 prefix.
+	metaKey := keys.MetaKey(wsPrefix, id)
+	if err := db.Set(metaKey, erf.MetaKeySlice(erfBytes), pebble.Sync); err != nil {
+		t.Fatalf("set meta: %v", err)
+	}
+
+	// Write embedding at 0x18 key (384 dimensions = 384 + 8 = 392 bytes value).
+	embedVal := make([]byte, 8+384)
+	embedKey := keys.EmbeddingKey(wsPrefix, id)
+	if err := db.Set(embedKey, embedVal, pebble.Sync); err != nil {
+		t.Fatalf("set embedding: %v", err)
+	}
+
+	// Run migration.
+	if err := BackfillEmbedDim(db); err != nil {
+		t.Fatalf("BackfillEmbedDim: %v", err)
+	}
+
+	// Verify EmbedDim is now Embed384 in the ERF record.
+	val, closer, err := db.Get(erfKey)
+	if err != nil {
+		t.Fatalf("get ERF after migration: %v", err)
+	}
+	defer closer.Close()
+	if val[erf.OffsetEmbedDim] != uint8(types.Embed384) {
+		t.Errorf("ERF EmbedDim = %d, want %d (Embed384)", val[erf.OffsetEmbedDim], types.Embed384)
+	}
+
+	// Verify the patched record is still decodable (CRC32 valid).
+	buf := make([]byte, len(val))
+	copy(buf, val)
+	closer.Close()
+
+	if _, err := erf.Decode(buf); err != nil {
+		t.Errorf("Decode after migration: %v (CRC32 should still be valid)", err)
+	}
+}
+
+func TestBackfillEmbedDim_Idempotent(t *testing.T) {
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	defer db.Close()
+
+	wsPrefix := [8]byte{0xAA, 0xBB}
+	id := [16]byte{2}
+
+	eng := &erf.Engram{
+		Concept:    "already-set",
+		Content:    "content",
+		Confidence: 0.8,
+		Relevance:  0.6,
+		Stability:  20.0,
+		State:      0x01,
+		EmbedDim:   0x02, // Embed768 — already set
+		CreatedAt:  time.Now().Truncate(time.Nanosecond),
+		UpdatedAt:  time.Now().Truncate(time.Nanosecond),
+		LastAccess: time.Now().Truncate(time.Nanosecond),
+	}
+	copy(eng.ID[:], id[:])
+
+	erfBytes, err := erf.Encode(eng)
+	if err != nil {
+		t.Fatalf("Encode ERF: %v", err)
+	}
+
+	erfKey := keys.EngramKey(wsPrefix, id)
+	if err := db.Set(erfKey, erfBytes, pebble.Sync); err != nil {
+		t.Fatalf("set ERF: %v", err)
+	}
+
+	// Write embedding with 384 dimensions (would map to Embed384 if overwritten).
+	embedVal := make([]byte, 8+384)
+	embedKey := keys.EmbeddingKey(wsPrefix, id)
+	if err := db.Set(embedKey, embedVal, pebble.Sync); err != nil {
+		t.Fatalf("set embedding: %v", err)
+	}
+
+	// Run migration — should skip because EmbedDim is already set.
+	if err := BackfillEmbedDim(db); err != nil {
+		t.Fatalf("BackfillEmbedDim: %v", err)
+	}
+
+	// Verify EmbedDim remains Embed768, not overwritten with Embed384.
+	val, closer, err := db.Get(erfKey)
+	if err != nil {
+		t.Fatalf("get ERF after migration: %v", err)
+	}
+	defer closer.Close()
+	if val[erf.OffsetEmbedDim] != uint8(types.Embed768) {
+		t.Errorf("EmbedDim = %d, want %d (Embed768, unchanged)", val[erf.OffsetEmbedDim], types.Embed768)
+	}
+}

--- a/internal/storage/plugin_store.go
+++ b/internal/storage/plugin_store.go
@@ -163,7 +163,7 @@ func (ps *PebbleStore) UpdateEmbedding(ctx context.Context, wsPrefix [8]byte, id
 	batch.Set(keys.EmbeddingKey(wsPrefix, [16]byte(id)), embedBytes, nil)
 
 	// Patch EmbedDim in the ERF record so the UI reflects embedding status.
-	// EmbedDim lives at absolute byte offset HeaderSize(8) + OffsetEmbedDim(67) = 75.
+	// EmbedDim lives at byte offset erf.OffsetEmbedDim (67) from the record start.
 	// PatchEmbedDim also recomputes the CRC32 trailer so the record stays valid.
 	dim := dimFromLen(len(vec))
 	if dim != types.EmbedNone {
@@ -176,8 +176,12 @@ func (ps *PebbleStore) UpdateEmbedding(ctx context.Context, wsPrefix [8]byte, id
 
 			if patchErr := erf.PatchEmbedDim(buf, uint8(dim)); patchErr == nil {
 				batch.Set(erfKey, buf, nil)
-				// Invalidate the L1 cache so the next GetEngram re-reads from Pebble.
+				// Also update the 0x02 meta key so GetMetadata sees the new EmbedDim.
+				metaKey := keys.MetaKey(wsPrefix, [16]byte(id))
+				batch.Set(metaKey, erf.MetaKeySlice(buf), nil)
+				// Invalidate both caches so the next read re-fetches from Pebble.
 				ps.cache.Delete(wsPrefix, id)
+				ps.metaCache.Remove([16]byte(id))
 			}
 		}
 		// If the ERF record doesn't exist (race), skip — WriteEngram will set it.

--- a/internal/storage/plugin_store.go
+++ b/internal/storage/plugin_store.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/scrypster/muninndb/internal/storage/erf"
@@ -124,25 +125,6 @@ func (ps *PebbleStore) getDigestFlagsRaw(id [16]byte) (uint8, error) {
 	return val[0], nil
 }
 
-// dimFromLen maps a vector length to the EmbedDimension enum value.
-// Returns EmbedOther for any non-zero length not in the known set.
-func dimFromLen(n int) types.EmbedDimension {
-	switch n {
-	case 0:
-		return types.EmbedNone
-	case 384:
-		return types.Embed384
-	case 768:
-		return types.Embed768
-	case 1536:
-		return types.Embed1536
-	case 3072:
-		return types.Embed3072
-	default:
-		return types.EmbedOther
-	}
-}
-
 // UpdateEmbedding stores an embedding vector for an engram.
 // The wsPrefix is looked up from the engram's key scan.
 // For ERF v2, only the 0x18 embedding key is written; the full engram is not re-encoded.
@@ -165,7 +147,7 @@ func (ps *PebbleStore) UpdateEmbedding(ctx context.Context, wsPrefix [8]byte, id
 	// Patch EmbedDim in the ERF record so the UI reflects embedding status.
 	// EmbedDim lives at byte offset erf.OffsetEmbedDim (67) from the record start.
 	// PatchEmbedDim also recomputes the CRC32 trailer so the record stays valid.
-	dim := dimFromLen(len(vec))
+	dim := DimFromLen(len(vec))
 	if dim != types.EmbedNone {
 		erfKey := keys.EngramKey(wsPrefix, [16]byte(id))
 		val, closer, err := ps.db.Get(erfKey)
@@ -174,7 +156,12 @@ func (ps *PebbleStore) UpdateEmbedding(ctx context.Context, wsPrefix [8]byte, id
 			copy(buf, val)
 			closer.Close()
 
-			if patchErr := erf.PatchEmbedDim(buf, uint8(dim)); patchErr == nil {
+			if patchErr := erf.PatchEmbedDim(buf, uint8(dim)); patchErr != nil {
+				slog.Warn("UpdateEmbedding: failed to patch EmbedDim in ERF record",
+					"id", id,
+					"err", patchErr,
+				)
+			} else {
 				batch.Set(erfKey, buf, nil)
 				// Also update the 0x02 meta key so GetMetadata sees the new EmbedDim.
 				metaKey := keys.MetaKey(wsPrefix, [16]byte(id))

--- a/internal/storage/plugin_store.go
+++ b/internal/storage/plugin_store.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/scrypster/muninndb/internal/storage/erf"
 	"github.com/scrypster/muninndb/internal/storage/keys"
+	"github.com/scrypster/muninndb/internal/types"
 )
 
 // CountWithoutFlag returns the number of engrams across all vaults that are
@@ -121,6 +122,25 @@ func (ps *PebbleStore) getDigestFlagsRaw(id [16]byte) (uint8, error) {
 		return 0, nil
 	}
 	return val[0], nil
+}
+
+// dimFromLen maps a vector length to the EmbedDimension enum value.
+// Returns EmbedOther for any non-zero length not in the known set.
+func dimFromLen(n int) types.EmbedDimension {
+	switch n {
+	case 0:
+		return types.EmbedNone
+	case 384:
+		return types.Embed384
+	case 768:
+		return types.Embed768
+	case 1536:
+		return types.Embed1536
+	case 3072:
+		return types.Embed3072
+	default:
+		return types.EmbedOther
+	}
 }
 
 // UpdateEmbedding stores an embedding vector for an engram.

--- a/internal/storage/plugin_store.go
+++ b/internal/storage/plugin_store.go
@@ -146,6 +146,7 @@ func dimFromLen(n int) types.EmbedDimension {
 // UpdateEmbedding stores an embedding vector for an engram.
 // The wsPrefix is looked up from the engram's key scan.
 // For ERF v2, only the 0x18 embedding key is written; the full engram is not re-encoded.
+// It also patches EmbedDim in the ERF record so the UI reflects embedding status.
 func (ps *PebbleStore) UpdateEmbedding(ctx context.Context, wsPrefix [8]byte, id ULID, vec []float32) error {
 	params, quantized := erf.Quantize(vec)
 	paramsBuf := erf.EncodeQuantizeParams(params)
@@ -157,7 +158,31 @@ func (ps *PebbleStore) UpdateEmbedding(ctx context.Context, wsPrefix [8]byte, id
 
 	batch := ps.db.NewBatch()
 	defer batch.Close()
+
+	// Write the quantized embedding vector.
 	batch.Set(keys.EmbeddingKey(wsPrefix, [16]byte(id)), embedBytes, nil)
+
+	// Patch EmbedDim in the ERF record so the UI reflects embedding status.
+	// EmbedDim lives at absolute byte offset HeaderSize(8) + OffsetEmbedDim(67) = 75.
+	// PatchEmbedDim also recomputes the CRC32 trailer so the record stays valid.
+	dim := dimFromLen(len(vec))
+	if dim != types.EmbedNone {
+		erfKey := keys.EngramKey(wsPrefix, [16]byte(id))
+		val, closer, err := ps.db.Get(erfKey)
+		if err == nil {
+			buf := make([]byte, len(val))
+			copy(buf, val)
+			closer.Close()
+
+			if patchErr := erf.PatchEmbedDim(buf, uint8(dim)); patchErr == nil {
+				batch.Set(erfKey, buf, nil)
+				// Invalidate the L1 cache so the next GetEngram re-reads from Pebble.
+				ps.cache.Delete(wsPrefix, id)
+			}
+		}
+		// If the ERF record doesn't exist (race), skip — WriteEngram will set it.
+	}
+
 	if err := batch.Commit(pebble.Sync); err != nil {
 		return fmt.Errorf("update embedding: commit: %w", err)
 	}

--- a/internal/storage/plugin_store_test.go
+++ b/internal/storage/plugin_store_test.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"context"
 	"testing"
+
+	"github.com/scrypster/muninndb/internal/types"
 )
 
 // digestFlagAll is a convenience flag covering all bits, used to identify any
@@ -99,6 +101,27 @@ func TestFindVaultPrefix(t *testing.T) {
 	}
 	if gotWS != ws {
 		t.Errorf("FindVaultPrefix: got ws %x, want %x", gotWS, ws)
+	}
+}
+
+func TestDimFromLen(t *testing.T) {
+	cases := []struct {
+		n    int
+		want types.EmbedDimension
+	}{
+		{0, types.EmbedNone},
+		{384, types.Embed384},
+		{768, types.Embed768},
+		{1536, types.Embed1536},
+		{3072, types.Embed3072},
+		{512, types.EmbedOther},
+		{1, types.EmbedOther},
+	}
+	for _, tc := range cases {
+		got := dimFromLen(tc.n)
+		if got != tc.want {
+			t.Errorf("dimFromLen(%d) = %d, want %d", tc.n, got, tc.want)
+		}
 	}
 }
 

--- a/internal/storage/plugin_store_test.go
+++ b/internal/storage/plugin_store_test.go
@@ -118,9 +118,9 @@ func TestDimFromLen(t *testing.T) {
 		{1, types.EmbedOther},
 	}
 	for _, tc := range cases {
-		got := dimFromLen(tc.n)
+		got := DimFromLen(tc.n)
 		if got != tc.want {
-			t.Errorf("dimFromLen(%d) = %d, want %d", tc.n, got, tc.want)
+			t.Errorf("DimFromLen(%d) = %d, want %d", tc.n, got, tc.want)
 		}
 	}
 }

--- a/internal/storage/plugin_store_test.go
+++ b/internal/storage/plugin_store_test.go
@@ -136,3 +136,69 @@ func TestFindVaultPrefix_NotFound(t *testing.T) {
 		t.Error("FindVaultPrefix: expected ok=false for unwritten ULID, got true")
 	}
 }
+
+func TestUpdateEmbedding_SetsDimInERF(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("embed-dim-test")
+
+	id, err := store.WriteEngram(ctx, ws, &Engram{
+		Concept: "test concept",
+		Content: "test content",
+	})
+	if err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+
+	// EmbedDim should initially be 0.
+	got, err := store.GetEngram(ctx, ws, id)
+	if err != nil {
+		t.Fatalf("GetEngram before update: %v", err)
+	}
+	if got.EmbedDim != EmbedNone {
+		t.Errorf("initial EmbedDim = %d, want 0", got.EmbedDim)
+	}
+
+	// Update with a 384-dim vector.
+	vec := make([]float32, 384)
+	vec[0] = 0.1
+	if err := store.UpdateEmbedding(ctx, ws, id, vec); err != nil {
+		t.Fatalf("UpdateEmbedding: %v", err)
+	}
+
+	got, err = store.GetEngram(ctx, ws, id)
+	if err != nil {
+		t.Fatalf("GetEngram after update: %v", err)
+	}
+	if got.EmbedDim != EmbedDimension(types.Embed384) {
+		t.Errorf("EmbedDim = %d, want %d (Embed384)", got.EmbedDim, types.Embed384)
+	}
+}
+
+func TestUpdateEmbedding_Dim3072(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("embed-dim-3072")
+
+	id, err := store.WriteEngram(ctx, ws, &Engram{
+		Concept: "gemini test",
+		Content: "3072-dim embedding test",
+	})
+	if err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+
+	vec := make([]float32, 3072)
+	vec[0] = 0.5
+	if err := store.UpdateEmbedding(ctx, ws, id, vec); err != nil {
+		t.Fatalf("UpdateEmbedding: %v", err)
+	}
+
+	got, err := store.GetEngram(ctx, ws, id)
+	if err != nil {
+		t.Fatalf("GetEngram: %v", err)
+	}
+	if got.EmbedDim != EmbedDimension(types.Embed3072) {
+		t.Errorf("EmbedDim = %d, want %d (Embed3072)", got.EmbedDim, types.Embed3072)
+	}
+}

--- a/internal/storage/plugin_store_test.go
+++ b/internal/storage/plugin_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/scrypster/muninndb/internal/storage/keys"
 	"github.com/scrypster/muninndb/internal/types"
 )
 
@@ -200,5 +201,102 @@ func TestUpdateEmbedding_Dim3072(t *testing.T) {
 	}
 	if got.EmbedDim != EmbedDimension(types.Embed3072) {
 		t.Errorf("EmbedDim = %d, want %d (Embed3072)", got.EmbedDim, types.Embed3072)
+	}
+}
+
+// TestUpdateEmbedding_MetaKeyPatched verifies that UpdateEmbedding patches EmbedDim
+// in the 0x02 meta key so that GetMetadata (used by list endpoints) also reflects
+// the correct embedding dimension — not just the full engram read path.
+func TestUpdateEmbedding_MetaKeyPatched(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("embed-meta-test")
+
+	id, err := store.WriteEngram(ctx, ws, &Engram{
+		Concept: "meta test",
+		Content: "meta key patch test",
+	})
+	if err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+
+	vec := make([]float32, 768)
+	vec[0] = 0.3
+	if err := store.UpdateEmbedding(ctx, ws, id, vec); err != nil {
+		t.Fatalf("UpdateEmbedding: %v", err)
+	}
+
+	// Verify via GetMetadata (reads from 0x02 meta key / metaCache path).
+	metas, err := store.GetMetadata(ctx, ws, []ULID{id})
+	if err != nil {
+		t.Fatalf("GetMetadata: %v", err)
+	}
+	if len(metas) != 1 || metas[0] == nil {
+		t.Fatalf("GetMetadata returned unexpected results: len=%d", len(metas))
+	}
+	if metas[0].EmbedDim != EmbedDimension(types.Embed768) {
+		t.Errorf("meta EmbedDim = %d, want %d (Embed768)", metas[0].EmbedDim, types.Embed768)
+	}
+}
+
+// TestUpdateEmbedding_MissingERF verifies that UpdateEmbedding does not return an
+// error when the ERF record (0x01 key) does not exist for the given ID, and that
+// the embedding key (0x18) is still written successfully.
+func TestUpdateEmbedding_MissingERF(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("embed-missing-erf")
+
+	// Call UpdateEmbedding for an ID that was never written as an engram.
+	id := NewULID()
+	vec := make([]float32, 384)
+	vec[0] = 0.1
+
+	// Should not return an error even though the ERF record doesn't exist.
+	if err := store.UpdateEmbedding(ctx, ws, id, vec); err != nil {
+		t.Errorf("UpdateEmbedding with missing ERF should not error: %v", err)
+	}
+
+	// The embedding key should still be written (0x18 prefix).
+	embedKey := keys.EmbeddingKey(ws, [16]byte(id))
+	val, closer, err := store.db.Get(embedKey)
+	if err != nil {
+		t.Errorf("embedding key should be written even when ERF missing: %v", err)
+	} else {
+		closer.Close()
+		// quantized: 8 bytes params + 384 bytes quantized values
+		if len(val) != 8+384 {
+			t.Errorf("embedding val len = %d, want %d", len(val), 8+384)
+		}
+	}
+}
+
+// TestUpdateEmbedding_EmbedOther verifies that a vector with an unknown dimension
+// (not 384, 768, 1536, or 3072) is stored with EmbedDim = EmbedOther (255).
+func TestUpdateEmbedding_EmbedOther(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("embed-other-test")
+
+	id, err := store.WriteEngram(ctx, ws, &Engram{
+		Concept: "unknown dim",
+		Content: "512-dim embedding",
+	})
+	if err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+
+	vec := make([]float32, 512) // not in known enum → EmbedOther
+	vec[0] = 0.7
+	if err := store.UpdateEmbedding(ctx, ws, id, vec); err != nil {
+		t.Fatalf("UpdateEmbedding: %v", err)
+	}
+
+	got, err := store.GetEngram(ctx, ws, id)
+	if err != nil {
+		t.Fatalf("GetEngram: %v", err)
+	}
+	if got.EmbedDim != EmbedDimension(types.EmbedOther) {
+		t.Errorf("EmbedDim = %d, want %d (EmbedOther=255)", got.EmbedDim, types.EmbedOther)
 	}
 }

--- a/internal/transport/rest/types.go
+++ b/internal/transport/rest/types.go
@@ -146,7 +146,7 @@ type EngramItem struct {
 	Vault      string   `json:"vault"`
 	CreatedAt  int64    `json:"created_at"`
 	// EmbedDim is the stored embedding dimensionality code (0 = no embedding).
-	// 1 = 384-dim, 2 = 768-dim, 3 = 1536-dim.
+	// 1 = 384-dim, 2 = 768-dim, 3 = 1536-dim, 4 = 3072-dim, 255 = embedded (unknown dimension).
 	EmbedDim uint8 `json:"embed_dim,omitempty"`
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -139,10 +139,12 @@ const (
 type EmbedDimension uint8
 
 const (
-	EmbedNone EmbedDimension = 0
-	Embed384  EmbedDimension = 1
-	Embed768  EmbedDimension = 2
-	Embed1536 EmbedDimension = 3
+	EmbedNone  EmbedDimension = 0
+	Embed384   EmbedDimension = 1
+	Embed768   EmbedDimension = 2
+	Embed1536  EmbedDimension = 3
+	Embed3072  EmbedDimension = 4
+	EmbedOther EmbedDimension = 255 // embedded, dimension not in known enum
 )
 
 // MemoryType is the rule-based classification.

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -571,6 +571,8 @@
                 <span x-show="selectedMemory.embed_dim === 1" style="font-size:0.875rem;color:var(--text-secondary);">Yes (384-dim)</span>
                 <span x-show="selectedMemory.embed_dim === 2" style="font-size:0.875rem;color:var(--text-secondary);">Yes (768-dim)</span>
                 <span x-show="selectedMemory.embed_dim === 3" style="font-size:0.875rem;color:var(--text-secondary);">Yes (1536-dim)</span>
+                <span x-show="selectedMemory.embed_dim === 4" style="font-size:0.875rem;color:var(--text-secondary);">Yes (3072-dim)</span>
+                <span x-show="selectedMemory.embed_dim > 0 && ![1,2,3,4].includes(selectedMemory.embed_dim)" style="font-size:0.875rem;color:var(--text-secondary);">Yes (embedded)</span>
                 <span x-show="!(selectedMemory.embed_dim && selectedMemory.embed_dim > 0)" style="font-size:0.875rem;color:var(--text-muted);">Not embedded</span>
               </div>
             </div>


### PR DESCRIPTION
Fixes #67

## Root Cause
`UpdateEmbedding` wrote the embedding vector to the `0x18` key but never updated the `EmbedDim` byte (offset 67) in the ERF engram record. The web UI reads `embed_dim` from the REST API → ERF → always 0 → always "Not embedded". Affects all providers, not just Ollama.

## Changes

**Storage**
- `Embed3072 = 4` and `EmbedOther = 255` added to `internal/types/types.go` (supports Google Gemini and other high-dim models)
- Shared `DimFromLen` helper in `internal/storage/embed_dim.go`
- `UpdateEmbedding` now atomically patches EmbedDim in both the `0x01` ERF record and `0x02` meta key (via `erf.PatchEmbedDim` which recomputes CRC32), then invalidates L1 + metaCache — all in one Pebble batch
- `slog.Warn` emitted if ERF patch fails (embedding write still proceeds)

**Migration**
- `BackfillEmbedDim` (v1) scans all `0x18` embedding keys, patches EmbedDim in ERF + meta for existing engrams; batched 100 records per sync commit; idempotent; registered in `server.go`

**UI**
- `web/templates/index.html`: adds "Yes (3072-dim)" for `embed_dim === 4`, generic "Yes (embedded)" fallback for unknown dimensions

**REST**
- Updated `EmbedDim` field comment in `types.go` to document all codes including 4 and 255

## Tests
- `TestUpdateEmbedding_SetsDimInERF` — end-to-end: write engram → embed → GetEngram → EmbedDim correct
- `TestUpdateEmbedding_Dim3072` — 3072-dim vector sets Embed3072
- `TestUpdateEmbedding_EmbedOther` — unknown dim (512) sets EmbedOther (255)
- `TestUpdateEmbedding_MetaKeyPatched` — verifies `0x02` meta key via `GetMetadata`
- `TestUpdateEmbedding_MissingERF` — no error when ERF doesn't exist; embedding still written
- `TestBackfillEmbedDim` — real ERF encode, CRC32 valid after patch
- `TestBackfillEmbedDim_Idempotent` — pre-set dim not overwritten
- `TestBackfillEmbedDim_MetaKeyPatched` — `0x02` key patched by migration
- `TestBackfillEmbedDim_MultiRecord` — mixed: needs patch / already set / orphaned embedding