### PR TITLE
fix(mcp): improve handleRecall context parameter validation

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -193,9 +193,24 @@ func (s *MCPServer) handleRememberBatch(ctx context.Context, w http.ResponseWrit
 }
 
 func (s *MCPServer) handleRecall(ctx context.Context, w http.ResponseWriter, id json.RawMessage, vault string, args map[string]any) {
-	ctxArr, ok := args["context"].([]any)
-	if !ok || len(ctxArr) == 0 {
+	raw, exists := args["context"]
+	if !exists {
 		sendError(w, id, -32602, "invalid params: 'context' is required")
+		return
+	}
+	var ctxArr []any
+	switch v := raw.(type) {
+	case string:
+		// LLM clients sometimes send a bare string instead of a single-element array — coerce it.
+		ctxArr = []any{v}
+	case []any:
+		ctxArr = v
+	default:
+		sendError(w, id, -32602, fmt.Sprintf("invalid params: 'context' must be a string or array of strings, got %T", raw))
+		return
+	}
+	if len(ctxArr) == 0 {
+		sendError(w, id, -32602, "invalid params: 'context' must not be empty")
 		return
 	}
 	var contexts []string
@@ -203,6 +218,10 @@ func (s *MCPServer) handleRecall(ctx context.Context, w http.ResponseWriter, id 
 		if str, ok := c.(string); ok {
 			contexts = append(contexts, str)
 		}
+	}
+	if len(contexts) == 0 {
+		sendError(w, id, -32602, "invalid params: 'context' must contain at least one string")
+		return
 	}
 
 	threshold := float32(0.5)

--- a/internal/mcp/handlers_coverage_test.go
+++ b/internal/mcp/handlers_coverage_test.go
@@ -231,6 +231,42 @@ func TestHandleRecall_EmptyContextArray(t *testing.T) {
 	}
 }
 
+func TestHandleRecall_ContextWrongType(t *testing.T) {
+	// A non-string, non-array context (e.g. a number) should return a clear type error.
+	srv := newTestServer()
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_recall","arguments":{"vault":"default","context":42}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error == nil || resp.Error.Code != -32602 {
+		t.Errorf("expected -32602 for wrong context type, got %v", resp.Error)
+	}
+	if resp.Error != nil && !strings.Contains(resp.Error.Message, "got") {
+		t.Errorf("expected error message to mention actual type, got: %q", resp.Error.Message)
+	}
+}
+
+func TestHandleRecall_ContextBareString(t *testing.T) {
+	// A bare string should be coerced into a single-element array and succeed.
+	srv := newTestServer()
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_recall","arguments":{"vault":"default","context":"some query"}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error != nil {
+		t.Errorf("expected bare string context to be coerced and succeed, got error: %v", resp.Error)
+	}
+}
+
+func TestHandleRecall_ContextAllNonStrings(t *testing.T) {
+	// An array containing only non-string elements should return -32602.
+	srv := newTestServer()
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_recall","arguments":{"vault":"default","context":[123,true]}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error == nil || resp.Error.Code != -32602 {
+		t.Errorf("expected -32602 for all-non-string context array, got %v", resp.Error)
+	}
+}
+
 func TestHandleRecall_ThresholdClampedBelow(t *testing.T) {
 	// threshold < 0 should be clamped to 0, not error.
 	srv := newTestServer()


### PR DESCRIPTION
Closes #75

## Summary

- Splits the collapsed `!ok || len == 0` check into four distinct, descriptive error cases
- Adds string coercion so LLM clients sending `"foo"` instead of `["foo"]` succeed rather than hitting a confusing error (the exact scenario that triggered the original issue)
- Adds post-loop guard so an array of all non-string elements (e.g. `[123, true]`) returns a clear error instead of silently producing zero recall results

## Error messages before / after

| Condition | Before | After |
|-----------|--------|-------|
| `context` missing | `'context' is required` | `'context' is required` |
| `context` is `42` | `'context' is required` | `must be a string or array of strings, got float64` |
| `context` is `[]` | `'context' is required` | `must not be empty` |
| `context` is `[123, true]` | *(silent: zero results)* | `must contain at least one string` |
| `context` is `"query"` | `'context' is required` | *(coerced to `["query"]`, succeeds)* |

## Test plan
- [x] `TestHandleRecall_MissingContext` — still passes
- [x] `TestHandleRecall_EmptyContextArray` — still passes
- [x] `TestHandleRecall_ContextWrongType` — new: verifies `-32602` and type name in message
- [x] `TestHandleRecall_ContextBareString` — new: verifies bare string coercion succeeds
- [x] `TestHandleRecall_ContextAllNonStrings` — new: verifies `-32602` for `[123, true]`
- [x] All 32 recall-related tests pass