### PR TITLE
fix(embed): harden OpenAI URL override from PR #79 review

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -174,7 +174,7 @@ func resolveOpenAIEmbedProviderURL(raw string) (string, error) {
 	if raw == "" {
 		return defaultOpenAIEmbedProviderURL, nil
 	}
-	if strings.HasPrefix(raw, "openai://") {
+	if strings.HasPrefix(strings.ToLower(raw), "openai://") {
 		if _, err := plugin.ParseProviderURL(raw); err != nil {
 			return "", err
 		}
@@ -204,7 +204,7 @@ func openAIEmbedLogAttrs(providerURL string) []any {
 	if err != nil {
 		return []any{"url", sanitizeProviderURLForLog(providerURL)}
 	}
-	return []any{"model", provCfg.Model, "base_url", provCfg.BaseURL}
+	return []any{"model", provCfg.Model, "custom_base_url", provCfg.BaseURL != "https://api.openai.com"}
 }
 
 // buildEmbedder constructs an embedder. Priority (highest → lowest):

--- a/cmd/muninn/server_test.go
+++ b/cmd/muninn/server_test.go
@@ -369,6 +369,29 @@ func TestResolveOpenAIEmbedProviderURL(t *testing.T) {
 	}
 }
 
+func TestResolveOpenAIEmbedProviderURL_CaseInsensitiveScheme(t *testing.T) {
+	// URI schemes are case-insensitive per RFC 3986 — OPENAI:// should work like openai://
+	got, err := resolveOpenAIEmbedProviderURL("OPENAI://text-embedding-3-small?base_url=http://localhost:8080/v1")
+	if err != nil {
+		t.Fatalf("unexpected error for uppercase scheme: %v", err)
+	}
+	if got == "" {
+		t.Error("expected non-empty provider URL")
+	}
+}
+
+func TestResolveEmbedInfo_OpenAIURLWithoutKey(t *testing.T) {
+	// MUNINN_OPENAI_URL without MUNINN_OPENAI_KEY should not activate the OpenAI embedder.
+	clearEmbedEnv(t)
+	t.Setenv("MUNINN_OPENAI_URL", "http://localhost:8080/v1")
+	t.Setenv("MUNINN_LOCAL_EMBED", "0")
+
+	info := resolveEmbedInfo(plugincfg.PluginConfig{})
+	if info.Provider == "openai" {
+		t.Errorf("OPENAI_URL without OPENAI_KEY should not activate openai, got provider=%q", info.Provider)
+	}
+}
+
 func TestResolveEmbedInfo_EnvPriorityOverConfig(t *testing.T) {
 	clearEmbedEnv(t)
 	t.Setenv("MUNINN_OPENAI_KEY", "sk-override")

--- a/internal/plugin/provider.go
+++ b/internal/plugin/provider.go
@@ -158,6 +158,12 @@ func parseHTTPBaseURL(raw, provider string) (string, string, int, error) {
 	if host == "" {
 		return "", "", 0, fmt.Errorf("%s base_url must include a host", provider)
 	}
+	if baseURL.RawQuery != "" {
+		return "", "", 0, fmt.Errorf("%s base_url must not contain query parameters", provider)
+	}
+	if baseURL.Fragment != "" {
+		return "", "", 0, fmt.Errorf("%s base_url must not contain a fragment", provider)
+	}
 
 	port := 0
 	if portStr := strings.TrimSpace(baseURL.Port()); portStr != "" {
@@ -175,6 +181,8 @@ func parseHTTPBaseURL(raw, provider string) (string, string, int, error) {
 	}
 
 	cleanPath := strings.TrimRight(baseURL.Path, "/")
+	// Strip trailing /v1 — the OpenAI embed client appends /v1/embeddings itself,
+	// so http://host/v1 and http://host resolve to the same endpoint.
 	cleanPath = strings.TrimSuffix(cleanPath, "/v1")
 	if cleanPath == "/" {
 		cleanPath = ""

--- a/internal/plugin/provider_test.go
+++ b/internal/plugin/provider_test.go
@@ -89,6 +89,8 @@ func TestParseOpenAIURL_InvalidBaseURL(t *testing.T) {
 		"openai://text-embedding-3-small?base_url=://not-a-url",
 		"openai://text-embedding-3-small?base_url=http://localhost:0",
 		"openai://text-embedding-3-small?base_url=http://localhost:65536",
+		// query string in base_url rejected to avoid silent config mismatch
+		"openai://text-embedding-3-small?base_url=http%3A%2F%2Flocalhost%3A8080%2Fv1%3Fkey%3Dfoo",
 	}
 	for _, providerURL := range tests {
 		if _, err := ParseProviderURL(providerURL); err == nil {


### PR DESCRIPTION
Follow-up to #79 (merged). Addresses the four issues flagged in code review.

## Changes

**Fix log leak** — `openAIEmbedLogAttrs` was logging `provCfg.BaseURL` verbatim, exposing internal hostnames in logs despite a `sanitizeProviderURLForLog` helper being added for exactly this purpose. Now logs `custom_base_url: true/false` instead.

**Fix case sensitivity** — `resolveOpenAIEmbedProviderURL` used a case-sensitive `HasPrefix` check, rejecting valid uppercase schemes like `OPENAI://...` (URI schemes are case-insensitive per RFC 3986). Lowercased before the check.

**Reject query/fragment in base_url** — `parseHTTPBaseURL` silently dropped query strings and fragments (e.g. `http://gateway/api?key=foo` → `key` lost without error). Now returns a clear error rather than silently discarding config.

**Add doc comment on `/v1` stripping** — The `TrimSuffix("/v1")` in `parseHTTPBaseURL` is non-obvious. Added a comment explaining that the OpenAI embed client appends `/v1/embeddings` itself, so stripping it from the input avoids double-pathing.

## New tests
- `TestResolveOpenAIEmbedProviderURL_CaseInsensitiveScheme` — uppercase `OPENAI://` works
- `TestResolveEmbedInfo_OpenAIURLWithoutKey` — `MUNINN_OPENAI_URL` without `MUNINN_OPENAI_KEY` does not activate the OpenAI embedder
- `TestParseOpenAIURL_InvalidBaseURL` — extended with query-string-in-base_url rejection case