### PR TITLE
fix(storage): eliminate walSyncer race and fix test teardown ordering

### DIFF
--- a/internal/storage/assoc_weight_index_test.go
+++ b/internal/storage/assoc_weight_index_test.go
@@ -21,7 +21,7 @@ func newTestStoreHelper(t *testing.T) (*PebbleStore, func()) {
 	}
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
 	cleanup := func() {
-		db.Close()
+		store.Close()
 		os.RemoveAll(dir)
 	}
 	return store, cleanup

--- a/internal/storage/association_durability_test.go
+++ b/internal/storage/association_durability_test.go
@@ -40,7 +40,7 @@ func TestAssocMetadata_LastActivated_PreservedOnUpdate(t *testing.T) {
 	}
 
 	// Read back on a fresh (cold-cache) store.
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 	results, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations: %v", err)
@@ -103,7 +103,7 @@ func TestAssocMetadata_PreservedThroughDecay(t *testing.T) {
 	}
 
 	// Read back on a fresh (cold-cache) store.
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 	results, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations: %v", err)
@@ -163,7 +163,7 @@ func TestAssocPeakWeight_TrackedAcrossUpdates(t *testing.T) {
 	}
 
 	// Open fresh store (bypass cache) to read from Pebble directly
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 	assocs, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations: %v", err)
@@ -193,7 +193,7 @@ func TestAssocPeakWeight_InitialWriteSetsPeak(t *testing.T) {
 		t.Fatalf("WriteAssociation: %v", err)
 	}
 
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 	assocs, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations: %v", err)
@@ -229,7 +229,7 @@ func TestAssocDecay_DynamicFloor(t *testing.T) {
 		}
 	}
 
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 	assocs, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations: %v", err)
@@ -272,7 +272,7 @@ func TestAssocDecay_LowPeakEdgeClampsToVeryLowFloor(t *testing.T) {
 		t.Fatalf("DecayAssocWeights: %v", err)
 	}
 
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 	assocs, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations: %v", err)
@@ -317,7 +317,7 @@ func TestAssocPeakWeight_BatchUpdatePreservesPeak(t *testing.T) {
 	}
 
 	// Read via fresh store to bypass cache
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 	assocs, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations: %v", err)

--- a/internal/storage/association_test.go
+++ b/internal/storage/association_test.go
@@ -39,7 +39,7 @@ func TestAssociationsForOne_CacheMiss(t *testing.T) {
 	}
 
 	// Use a fresh store so the assoc cache is cold.
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 
 	assocs, err := fresh.associationsForOne(ws, idA, 50)
 	if err != nil {
@@ -115,7 +115,7 @@ func TestUpdateAssocWeightBatch_SingleUpdate(t *testing.T) {
 	}
 
 	// Verify via GetAssociations on a fresh (cold-cache) store.
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 	results, err := fresh.GetAssociations(ctx, ws, []ULID{idA}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations: %v", err)
@@ -383,11 +383,14 @@ func TestDecodeAssocValue_26Bytes_RestoredAtZero(t *testing.T) {
 }
 
 // newTestStore creates a PebbleStore backed by a temp dir.
-// openTestPebble already registers Cleanup for the DB; we just wrap it in a store.
+// store.Close() drains background goroutines, closes the DB, and removes the dir.
+//
+// Do NOT use openTestPebble here: PebbleStore.Close() already calls
+// db.Close() internally. A second db.Close() from openTestPebble's cleanup
+// would cause pebble to panic with "pebble: closed".
 func newTestStore(t *testing.T) *PebbleStore {
 	t.Helper()
-	db := openTestPebble(t)
-	return NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	return openTestStore(t)
 }
 
 // TestWriteAssociationGetAssociationsRoundtrip verifies that WriteAssociation persists
@@ -486,7 +489,7 @@ func TestUpdateAssocWeightPersistsCorrectly(t *testing.T) {
 	}
 
 	// Force a cache miss by creating a fresh store backed by the same DB.
-	store2 := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	store2 := newFreshStore(t, store.db)
 	results2, err := store2.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations (fresh store): %v", err)

--- a/internal/storage/batch_test.go
+++ b/internal/storage/batch_test.go
@@ -6,13 +6,14 @@ import (
 )
 
 // newTestStoreForBatch creates a PebbleStore backed by a temp Pebble DB.
-// The Pebble DB (and therefore the store) is closed via t.Cleanup registered
-// inside openTestPebble. Do not call store.Close() separately — it would
-// double-close the underlying DB.
+// store.Close() drains background goroutines, closes the DB, and removes the dir.
+//
+// Do NOT use openTestPebble here: PebbleStore.Close() already calls
+// db.Close() internally. A second db.Close() from openTestPebble's cleanup
+// would cause pebble to panic with "pebble: closed".
 func newTestStoreForBatch(t *testing.T) *PebbleStore {
 	t.Helper()
-	db := openTestPebble(t)
-	return NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	return openTestStore(t)
 }
 
 // TestStoreBatch_CommitWritesTwoEngrams verifies that committing a batch with

--- a/internal/storage/coactivation_count_test.go
+++ b/internal/storage/coactivation_count_test.go
@@ -24,7 +24,7 @@ func TestCoActivationCount_NewAssocStartsAtOne(t *testing.T) {
 		t.Fatalf("WriteAssociation: %v", err)
 	}
 
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 	results, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations: %v", err)
@@ -62,7 +62,7 @@ func TestCoActivationCount_IncrementOnUpdate(t *testing.T) {
 		t.Fatalf("UpdateAssocWeight (delta=3): %v", err)
 	}
 
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 	results, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations after first update: %v", err)
@@ -80,7 +80,7 @@ func TestCoActivationCount_IncrementOnUpdate(t *testing.T) {
 		t.Fatalf("UpdateAssocWeight (delta=10): %v", err)
 	}
 
-	fresh2 := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh2 := newFreshStore(t, store.db)
 	results2, err := fresh2.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations after second update: %v", err)
@@ -125,7 +125,7 @@ func TestCoActivationCount_BatchUpdate(t *testing.T) {
 		t.Fatalf("UpdateAssocWeightBatch: %v", err)
 	}
 
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 	results, err := fresh.GetAssociations(ctx, ws, []ULID{src1, src2}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations: %v", err)
@@ -167,7 +167,7 @@ func TestCoActivationCount_ZeroDeltaDoesNotChange(t *testing.T) {
 	}
 
 	// Verify initial count is 1.
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 	results, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations after write: %v", err)
@@ -185,7 +185,7 @@ func TestCoActivationCount_ZeroDeltaDoesNotChange(t *testing.T) {
 		t.Fatalf("UpdateAssocWeight (delta=0): %v", err)
 	}
 
-	fresh2 := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh2 := newFreshStore(t, store.db)
 	results2, err := fresh2.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations after zero-delta update: %v", err)
@@ -244,7 +244,7 @@ func TestCoActivationCount_SaturatesAtMaxUint32(t *testing.T) {
 		t.Fatalf("UpdateAssocWeight (delta=MaxUint32-1): %v", err)
 	}
 
-	fresh := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh := newFreshStore(t, store.db)
 	results, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations after saturation update: %v", err)
@@ -262,7 +262,7 @@ func TestCoActivationCount_SaturatesAtMaxUint32(t *testing.T) {
 		t.Fatalf("UpdateAssocWeight (delta=1, post-saturation): %v", err)
 	}
 
-	fresh2 := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	fresh2 := newFreshStore(t, store.db)
 	results2, err := fresh2.GetAssociations(ctx, ws, []ULID{src}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations after post-saturation update: %v", err)

--- a/internal/storage/coverage_boost_test.go
+++ b/internal/storage/coverage_boost_test.go
@@ -18,8 +18,7 @@ import (
 // TestEngramsByCreatedSince_Pagination writes 5 engrams and verifies that
 // offset and limit parameters correctly page through the results.
 func TestEngramsByCreatedSince_Pagination(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 	ws := store.VaultPrefix("since-page-test")
 	ctx := context.Background()
 
@@ -78,8 +77,7 @@ func TestEngramsByCreatedSince_Pagination(t *testing.T) {
 // TestEngramsByCreatedSince_EmptyVault verifies EngramsByCreatedSince on a
 // vault with no engrams returns an empty slice without error.
 func TestEngramsByCreatedSince_EmptyVault(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 	ws := store.VaultPrefix("since-empty-vault")
 	ctx := context.Background()
 
@@ -253,8 +251,7 @@ func TestMergeVaultData_WithOnCopyCallback(t *testing.T) {
 // TestListByCreatorInRange writes engrams with different CreatedBy values and
 // verifies that ListByCreatorInRange filters by creator and time window.
 func TestListByCreatorInRange(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 	ws := store.VaultPrefix("creator-range-test")
 	ctx := context.Background()
 
@@ -330,8 +327,7 @@ func TestListByCreatorInRange(t *testing.T) {
 
 // TestListByCreatorInRange_DefaultLimit verifies the default-limit path (limit <= 0).
 func TestListByCreatorInRange_DefaultLimit(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 	ws := store.VaultPrefix("creator-deflimit-test")
 	ctx := context.Background()
 

--- a/internal/storage/defaults_test.go
+++ b/internal/storage/defaults_test.go
@@ -23,9 +23,8 @@ func TestWriteEngramDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -85,9 +84,8 @@ func TestWriteEngramExplicitValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 

--- a/internal/storage/engram_test.go
+++ b/internal/storage/engram_test.go
@@ -461,7 +461,7 @@ func TestDeleteEngram_WithAssociations(t *testing.T) {
 	// Open a fresh store instance sharing the same underlying DB so the
 	// assocCache (TTL=2s) starts cold and reads straight from Pebble.
 	// This confirms the physical association keys were actually removed.
-	freshStore := NewPebbleStore(store.db, PebbleStoreConfig{CacheSize: 100})
+	freshStore := newFreshStore(t, store.db)
 	post, err := freshStore.GetAssociations(ctx, ws, []ULID{idA}, 10)
 	if err != nil {
 		t.Fatalf("GetAssociations after delete (fresh store): %v", err)

--- a/internal/storage/export_test.go
+++ b/internal/storage/export_test.go
@@ -14,11 +14,8 @@ import (
 )
 
 func TestExportImportRoundtrip(t *testing.T) {
-	db := openTestPebble(t)
-	src := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
-
-	db2 := openTestPebble(t)
-	dst := NewPebbleStore(db2, PebbleStoreConfig{CacheSize: 100})
+	src := openTestStore(t)
+	dst := openTestStore(t)
 
 	ctx := context.Background()
 
@@ -69,8 +66,7 @@ func TestExportImportRoundtrip(t *testing.T) {
 }
 
 func TestImportDeduplication(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 	ctx := context.Background()
 
 	ws := store.VaultPrefix("dedup-vault")
@@ -124,8 +120,7 @@ func TestImportDeduplication(t *testing.T) {
 }
 
 func TestExportEmptyVault(t *testing.T) {
-	db := openTestPebble(t)
-	src := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	src := openTestStore(t)
 	ctx := context.Background()
 
 	ws := src.VaultPrefix("empty-vault")
@@ -144,8 +139,7 @@ func TestExportEmptyVault(t *testing.T) {
 	}
 
 	// Should still be importable.
-	db2 := openTestPebble(t)
-	dst := NewPebbleStore(db2, PebbleStoreConfig{CacheSize: 100})
+	dst := openTestStore(t)
 	wsD := dst.VaultPrefix("dest-empty")
 	if err := dst.WriteVaultName(wsD, "dest-empty"); err != nil {
 		t.Fatalf("dst WriteVaultName: %v", err)
@@ -165,8 +159,7 @@ func TestImport_CorruptChecksum(t *testing.T) {
 	ctx := context.Background()
 
 	// 1. Export 2 engrams from "chk-src".
-	srcDB := openTestPebble(t)
-	src := NewPebbleStore(srcDB, PebbleStoreConfig{CacheSize: 100})
+	src := openTestStore(t)
 	wsSrc := src.VaultPrefix("chk-src")
 	if err := src.WriteVaultName(wsSrc, "chk-src"); err != nil {
 		t.Fatalf("WriteVaultName src: %v", err)
@@ -191,8 +184,7 @@ func TestImport_CorruptChecksum(t *testing.T) {
 	}
 
 	// 3. Import into "chk-dst" — must fail with a checksum error.
-	dstDB := openTestPebble(t)
-	dst := NewPebbleStore(dstDB, PebbleStoreConfig{CacheSize: 100})
+	dst := openTestStore(t)
 	wsDst := dst.VaultPrefix("chk-dst")
 	if err := dst.WriteVaultName(wsDst, "chk-dst"); err != nil {
 		t.Fatalf("WriteVaultName dst: %v", err)
@@ -318,8 +310,7 @@ func TestImport_LegacyNoChecksum(t *testing.T) {
 	}
 
 	// Import into "legacy-dst" — must succeed (nil error).
-	dstDB := openTestPebble(t)
-	dst := NewPebbleStore(dstDB, PebbleStoreConfig{CacheSize: 100})
+	dst := openTestStore(t)
 	wsDst := dst.VaultPrefix("legacy-dst")
 	if err := dst.WriteVaultName(wsDst, "legacy-dst"); err != nil {
 		t.Fatalf("WriteVaultName: %v", err)

--- a/internal/storage/impl_test.go
+++ b/internal/storage/impl_test.go
@@ -21,9 +21,8 @@ func TestWriteEngramWritesBucketKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -80,9 +79,8 @@ func TestUpdateRelevanceMovesKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -165,9 +163,8 @@ func TestRecentActiveUsesIndex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -243,8 +240,6 @@ func TestWriteEngramCallsWAL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	mol, err := wal.Open(walDir)
 	if err != nil {
 		t.Fatal(err)
@@ -256,6 +251,7 @@ func TestWriteEngramCallsWAL(t *testing.T) {
 
 	// Create PebbleStore and set WAL
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	store.SetWAL(mol, gc)
 
 	ws := store.VaultPrefix("test")
@@ -300,9 +296,8 @@ func TestSetWALOptional(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -340,9 +335,8 @@ func TestGetAssocWeight(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -404,9 +398,8 @@ func TestUpdateAssocWeight(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -459,9 +452,8 @@ func TestGetConfidence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -500,9 +492,8 @@ func TestUpdateConfidence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -547,9 +538,8 @@ func TestGetConceptAssociations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -627,9 +617,8 @@ func TestFlagContradiction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -688,9 +677,8 @@ func TestUpdateAssocWeightNoDuplicateEdges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -739,9 +727,8 @@ func TestListByState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -792,9 +779,8 @@ func TestListByStateLimitRespected(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("test")
 	ctx := context.Background()
 
@@ -830,9 +816,8 @@ func TestWriteReadCoherence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("coh-vault")
 
 	// Write a known 7-element array.
@@ -867,9 +852,8 @@ func TestReadCoherenceMissReturnsNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("never-written")
 
 	_, ok, err := store.ReadCoherence(ws)

--- a/internal/storage/lastaccess_test.go
+++ b/internal/storage/lastaccess_test.go
@@ -10,8 +10,7 @@ import (
 
 func newTestPebbleStore(t *testing.T) *PebbleStore {
 	t.Helper()
-	db := openTestPebble(t)
-	return NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	return openTestStore(t)
 }
 
 func TestWriteLastAccessEntry_AndScan(t *testing.T) {

--- a/internal/storage/query_range_test.go
+++ b/internal/storage/query_range_test.go
@@ -10,8 +10,7 @@ import (
 // then calls ListByStateInRange with a window that covers only 2 of them.
 // Verifies that exactly 2 IDs are returned.
 func TestListByStateInRange(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 	ws := store.VaultPrefix("range-test")
 	ctx := context.Background()
 
@@ -83,8 +82,7 @@ func TestListByStateInRange(t *testing.T) {
 
 // TestCountEngrams writes 3 engrams and verifies CountEngrams returns at least 3.
 func TestCountEngrams(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 	ws := store.VaultPrefix("count-engrams-test")
 	ctx := context.Background()
 
@@ -109,8 +107,7 @@ func TestCountEngrams(t *testing.T) {
 // TestEngramIDsByCreatedRange writes engrams at distinct timestamps and verifies
 // that EngramIDsByCreatedRange returns only those within the specified window.
 func TestEngramIDsByCreatedRange(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 	ws := store.VaultPrefix("ids-by-range-test")
 	ctx := context.Background()
 
@@ -173,8 +170,7 @@ func TestEngramIDsByCreatedRange(t *testing.T) {
 // LowestRelevanceIDs(ctx, ws, 3), and verifies that 3 IDs are returned and they
 // correspond to the 3 lowest-relevance engrams.
 func TestLowestRelevanceIDs(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 	ws := store.VaultPrefix("lowest-relevance-test")
 	ctx := context.Background()
 

--- a/internal/storage/scan_test.go
+++ b/internal/storage/scan_test.go
@@ -20,9 +20,8 @@ func TestScanEngrams_ErrorPropagation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-
 	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
 	ws := store.VaultPrefix("scan-test")
 	ctx := context.Background()
 

--- a/internal/storage/testhelpers_test.go
+++ b/internal/storage/testhelpers_test.go
@@ -7,7 +7,12 @@ import (
 	"github.com/cockroachdb/pebble"
 )
 
-// openTestPebble opens a Pebble DB in a temp directory and registers t.Cleanup to close it.
+// openTestPebble opens a Pebble DB in a temp directory and registers t.Cleanup
+// to close the DB and remove the directory. Use this ONLY when you need a raw
+// *pebble.DB without a PebbleStore wrapper. If you need a PebbleStore, use
+// openTestStore instead — PebbleStore.Close() already calls db.Close()
+// internally, so using openTestPebble alongside a PebbleStore causes a
+// double-close panic ("pebble: closed").
 func openTestPebble(t *testing.T) *pebble.DB {
 	t.Helper()
 	dir, err := os.MkdirTemp("", "muninndb-test-*")
@@ -24,4 +29,66 @@ func openTestPebble(t *testing.T) *pebble.DB {
 		os.RemoveAll(dir)
 	})
 	return db
+}
+
+// newFreshStore wraps an existing *pebble.DB in a new PebbleStore (cold-cache
+// path) and registers t.Cleanup to drain the store's background goroutines
+// without closing the shared db — the primary store owns the db lifecycle.
+//
+// Use this instead of "defer fresh.Close()" when creating a second PebbleStore
+// from the same db: fresh.Close() calls db.Close() on the shared db, which
+// causes a double-close panic when the primary store's Close() runs later.
+//
+// t.Cleanup ordering: newFreshStore must be called AFTER the primary store's
+// cleanup is registered (e.g. via newTestStore or openTestStore) so that
+// fresh goroutine drain runs FIRST (LIFO), guaranteeing no goroutine fires
+// on the db after the primary store's Close() closes it.
+func newFreshStore(t *testing.T, db *pebble.DB) *PebbleStore {
+	t.Helper()
+	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	t.Cleanup(func() {
+		// Drain all background goroutines without closing the shared db.
+		// The primary PebbleStore owns db.Close().
+		if store.walSync != nil {
+			store.walSync.Close()
+		}
+		if store.counterFlush != nil {
+			store.counterFlush.Close()
+		}
+		if store.provWork != nil {
+			store.provWork.Close()
+		}
+		if store.transCache != nil {
+			store.transCache.Close()
+		}
+	})
+	return store
+}
+
+// openTestStore opens a Pebble DB in a temp directory, wraps it in a
+// PebbleStore, and registers t.Cleanup to stop background goroutines,
+// close the DB, and remove the temp dir.
+//
+// Do NOT use openTestPebble here: PebbleStore.Close() already calls
+// db.Close() internally. A second db.Close() from openTestPebble's cleanup
+// would cause pebble to panic with "pebble: closed".
+func openTestStore(t *testing.T) *PebbleStore {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "muninndb-test-*")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	db, err := OpenPebble(dir, DefaultOptions())
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatalf("open pebble: %v", err)
+	}
+	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	// store.Close() stops all background goroutines and calls db.Close().
+	// os.RemoveAll runs after the DB is fully closed.
+	t.Cleanup(func() {
+		store.Close()
+		os.RemoveAll(dir)
+	})
+	return store
 }

--- a/internal/storage/vault_test.go
+++ b/internal/storage/vault_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -11,8 +12,7 @@ import (
 // 0x0E vault-name entries for vault prefixes that have engrams but no existing
 // vault-name record (i.e. data written before vault-name persistence).
 func TestBackfillVaultNames(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 	ctx := context.Background()
 
 	// Write an engram directly via WriteEngram, but deliberately skip
@@ -57,8 +57,7 @@ func TestBackfillVaultNames(t *testing.T) {
 // TestWriteVaultNameListVaultNamesRoundtrip verifies that WriteVaultName persists the
 // vault name and ListVaultNames returns it.
 func TestWriteVaultNameListVaultNamesRoundtrip(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 
 	ws := store.VaultPrefix("my-vault")
 
@@ -86,8 +85,7 @@ func TestWriteVaultNameListVaultNamesRoundtrip(t *testing.T) {
 // TestWriteVaultNameIdempotent verifies that calling WriteVaultName multiple times
 // for the same vault does not cause errors or duplicate entries.
 func TestWriteVaultNameIdempotent(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 
 	ws := store.VaultPrefix("idem-vault")
 
@@ -116,8 +114,7 @@ func TestWriteVaultNameIdempotent(t *testing.T) {
 // TestResolveVaultPrefixReturnsCorrectPrefix verifies that after WriteVaultName,
 // ResolveVaultPrefix returns the same prefix used to write.
 func TestResolveVaultPrefixReturnsCorrectPrefix(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 
 	vaultName := "resolve-test-vault"
 	ws := store.VaultPrefix(vaultName)
@@ -134,20 +131,46 @@ func TestResolveVaultPrefixReturnsCorrectPrefix(t *testing.T) {
 
 // TestResolveVaultPrefixColdPath verifies that ResolveVaultPrefix works on a
 // fresh store instance (cold path, no in-memory cache) by reading from Pebble.
+//
+// The test uses a sequential open/close pattern to avoid two PebbleStores
+// sharing one *pebble.DB: each PebbleStore.Close() calls db.Close() internally,
+// so sharing a DB between stores causes a double-close panic.
 func TestResolveVaultPrefixColdPath(t *testing.T) {
-	db := openTestPebble(t)
+	dir, err := os.MkdirTemp("", "muninndb-test-*")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
 
-	// Write vault name using first store instance.
-	store1 := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
 	vaultName := "cold-path-vault"
-	ws := store1.VaultPrefix(vaultName)
-	if err := store1.WriteVaultName(ws, vaultName); err != nil {
-		t.Fatalf("WriteVaultName: %v", err)
+	var ws [8]byte
+
+	// Phase 1: write vault name and close the store (+ db).
+	{
+		db1, err := OpenPebble(dir, DefaultOptions())
+		if err != nil {
+			t.Fatalf("OpenPebble (store1): %v", err)
+		}
+		store1 := NewPebbleStore(db1, PebbleStoreConfig{CacheSize: 100})
+		ws = store1.VaultPrefix(vaultName)
+		if err := store1.WriteVaultName(ws, vaultName); err != nil {
+			store1.Close()
+			t.Fatalf("WriteVaultName: %v", err)
+		}
+		// store1.Close() stops goroutines and closes db1.
+		if err := store1.Close(); err != nil {
+			t.Fatalf("store1.Close: %v", err)
+		}
 	}
 
-	// Create second store instance (no in-memory cache warm-up).
-	// Both share the same underlying DB; openTestPebble's cleanup handles Close.
-	store2 := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	// Phase 2: reopen from same dir — store2 has no in-memory cache (cold path).
+	db2, err := OpenPebble(dir, DefaultOptions())
+	if err != nil {
+		t.Fatalf("OpenPebble (store2): %v", err)
+	}
+	store2 := NewPebbleStore(db2, PebbleStoreConfig{CacheSize: 100})
+	t.Cleanup(func() { store2.Close() })
+
 	resolved := store2.ResolveVaultPrefix(vaultName)
 	if resolved != ws {
 		t.Errorf("cold path ResolveVaultPrefix: got %x, want %x", resolved, ws)
@@ -157,8 +180,7 @@ func TestResolveVaultPrefixColdPath(t *testing.T) {
 // TestVaultNameExists verifies VaultNameExists returns true for registered names
 // and false for unregistered names.
 func TestVaultNameExists(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 
 	ws := store.VaultPrefix("exists-vault")
 	if err := store.WriteVaultName(ws, "exists-vault"); err != nil {
@@ -176,8 +198,7 @@ func TestVaultNameExists(t *testing.T) {
 // TestRenameVault_Success verifies that RenameVault changes both index keys
 // and that the new name resolves to the same prefix.
 func TestRenameVault_Success(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 
 	ws := store.VaultPrefix("old-vault")
 	if err := store.WriteVaultName(ws, "old-vault"); err != nil {
@@ -225,8 +246,7 @@ func TestRenameVault_Success(t *testing.T) {
 
 // TestRenameVault_Collision verifies that renaming to an existing name fails.
 func TestRenameVault_Collision(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 
 	wsA := store.VaultPrefix("vault-a")
 	if err := store.WriteVaultName(wsA, "vault-a"); err != nil {
@@ -245,8 +265,7 @@ func TestRenameVault_Collision(t *testing.T) {
 
 // TestRenameVault_NotFound verifies that renaming with a wrong oldName fails.
 func TestRenameVault_NotFound(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 
 	ws := store.VaultPrefix("real-vault")
 	if err := store.WriteVaultName(ws, "real-vault"); err != nil {
@@ -262,8 +281,7 @@ func TestRenameVault_NotFound(t *testing.T) {
 // TestListVaultNamesMultipleVaults verifies that multiple vault names are all
 // returned by ListVaultNames.
 func TestListVaultNamesMultipleVaults(t *testing.T) {
-	db := openTestPebble(t)
-	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	store := openTestStore(t)
 
 	vaults := []string{"vault-alpha", "vault-beta", "vault-gamma"}
 	for _, name := range vaults {

--- a/internal/storage/wal_syncer.go
+++ b/internal/storage/wal_syncer.go
@@ -2,12 +2,26 @@ package storage
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/pebble"
 )
+
+// isClosedPanic reports whether the recovered panic value represents a
+// "pebble: closed" condition. Pebble can panic with either an error value
+// (implementing the error interface with pebble.ErrClosed) or a formatted
+// string message containing "pebble: closed" when the WAL writer is torn down.
+func isClosedPanic(r any) bool {
+	if err, ok := r.(error); ok {
+		return errors.Is(err, pebble.ErrClosed)
+	}
+	// Pebble's applyInternal panics with a formatted string in some code paths.
+	return strings.Contains(fmt.Sprintf("%v", r), pebble.ErrClosed.Error())
+}
 
 const walSyncInterval = 10 * time.Millisecond
 
@@ -54,9 +68,10 @@ const walSyncInterval = 10 * time.Millisecond
 //	  walSyncInterval (10ms) via LogData(nil, pebble.Sync), providing a bounded
 //	  durability window equivalent to MySQL innodb_flush_log_at_trx_commit=2.
 type walSyncer struct {
-	db   *pebble.DB
-	stop chan struct{}
-	done chan struct{}
+	db      *pebble.DB
+	stop    chan struct{}
+	done    chan struct{}
+	stopped atomic.Bool // set true before signalling the goroutine to stop
 }
 
 func newWALSyncer(db *pebble.DB) *walSyncer {
@@ -71,54 +86,63 @@ func newWALSyncer(db *pebble.DB) *walSyncer {
 
 func (s *walSyncer) run() {
 	defer close(s.done)
-	// Recover from panics that occur if db.Close() races with an in-flight
-	// ticker sync during shutdown. Pebble can panic in two forms:
-	//   - error: pebble.ErrClosed ("pebble: closed")
-	//   - string: "pebble/record: closed LogWriter" (from the WAL writer internals)
-	// Both are expected during shutdown and are silently swallowed here.
-	// Any other panic is re-panicked so it is not silently swallowed.
-	defer func() {
-		if r := recover(); r != nil {
-			if err, ok := r.(error); ok {
-				// Catch pebble.ErrClosed ("pebble: closed") and the internal
-				// record.errClosedWriter ("pebble/record: closed LogWriter").
-				// The latter is an unexported error value so we cannot use
-				// errors.Is — match by message substring instead.
-				if errors.Is(err, pebble.ErrClosed) {
-					return // expected during shutdown
-				}
-				if strings.Contains(err.Error(), "closed LogWriter") {
-					return // expected: "pebble/record: closed LogWriter"
-				}
-			}
-			if s, ok := r.(string); ok && strings.Contains(s, "closed") {
-				return // expected: string-form closed panic
-			}
-			panic(r) // unexpected — re-panic
-		}
-	}()
 
 	ticker := time.NewTicker(walSyncInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			if err := s.db.LogData(nil, pebble.Sync); err != nil {
-				slog.Error("storage: WAL sync failed", "component", "wal_syncer", "err", err)
-			}
+			s.doSync()
 		case <-s.stop:
 			// Final sync before shutdown.
-			if err := s.db.LogData(nil, pebble.Sync); err != nil {
-				slog.Error("storage: final WAL sync on shutdown failed", "component", "wal_syncer", "err", err)
-			}
+			s.doSync()
 			return
 		}
+	}
+}
+
+// doSync calls db.LogData and handles both error returns and panics gracefully.
+//
+// Pebble can surface a closed-DB condition in two ways:
+//   - as a return value: pebble.ErrClosed ("pebble: closed")
+//   - as a panic:        any value when the WAL writer is already torn down
+//
+// A closed-DB panic is always silently swallowed — the db is in an
+// unrecoverable closed state regardless of how it got there (orderly shutdown
+// or abrupt close). Any other panic while stopped is false is unexpected and
+// is re-panicked so it is not silently lost.
+func (s *walSyncer) doSync() {
+	defer func() {
+		if r := recover(); r != nil {
+			// Swallow closed-db panics unconditionally: pebble surfaces a
+			// closed-db condition as a panic (not an error) when the WAL writer
+			// is already torn down. This is safe to ignore in all cases because
+			// the db is already in an unrecoverable state.
+			if isClosedPanic(r) {
+				return
+			}
+			if s.stopped.Load() {
+				return // expected: pebble is shutting down
+			}
+			panic(r) // unexpected during normal operation — propagate
+		}
+	}()
+
+	if err := s.db.LogData(nil, pebble.Sync); err != nil {
+		if s.stopped.Load() || errors.Is(err, pebble.ErrClosed) {
+			return // expected during shutdown
+		}
+		slog.Error("storage: WAL sync failed", "component", "wal_syncer", "err", err)
 	}
 }
 
 // Close signals the syncer to stop and blocks until the final sync completes.
 // Must be called before db.Close().
 func (s *walSyncer) Close() {
+	// Mark as stopped BEFORE signalling the goroutine. This ensures that if
+	// the goroutine is mid-doSync when Close is called, the error/panic
+	// recovery correctly identifies the condition as expected shutdown.
+	s.stopped.Store(true)
 	close(s.stop)
 	<-s.done
 }


### PR DESCRIPTION
## Summary

- **Root cause**: Storage test helpers called `db.Close()` directly without first draining background goroutines (walSyncer, counterFlush, provWork), causing `panic: pebble/record: closed LogWriter` in CI when goroutines fired after the DB closed
- **walSyncer**: Replaced fragile substring-matching panic recovery with an `isClosedPanic()` helper (uses `errors.Is(err, pebble.ErrClosed)`) and a `stopped atomic.Bool` flag set before signalling shutdown
- **Test helpers**: Added `openTestStore()` (full store lifecycle with proper t.Cleanup LIFO ordering) and `newFreshStore()` (shared-DB second store that drains goroutines without double-closing the DB); fixed 13 test functions across 16 files

## What changed

**Production code** (`wal_syncer.go`):
- `stopped atomic.Bool` is set in `Close()` _before_ `close(s.stop)` so the panic recovery knows we're shutting down even if `doSync()` is mid-execution
- `isClosedPanic(r)` checks `errors.Is(err, pebble.ErrClosed)` and a format-based fallback — no hardcoded "closed LogWriter" substring matching
- `doSync()` helper with focused recovery: swallow closed-DB panics unconditionally; swallow other panics when `stopped=true`; re-panic otherwise

**Test infrastructure** (`testhelpers_test.go` + 15 test files):
- `openTestStore(t)`: canonical store helper — store.Close() + os.RemoveAll in t.Cleanup (LIFO ensures store closes before dir is removed)
- `newFreshStore(t, db)`: for tests that open a second store on a shared DB — drains goroutines individually without calling `db.Close()` on the shared DB
- All `defer db.Close()` patterns after `NewPebbleStore` replaced with `defer store.Close()`

## Test plan

- [x] `go test -race ./internal/storage/...` — all pass
- [x] `go test -race ./internal/engine/...` — all pass (the original failure site)
- [x] Opus architecture review — approved