### PR TITLE
feat(ui): expose OpenAI Base URL in Plugins settings panel

### DIFF
--- a/cmd/muninn/coverage_hardening_test.go
+++ b/cmd/muninn/coverage_hardening_test.go
@@ -1663,6 +1663,33 @@ func TestBuildEmbedder_SavedConfigOpenAI(t *testing.T) {
 	}
 }
 
+func TestBuildEmbedder_SavedConfigOpenAI_CustomBaseURL(t *testing.T) {
+	// Covers the path where the UI saves a custom embed_url for the openai provider
+	// (e.g. LocalAI, LM Studio, Azure OpenAI) and the server loads it from disk.
+	t.Setenv("MUNINN_OLLAMA_URL", "")
+	t.Setenv("MUNINN_OPENAI_KEY", "")
+	t.Setenv("MUNINN_OPENAI_URL", "")
+	t.Setenv("MUNINN_VOYAGE_KEY", "")
+	t.Setenv("MUNINN_COHERE_KEY", "")
+	t.Setenv("MUNINN_GOOGLE_KEY", "")
+	t.Setenv("MUNINN_JINA_KEY", "")
+	t.Setenv("MUNINN_MISTRAL_KEY", "")
+	t.Setenv("MUNINN_LOCAL_EMBED", "0")
+
+	cfg := plugincfg.PluginConfig{
+		EmbedProvider: "openai",
+		EmbedAPIKey:   "fake-key",
+		EmbedURL:      "http://127.0.0.1:1/unreachable", // custom base URL (port 1 = connection refused)
+	}
+	embedder, _, err := buildEmbedder(context.Background(), cfg, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if embedder == nil {
+		t.Error("expected noop embedder fallback when custom base URL is unreachable")
+	}
+}
+
 func TestBuildEmbedder_SavedConfigVoyage(t *testing.T) {
 	t.Setenv("MUNINN_OLLAMA_URL", "")
 	t.Setenv("MUNINN_OPENAI_KEY", "")

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -188,6 +188,7 @@ document.addEventListener('alpine:init', () => {
       embedProvider: 'none',  // 'none' | 'ollama' | 'openai' | 'voyage'
       embedOllamaModel: 'nomic-embed-text',
       embedApiKey: '',
+      embedUrl: '',           // custom base URL for openai-compatible endpoints
       embedShowForm: false,
       embedSaved: false,
       embedError: '',
@@ -1543,6 +1544,19 @@ document.addEventListener('alpine:init', () => {
             this.plugins = [];
         }
     },
+    async loadSavedPluginConfig() {
+        try {
+            const data = await this.apiCall('/api/admin/plugin-config');
+            const embedUrl = data.embed_url || '';
+            // Only populate the Base URL field when it's an HTTP/HTTPS URL.
+            // ollama:// and other scheme URLs encode a model name, not a base URL.
+            if (embedUrl.startsWith('http://') || embedUrl.startsWith('https://')) {
+                this.pluginCfg.embedUrl = embedUrl;
+            }
+        } catch (_) {
+            // Non-critical — leave embedUrl at default
+        }
+    },
     async loadWorkers() {
         try {
             this.cogWorkerStats = await this.apiCall('/api/workers');
@@ -2148,7 +2162,7 @@ document.addEventListener('alpine:init', () => {
       // Build payload from current pluginCfg state.
       const payload = {
         embed_provider: c.embedProvider === 'none' ? '' : c.embedProvider,
-        embed_url: c.embedProvider === 'ollama' ? `ollama://localhost:11434/${c.embedOllamaModel}` : '',
+        embed_url: c.embedProvider === 'ollama' ? `ollama://localhost:11434/${c.embedOllamaModel}` : (c.embedProvider === 'openai' && c.embedUrl ? c.embedUrl : ''),
         embed_api_key: (c.embedProvider === 'openai' || c.embedProvider === 'voyage') ? c.embedApiKey : '',
         enrich_provider: c.enrichProvider === 'none' ? '' : c.enrichProvider,
         enrich_url: c.enrichProvider === 'ollama'

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1367,7 +1367,7 @@
                 </div>
               </template>
               <div style="display:flex;gap:0.5rem;margin-top:0.5rem;">
-                <button class="btn-secondary" style="font-size:0.8125rem;" @click="pluginCfg.embedShowForm=true;pluginCfg.embedCmd=''">Reconfigure</button>
+                <button class="btn-secondary" style="font-size:0.8125rem;" @click="pluginCfg.embedShowForm=true;pluginCfg.embedCmd='';loadSavedPluginConfig()">Reconfigure</button>
                 <button class="btn-secondary" style="font-size:0.8125rem;" @click="reembedVault()">Re-embed vault</button>
               </div>
             </div>
@@ -1441,11 +1441,16 @@
                 </template>
               </div>
 
-              <!-- OpenAI key field -->
+              <!-- OpenAI key + base URL fields -->
               <div x-show="pluginCfg.embedProvider==='openai'" style="margin-bottom:1rem;">
                 <div class="form-group">
                   <label>OpenAI API Key</label>
                   <input class="input-field" type="password" x-model="pluginCfg.embedApiKey" placeholder="sk-..." autocomplete="off" />
+                </div>
+                <div class="form-group" style="margin-top:0.75rem;">
+                  <label>Base URL <span style="font-weight:400;color:var(--text-muted);">(optional)</span></label>
+                  <input class="input-field" type="text" x-model="pluginCfg.embedUrl" placeholder="https://api.openai.com/v1" autocomplete="off" />
+                  <div style="font-size:0.75rem;color:var(--text-muted);margin-top:0.25rem;">Leave blank for standard OpenAI. Set to use LocalAI, LM Studio, Azure OpenAI, or any compatible endpoint.</div>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary

- Adds an optional **Base URL** field under the OpenAI embed tab in the Plugins settings panel
- Allows users to point MuninnDB at any OpenAI-compatible endpoint (LocalAI, LM Studio, Azure OpenAI, Ollama with OpenAI adapter) without touching environment variables
- Reconfigure button now fetches and pre-populates the saved URL so the field isn't blank when reopening config
- Placeholder `https://api.openai.com/v1` and hint text guide the user; leaving blank uses standard OpenAI

## Backend wiring

- `savePluginConfig` now sends `embed_url` when `embedProvider === 'openai'` and the user typed a URL
- `loadSavedPluginConfig` fetches `GET /api/admin/plugin-config` and populates `embedUrl` for HTTP/HTTPS URLs only (ollama:// scheme URLs encode a model name, not a base URL — excluded intentionally)
- Server already consumed `cfg.EmbedURL` for the openai provider (from PR #79/#80); this just closes the UI gap

## Test plan

- [ ] Open Plugins → Embeddings → select OpenAI — Base URL field appears below API Key with placeholder
- [ ] Set `http://localhost:1234/v1`, save — config file written with `"embed_url": "http://localhost:1234/v1"`
- [ ] Click Reconfigure — field pre-populates with saved URL
- [ ] Leave blank, save — `embed_url` omitted; standard OpenAI behavior unchanged
- [ ] CI: `TestBuildEmbedder_SavedConfigOpenAI_CustomBaseURL` covers the server-side path