### PR TITLE
feat(embed): add MUNINN_OPENAI_URL env var for custom OpenAI base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ When you're ready to customize:
 |------|-----|
 | Embedder: bundled (default) | On automatically — set `MUNINN_LOCAL_EMBED=0` to disable |
 | Embedder: Ollama | `MUNINN_OLLAMA_URL=ollama://localhost:11434/nomic-embed-text` |
-| Embedder: OpenAI | `MUNINN_OPENAI_KEY=sk-...` |
+| Embedder: OpenAI | `MUNINN_OPENAI_KEY=sk-...` (+ optional `MUNINN_OPENAI_URL=http://localhost:8080/v1`; invalid override disables OpenAI init) |
 | Embedder: Voyage | `MUNINN_VOYAGE_KEY=pa-...` |
 | Embedder: Cohere | `MUNINN_COHERE_KEY=...` |
 | Embedder: Google (Gemini) | `MUNINN_GOOGLE_KEY=...` |

--- a/cmd/muninn/help.go
+++ b/cmd/muninn/help.go
@@ -328,6 +328,7 @@ func printHelp() {
 	fmt.Println()
 	fmt.Printf("  %-28s %s\n", "MUNINN_OLLAMA_URL", "Local Ollama embed model (e.g. ollama://localhost:11434/nomic-embed-text)")
 	fmt.Printf("  %-28s %s\n", "MUNINN_OPENAI_KEY", "OpenAI embeddings API key (text-embedding-3-small, 1536d)")
+	fmt.Printf("  %-28s %s\n", "MUNINN_OPENAI_URL", "Optional OpenAI base URL or provider URL override")
 	fmt.Printf("  %-28s %s\n", "MUNINN_VOYAGE_KEY", "Voyage AI embeddings API key (voyage-3, 1024d)")
 	fmt.Printf("  %-28s %s\n", "MUNINN_COHERE_KEY", "Cohere embeddings API key (embed-v4, 1024d)")
 	fmt.Printf("  %-28s %s\n", "MUNINN_GOOGLE_KEY", "Google Gemini embeddings API key (text-embedding-004, 768d)")

--- a/cmd/muninn/init.go
+++ b/cmd/muninn/init.go
@@ -533,6 +533,7 @@ func printEmbedderNote(choice string) {
 	case "3":
 		fmt.Println()
 		fmt.Println("  OpenAI selected. Set MUNINN_OPENAI_KEY to configure.")
+		fmt.Println("  Optional: set MUNINN_OPENAI_URL for custom base URL (e.g. LocalAI).")
 	case "4":
 		fmt.Println()
 		fmt.Println("  Voyage selected. Set MUNINN_VOYAGE_KEY to configure.")

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	neturl "net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -34,21 +35,22 @@ import (
 	"github.com/scrypster/muninndb/internal/mcp"
 	"github.com/scrypster/muninndb/internal/metrics"
 	"github.com/scrypster/muninndb/internal/metrics/latency"
-	"github.com/scrypster/muninndb/internal/storage/migrate"
 	"github.com/scrypster/muninndb/internal/plugin"
 	embedpkg "github.com/scrypster/muninndb/internal/plugin/embed"
 	enrichpkg "github.com/scrypster/muninndb/internal/plugin/enrich"
 	"github.com/scrypster/muninndb/internal/replication"
 	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/storage/migrate"
+	grpcpkg "github.com/scrypster/muninndb/internal/transport/grpc"
 	"github.com/scrypster/muninndb/internal/transport/mbp"
 	"github.com/scrypster/muninndb/internal/transport/rest"
-	grpcpkg "github.com/scrypster/muninndb/internal/transport/grpc"
 	"github.com/scrypster/muninndb/internal/ui"
 	"github.com/scrypster/muninndb/internal/wal"
 	webui "github.com/scrypster/muninndb/web"
 )
 
 const defaultMCPPort = "8750"
+const defaultOpenAIEmbedProviderURL = "openai://text-embedding-3-small"
 
 const vaultUpgradeWarning = `
 ================================================================
@@ -75,6 +77,14 @@ Or generate an API key:
 // active embed provider + model without side-effects (no network calls).
 // Priority: env vars → plugin_config.json → local bundled → none.
 func resolveEmbedInfo(cfg plugincfg.PluginConfig) rest.EmbedInfo {
+	openAIOverride := strings.TrimSpace(os.Getenv("MUNINN_OPENAI_URL"))
+	openAIOverrideValid := true
+	if openAIOverride != "" {
+		if _, err := resolveOpenAIEmbedProviderURL(openAIOverride); err != nil {
+			openAIOverrideValid = false
+		}
+	}
+
 	if rawURL := os.Getenv("MUNINN_OLLAMA_URL"); rawURL != "" {
 		if provCfg, err := plugin.ParseProviderURL(rawURL); err == nil {
 			return rest.EmbedInfo{Provider: "ollama", Model: provCfg.Model}
@@ -82,7 +92,16 @@ func resolveEmbedInfo(cfg plugincfg.PluginConfig) rest.EmbedInfo {
 		return rest.EmbedInfo{Provider: "ollama", Model: ""}
 	}
 	if os.Getenv("MUNINN_OPENAI_KEY") != "" {
-		return rest.EmbedInfo{Provider: "openai", Model: "text-embedding-3-small"}
+		if openAIOverrideValid {
+			if providerURL, err := resolveOpenAIEmbedProviderURL(openAIOverride); err == nil {
+				if provCfg, parseErr := plugin.ParseProviderURL(providerURL); parseErr == nil {
+					return rest.EmbedInfo{Provider: "openai", Model: provCfg.Model}
+				}
+			}
+			return rest.EmbedInfo{Provider: "openai", Model: "text-embedding-3-small"}
+		}
+		// Explicit invalid override disables OpenAI so we don't accidentally
+		// send traffic to the default OpenAI endpoint.
 	}
 	if os.Getenv("MUNINN_VOYAGE_KEY") != "" {
 		return rest.EmbedInfo{Provider: "voyage", Model: "voyage-3"}
@@ -109,7 +128,23 @@ func resolveEmbedInfo(cfg plugincfg.PluginConfig) rest.EmbedInfo {
 			return rest.EmbedInfo{Provider: "ollama", Model: ""}
 		}
 	case "openai":
-		return rest.EmbedInfo{Provider: "openai", Model: "text-embedding-3-small"}
+		if !openAIOverrideValid {
+			break
+		}
+		openaiSource := cfg.EmbedURL
+		if openAIOverride != "" {
+			openaiSource = openAIOverride
+		}
+		if providerURL, err := resolveOpenAIEmbedProviderURL(openaiSource); err == nil {
+			if provCfg, parseErr := plugin.ParseProviderURL(providerURL); parseErr == nil {
+				return rest.EmbedInfo{Provider: "openai", Model: provCfg.Model}
+			}
+			return rest.EmbedInfo{Provider: "openai", Model: "text-embedding-3-small"}
+		}
+		// Explicit invalid override in saved config disables OpenAI.
+		if strings.TrimSpace(openaiSource) == "" {
+			return rest.EmbedInfo{Provider: "openai", Model: "text-embedding-3-small"}
+		}
 	case "voyage":
 		return rest.EmbedInfo{Provider: "voyage", Model: "voyage-3"}
 	case "cohere":
@@ -130,8 +165,50 @@ func resolveEmbedInfo(cfg plugincfg.PluginConfig) rest.EmbedInfo {
 	return rest.EmbedInfo{Provider: "none", Model: ""}
 }
 
+// resolveOpenAIEmbedProviderURL resolves an OpenAI embed URL override into a
+// provider URL that ParseProviderURL can handle. Supports both:
+//   - openai://text-embedding-3-small?base_url=http://localhost:8080
+//   - http://localhost:8080 (treated as base_url with default model)
+func resolveOpenAIEmbedProviderURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultOpenAIEmbedProviderURL, nil
+	}
+	if strings.HasPrefix(raw, "openai://") {
+		if _, err := plugin.ParseProviderURL(raw); err != nil {
+			return "", err
+		}
+		return raw, nil
+	}
+	providerURL := defaultOpenAIEmbedProviderURL + "?base_url=" + neturl.QueryEscape(raw)
+	if _, err := plugin.ParseProviderURL(providerURL); err != nil {
+		return "", err
+	}
+	return providerURL, nil
+}
+
+func sanitizeProviderURLForLog(providerURL string) string {
+	parsed, err := neturl.Parse(providerURL)
+	if err != nil {
+		return providerURL
+	}
+	if strings.EqualFold(parsed.Scheme, "openai") {
+		parsed.RawQuery = ""
+		return parsed.String()
+	}
+	return providerURL
+}
+
+func openAIEmbedLogAttrs(providerURL string) []any {
+	provCfg, err := plugin.ParseProviderURL(providerURL)
+	if err != nil {
+		return []any{"url", sanitizeProviderURLForLog(providerURL)}
+	}
+	return []any{"model", provCfg.Model, "base_url", provCfg.BaseURL}
+}
+
 // buildEmbedder constructs an embedder. Priority (highest → lowest):
-//  1. Environment variables (MUNINN_OLLAMA_URL, MUNINN_OPENAI_KEY, MUNINN_VOYAGE_KEY, MUNINN_COHERE_KEY, MUNINN_GOOGLE_KEY, MUNINN_JINA_KEY, MUNINN_MISTRAL_KEY)
+//  1. Environment variables (MUNINN_OLLAMA_URL, MUNINN_OPENAI_KEY (+ optional MUNINN_OPENAI_URL), MUNINN_VOYAGE_KEY, MUNINN_COHERE_KEY, MUNINN_GOOGLE_KEY, MUNINN_JINA_KEY, MUNINN_MISTRAL_KEY)
 //  2. Saved plugin_config.json (cfg parameter)
 //  3. Bundled local ONNX model — enabled by default when the binary was built
 //     with embedded assets. Disable with MUNINN_LOCAL_EMBED=0.
@@ -143,6 +220,7 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 	const (
 		ollamaURL  = "MUNINN_OLLAMA_URL"
 		openaiKey  = "MUNINN_OPENAI_KEY"
+		openaiURL  = "MUNINN_OPENAI_URL"
 		voyageKey  = "MUNINN_VOYAGE_KEY"
 		cohereKey  = "MUNINN_COHERE_KEY"
 		googleKey  = "MUNINN_GOOGLE_KEY"
@@ -151,14 +229,24 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 		localEmbed = "MUNINN_LOCAL_EMBED"
 	)
 
+	openAIEnvOverride := strings.TrimSpace(os.Getenv(openaiURL))
+	openAIEnvOverrideInvalid := false
+	if openAIEnvOverride != "" {
+		if _, err := resolveOpenAIEmbedProviderURL(openAIEnvOverride); err != nil {
+			openAIEnvOverrideInvalid = true
+			slog.Warn("invalid OpenAI URL override detected, OpenAI embedder disabled", "env_var", openaiURL, "error", err)
+		}
+	}
+
 	tryEmbedService := func(providerURL string, pcfg plugin.PluginConfig) *embedpkg.EmbedService {
+		logURL := sanitizeProviderURLForLog(providerURL)
 		svc, err := embedpkg.NewEmbedService(providerURL)
 		if err != nil {
-			slog.Warn("embedder service creation failed", "url", providerURL, "error", err)
+			slog.Warn("embedder service creation failed", "url", logURL, "error", err)
 			return nil
 		}
 		if err := svc.Init(ctx, pcfg); err != nil {
-			slog.Warn("embedder init failed, trying next provider", "url", providerURL, "error", err)
+			slog.Warn("embedder init failed, trying next provider", "url", logURL, "error", err)
 			_ = svc.Close()
 			return nil
 		}
@@ -175,9 +263,16 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 
 	// 1. Env var: OpenAI
 	if key := os.Getenv(openaiKey); key != "" {
-		slog.Info("initializing OpenAI embedder")
-		if svc := tryEmbedService("openai://text-embedding-3-small", plugin.PluginConfig{APIKey: key}); svc != nil {
-			return embedpkg.NewEmbedServiceAdapter(svc), svc, nil
+		if !openAIEnvOverrideInvalid {
+			openaiProviderURL, err := resolveOpenAIEmbedProviderURL(openAIEnvOverride)
+			if err != nil {
+				slog.Warn("failed to resolve OpenAI provider URL, skipping OpenAI embedder", "error", err)
+			} else {
+				slog.Info("initializing OpenAI embedder", openAIEmbedLogAttrs(openaiProviderURL)...)
+				if svc := tryEmbedService(openaiProviderURL, plugin.PluginConfig{APIKey: key}); svc != nil {
+					return embedpkg.NewEmbedServiceAdapter(svc), svc, nil
+				}
+			}
 		}
 	}
 
@@ -232,8 +327,25 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 				}
 			}
 		case "openai":
-			slog.Info("initializing OpenAI embedder from saved config")
-			if svc := tryEmbedService("openai://text-embedding-3-small", plugin.PluginConfig{APIKey: cfg.EmbedAPIKey}); svc != nil {
+			if openAIEnvOverrideInvalid {
+				slog.Warn("invalid OpenAI URL override is set, skipping OpenAI embedder from saved config", "env_var", openaiURL)
+				break
+			}
+			openaiSource := cfg.EmbedURL
+			if openAIEnvOverride != "" {
+				openaiSource = openAIEnvOverride
+			}
+			openaiProviderURL, err := resolveOpenAIEmbedProviderURL(openaiSource)
+			if err != nil {
+				if strings.TrimSpace(openaiSource) != "" {
+					slog.Warn("invalid OpenAI URL in saved config, skipping OpenAI embedder", "error", err)
+				} else {
+					slog.Warn("failed to resolve OpenAI provider URL from saved config, skipping OpenAI embedder", "error", err)
+				}
+				break
+			}
+			slog.Info("initializing OpenAI embedder from saved config", openAIEmbedLogAttrs(openaiProviderURL)...)
+			if svc := tryEmbedService(openaiProviderURL, plugin.PluginConfig{APIKey: cfg.EmbedAPIKey}); svc != nil {
 				return embedpkg.NewEmbedServiceAdapter(svc), svc, nil
 			}
 		case "voyage":
@@ -279,7 +391,7 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 	slog.Warn("no embedder configured, semantic similarity disabled")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "  ⚠  No embedder configured — semantic search disabled.")
-	fmt.Fprintln(os.Stderr, "     To use a cloud embedder: set MUNINN_OPENAI_KEY, MUNINN_COHERE_KEY, MUNINN_GOOGLE_KEY, etc.")
+	fmt.Fprintln(os.Stderr, "     To use a cloud embedder: set MUNINN_OPENAI_KEY (optionally MUNINN_OPENAI_URL), MUNINN_COHERE_KEY, MUNINN_GOOGLE_KEY, etc.")
 	fmt.Fprintln(os.Stderr, "     To disable this warning: set MUNINN_LOCAL_EMBED=0")
 	fmt.Fprintln(os.Stderr, "")
 	return activation.NewNoopEmbedder(), nil, nil
@@ -484,7 +596,7 @@ func runServer() {
 	backupDir := flag.String("backup-dir", "", "Directory to write automated backups into")
 	backupRetain := flag.Int("backup-retain", 5, "Number of automated backups to keep")
 	tlsCert := flag.String("tls-cert", "", "Path to TLS certificate file (PEM)")
-	tlsKey  := flag.String("tls-key",  "", "Path to TLS private key file (PEM)")
+	tlsKey := flag.String("tls-key", "", "Path to TLS private key file (PEM)")
 	corsOriginsDefault := os.Getenv("MUNINN_CORS_ORIGINS")
 	corsOriginsFlag := flag.String("cors-origins", corsOriginsDefault, "Comma-separated allowed CORS origins for browser clients (e.g. http://myapp.local:3000); overrides MUNINN_CORS_ORIGINS")
 	var logLevelStr string
@@ -495,6 +607,7 @@ func runServer() {
 		fmt.Fprintf(os.Stderr, "\nEnvironment variables (primary configuration; see docs for full list):\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_OLLAMA_URL            Ollama embedder base URL (e.g. http://localhost:11434)\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_OPENAI_KEY            OpenAI embedder API key\n")
+		fmt.Fprintf(os.Stderr, "  MUNINN_OPENAI_URL            Optional OpenAI base URL or provider URL override\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_VOYAGE_KEY            Voyage embedder API key\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_COHERE_KEY            Cohere embedder API key\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_GOOGLE_KEY            Google Gemini embedder API key\n")
@@ -516,12 +629,20 @@ func runServer() {
 	flag.Parse()
 
 	// TLS env fallbacks — flags take priority; env vars are the fallback.
-	if *tlsCert == "" { *tlsCert = os.Getenv("MUNINN_TLS_CERT") }
-	if *tlsKey == "" { *tlsKey = os.Getenv("MUNINN_TLS_KEY") }
+	if *tlsCert == "" {
+		*tlsCert = os.Getenv("MUNINN_TLS_CERT")
+	}
+	if *tlsKey == "" {
+		*tlsKey = os.Getenv("MUNINN_TLS_KEY")
+	}
 
 	// Backup env fallbacks — flags take priority; env vars are the fallback.
-	if *backupInterval == "" { *backupInterval = os.Getenv("MUNINN_BACKUP_INTERVAL") }
-	if *backupDir == "" { *backupDir = os.Getenv("MUNINN_BACKUP_DIR") }
+	if *backupInterval == "" {
+		*backupInterval = os.Getenv("MUNINN_BACKUP_INTERVAL")
+	}
+	if *backupDir == "" {
+		*backupDir = os.Getenv("MUNINN_BACKUP_DIR")
+	}
 	if *backupRetain == 5 {
 		if s := os.Getenv("MUNINN_BACKUP_RETAIN"); s != "" {
 			if n, err := strconv.Atoi(s); err == nil && n > 0 {

--- a/cmd/muninn/server_test.go
+++ b/cmd/muninn/server_test.go
@@ -118,6 +118,50 @@ func TestResolveEmbedInfo_EnvOpenAI(t *testing.T) {
 	}
 }
 
+func TestResolveEmbedInfo_EnvOpenAIWithURLOverride(t *testing.T) {
+	clearEmbedEnv(t)
+	t.Setenv("MUNINN_OPENAI_KEY", "sk-test-key")
+	t.Setenv("MUNINN_OPENAI_URL", "openai://text-embedding-3-large?base_url=http://localhost:8080/v1")
+
+	info := resolveEmbedInfo(plugincfg.PluginConfig{})
+	if info.Provider != "openai" {
+		t.Errorf("expected provider=openai, got %q", info.Provider)
+	}
+	if info.Model != "text-embedding-3-large" {
+		t.Errorf("expected model=text-embedding-3-large, got %q", info.Model)
+	}
+}
+
+func TestResolveEmbedInfo_EnvOpenAIInvalidURLSkipsOpenAI(t *testing.T) {
+	clearEmbedEnv(t)
+	t.Setenv("MUNINN_OPENAI_KEY", "sk-test-key")
+	t.Setenv("MUNINN_OPENAI_URL", "ftp://localhost:8080")
+	t.Setenv("MUNINN_LOCAL_EMBED", "0")
+
+	info := resolveEmbedInfo(plugincfg.PluginConfig{})
+	if info.Provider != "none" {
+		t.Errorf("expected provider=none, got %q", info.Provider)
+	}
+	if info.Model != "" {
+		t.Errorf("expected model=\"\", got %q", info.Model)
+	}
+}
+
+func TestResolveEmbedInfo_EnvOpenAIInvalidURLFallsThroughToNextProvider(t *testing.T) {
+	clearEmbedEnv(t)
+	t.Setenv("MUNINN_OPENAI_KEY", "sk-test-key")
+	t.Setenv("MUNINN_OPENAI_URL", "ftp://localhost:8080")
+	t.Setenv("MUNINN_VOYAGE_KEY", "voy-test-key")
+
+	info := resolveEmbedInfo(plugincfg.PluginConfig{})
+	if info.Provider != "voyage" {
+		t.Errorf("expected provider=voyage, got %q", info.Provider)
+	}
+	if info.Model != "voyage-3" {
+		t.Errorf("expected model=voyage-3, got %q", info.Model)
+	}
+}
+
 func TestResolveEmbedInfo_EnvVoyage(t *testing.T) {
 	clearEmbedEnv(t)
 	t.Setenv("MUNINN_VOYAGE_KEY", "voy-test-key")
@@ -224,6 +268,104 @@ func TestResolveEmbedInfo_ConfigOllamaWithURL(t *testing.T) {
 	}
 	if info.Model != "mxbai-embed-large" {
 		t.Errorf("expected model=mxbai-embed-large, got %q", info.Model)
+	}
+}
+
+func TestResolveEmbedInfo_ConfigOpenAIWithURLOverride(t *testing.T) {
+	clearEmbedEnv(t)
+
+	cfg := plugincfg.PluginConfig{
+		EmbedProvider: "openai",
+		EmbedURL:      "openai://text-embedding-3-large?base_url=http://localhost:8080/v1",
+	}
+	info := resolveEmbedInfo(cfg)
+	if info.Provider != "openai" {
+		t.Errorf("expected provider=openai, got %q", info.Provider)
+	}
+	if info.Model != "text-embedding-3-large" {
+		t.Errorf("expected model=text-embedding-3-large, got %q", info.Model)
+	}
+}
+
+func TestResolveEmbedInfo_ConfigOpenAIInvalidURLSkipsOpenAI(t *testing.T) {
+	clearEmbedEnv(t)
+	t.Setenv("MUNINN_LOCAL_EMBED", "0")
+
+	cfg := plugincfg.PluginConfig{
+		EmbedProvider: "openai",
+		EmbedURL:      "ftp://localhost:8080",
+	}
+	info := resolveEmbedInfo(cfg)
+	if info.Provider != "none" {
+		t.Errorf("expected provider=none, got %q", info.Provider)
+	}
+	if info.Model != "" {
+		t.Errorf("expected model=\"\", got %q", info.Model)
+	}
+}
+
+func TestResolveEmbedInfo_InvalidEnvOpenAIURLSkipsSavedConfigOpenAI(t *testing.T) {
+	clearEmbedEnv(t)
+	t.Setenv("MUNINN_OPENAI_URL", "ftp://localhost:8080")
+	t.Setenv("MUNINN_LOCAL_EMBED", "0")
+
+	cfg := plugincfg.PluginConfig{
+		EmbedProvider: "openai",
+		EmbedURL:      "openai://text-embedding-3-large?base_url=http://localhost:8080/v1",
+	}
+	info := resolveEmbedInfo(cfg)
+	if info.Provider != "none" {
+		t.Errorf("expected provider=none, got %q", info.Provider)
+	}
+	if info.Model != "" {
+		t.Errorf("expected model=\"\", got %q", info.Model)
+	}
+}
+
+func TestResolveOpenAIEmbedProviderURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "default_when_empty",
+			raw:  "",
+			want: defaultOpenAIEmbedProviderURL,
+		},
+		{
+			name: "provider_url_passthrough",
+			raw:  "openai://text-embedding-3-small?base_url=http://localhost:8080/v1",
+			want: "openai://text-embedding-3-small?base_url=http://localhost:8080/v1",
+		},
+		{
+			name: "base_url_converted",
+			raw:  "https://gateway.example.com/openai/v1",
+			want: "openai://text-embedding-3-small?base_url=https%3A%2F%2Fgateway.example.com%2Fopenai%2Fv1",
+		},
+		{
+			name:    "invalid_url_rejected",
+			raw:     "ftp://localhost:8080",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := resolveOpenAIEmbedProviderURL(tc.raw)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: expected error, got nil", tc.name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
 	}
 }
 
@@ -397,7 +539,7 @@ func TestListenHostFlag_ExplicitAddrOverrides(t *testing.T) {
 func clearEmbedEnv(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{
-		"MUNINN_OLLAMA_URL", "MUNINN_OPENAI_KEY", "MUNINN_VOYAGE_KEY",
+		"MUNINN_OLLAMA_URL", "MUNINN_OPENAI_KEY", "MUNINN_OPENAI_URL", "MUNINN_VOYAGE_KEY",
 		"MUNINN_COHERE_KEY", "MUNINN_GOOGLE_KEY", "MUNINN_JINA_KEY",
 		"MUNINN_MISTRAL_KEY", "MUNINN_LOCAL_EMBED",
 	} {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ Consumers (AI agents, applications, Claude, Cursor)
 └─────────────────────────────────────────────────────┘
 ```
 
-The plugin layer is intentionally optional. MuninnDB without any plugins is a fully functional cognitive database: full-text search, ACT-R temporal scoring, Hebbian association, contradiction detection, Bayesian confidence updates, and graph traversal all work without an embedding model or LLM. The embed plugin is configured via env vars (MUNINN_OLLAMA_URL, MUNINN_OPENAI_KEY, MUNINN_VOYAGE_KEY) and adds vector search. The enrich plugin is configured via MUNINN_ENRICH_URL and adds semantic contradiction detection and LLM-powered enrichment. Neither is required.
+The plugin layer is intentionally optional. MuninnDB without any plugins is a fully functional cognitive database: full-text search, ACT-R temporal scoring, Hebbian association, contradiction detection, Bayesian confidence updates, and graph traversal all work without an embedding model or LLM. The embed plugin is configured via env vars (MUNINN_OLLAMA_URL, MUNINN_OPENAI_KEY, MUNINN_OPENAI_URL, MUNINN_VOYAGE_KEY) and adds vector search. The enrich plugin is configured via MUNINN_ENRICH_URL and adds semantic contradiction detection and LLM-powered enrichment. Neither is required.
 
 ---
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -72,6 +72,8 @@ muninn server
 
 # OpenAI
 export MUNINN_OPENAI_KEY="sk-..."
+# Optional: override OpenAI base URL (for LocalAI/OpenAI-compatible gateways)
+export MUNINN_OPENAI_URL="http://localhost:8080/v1"
 muninn server
 
 # Voyage AI — optimized for retrieval tasks
@@ -107,6 +109,8 @@ Provider comparison:
 | Google | `MUNINN_GOOGLE_KEY` | text-embedding-004 | 768 | Per token | API |
 | Jina | `MUNINN_JINA_KEY` | jina-embeddings-v3 | 1024 | Per token | API |
 | Mistral | `MUNINN_MISTRAL_KEY` | mistral-embed | 1024 | Per token | API |
+
+`MUNINN_OPENAI_URL` can optionally override the OpenAI base URL for compatible endpoints (for example LocalAI or an internal gateway). If set to an invalid value, MuninnDB skips OpenAI initialization instead of falling back to `api.openai.com`.
 
 ### Retroactive Enrichment
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -152,7 +152,7 @@ The bundled local embedder (all-MiniLM-L6-v2, 384-dim) is included and works off
 |----------|--------|-------|
 | Local (bundled) | On by default — no config needed | Offline. ~80MB. Opt out with `MUNINN_LOCAL_EMBED=0`. |
 | Ollama | `MUNINN_OLLAMA_URL=ollama://localhost:11434/nomic-embed-text` | Self-hosted. |
-| OpenAI | `MUNINN_OPENAI_KEY=sk-...` | `text-embedding-3-small`, 1536d. |
+| OpenAI | `MUNINN_OPENAI_KEY=sk-...` | `text-embedding-3-small`, 1536d. Optional base URL override: `MUNINN_OPENAI_URL=http://localhost:8080/v1` (invalid override disables OpenAI init). |
 | Voyage | `MUNINN_VOYAGE_KEY=pa-...` | voyage-3, 1024d. |
 | Cohere | `MUNINN_COHERE_KEY=...` | embed-v4, 1024d. |
 | Google | `MUNINN_GOOGLE_KEY=...` | text-embedding-004, 768d. |

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -120,6 +120,8 @@ ollama pull nomic-embed-text
 
 ```sh
 MUNINN_OPENAI_KEY=sk-...
+# Optional: OpenAI-compatible base URL (e.g. LocalAI)
+MUNINN_OPENAI_URL=http://localhost:8080/v1
 ```
 
 Uses `text-embedding-3-small` (1536-dim). ~$0.02 per million tokens.
@@ -272,6 +274,7 @@ curl http://localhost:8750/mcp/health
 | `MUNINNDB_DATA` | `~/.muninn/data` | Data directory (binary) or `/data` (Docker) |
 | `MUNINN_LOCAL_EMBED` | on | Set to `"0"` to disable the bundled ONNX embedder |
 | `MUNINN_OPENAI_KEY` | `""` | OpenAI API key for embeddings |
+| `MUNINN_OPENAI_URL` | `""` | Optional OpenAI base URL or provider URL override (invalid values skip OpenAI init) |
 | `MUNINN_OLLAMA_URL` | `""` | Ollama URL for embeddings, e.g. `ollama://localhost:11434/nomic-embed-text` |
 | `MUNINN_VOYAGE_KEY` | `""` | Voyage AI key for embeddings |
 | `MUNINN_ENRICH_URL` | `""` | LLM enrichment URL (optional) |

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -13,7 +13,7 @@ const pluginConfigFile = "plugin_config.json"
 type PluginConfig struct {
 	// Embed provider settings
 	EmbedProvider string `json:"embed_provider"` // "ollama", "openai", "voyage", "local", "none"
-	EmbedURL      string `json:"embed_url"`      // provider URL (used for ollama)
+	EmbedURL      string `json:"embed_url"`      // provider URL override (ollama) or OpenAI base/provider URL override
 	EmbedAPIKey   string `json:"embed_api_key"`  // API key (openai, voyage)
 
 	// Enrich provider settings

--- a/internal/plugin/provider.go
+++ b/internal/plugin/provider.go
@@ -133,7 +133,58 @@ func parseOpenAIURL(parsed *url.URL, config *ProviderConfig) (*ProviderConfig, e
 	config.Host = "api.openai.com"
 	config.Port = 443
 	config.BaseURL = "https://api.openai.com"
+	if raw := strings.TrimSpace(parsed.Query().Get("base_url")); raw != "" {
+		baseURL, host, port, err := parseHTTPBaseURL(raw, "openai")
+		if err != nil {
+			return nil, err
+		}
+		config.Host = host
+		config.Port = port
+		config.BaseURL = baseURL
+	}
 	return config, nil
+}
+
+func parseHTTPBaseURL(raw, provider string) (string, string, int, error) {
+	baseURL, err := url.Parse(raw)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("%s base_url is malformed: %w", provider, err)
+	}
+	scheme := strings.ToLower(strings.TrimSpace(baseURL.Scheme))
+	if scheme != "http" && scheme != "https" {
+		return "", "", 0, fmt.Errorf("%s base_url must use http or https", provider)
+	}
+	host := strings.TrimSpace(baseURL.Hostname())
+	if host == "" {
+		return "", "", 0, fmt.Errorf("%s base_url must include a host", provider)
+	}
+
+	port := 0
+	if portStr := strings.TrimSpace(baseURL.Port()); portStr != "" {
+		port, err = strconv.Atoi(portStr)
+		if err != nil {
+			return "", "", 0, fmt.Errorf("%s base_url has invalid port: %w", provider, err)
+		}
+		if port < 1 || port > 65535 {
+			return "", "", 0, fmt.Errorf("%s base_url port must be between 1 and 65535", provider)
+		}
+	} else if scheme == "https" {
+		port = 443
+	} else {
+		port = 80
+	}
+
+	cleanPath := strings.TrimRight(baseURL.Path, "/")
+	cleanPath = strings.TrimSuffix(cleanPath, "/v1")
+	if cleanPath == "/" {
+		cleanPath = ""
+	}
+	normalized := &url.URL{
+		Scheme: scheme,
+		Host:   baseURL.Host,
+		Path:   cleanPath,
+	}
+	return normalized.String(), host, port, nil
 }
 
 func parseAnthropicURL(parsed *url.URL, config *ProviderConfig) (*ProviderConfig, error) {

--- a/internal/plugin/provider_test.go
+++ b/internal/plugin/provider_test.go
@@ -50,6 +50,53 @@ func TestParseOpenAIURL(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIURL_CustomBaseURL(t *testing.T) {
+	config, err := ParseProviderURL("openai://text-embedding-3-small?base_url=http://localhost:8080/v1")
+	if err != nil {
+		t.Fatalf("failed to parse openai URL with custom base_url: %v", err)
+	}
+	if config.Host != "localhost" {
+		t.Errorf("expected host 'localhost', got %q", config.Host)
+	}
+	if config.Port != 8080 {
+		t.Errorf("expected port 8080, got %d", config.Port)
+	}
+	if config.BaseURL != "http://localhost:8080" {
+		t.Errorf("expected BaseURL 'http://localhost:8080', got %q", config.BaseURL)
+	}
+}
+
+func TestParseOpenAIURL_CustomBaseURLPathPrefix(t *testing.T) {
+	config, err := ParseProviderURL("openai://text-embedding-3-small?base_url=https://gateway.example.com/openai/v1")
+	if err != nil {
+		t.Fatalf("failed to parse openai URL with path-prefixed base_url: %v", err)
+	}
+	if config.Host != "gateway.example.com" {
+		t.Errorf("expected host 'gateway.example.com', got %q", config.Host)
+	}
+	if config.Port != 443 {
+		t.Errorf("expected port 443, got %d", config.Port)
+	}
+	if config.BaseURL != "https://gateway.example.com/openai" {
+		t.Errorf("expected BaseURL 'https://gateway.example.com/openai', got %q", config.BaseURL)
+	}
+}
+
+func TestParseOpenAIURL_InvalidBaseURL(t *testing.T) {
+	tests := []string{
+		"openai://text-embedding-3-small?base_url=ftp://localhost:8080",
+		"openai://text-embedding-3-small?base_url=https://",
+		"openai://text-embedding-3-small?base_url=://not-a-url",
+		"openai://text-embedding-3-small?base_url=http://localhost:0",
+		"openai://text-embedding-3-small?base_url=http://localhost:65536",
+	}
+	for _, providerURL := range tests {
+		if _, err := ParseProviderURL(providerURL); err == nil {
+			t.Errorf("expected parse error for provider URL %q", providerURL)
+		}
+	}
+}
+
 func TestParseAnthropicURL(t *testing.T) {
 	config, err := ParseProviderURL("anthropic://claude-haiku")
 	if err != nil {
@@ -105,11 +152,11 @@ func TestParseInvalidScheme(t *testing.T) {
 
 func TestParseMalformedURL(t *testing.T) {
 	tests := []string{
-		"",                        // empty
-		"not-a-url",               // no scheme
-		"openai://",               // missing model
-		"ollama://localhost/",     // missing port
-		"ollama://localhost/",     // missing port
+		"",                    // empty
+		"not-a-url",           // no scheme
+		"openai://",           // missing model
+		"ollama://localhost/", // missing port
+		"ollama://localhost/", // missing port
 	}
 
 	for _, url := range tests {


### PR DESCRIPTION
### Summary

Adds `MUNINN_OPENAI_URL` to override the OpenAI embeddings base URL, so users can point embedding requests at OpenAI-compatible endpoints like LocalAI or an internal gateway.

### What changed

- New env var `MUNINN_OPENAI_URL` accepted in both `resolveEmbedInfo()` and `buildEmbedder()`, with support for plain HTTP URLs (`http://localhost:8080/v1`) and provider-style URLs (`openai://text-embedding-3-small?base_url=http://localhost:8080`)
- Saved config (`plugin_config.json`) also respects the URL override
- If the override is invalid (e.g. `ftp://...`), OpenAI is skipped rather than silently falling back to `api.openai.com` — avoids accidentally leaking traffic to the public API when the user explicitly configured a private endpoint
- Port range validation added to `parseHTTPBaseURL()` (rejects port 0 / 65536)
- Provider URLs are sanitized before logging to avoid leaking internal hostnames
- `muninn help` and `muninn init` mention the new env var
- Docs updated in README, architecture, plugins, quickstart, and self-hosting

### Tests

- Valid URL override resolves correct provider/model
- Invalid override skips OpenAI, falls through to next provider
- Invalid env override takes precedence over valid saved config
- Port boundary validation

### Notes

This does not add any additional functionality to the web ui.

Aligns with the enrich option such that a plugin_config.json config file can be configured as follows:
{
    "embed_provider": "openai",
    "embed_url": "openai://qwen3-embedding-4b?base_url=http://127.0.0.1:8080/v1",
    "embed_api_key": "api-key",
    "enrich_provider": "openai",
    "enrich_url": "openai://GLM-4.7-Flash-GGUF?base_url=http://127.0.0.1:8080/v1",
    "enrich_api_key": "api-key"
}

Closes #78