### PR TITLE
fix(adjacency): correct prefix upper-bound overflow in GetAssociations

### DIFF
--- a/internal/index/adjacency/adjacency.go
+++ b/internal/index/adjacency/adjacency.go
@@ -54,13 +54,10 @@ func (g *Graph) GetAssociations(ctx context.Context, ws [8]byte, id [16]byte, ma
 	copy(prefix[1:9], ws[:])
 	copy(prefix[9:25], id[:])
 
-	upperBound := make([]byte, len(prefix))
-	copy(upperBound, prefix)
-	upperBound[len(upperBound)-1]++
-
+	// prefixSuccessor handles 0xFF overflow correctly; nil means no upper bound.
 	iter, err := g.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
-		UpperBound: upperBound,
+		UpperBound: prefixSuccessor(prefix),
 	})
 	if err != nil {
 		return nil, err
@@ -218,4 +215,20 @@ func (g *Graph) Traverse(
 	}
 
 	return results, nil
+}
+
+// prefixSuccessor returns the smallest byte slice that is strictly greater than
+// any key sharing the given prefix. It finds the rightmost byte that is not 0xFF,
+// increments it, and truncates — correctly handling carry without overflow.
+// Returns nil if every byte is 0xFF (no upper bound needed).
+func prefixSuccessor(prefix []byte) []byte {
+	for i := len(prefix) - 1; i >= 0; i-- {
+		if prefix[i] < 0xFF {
+			succ := make([]byte, i+1)
+			copy(succ, prefix)
+			succ[i]++
+			return succ
+		}
+	}
+	return nil // all 0xFF — no upper bound
 }

--- a/internal/index/adjacency/adjacency_test.go
+++ b/internal/index/adjacency/adjacency_test.go
@@ -292,6 +292,38 @@ func TestBFSThresholdCutsOff(t *testing.T) {
 	}
 }
 
+// TestGetAssociations_NodeIDEndsIn0xFF is a regression test for the prefix upper-bound
+// overflow bug. When a node ID's last byte is 0xFF, the naive "+1" calculation wraps to
+// 0x00, producing upperBound < lowerBound and causing the Pebble iterator to return
+// nothing. prefixSuccessor carries the increment correctly, so associations are found.
+func TestGetAssociations_NodeIDEndsIn0xFF(t *testing.T) {
+	db := newTestDB(t)
+	g := adjacency.New(db)
+	ws := testWS()
+	ctx := context.Background()
+
+	// Construct a node ID whose last byte is 0xFF to trigger the overflow.
+	var srcID [16]byte
+	for i := range srcID {
+		srcID[i] = 0xAA
+	}
+	srcID[15] = 0xFF
+
+	dstID := newID()
+	writeAssoc(t, g, ws, srcID, dstID, 0.9)
+
+	results, err := g.GetAssociations(ctx, ws, srcID, 100)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 association for node with 0xFF last byte, got %d (prefix overflow bug)", len(results))
+	}
+	if results[0].TargetID != dstID {
+		t.Errorf("expected TargetID=%v, got %v", dstID, results[0].TargetID)
+	}
+}
+
 // TestGetAssociationsEmptyNode calls GetAssociations on a node with no associations
 // and verifies it returns an empty slice without error.
 func TestGetAssociationsEmptyNode(t *testing.T) {


### PR DESCRIPTION
## Root Cause

`GetAssociations` computed the Pebble iterator upper bound with:
```go
upperBound[len(upperBound)-1]++
```
When the last byte of a node's ID is `0xFF`, this wraps to `0x00`, making `upperBound < lowerBound`. Pebble returns nothing — the node appears to have zero associations.

Since node IDs are ULIDs with a random suffix, any node has a **~1/256 (~0.4%) chance** of triggering this. With multiple nodes per test and many test runs in CI under parallel load, it manifests as a rare, non-reproducible flake (`TestBFSHopPenalty: node B (hop 1) not found`).

## Fix

Replaced the naive increment with `prefixSuccessor()`, which walks right-to-left to find the first non-`0xFF` byte and increments it with correct carry semantics. Returns `nil` (no upper bound) only if the entire prefix is `0xFF`, which Pebble handles safely.

## Test

`TestGetAssociations_NodeIDEndsIn0xFF` pins a node ID with `lastByte = 0xFF` and asserts the association is found — this test would have failed deterministically before the fix.

## Verification

```
=== RUN   TestGetAssociations_NodeIDEndsIn0xFF
--- PASS
=== RUN   TestBFSHopPenalty  
--- PASS
ok  github.com/scrypster/muninndb/internal/index/adjacency
```