### PR TITLE
fix: display provider and model for LLM enrichment plugin in UI

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -165,6 +165,28 @@ func resolveEmbedInfo(cfg plugincfg.PluginConfig) rest.EmbedInfo {
 	return rest.EmbedInfo{Provider: "none", Model: ""}
 }
 
+// resolveEnrichInfo determines the LLM enrichment provider and model from
+// env variables and saved plugin config. Order: env vars → saved config.
+func resolveEnrichInfo(cfg plugincfg.PluginConfig) rest.EnrichInfo {
+	// Env var takes precedence.
+	if enrichURL := os.Getenv("MUNINN_ENRICH_URL"); enrichURL != "" {
+		if provCfg, err := plugin.ParseProviderURL(enrichURL); err == nil {
+			return rest.EnrichInfo{Provider: string(provCfg.Scheme), Model: provCfg.Model}
+		}
+		return rest.EnrichInfo{Provider: "unknown", Model: ""}
+	}
+	// Saved config fallback.
+	if cfg.EnrichProvider != "" && cfg.EnrichProvider != "none" {
+		if cfg.EnrichURL != "" {
+			if provCfg, err := plugin.ParseProviderURL(cfg.EnrichURL); err == nil {
+				return rest.EnrichInfo{Provider: string(provCfg.Scheme), Model: provCfg.Model}
+			}
+		}
+		return rest.EnrichInfo{Provider: cfg.EnrichProvider, Model: ""}
+	}
+	return rest.EnrichInfo{}
+}
+
 // resolveOpenAIEmbedProviderURL resolves an OpenAI embed URL override into a
 // provider URL that ParseProviderURL can handle. Supports both:
 //   - openai://text-embedding-3-small?base_url=http://localhost:8080
@@ -973,7 +995,8 @@ func runServer() {
 	// Build transport servers
 	mbpServer := mbp.NewServer(*mbpAddr, eng, authStore, clientTLS)
 	corsOrigins := parseCORSOrigins(*corsOriginsFlag)
-	restServer := rest.NewServer(*restAddr, restWrapper, authStore, sessionSecret, corsOrigins, embedInfo, pluginRegistry, *dataDir, clientTLS, rest.MCPInfo{
+	enrichInfo := resolveEnrichInfo(savedPluginCfg)
+	restServer := rest.NewServer(*restAddr, restWrapper, authStore, sessionSecret, corsOrigins, embedInfo, enrichInfo, pluginRegistry, *dataDir, clientTLS, rest.MCPInfo{
 		Addr:     *mcpAddr,
 		HasToken: *mcpToken != "",
 	})

--- a/internal/transport/rest/admin_coverage_test.go
+++ b/internal/transport/rest/admin_coverage_test.go
@@ -20,7 +20,7 @@ func TestHandleEmbedStatus(t *testing.T) {
 	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{
 		Provider: "openai",
 		Model:    "text-embedding-3-small",
-	}, nil, "", nil)
+	}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/admin/embed/status", nil)
 	w := httptest.NewRecorder()
@@ -52,7 +52,7 @@ func TestHandleEmbedStatus_NoneProvider(t *testing.T) {
 	store := newTestAuthStore(t)
 	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{
 		Provider: "none",
-	}, nil, "", nil)
+	}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/admin/embed/status", nil)
 	w := httptest.NewRecorder()
@@ -71,7 +71,7 @@ func TestHandleEmbedStatus_NoneProvider(t *testing.T) {
 
 func TestHandleEmbedStatus_EmptyProvider(t *testing.T) {
 	store := newTestAuthStore(t)
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/admin/embed/status", nil)
 	w := httptest.NewRecorder()
@@ -91,7 +91,7 @@ func TestHandleEmbedStatus_EmptyProvider(t *testing.T) {
 
 func TestHandleGetPluginConfig_NoDataDir(t *testing.T) {
 	store := newTestAuthStore(t)
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/admin/plugin-config", nil)
 	w := httptest.NewRecorder()
@@ -110,7 +110,7 @@ func TestHandleGetPluginConfig_WithDataDir(t *testing.T) {
 	}
 
 	store := newTestAuthStore(t)
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, dir, nil)
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, dir, nil)
 
 	req := httptest.NewRequest("GET", "/api/admin/plugin-config", nil)
 	w := httptest.NewRecorder()
@@ -129,7 +129,7 @@ func TestHandleGetPluginConfig_WithDataDir(t *testing.T) {
 
 func TestHandlePutPluginConfig_NoDataDir(t *testing.T) {
 	store := newTestAuthStore(t)
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body, _ := json.Marshal(config.PluginConfig{EmbedProvider: "openai"})
 	req := httptest.NewRequest("PUT", "/api/admin/plugin-config", bytes.NewReader(body))
@@ -145,7 +145,7 @@ func TestHandlePutPluginConfig_NoDataDir(t *testing.T) {
 func TestHandlePutPluginConfig_Success(t *testing.T) {
 	dir := t.TempDir()
 	store := newTestAuthStore(t)
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, dir, nil)
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, dir, nil)
 
 	cfg := config.PluginConfig{
 		EmbedProvider: "voyage",
@@ -173,7 +173,7 @@ func TestHandlePutPluginConfig_Success(t *testing.T) {
 func TestHandlePutPluginConfig_InvalidJSON(t *testing.T) {
 	dir := t.TempDir()
 	store := newTestAuthStore(t)
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, dir, nil)
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, dir, nil)
 
 	req := httptest.NewRequest("PUT", "/api/admin/plugin-config", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -616,7 +616,7 @@ func TestChangeAdminPassword_InvalidJSON(t *testing.T) {
 
 func TestMCPInfo_HostSpecific(t *testing.T) {
 	store := newTestAuthStore(t)
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, "", nil, MCPInfo{
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil, MCPInfo{
 		Addr:     "192.168.1.5:8750",
 		HasToken: true,
 	})
@@ -634,7 +634,7 @@ func TestMCPInfo_HostSpecific(t *testing.T) {
 
 func TestMCPInfo_EmptyAddr(t *testing.T) {
 	store := newTestAuthStore(t)
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, "", nil, MCPInfo{
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil, MCPInfo{
 		Addr: "",
 	})
 
@@ -651,7 +651,7 @@ func TestMCPInfo_EmptyAddr(t *testing.T) {
 
 func TestMCPInfo_IPv6Wildcard(t *testing.T) {
 	store := newTestAuthStore(t)
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, "", nil, MCPInfo{
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil, MCPInfo{
 		Addr: "[::]:8750",
 	})
 
@@ -669,7 +669,7 @@ func TestMCPInfo_IPv6Wildcard(t *testing.T) {
 // --- handleHello error paths ---
 
 func TestHandleHello_InvalidJSON(t *testing.T) {
-	srv := NewServer("localhost:0", &MockEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/hello", strings.NewReader("not json"))
 	w := httptest.NewRecorder()
@@ -683,7 +683,7 @@ func TestHandleHello_InvalidJSON(t *testing.T) {
 // --- handleLink error paths ---
 
 func TestHandleLink_InvalidJSON(t *testing.T) {
-	srv := NewServer("localhost:0", &MockEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/link", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -698,7 +698,7 @@ func TestHandleLink_InvalidJSON(t *testing.T) {
 // --- handleBatchCreate error paths ---
 
 func TestBatchCreate_InvalidJSON(t *testing.T) {
-	srv := NewServer("localhost:0", &MockEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/engrams/batch", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -769,7 +769,7 @@ func TestClientIP(t *testing.T) {
 // --- Server health and ready ---
 
 func TestHealthEndpoint_Version(t *testing.T) {
-	srv := NewServer("localhost:0", &MockEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	srv.SetVersion("v1.2.3")
 
 	req := httptest.NewRequest("GET", "/api/health", nil)
@@ -784,7 +784,7 @@ func TestHealthEndpoint_Version(t *testing.T) {
 }
 
 func TestReadyEndpoint_NotReady(t *testing.T) {
-	srv := NewServer("localhost:0", &MockEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	srv.subsystemsReady.Store(false)
 
 	req := httptest.NewRequest("GET", "/api/ready", nil)
@@ -930,7 +930,7 @@ func TestHandleGetPluginConfig_CorruptFile(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "plugin_config.json"), []byte("not json"), 0600)
 
 	store := newTestAuthStore(t)
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, dir, nil)
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, dir, nil)
 
 	req := httptest.NewRequest("GET", "/api/admin/plugin-config", nil)
 	w := httptest.NewRecorder()

--- a/internal/transport/rest/admin_handler_boost_test.go
+++ b/internal/transport/rest/admin_handler_boost_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestHandleReindexFTSVault_VaultNotFound(t *testing.T) {
 	eng := &reindexNotFoundEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/admin/vaults/missing-vault/reindex-fts", nil)
 	w := httptest.NewRecorder()
@@ -39,7 +39,7 @@ func TestHandleReindexFTSVault_VaultNotFound(t *testing.T) {
 
 func TestHandleReindexFTSVault_GenericError(t *testing.T) {
 	eng := &reindexErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/admin/vaults/some-vault/reindex-fts", nil)
 	w := httptest.NewRecorder()
@@ -69,7 +69,7 @@ func (e *reindexErrorEngine) ReindexFTSVault(_ context.Context, _ string) (int64
 
 func TestHandleReembedVault_InvalidVaultName(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/admin/vaults/INVALID!NAME/reembed", nil)
 	w := httptest.NewRecorder()
@@ -82,7 +82,7 @@ func TestHandleReembedVault_InvalidVaultName(t *testing.T) {
 
 func TestHandleReembedVault_VaultNotFound(t *testing.T) {
 	eng := &reembedNotFoundEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/admin/vaults/missing-vault/reembed", nil)
 	w := httptest.NewRecorder()
@@ -95,7 +95,7 @@ func TestHandleReembedVault_VaultNotFound(t *testing.T) {
 
 func TestHandleReembedVault_GenericError(t *testing.T) {
 	eng := &reembedErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/admin/vaults/some-vault/reembed", nil)
 	w := httptest.NewRecorder()
@@ -108,7 +108,7 @@ func TestHandleReembedVault_GenericError(t *testing.T) {
 
 func TestHandleReembedVault_WithModelOverride(t *testing.T) {
 	eng := &reembedCapturingEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"model":"bge-small-en-v1.5"}`
 	req := httptest.NewRequest("POST", "/api/admin/vaults/test-vault/reembed", strings.NewReader(body))
@@ -153,7 +153,7 @@ func (e *reembedCapturingEngine) StartReembedVault(_ context.Context, _, model s
 
 func TestHandleExportVault_VaultNotFound(t *testing.T) {
 	eng := &exportNotFoundEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/admin/vaults/missing-vault/export", nil)
 	w := httptest.NewRecorder()
@@ -166,7 +166,7 @@ func TestHandleExportVault_VaultNotFound(t *testing.T) {
 
 func TestHandleExportVault_PreStreamError(t *testing.T) {
 	eng := &exportPreStreamErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/admin/vaults/some-vault/export", nil)
 	w := httptest.NewRecorder()
@@ -196,7 +196,7 @@ func (e *exportPreStreamErrorEngine) ExportVault(_ context.Context, _, _ string,
 
 func TestHandleImportVault_VaultNotFound(t *testing.T) {
 	eng := &importNotFoundEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/admin/vaults/import?vault=missing-vault", strings.NewReader("data"))
 	w := httptest.NewRecorder()
@@ -209,7 +209,7 @@ func TestHandleImportVault_VaultNotFound(t *testing.T) {
 
 func TestHandleImportVault_Collision(t *testing.T) {
 	eng := &importCollisionEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/admin/vaults/import?vault=existing-vault", strings.NewReader("data"))
 	w := httptest.NewRecorder()
@@ -222,7 +222,7 @@ func TestHandleImportVault_Collision(t *testing.T) {
 
 func TestHandleImportVault_GenericError(t *testing.T) {
 	eng := &importErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/admin/vaults/import?vault=some-vault", strings.NewReader("data"))
 	w := httptest.NewRecorder()
@@ -259,7 +259,7 @@ func (e *importErrorEngine) StartImport(_ context.Context, _, _ string, _ int, _
 func TestHandleGetPluginConfig_NoDataDirBoost(t *testing.T) {
 	eng := &MockEngine{}
 	// No data dir → returns empty config.
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/admin/plugin-config", nil)
 	w := httptest.NewRecorder()
@@ -276,7 +276,7 @@ func TestHandleGetPluginConfig_NoDataDirBoost(t *testing.T) {
 
 func TestHandleRenameVault_NameCollision(t *testing.T) {
 	eng := &renameCollisionEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := strings.NewReader(`{"new_name":"existing-vault"}`)
 	req := httptest.NewRequest("POST", "/api/admin/vaults/old-vault/rename", body)
@@ -291,7 +291,7 @@ func TestHandleRenameVault_NameCollision(t *testing.T) {
 
 func TestHandleRenameVault_GenericError(t *testing.T) {
 	eng := &renameGenericErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := strings.NewReader(`{"new_name":"new-vault"}`)
 	req := httptest.NewRequest("POST", "/api/admin/vaults/old-vault/rename", body)
@@ -323,7 +323,7 @@ func (e *renameGenericErrorEngine) RenameVault(_ context.Context, _, _ string) e
 
 func TestHandleDeleteVault_StoreError(t *testing.T) {
 	eng := &deleteVaultErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("DELETE", "/api/admin/vaults/problem-vault", nil)
 	req.Header.Set("X-Allow-Default", "true")
@@ -347,7 +347,7 @@ func (e *deleteVaultErrorEngine) DeleteVault(_ context.Context, _ string) error 
 
 func TestHandleClearVault_StoreError(t *testing.T) {
 	eng := &clearVaultErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/admin/vaults/problem-vault/clear", nil)
 	req.Header.Set("X-Allow-Default", "true")
@@ -371,7 +371,7 @@ func (e *clearVaultErrorEngine) ClearVault(_ context.Context, _ string) error {
 
 func TestHandleCloneVault_GenericError(t *testing.T) {
 	eng := &cloneGenericErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"new_name":"target-vault"}`
 	req := httptest.NewRequest("POST", "/api/admin/vaults/source-vault/clone", strings.NewReader(body))
@@ -396,7 +396,7 @@ func (e *cloneGenericErrorEngine) StartClone(_ context.Context, _, _ string) (*v
 
 func TestHandleMergeVault_GenericError(t *testing.T) {
 	eng := &mergeGenericErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"target":"target-vault"}`
 	req := httptest.NewRequest("POST", "/api/admin/vaults/source-vault/merge-into", strings.NewReader(body))
@@ -421,7 +421,7 @@ func (e *mergeGenericErrorEngine) StartMerge(_ context.Context, _, _ string, _ b
 
 func TestHandleStats_WithVault(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/stats?vault=my-vault", nil)
 	w := httptest.NewRecorder()

--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -474,8 +474,8 @@ type PluginStatusResponse struct {
 	Healthy   bool      `json:"healthy"`
 	LastCheck time.Time `json:"last_check"`
 	Error     string    `json:"error,omitempty"`
-	Provider  string    `json:"provider,omitempty"` // embed plugins only
-	Model     string    `json:"model,omitempty"`    // embed plugins only
+	Provider  string    `json:"provider,omitempty"`
+	Model     string    `json:"model,omitempty"`
 }
 
 // handlePlugins returns the list of registered plugins with runtime status.
@@ -497,6 +497,9 @@ func (s *Server) handlePlugins(w http.ResponseWriter, r *http.Request) {
 		if p.Tier == plugin.TierEmbed {
 			entry.Provider = s.embedProvider
 			entry.Model = s.embedModel
+		} else if p.Tier == plugin.TierEnrich {
+			entry.Provider = s.enrichProvider
+			entry.Model = s.enrichModel
 		}
 		out = append(out, entry)
 	}

--- a/internal/transport/rest/admin_handlers_test.go
+++ b/internal/transport/rest/admin_handlers_test.go
@@ -27,7 +27,7 @@ func newTestAuthStore(t *testing.T) *auth.Store {
 
 func newTestServer(t *testing.T, store *auth.Store) *Server {
 	t.Helper()
-	return NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, "", nil)
+	return NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 }
 
 // TestCreateAPIKey tests POST /api/admin/keys
@@ -220,7 +220,7 @@ func TestChangeAdminPasswordEndpoint(t *testing.T) {
 // TestMCPInfo tests GET /api/admin/mcp-info
 func TestMCPInfo(t *testing.T) {
 	store := newTestAuthStore(t)
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, "", nil, MCPInfo{
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil, MCPInfo{
 		Addr:     ":8750",
 		HasToken: true,
 	})
@@ -248,7 +248,7 @@ func TestMCPInfo(t *testing.T) {
 // TestMCPInfo_NoToken verifies token_configured=false when no token.
 func TestMCPInfo_NoToken(t *testing.T) {
 	store := newTestAuthStore(t)
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, "", nil, MCPInfo{
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil, MCPInfo{
 		Addr:     ":8750",
 		HasToken: false,
 	})
@@ -267,7 +267,7 @@ func TestMCPInfo_NoToken(t *testing.T) {
 // TestMCPInfo_CustomPort verifies custom port is reflected in URL.
 func TestMCPInfo_CustomPort(t *testing.T) {
 	store := newTestAuthStore(t)
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, nil, "", nil, MCPInfo{
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil, MCPInfo{
 		Addr:     ":9999",
 		HasToken: false,
 	})
@@ -327,7 +327,7 @@ func TestHandlePlugins_NilRegistry(t *testing.T) {
 func TestHandlePlugins_EmptyRegistry(t *testing.T) {
 	store := newTestAuthStore(t)
 	reg := plugin.NewRegistry()
-	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, reg, "", nil, MCPInfo{})
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, reg, "", nil, MCPInfo{})
 
 	req := httptest.NewRequest("GET", "/api/admin/plugins", nil)
 	w := httptest.NewRecorder()
@@ -612,7 +612,7 @@ func TestHandleSetVaultConfig_ForcePreservesAuth(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 	secret := []byte("test-secret")
-	srv := NewServer("localhost:0", &MockEngine{}, store, secret, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", &MockEngine{}, store, secret, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body, _ := json.Marshal(map[string]interface{}{"name": "datadogclone"})
 	req := httptest.NewRequest("PUT", "/api/admin/vaults/config?force=true", bytes.NewReader(body))

--- a/internal/transport/rest/admin_vault_handlers_test.go
+++ b/internal/transport/rest/admin_vault_handlers_test.go
@@ -59,7 +59,7 @@ func (e *jobEngine) GetVaultJob(_ string) (*vaultjob.Job, bool) { return e.job, 
 
 // newVaultTestServer builds a Server with no session secret (admin middleware passes through).
 func newVaultTestServer(engine EngineAPI) *Server {
-	return NewServer("localhost:0", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	return NewServer("localhost:0", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 }
 
 // serveVault is a shorthand to dispatch a request through the mux and return the recorder.

--- a/internal/transport/rest/backup_boost_test.go
+++ b/internal/transport/rest/backup_boost_test.go
@@ -88,7 +88,7 @@ func TestBackupCopyDir_CopiesFiles(t *testing.T) {
 
 func TestHandleBackup_CheckpointFailure(t *testing.T) {
 	eng := &checkpointErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	outputDir := filepath.Join(t.TempDir(), "backup-fail-out")
 	body := `{"output_dir":"` + outputDir + `"}`
@@ -134,7 +134,7 @@ func TestHandleBackup_WithDataDir_CopiesWalAndSecret(t *testing.T) {
 	// Use a real Pebble checkpoint engine.
 	pebbleDir := filepath.Join(dataDir, "pebble")
 	eng := &backupMockEngine{pebbleDir: pebbleDir}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, dataDir, nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, dataDir, nil)
 
 	outputDir := filepath.Join(t.TempDir(), "backup-with-wal")
 	body := `{"output_dir":"` + outputDir + `"}`
@@ -163,7 +163,7 @@ func TestHandleBackup_WithDataDir_CopiesWalAndSecret(t *testing.T) {
 
 func TestReadyEndpoint_NotReady_Boost(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	// Force subsystemsReady to false (it defaults to false, but subsystemsReady
 	// is set to true somewhere in the initialization. Let's check.)
 	server.subsystemsReady.Store(false)
@@ -183,7 +183,7 @@ func TestReadyEndpoint_NotReady_Boost(t *testing.T) {
 
 func TestHealthEndpoint_WithVersion(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	server.version = "1.2.3"
 
 	req := httptest.NewRequest("GET", "/api/health", nil)
@@ -264,7 +264,7 @@ func TestWithClusterAuth_InactiveCluster_PassesThrough(t *testing.T) {
 
 func TestContradictionsEndpoint_EngineError(t *testing.T) {
 	eng := &contradictionsErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/contradictions?vault=default", nil)
 	w := httptest.NewRecorder()
@@ -287,7 +287,7 @@ func (e *contradictionsErrorEngine) GetContradictions(_ context.Context, _ strin
 
 func TestGuideEndpoint_EngineError(t *testing.T) {
 	eng := &guideErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/guide?vault=default", nil)
 	w := httptest.NewRecorder()

--- a/internal/transport/rest/consolidation_handlers_test.go
+++ b/internal/transport/rest/consolidation_handlers_test.go
@@ -76,7 +76,7 @@ func newConsolidationTestEngine(t *testing.T) *consolidationMockEngine {
 // TestHandleConsolidate_Success posts a valid consolidation request and expects HTTP 200.
 func TestHandleConsolidate_Success(t *testing.T) {
 	eng := newConsolidationTestEngine(t)
-	srv := NewServer("localhost:0", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	handler := srv.handleConsolidate()
 
@@ -95,7 +95,7 @@ func TestHandleConsolidate_Success(t *testing.T) {
 // TestHandleConsolidate_MissingVault expects HTTP 400 when the vault path value is empty.
 func TestHandleConsolidate_MissingVault(t *testing.T) {
 	eng := newConsolidationTestEngine(t)
-	srv := NewServer("localhost:0", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	handler := srv.handleConsolidate()
 
@@ -115,7 +115,7 @@ func TestHandleConsolidate_MissingVault(t *testing.T) {
 // (the consolidation worker performs a best-effort run on any vault name).
 func TestHandleConsolidate_UnknownVault(t *testing.T) {
 	eng := newConsolidationTestEngine(t)
-	srv := NewServer("localhost:0", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	handler := srv.handleConsolidate()
 
@@ -136,7 +136,7 @@ func TestHandleConsolidate_UnknownVault(t *testing.T) {
 // TestHandleConsolidate_InvalidJSON expects HTTP 400 when the request body is not valid JSON.
 func TestHandleConsolidate_InvalidJSON(t *testing.T) {
 	eng := newConsolidationTestEngine(t)
-	srv := NewServer("localhost:0", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	handler := srv.handleConsolidate()
 

--- a/internal/transport/rest/coverage_boost_test.go
+++ b/internal/transport/rest/coverage_boost_test.go
@@ -134,7 +134,7 @@ func TestApplyRecallModePreset_ZeroPresetIsNoop(t *testing.T) {
 
 func TestActivate_WithSemanticMode(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"context":["test"],"vault":"default","mode":"semantic"}`
 	req := httptest.NewRequest("POST", "/api/activate", strings.NewReader(body))
@@ -149,7 +149,7 @@ func TestActivate_WithSemanticMode(t *testing.T) {
 
 func TestActivate_WithRecentMode(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"context":["test"],"vault":"default","mode":"recent"}`
 	req := httptest.NewRequest("POST", "/api/activate", strings.NewReader(body))
@@ -164,7 +164,7 @@ func TestActivate_WithRecentMode(t *testing.T) {
 
 func TestActivate_WithBalancedMode(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"context":["test"],"vault":"default","mode":"balanced"}`
 	req := httptest.NewRequest("POST", "/api/activate", strings.NewReader(body))
@@ -179,7 +179,7 @@ func TestActivate_WithBalancedMode(t *testing.T) {
 
 func TestActivate_WithDeepMode(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"context":["test"],"vault":"default","mode":"deep"}`
 	req := httptest.NewRequest("POST", "/api/activate", strings.NewReader(body))
@@ -194,7 +194,7 @@ func TestActivate_WithDeepMode(t *testing.T) {
 
 func TestActivate_InvalidMode(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"context":["test"],"vault":"default","mode":"nonexistent"}`
 	req := httptest.NewRequest("POST", "/api/activate", strings.NewReader(body))
@@ -209,7 +209,7 @@ func TestActivate_InvalidMode(t *testing.T) {
 
 func TestActivate_EngineError(t *testing.T) {
 	eng := &activateErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"context":["test"],"vault":"default"}`
 	req := httptest.NewRequest("POST", "/api/activate", strings.NewReader(body))
@@ -235,7 +235,7 @@ func (e *activateErrorEngine) Activate(_ context.Context, _ *ActivateRequest) (*
 
 func TestGetEngram_EngineError_Boost(t *testing.T) {
 	eng := &readErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/engrams/some-id", nil)
 	w := httptest.NewRecorder()
@@ -259,7 +259,7 @@ func (e *readErrorEngine) Read(_ context.Context, _ *ReadRequest) (*ReadResponse
 
 func TestDeleteEngram_EngineError(t *testing.T) {
 	eng := &forgetErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("DELETE", "/api/engrams/01ARZ3NDEKTSV4RRFFQ69G5FAV", nil)
 	w := httptest.NewRecorder()
@@ -283,7 +283,7 @@ func (e *forgetErrorEngine) Forget(_ context.Context, _ *ForgetRequest) (*Forget
 
 func TestHandleLink_Success(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"source_id":"id-a","target_id":"id-b","rel_type":1,"weight":0.9,"vault":"default"}`
 	req := httptest.NewRequest("POST", "/api/link", strings.NewReader(body))
@@ -305,7 +305,7 @@ func TestHandleLink_Success(t *testing.T) {
 
 func TestHandleLink_InvalidJSON_Boost(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/link", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -319,7 +319,7 @@ func TestHandleLink_InvalidJSON_Boost(t *testing.T) {
 
 func TestHandleLink_EngramNotFound(t *testing.T) {
 	eng := &linkNotFoundEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"source_id":"id-a","target_id":"id-b"}`
 	req := httptest.NewRequest("POST", "/api/link", strings.NewReader(body))
@@ -334,7 +334,7 @@ func TestHandleLink_EngramNotFound(t *testing.T) {
 
 func TestHandleLink_EngramSoftDeleted(t *testing.T) {
 	eng := &linkSoftDeletedEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"source_id":"id-a","target_id":"id-b"}`
 	req := httptest.NewRequest("POST", "/api/link", strings.NewReader(body))
@@ -349,7 +349,7 @@ func TestHandleLink_EngramSoftDeleted(t *testing.T) {
 
 func TestHandleLink_GenericError(t *testing.T) {
 	eng := &linkGenericErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"source_id":"id-a","target_id":"id-b"}`
 	req := httptest.NewRequest("POST", "/api/link", strings.NewReader(body))
@@ -388,7 +388,7 @@ func (e *linkGenericErrorEngine) Link(_ context.Context, _ *mbp.LinkRequest) (*L
 
 func TestHandleStats_EngineError(t *testing.T) {
 	eng := &statErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/stats?vault=default", nil)
 	w := httptest.NewRecorder()
@@ -412,7 +412,7 @@ func (e *statErrorEngine) Stat(_ context.Context, _ *StatRequest) (*StatResponse
 
 func TestHandleWorkerStats(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/workers", nil)
 	w := httptest.NewRecorder()
@@ -429,7 +429,7 @@ func TestHandleWorkerStats(t *testing.T) {
 
 func TestHandleHello_InvalidJSON_Boost(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/hello", strings.NewReader("{bad"))
 	req.Header.Set("Content-Type", "application/json")
@@ -443,7 +443,7 @@ func TestHandleHello_InvalidJSON_Boost(t *testing.T) {
 
 func TestHandleHello_EngineError(t *testing.T) {
 	eng := &helloErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"vault":"default"}`
 	req := httptest.NewRequest("POST", "/api/hello", strings.NewReader(body))
@@ -468,7 +468,7 @@ func (e *helloErrorEngine) Hello(_ context.Context, _ *HelloRequest) (*HelloResp
 
 func TestCreateEngram_EngineError(t *testing.T) {
 	eng := &writeErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"concept":"test","content":"test content"}`
 	req := httptest.NewRequest("POST", "/api/engrams", strings.NewReader(body))
@@ -493,7 +493,7 @@ func (e *writeErrorEngine) Write(_ context.Context, _ *WriteRequest) (*WriteResp
 
 func TestEvolveEndpoint_InvalidJSON(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/engrams/test-id/evolve", strings.NewReader("{bad json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -507,7 +507,7 @@ func TestEvolveEndpoint_InvalidJSON(t *testing.T) {
 
 func TestEvolveEndpoint_EngineError(t *testing.T) {
 	eng := &evolveErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"new_content":"updated","reason":"fix"}`
 	req := httptest.NewRequest("POST", "/api/engrams/test-id/evolve", strings.NewReader(body))
@@ -532,7 +532,7 @@ func (e *evolveErrorEngine) Evolve(_ context.Context, _, _, _, _ string) (*Evolv
 
 func TestConsolidateEndpoint_InvalidJSON(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/consolidate", strings.NewReader("{bad"))
 	req.Header.Set("Content-Type", "application/json")
@@ -546,7 +546,7 @@ func TestConsolidateEndpoint_InvalidJSON(t *testing.T) {
 
 func TestConsolidateEndpoint_TooManyIDs(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	ids := make([]string, 51)
 	for i := range ids {
@@ -568,7 +568,7 @@ func TestConsolidateEndpoint_TooManyIDs(t *testing.T) {
 
 func TestConsolidateEndpoint_MissingMergedContent(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"ids":["id-1","id-2"]}`
 	req := httptest.NewRequest("POST", "/api/consolidate", strings.NewReader(body))
@@ -583,7 +583,7 @@ func TestConsolidateEndpoint_MissingMergedContent(t *testing.T) {
 
 func TestConsolidateEndpoint_EngineError(t *testing.T) {
 	eng := &consolidateErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"ids":["id-1","id-2"],"merged_content":"combined"}`
 	req := httptest.NewRequest("POST", "/api/consolidate", strings.NewReader(body))
@@ -608,7 +608,7 @@ func (e *consolidateErrorEngine) Consolidate(_ context.Context, _ string, _ []st
 
 func TestDecideEndpoint_InvalidJSON(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/decide", strings.NewReader("{bad"))
 	req.Header.Set("Content-Type", "application/json")
@@ -622,7 +622,7 @@ func TestDecideEndpoint_InvalidJSON(t *testing.T) {
 
 func TestDecideEndpoint_EngineError(t *testing.T) {
 	eng := &decideErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"decision":"go with X","rationale":"because Y"}`
 	req := httptest.NewRequest("POST", "/api/decide", strings.NewReader(body))
@@ -647,7 +647,7 @@ func (e *decideErrorEngine) Decide(_ context.Context, _, _, _ string, _, _ []str
 
 func TestRestoreEndpoint_EngineError(t *testing.T) {
 	eng := &restoreErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/engrams/missing-id/restore", nil)
 	w := httptest.NewRecorder()
@@ -670,7 +670,7 @@ func (e *restoreErrorEngine) Restore(_ context.Context, _, _ string) (*RestoreRe
 
 func TestTraverseEndpoint_InvalidJSON(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/traverse", strings.NewReader("{bad"))
 	req.Header.Set("Content-Type", "application/json")
@@ -684,7 +684,7 @@ func TestTraverseEndpoint_InvalidJSON(t *testing.T) {
 
 func TestTraverseEndpoint_EngineError(t *testing.T) {
 	eng := &traverseErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"start_id":"node-1"}`
 	req := httptest.NewRequest("POST", "/api/traverse", strings.NewReader(body))
@@ -699,7 +699,7 @@ func TestTraverseEndpoint_EngineError(t *testing.T) {
 
 func TestTraverseEndpoint_ClampMaxHopsAndNodes(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	// max_hops > 5 should be clamped to 5; max_nodes > 100 clamped to 100.
 	body := `{"start_id":"node-1","max_hops":99,"max_nodes":999}`
@@ -725,7 +725,7 @@ func (e *traverseErrorEngine) Traverse(_ context.Context, _ string, _ *TraverseR
 
 func TestExplainEndpoint_InvalidJSON(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/explain", strings.NewReader("{bad"))
 	req.Header.Set("Content-Type", "application/json")
@@ -739,7 +739,7 @@ func TestExplainEndpoint_InvalidJSON(t *testing.T) {
 
 func TestExplainEndpoint_EngineError(t *testing.T) {
 	eng := &explainErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"engram_id":"eng-1","query":["test"]}`
 	req := httptest.NewRequest("POST", "/api/explain", strings.NewReader(body))
@@ -764,7 +764,7 @@ func (e *explainErrorEngine) Explain(_ context.Context, _ string, _ *ExplainRequ
 
 func TestSetStateEndpoint_InvalidJSON(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("PUT", "/api/engrams/test-id/state", strings.NewReader("{bad"))
 	req.Header.Set("Content-Type", "application/json")
@@ -778,7 +778,7 @@ func TestSetStateEndpoint_InvalidJSON(t *testing.T) {
 
 func TestSetStateEndpoint_EngineError(t *testing.T) {
 	eng := &setStateErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"state":"active"}`
 	req := httptest.NewRequest("PUT", "/api/engrams/test-id/state", strings.NewReader(body))
@@ -803,7 +803,7 @@ func (e *setStateErrorEngine) UpdateState(_ context.Context, _, _, _, _ string) 
 
 func TestRetryEnrichEndpoint_EngineError(t *testing.T) {
 	eng := &retryEnrichErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/engrams/test-id/retry-enrich", nil)
 	w := httptest.NewRecorder()
@@ -826,7 +826,7 @@ func (e *retryEnrichErrorEngine) RetryEnrich(_ context.Context, _, _ string) (*R
 
 func TestListDeletedEndpoint_LimitClamping(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/deleted?vault=default&limit=9999", nil)
 	w := httptest.NewRecorder()
@@ -839,7 +839,7 @@ func TestListDeletedEndpoint_LimitClamping(t *testing.T) {
 
 func TestListDeletedEndpoint_EngineError(t *testing.T) {
 	eng := &listDeletedErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/deleted?vault=default", nil)
 	w := httptest.NewRecorder()
@@ -862,7 +862,7 @@ func (e *listDeletedErrorEngine) ListDeleted(_ context.Context, _ string, _ int)
 
 func TestGetEngramLinks_EngineError(t *testing.T) {
 	eng := &engramLinksErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/engrams/test-id/links", nil)
 	w := httptest.NewRecorder()
@@ -885,7 +885,7 @@ func (e *engramLinksErrorEngine) GetEngramLinks(_ context.Context, _ *GetEngramL
 
 func TestGetSession_EngineError(t *testing.T) {
 	eng := &sessionErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/session?vault=default", nil)
 	w := httptest.NewRecorder()
@@ -908,7 +908,7 @@ func (e *sessionErrorEngine) GetSession(_ context.Context, _ *GetSessionRequest)
 
 func TestRecoveryMiddleware_PanicReturns500(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	// Wrap a panicking handler in the recovery middleware and invoke it directly.
 	panickingHandler := server.recoveryMiddleware(func(w http.ResponseWriter, r *http.Request) {
@@ -970,7 +970,7 @@ func TestCtxVault_FallbackToDefault(t *testing.T) {
 
 func TestListEngrams_NegativeOffset(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/engrams?vault=default&offset=-5", nil)
 	w := httptest.NewRecorder()
@@ -987,7 +987,7 @@ func TestListEngrams_NegativeOffset(t *testing.T) {
 
 func TestHandleHello_Success(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"vault":"default"}`
 	req := httptest.NewRequest("POST", "/api/hello", strings.NewReader(body))
@@ -1013,7 +1013,7 @@ func TestHandleHello_Success(t *testing.T) {
 
 func TestHandleStats_NoVault(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/stats", nil)
 	w := httptest.NewRecorder()

--- a/internal/transport/rest/final_boost_test.go
+++ b/internal/transport/rest/final_boost_test.go
@@ -40,7 +40,7 @@ func TestListAPIKeys_InvalidVaultName_Boost(t *testing.T) {
 
 func TestHandleDeleteVault_JobActive(t *testing.T) {
 	eng := &deleteVaultJobActiveEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("DELETE", "/api/admin/vaults/busy-vault", nil)
 	req.Header.Set("X-Allow-Default", "true")
@@ -64,7 +64,7 @@ func (e *deleteVaultJobActiveEngine) DeleteVault(_ context.Context, _ string) er
 
 func TestHandleObservability_EngineError(t *testing.T) {
 	eng := &observabilityErrorEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/admin/observability", nil)
 	w := httptest.NewRecorder()
@@ -87,7 +87,7 @@ func (e *observabilityErrorEngine) Observability(_ context.Context, _ string, _ 
 
 func TestHandleGetEngramLinks_EmptyID(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/engrams//links", nil)
 	req.SetPathValue("id", "")
@@ -105,7 +105,7 @@ func TestHandleGetEngramLinks_EmptyID(t *testing.T) {
 
 func TestHandleRestore_EmptyID(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/engrams//restore", nil)
 	req.SetPathValue("id", "")
@@ -123,7 +123,7 @@ func TestHandleRestore_EmptyID(t *testing.T) {
 
 func TestHandleRetryEnrich_EmptyID(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/engrams//retry-enrich", nil)
 	req.SetPathValue("id", "")
@@ -141,7 +141,7 @@ func TestHandleRetryEnrich_EmptyID(t *testing.T) {
 
 func TestHandleBackup_EmptyBody(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	// Send empty/invalid JSON body.
 	req := httptest.NewRequest("POST", "/api/admin/backup", strings.NewReader("{bad"))
@@ -156,7 +156,7 @@ func TestHandleBackup_EmptyBody(t *testing.T) {
 
 func TestHandleBackup_MissingOutputDir(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/admin/backup", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -170,7 +170,7 @@ func TestHandleBackup_MissingOutputDir(t *testing.T) {
 
 func TestHandleBackup_OutputDirAlreadyExists(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	// Create the output dir before issuing the request.
 	existingDir := filepath.Join(t.TempDir(), "already-exists")
@@ -201,7 +201,7 @@ func TestHandlePlugins_WithEnrichPlugin(t *testing.T) {
 	}
 
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, registry, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, registry, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/admin/plugins", nil)
 	w := httptest.NewRecorder()
@@ -231,7 +231,7 @@ func (p *testEnrichPlugin) Enrich(_ context.Context, _ *plugin.Engram) (*plugin.
 
 func TestHandleClearVault_NotFound_Boost(t *testing.T) {
 	eng := &clearVaultNotFoundEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("DELETE", "/api/admin/vaults/nonexistent/entries", nil)
 	req.Header.Set("X-Allow-Default", "true")

--- a/internal/transport/rest/parse_key_expiry_test.go
+++ b/internal/transport/rest/parse_key_expiry_test.go
@@ -135,7 +135,7 @@ func (e *consolidateErrEngine) Consolidate(_ context.Context, _ string, _ []stri
 // ── TestHandleSetState_EngineError ───────────────────────────────────────────
 
 func TestHandleSetState_EngineError(t *testing.T) {
-	server := NewServer("localhost:8080", &updateStateErrEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &updateStateErrEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"state":"active"}`
 	req := httptest.NewRequest(http.MethodPut, "/api/engrams/test-id/state", strings.NewReader(body))
@@ -151,7 +151,7 @@ func TestHandleSetState_EngineError(t *testing.T) {
 // ── TestHandleListDeleted_EngineError ─────────────────────────────────────────
 
 func TestHandleListDeleted_EngineError(t *testing.T) {
-	server := NewServer("localhost:8080", &listDeletedErrRESTEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &listDeletedErrRESTEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/deleted?vault=default", nil)
 	w := httptest.NewRecorder()
@@ -165,7 +165,7 @@ func TestHandleListDeleted_EngineError(t *testing.T) {
 // ── TestHandleRetryEnrich_EngineError ─────────────────────────────────────────
 
 func TestHandleRetryEnrich_EngineError(t *testing.T) {
-	server := NewServer("localhost:8080", &retryEnrichErrRESTEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &retryEnrichErrRESTEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/engrams/test-id/retry-enrich", nil)
 	w := httptest.NewRecorder()
@@ -179,7 +179,7 @@ func TestHandleRetryEnrich_EngineError(t *testing.T) {
 // ── TestHandleEvolve_EngineError ──────────────────────────────────────────────
 
 func TestHandleEvolve_EngineError(t *testing.T) {
-	server := NewServer("localhost:8080", &evolveErrEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &evolveErrEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"new_content":"updated content","reason":"fixing a bug"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/engrams/test-id/evolve", strings.NewReader(body))
@@ -195,7 +195,7 @@ func TestHandleEvolve_EngineError(t *testing.T) {
 // ── TestHandleConsolidate_EngineError ─────────────────────────────────────────
 
 func TestHandleConsolidate_EngineError(t *testing.T) {
-	server := NewServer("localhost:8080", &consolidateErrEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &consolidateErrEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	payload := map[string]interface{}{
 		"ids":            []string{"id-1", "id-2"},

--- a/internal/transport/rest/remaining_boost_test.go
+++ b/internal/transport/rest/remaining_boost_test.go
@@ -106,7 +106,7 @@ func TestPutVaultPlasticity_EmptyVaultName(t *testing.T) {
 
 func TestHandleRenameVault_EmptyName(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := bytes.NewReader([]byte(`{"new_name":"new-vault"}`))
 	req := httptest.NewRequest("POST", "/api/admin/vaults//rename", body)
@@ -126,7 +126,7 @@ func TestHandleRenameVault_EmptyName(t *testing.T) {
 
 func TestHandleReindexFTSVault_EmptyName_Boost(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/admin/vaults//reindex-fts", nil)
 	req.SetPathValue("name", "")
@@ -144,7 +144,7 @@ func TestHandleReindexFTSVault_EmptyName_Boost(t *testing.T) {
 
 func TestHandleDeleteVault_NotFoundVault(t *testing.T) {
 	eng := &deleteVaultNotFoundEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("DELETE", "/api/admin/vaults/nonexistent-vault", nil)
 	req.Header.Set("X-Allow-Default", "true")
@@ -168,7 +168,7 @@ func (e *deleteVaultNotFoundEngine) DeleteVault(_ context.Context, _ string) err
 
 func TestHandleExportVault_WithResetMetadata(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/admin/vaults/test-vault/export?reset_metadata=true", nil)
 	w := httptest.NewRecorder()

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -2,8 +2,8 @@ package rest
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/subtle"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,8 +18,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/google/uuid"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/scrypster/muninndb/internal/auth"
 	"github.com/scrypster/muninndb/internal/config"
 	"github.com/scrypster/muninndb/internal/engine"
@@ -62,6 +62,10 @@ type Server struct {
 	embedProvider string // "ollama", "openai", "voyage", or "none"
 	embedModel    string // model name, or "" if none
 
+	// Enrichment info — set at construction time, static for the lifetime of the server.
+	enrichProvider string // "ollama", "openai", "anthropic", or ""
+	enrichModel    string // model name, or ""
+
 	// MCP info — set at construction time for the /api/admin/mcp-info endpoint.
 	mcpAddr     string // MCP listen address, e.g. ":8750"
 	mcpHasToken bool   // whether a bearer token is configured
@@ -81,7 +85,7 @@ type Server struct {
 
 	// Health check fields.
 	startTime       time.Time
-	version         string     // set at construction time; empty falls back to "dev"
+	version         string // set at construction time; empty falls back to "dev"
 	dbWritable      atomic.Bool
 	subsystemsReady atomic.Bool
 
@@ -97,6 +101,12 @@ type EmbedInfo struct {
 	Model    string // model name, or ""
 }
 
+// EnrichInfo carries static enrichment metadata set at server construction time.
+type EnrichInfo struct {
+	Provider string // "ollama", "openai", "anthropic", or ""
+	Model    string // model name, or ""
+}
+
 // MCPInfo carries static MCP server metadata set at server construction time.
 type MCPInfo struct {
 	Addr     string // MCP listen address, e.g. ":8750"
@@ -107,7 +117,7 @@ type MCPInfo struct {
 //
 // sessionSecret is used to validate admin session cookies on /api/admin/* routes.
 // corsOrigins is the set of allowed CORS origins; nil disables cross-origin access.
-func NewServer(addr string, engine EngineAPI, authStore *auth.Store, sessionSecret []byte, corsOrigins []string, embedInfo EmbedInfo, pluginRegistry *plugin.Registry, dataDir string, tlsConfig *tls.Config, mcpInfo ...MCPInfo) *Server {
+func NewServer(addr string, engine EngineAPI, authStore *auth.Store, sessionSecret []byte, corsOrigins []string, embedInfo EmbedInfo, enrichInfo EnrichInfo, pluginRegistry *plugin.Registry, dataDir string, tlsConfig *tls.Config, mcpInfo ...MCPInfo) *Server {
 	mux := http.NewServeMux()
 	s := &Server{
 		addr:           addr,
@@ -118,6 +128,8 @@ func NewServer(addr string, engine EngineAPI, authStore *auth.Store, sessionSecr
 		mux:            mux,
 		embedProvider:  embedInfo.Provider,
 		embedModel:     embedInfo.Model,
+		enrichProvider: enrichInfo.Provider,
+		enrichModel:    enrichInfo.Model,
 		pluginRegistry: pluginRegistry,
 		dataDir:        dataDir,
 		tlsConfig:      tlsConfig,

--- a/internal/transport/rest/server_test.go
+++ b/internal/transport/rest/server_test.go
@@ -299,7 +299,7 @@ var _ = bytes.NewReader
 
 func TestHealthEndpoint(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	// Create a test request
 	req := httptest.NewRequest("GET", "/api/health", nil)
@@ -325,7 +325,7 @@ func TestHealthEndpoint(t *testing.T) {
 
 func TestReadyEndpoint(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/ready", nil)
 	w := httptest.NewRecorder()
@@ -348,7 +348,7 @@ func TestReadyEndpoint(t *testing.T) {
 
 func TestListEngrams(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/engrams?vault=default", nil)
 	w := httptest.NewRecorder()
@@ -371,7 +371,7 @@ func TestListEngrams(t *testing.T) {
 
 func TestListVaults(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/vaults", nil)
 	w := httptest.NewRecorder()
@@ -394,7 +394,7 @@ func TestListVaults(t *testing.T) {
 
 func TestGetSession(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/session?vault=default&since=2020-01-01T00:00:00Z", nil)
 	w := httptest.NewRecorder()
@@ -414,7 +414,7 @@ func TestGetSession(t *testing.T) {
 func TestCORSHeaders(t *testing.T) {
 	engine := &MockEngine{}
 	const testOrigin = "http://example.com"
-	server := NewServer("localhost:8080", engine, nil, nil, []string{testOrigin}, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, []string{testOrigin}, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	// Test OPTIONS preflight with matching origin.
 	req := httptest.NewRequest("OPTIONS", "/api/health", nil)
@@ -449,7 +449,7 @@ func TestCORSHeaders(t *testing.T) {
 
 func TestListEngramsDefaultVault(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	// No vault param — should default to "default"
 	req := httptest.NewRequest("GET", "/api/engrams", nil)
@@ -471,7 +471,7 @@ func TestListEngramsDefaultVault(t *testing.T) {
 
 func TestListEngramsLimitClamping(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	// Overlarge limit should be clamped to 100
 	req := httptest.NewRequest("GET", "/api/engrams?vault=default&limit=500", nil)
@@ -493,7 +493,7 @@ func TestListEngramsLimitClamping(t *testing.T) {
 
 func TestGetEngramLinks(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/engrams/test-id/links", nil)
 	w := httptest.NewRecorder()
@@ -514,7 +514,7 @@ func TestGetEngramLinks(t *testing.T) {
 
 func TestGetSessionDefaultSince(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	// No since param — should default to last 24h
 	req := httptest.NewRequest("GET", "/api/session?vault=default", nil)
@@ -528,7 +528,7 @@ func TestGetSessionDefaultSince(t *testing.T) {
 
 func TestGetSessionMalformedSince(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	// Malformed since — should fall back to 24h, not error
 	req := httptest.NewRequest("GET", "/api/session?vault=default&since=not-a-date", nil)
@@ -542,7 +542,7 @@ func TestGetSessionMalformedSince(t *testing.T) {
 
 func TestGetSessionLimitClamping(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/session?vault=default&limit=9999", nil)
 	w := httptest.NewRecorder()
@@ -556,7 +556,7 @@ func TestGetSessionLimitClamping(t *testing.T) {
 func TestCORSHeadersOnNewRoutes(t *testing.T) {
 	engine := &MockEngine{}
 	const testOrigin = "http://example.com"
-	server := NewServer("localhost:8080", engine, nil, nil, []string{testOrigin}, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, []string{testOrigin}, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	routes := []string{
 		"/api/engrams",
@@ -577,7 +577,7 @@ func TestCORSHeadersOnNewRoutes(t *testing.T) {
 
 func TestPreflightOnNewRoutes(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	routes := []string{"/api/engrams", "/api/vaults", "/api/session"}
 	for _, path := range routes {
@@ -607,7 +607,7 @@ func (e *errorEngine) GetEngramLinks(ctx context.Context, req *GetEngramLinksReq
 }
 
 func TestListEngramsEngineError(t *testing.T) {
-	server := NewServer("localhost:8080", &errorEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &errorEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	req := httptest.NewRequest("GET", "/api/engrams?vault=default", nil)
 	w := httptest.NewRecorder()
 	server.mux.ServeHTTP(w, req)
@@ -618,7 +618,7 @@ func TestListEngramsEngineError(t *testing.T) {
 }
 
 func TestListVaultsEngineError(t *testing.T) {
-	server := NewServer("localhost:8080", &errorEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &errorEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	req := httptest.NewRequest("GET", "/api/vaults", nil)
 	w := httptest.NewRecorder()
 	server.mux.ServeHTTP(w, req)
@@ -629,7 +629,7 @@ func TestListVaultsEngineError(t *testing.T) {
 }
 
 func TestGetSessionEngineError(t *testing.T) {
-	server := NewServer("localhost:8080", &errorEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &errorEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	req := httptest.NewRequest("GET", "/api/session?vault=default", nil)
 	w := httptest.NewRecorder()
 	server.mux.ServeHTTP(w, req)
@@ -640,7 +640,7 @@ func TestGetSessionEngineError(t *testing.T) {
 }
 
 func TestGetEngramLinksEngineError(t *testing.T) {
-	server := NewServer("localhost:8080", &errorEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &errorEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	req := httptest.NewRequest("GET", "/api/engrams/test-id/links", nil)
 	w := httptest.NewRecorder()
 	server.mux.ServeHTTP(w, req)
@@ -652,7 +652,7 @@ func TestGetEngramLinksEngineError(t *testing.T) {
 
 func TestShutdown(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:0", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:0", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -685,7 +685,7 @@ func TestShutdown(t *testing.T) {
 func TestContextPropagation(t *testing.T) {
 	var gotCtx context.Context
 	eng := &ctxCapturingEngine{captureCtx: func(ctx context.Context) { gotCtx = ctx }}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/stats", nil)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -737,7 +737,7 @@ func TestServer_PersistClusterDisabled_NoDataDir(t *testing.T) {
 // TestCreateEngram tests POST /api/engrams → 201
 func TestCreateEngram(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"concept":"test concept","content":"test content","vault":"default"}`
 	req := httptest.NewRequest("POST", "/api/engrams", strings.NewReader(body))
@@ -760,7 +760,7 @@ func TestCreateEngram(t *testing.T) {
 // TestCreateEngram_InvalidJSON tests POST /api/engrams with bad body → 400
 func TestCreateEngram_InvalidJSON(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/engrams", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -775,7 +775,7 @@ func TestCreateEngram_InvalidJSON(t *testing.T) {
 // TestActivate tests POST /api/activate → 200
 func TestActivate(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"context":["memory","learning"],"vault":"default","max_results":10}`
 	req := httptest.NewRequest("POST", "/api/activate", strings.NewReader(body))
@@ -798,7 +798,7 @@ func TestActivate(t *testing.T) {
 // TestActivate_InvalidJSON tests POST /api/activate with bad body → 400
 func TestActivate_InvalidJSON(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/activate", strings.NewReader("invalid json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -813,7 +813,7 @@ func TestActivate_InvalidJSON(t *testing.T) {
 // TestDeleteEngram tests DELETE /api/engrams/{id} → 200
 func TestDeleteEngram(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("DELETE", "/api/engrams/01ARZ3NDEKTSV4RRFFQ69G5FAV", nil)
 	w := httptest.NewRecorder()
@@ -834,7 +834,7 @@ func TestDeleteEngram(t *testing.T) {
 // TestDeleteEngram_MissingID tests DELETE /api/engrams/ without ID → 400
 func TestDeleteEngram_MissingID(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	// The mux will not match /api/engrams/ (missing {id}), so request will 404
 	req := httptest.NewRequest("DELETE", "/api/engrams/", nil)
@@ -851,7 +851,7 @@ func TestDeleteEngram_MissingID(t *testing.T) {
 // TestActivate_EmptyContext tests POST /api/activate with empty context array
 func TestActivate_EmptyContext(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"context":[],"vault":"default","max_results":10}`
 	req := httptest.NewRequest("POST", "/api/activate", strings.NewReader(body))
@@ -886,7 +886,7 @@ func TestOnlineBackupEndpoint(t *testing.T) {
 	db.Close()
 
 	eng := &backupMockEngine{pebbleDir: pebbleDir}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	outputDir := filepath.Join(t.TempDir(), "online-backup-out")
 	body := fmt.Sprintf(`{"output_dir":%q}`, outputDir)
@@ -933,7 +933,7 @@ func TestOnlineBackupEndpoint(t *testing.T) {
 
 func TestOnlineBackupEndpoint_ConflictExistingDir(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	existingDir := t.TempDir()
 	body := fmt.Sprintf(`{"output_dir":%q}`, existingDir)
@@ -949,7 +949,7 @@ func TestOnlineBackupEndpoint_ConflictExistingDir(t *testing.T) {
 
 func TestOnlineBackupEndpoint_MissingOutputDir(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{}`
 	req := httptest.NewRequest("POST", "/api/admin/backup", strings.NewReader(body))
@@ -986,7 +986,7 @@ func TestRemoveNode_SelfRemoval_Returns400(t *testing.T) {
 	coord := replication.NewClusterCoordinator(cfg, repLog, applier, epochStore)
 
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	server.SetCoordinator(coord)
 
 	req := httptest.NewRequest("DELETE", "/api/admin/cluster/nodes/cortex-1", nil)
@@ -1030,7 +1030,7 @@ func TestRemoveNode_OtherNode_Returns200(t *testing.T) {
 	coord := replication.NewClusterCoordinator(cfg, repLog, applier, epochStore)
 
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	server.SetCoordinator(coord)
 
 	req := httptest.NewRequest("DELETE", "/api/admin/cluster/nodes/lobe-2", nil)
@@ -1044,7 +1044,7 @@ func TestRemoveNode_OtherNode_Returns200(t *testing.T) {
 
 func TestBatchCreateEngrams(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"engrams":[{"content":"one","concept":"c1"},{"content":"two","concept":"c2"},{"content":"three"}]}`
 	req := httptest.NewRequest("POST", "/api/engrams/batch", strings.NewReader(body))
@@ -1082,7 +1082,7 @@ func TestBatchCreateEngrams(t *testing.T) {
 
 func TestBatchCreateEngramsExceedsLimit(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	engrams := make([]map[string]string, 51)
 	for i := range engrams {
@@ -1101,7 +1101,7 @@ func TestBatchCreateEngramsExceedsLimit(t *testing.T) {
 
 func TestBatchCreateEngramsEmptyArray(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"engrams":[]}`
 	req := httptest.NewRequest("POST", "/api/engrams/batch", strings.NewReader(body))
@@ -1116,7 +1116,7 @@ func TestBatchCreateEngramsEmptyArray(t *testing.T) {
 
 func TestEvolveEndpoint(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"new_content":"updated content","reason":"correction"}`
 	req := httptest.NewRequest("POST", "/api/engrams/test-id/evolve", strings.NewReader(body))
@@ -1139,7 +1139,7 @@ func TestEvolveEndpoint(t *testing.T) {
 
 func TestEvolveEndpoint_MissingFields(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{}`
 	req := httptest.NewRequest("POST", "/api/engrams/test-id/evolve", strings.NewReader(body))
@@ -1154,7 +1154,7 @@ func TestEvolveEndpoint_MissingFields(t *testing.T) {
 
 func TestConsolidateEndpoint(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"vault":"default","ids":["id-1","id-2","id-3"],"merged_content":"combined content"}`
 	req := httptest.NewRequest("POST", "/api/consolidate", strings.NewReader(body))
@@ -1180,7 +1180,7 @@ func TestConsolidateEndpoint(t *testing.T) {
 
 func TestConsolidateEndpoint_TooFewIDs(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"vault":"default","ids":["only-one"],"merged_content":"content"}`
 	req := httptest.NewRequest("POST", "/api/consolidate", strings.NewReader(body))
@@ -1195,7 +1195,7 @@ func TestConsolidateEndpoint_TooFewIDs(t *testing.T) {
 
 func TestDecideEndpoint(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"vault":"default","decision":"use postgres","rationale":"better for relational data"}`
 	req := httptest.NewRequest("POST", "/api/decide", strings.NewReader(body))
@@ -1218,7 +1218,7 @@ func TestDecideEndpoint(t *testing.T) {
 
 func TestDecideEndpoint_MissingFields(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"vault":"default"}`
 	req := httptest.NewRequest("POST", "/api/decide", strings.NewReader(body))
@@ -1233,7 +1233,7 @@ func TestDecideEndpoint_MissingFields(t *testing.T) {
 
 func TestRestoreEndpoint(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/engrams/test-id/restore", nil)
 	w := httptest.NewRecorder()
@@ -1257,7 +1257,7 @@ func TestRestoreEndpoint(t *testing.T) {
 
 func TestTraverseEndpoint(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"vault":"default","start_id":"node-1"}`
 	req := httptest.NewRequest("POST", "/api/traverse", strings.NewReader(body))
@@ -1283,7 +1283,7 @@ func TestTraverseEndpoint(t *testing.T) {
 
 func TestTraverseEndpoint_MissingStartID(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"vault":"default"}`
 	req := httptest.NewRequest("POST", "/api/traverse", strings.NewReader(body))
@@ -1298,7 +1298,7 @@ func TestTraverseEndpoint_MissingStartID(t *testing.T) {
 
 func TestExplainEndpoint(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"vault":"default","engram_id":"eng-1","query":["test query"]}`
 	req := httptest.NewRequest("POST", "/api/explain", strings.NewReader(body))
@@ -1324,7 +1324,7 @@ func TestExplainEndpoint(t *testing.T) {
 
 func TestExplainEndpoint_MissingFields(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"vault":"default","query":["test"]}`
 	req := httptest.NewRequest("POST", "/api/explain", strings.NewReader(body))
@@ -1339,7 +1339,7 @@ func TestExplainEndpoint_MissingFields(t *testing.T) {
 
 func TestSetStateEndpoint(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"state":"active","reason":"resuming work"}`
 	req := httptest.NewRequest("PUT", "/api/engrams/test-id/state", strings.NewReader(body))
@@ -1365,7 +1365,7 @@ func TestSetStateEndpoint(t *testing.T) {
 
 func TestSetStateEndpoint_InvalidState(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"state":"invalid"}`
 	req := httptest.NewRequest("PUT", "/api/engrams/test-id/state", strings.NewReader(body))
@@ -1380,7 +1380,7 @@ func TestSetStateEndpoint_InvalidState(t *testing.T) {
 
 func TestListDeletedEndpoint(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/deleted?vault=default", nil)
 	w := httptest.NewRecorder()
@@ -1404,7 +1404,7 @@ func TestListDeletedEndpoint(t *testing.T) {
 
 func TestRetryEnrichEndpoint(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/engrams/test-id/retry-enrich", nil)
 	w := httptest.NewRecorder()
@@ -1428,7 +1428,7 @@ func TestRetryEnrichEndpoint(t *testing.T) {
 
 func TestContradictionsEndpoint(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/contradictions?vault=default", nil)
 	w := httptest.NewRecorder()
@@ -1449,7 +1449,7 @@ func TestContradictionsEndpoint(t *testing.T) {
 
 func TestGuideEndpoint(t *testing.T) {
 	engine := &MockEngine{}
-	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/guide?vault=default", nil)
 	w := httptest.NewRecorder()
@@ -1470,7 +1470,7 @@ func TestGuideEndpoint(t *testing.T) {
 
 func TestHandleReembedVault(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/admin/vaults/test-vault/reembed", nil)
 	w := httptest.NewRecorder()
@@ -1491,7 +1491,7 @@ func TestHandleReembedVault(t *testing.T) {
 
 func TestHandleObservability(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/admin/observability", nil)
 	w := httptest.NewRecorder()
@@ -1509,7 +1509,7 @@ func TestHandleObservability(t *testing.T) {
 
 func TestHandleRenameVault_Success(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := strings.NewReader(`{"new_name":"renamed-vault"}`)
 	req := httptest.NewRequest("POST", "/api/admin/vaults/old-vault/rename", body)
@@ -1532,7 +1532,7 @@ func TestHandleRenameVault_Success(t *testing.T) {
 
 func TestHandleRenameVault_InvalidName(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := strings.NewReader(`{"new_name":"BAD NAME!"}`)
 	req := httptest.NewRequest("POST", "/api/admin/vaults/old-vault/rename", body)
@@ -1547,7 +1547,7 @@ func TestHandleRenameVault_InvalidName(t *testing.T) {
 
 func TestHandleRenameVault_SameName(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := strings.NewReader(`{"new_name":"same-vault"}`)
 	req := httptest.NewRequest("POST", "/api/admin/vaults/same-vault/rename", body)
@@ -1570,7 +1570,7 @@ func (m *renameMockNotFound) RenameVault(_ context.Context, _, _ string) error {
 
 func TestHandleRenameVault_NotFound(t *testing.T) {
 	eng := &renameMockNotFound{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := strings.NewReader(`{"new_name":"new-vault"}`)
 	req := httptest.NewRequest("POST", "/api/admin/vaults/old-vault/rename", body)
@@ -1593,7 +1593,7 @@ func (m *renameMockJobActive) RenameVault(_ context.Context, _, _ string) error 
 
 func TestHandleRenameVault_JobActive(t *testing.T) {
 	eng := &renameMockJobActive{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := strings.NewReader(`{"new_name":"new-vault"}`)
 	req := httptest.NewRequest("POST", "/api/admin/vaults/old-vault/rename", body)
@@ -1616,7 +1616,7 @@ func (m *renameMockCollision) RenameVault(_ context.Context, _, _ string) error 
 
 func TestHandleRenameVault_Collision(t *testing.T) {
 	eng := &renameMockCollision{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := strings.NewReader(`{"new_name":"new-vault"}`)
 	req := httptest.NewRequest("POST", "/api/admin/vaults/old-vault/rename", body)
@@ -1631,7 +1631,7 @@ func TestHandleRenameVault_Collision(t *testing.T) {
 
 func TestHandleRenameVault_MissingBody(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/api/admin/vaults/old-vault/rename", strings.NewReader(""))
 	req.Header.Set("Content-Type", "application/json")
@@ -1645,7 +1645,7 @@ func TestHandleRenameVault_MissingBody(t *testing.T) {
 
 func TestHandleRenameVault_EmptyNewName(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := strings.NewReader(`{"new_name":""}`)
 	req := httptest.NewRequest("POST", "/api/admin/vaults/old-vault/rename", body)
@@ -1662,7 +1662,7 @@ func TestHandleRenameVault_EmptyNewName(t *testing.T) {
 // exactly two keys (old_name, new_name), correct Content-Type header.
 func TestHandleRenameVault_ResponseBody(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := strings.NewReader(`{"new_name":"renamed-vault"}`)
 	req := httptest.NewRequest("POST", "/api/admin/vaults/old-vault/rename", body)
@@ -1718,7 +1718,7 @@ func (m *renameMockInternalError) RenameVault(_ context.Context, _, _ string) er
 // error falls through to the 500 Internal Server Error branch.
 func TestHandleRenameVault_InternalServerError(t *testing.T) {
 	eng := &renameMockInternalError{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := strings.NewReader(`{"new_name":"new-vault"}`)
 	req := httptest.NewRequest("POST", "/api/admin/vaults/old-vault/rename", body)
@@ -1749,7 +1749,7 @@ func TestHandleRenameVault_InternalServerError(t *testing.T) {
 // returns 200 with a ReadResponse body.
 func TestGetEngram_HappyPath(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/engrams/test-id?vault=default", nil)
 	w := httptest.NewRecorder()
@@ -1779,7 +1779,7 @@ func (e *readErrEngine) Read(ctx context.Context, req *ReadRequest) (*ReadRespon
 
 // TestGetEngram_EngineError verifies that a Read engine error produces a 4xx/5xx response.
 func TestGetEngram_EngineError(t *testing.T) {
-	server := NewServer("localhost:8080", &readErrEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &readErrEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/engrams/missing-id?vault=default", nil)
 	w := httptest.NewRecorder()
@@ -1797,7 +1797,7 @@ func TestGetEngram_EngineError(t *testing.T) {
 // non-empty body and the correct Content-Type header.
 func TestOpenAPISpec_Returns200(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/openapi.yaml", nil)
 	w := httptest.NewRecorder()
@@ -1818,7 +1818,7 @@ func TestOpenAPISpec_Returns200(t *testing.T) {
 // TestOpenAPISpec_CacheControl verifies that the Cache-Control header contains "max-age".
 func TestOpenAPISpec_CacheControl(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/openapi.yaml", nil)
 	w := httptest.NewRecorder()
@@ -1841,7 +1841,7 @@ func (e *contradictionsErrEngine) GetContradictions(ctx context.Context, vault s
 
 // TestContradictions_EngineError verifies that a GetContradictions engine error → 500.
 func TestContradictions_EngineError(t *testing.T) {
-	server := NewServer("localhost:8080", &contradictionsErrEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &contradictionsErrEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/contradictions?vault=default", nil)
 	w := httptest.NewRecorder()
@@ -1856,7 +1856,7 @@ func TestContradictions_EngineError(t *testing.T) {
 
 // TestResolveContradiction_Success verifies the happy path returns {resolved:true}.
 func TestResolveContradiction_Success(t *testing.T) {
-	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"vault":"default","id_a":"01ARZ3NDEKTSV4RRFFQ69G5FAV","id_b":"01ARZ3NDEKTSV4RRFFQ69G5FAW"}`
 	req := httptest.NewRequest("POST", "/api/admin/contradictions/resolve", strings.NewReader(body))
@@ -1878,7 +1878,7 @@ func TestResolveContradiction_Success(t *testing.T) {
 
 // TestResolveContradiction_MissingIDs verifies missing IDs returns 400.
 func TestResolveContradiction_MissingIDs(t *testing.T) {
-	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"vault":"default","id_a":"","id_b":""}`
 	req := httptest.NewRequest("POST", "/api/admin/contradictions/resolve", strings.NewReader(body))
@@ -1900,7 +1900,7 @@ func (e *resolveContradictionErrEngine) ResolveContradiction(ctx context.Context
 
 // TestResolveContradiction_EngineError verifies engine error → 500.
 func TestResolveContradiction_EngineError(t *testing.T) {
-	server := NewServer("localhost:8080", &resolveContradictionErrEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &resolveContradictionErrEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := `{"vault":"default","id_a":"01ARZ3NDEKTSV4RRFFQ69G5FAV","id_b":"01ARZ3NDEKTSV4RRFFQ69G5FAW"}`
 	req := httptest.NewRequest("POST", "/api/admin/contradictions/resolve", strings.NewReader(body))
@@ -1924,7 +1924,7 @@ func (e *guideErrEngine) GetGuide(ctx context.Context, vault string) (string, er
 
 // TestGuide_EngineError verifies that a GetGuide engine error → 500.
 func TestGuide_EngineError(t *testing.T) {
-	server := NewServer("localhost:8080", &guideErrEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", &guideErrEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/guide?vault=default", nil)
 	w := httptest.NewRecorder()
@@ -1941,7 +1941,7 @@ func TestGuide_EngineError(t *testing.T) {
 // returns correct MCP URL for the UI to call entity graph via MCP.
 func TestEntityGraphVisualization_MCPInfoEndpoint(t *testing.T) {
 	// Create server with MCP address configured
-	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, nil, "", nil, MCPInfo{Addr: "localhost:8750", HasToken: false})
+	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil, MCPInfo{Addr: "localhost:8750", HasToken: false})
 
 	req := httptest.NewRequest("GET", "/api/admin/mcp-info", nil)
 	w := httptest.NewRecorder()
@@ -1997,7 +1997,7 @@ func TestHandleVaultStats_ReturnsAllVaults(t *testing.T) {
 		t.Fatalf("SetVaultConfig: %v", err)
 	}
 
-	srv := NewServer("localhost:0", eng, store, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", eng, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	req := httptest.NewRequest("GET", "/api/vaults/stats", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -2041,7 +2041,7 @@ func TestHandleVaultStats_AccurateCount(t *testing.T) {
 			"beta":  7,
 		},
 	}
-	srv := NewServer("localhost:0", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	req := httptest.NewRequest("GET", "/api/vaults/stats", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -2077,7 +2077,7 @@ func TestHandleVaultStats_RequiresAdminAuth(t *testing.T) {
 	// session cookie must be rejected with 401.
 	store := newTestAuthStore(t)
 	secret := []byte("test-secret")
-	srv := NewServer("localhost:0", &MockEngine{}, store, secret, nil, EmbedInfo{}, nil, "", nil)
+	srv := NewServer("localhost:0", &MockEngine{}, store, secret, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/vaults/stats", nil)
 	// No session cookie — should be rejected by admin auth middleware.

--- a/internal/transport/rest/targeted_boost_test.go
+++ b/internal/transport/rest/targeted_boost_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestHandleGetEngram_EmptyID(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/engrams/x", nil)
 	req.SetPathValue("id", "") // force empty
@@ -38,7 +38,7 @@ func TestHandleGetEngram_EmptyID(t *testing.T) {
 
 func TestHandleDeleteEngram_EmptyID_Direct(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("DELETE", "/api/engrams/x", nil)
 	req.SetPathValue("id", "")
@@ -56,7 +56,7 @@ func TestHandleDeleteEngram_EmptyID_Direct(t *testing.T) {
 
 func TestHandleMCPInfo_WithMalformedAddr(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	// A malformed mcpAddr that will make net.SplitHostPort fail.
 	server.mcpAddr = "not-a-valid-addr:with:too:many:colons"
 
@@ -71,7 +71,7 @@ func TestHandleMCPInfo_WithMalformedAddr(t *testing.T) {
 
 func TestHandleMCPInfo_WithWildcardHost(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 	server.mcpAddr = "0.0.0.0:8750"
 
 	req := httptest.NewRequest("GET", "/api/admin/mcp", nil)
@@ -89,7 +89,7 @@ func TestHandleMCPInfo_WithWildcardHost(t *testing.T) {
 
 func TestHandleCloneVault_SameNameAsSource(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := bytes.NewReader([]byte(`{"new_name":"source-vault"}`))
 	req := httptest.NewRequest("POST", "/api/admin/vaults/source-vault/clone", body)
@@ -110,7 +110,7 @@ func TestHandleCloneVault_SameNameAsSource(t *testing.T) {
 func TestHandlePutPluginConfig_Success_Targeted(t *testing.T) {
 	eng := &MockEngine{}
 	dataDir := t.TempDir()
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, dataDir, nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, dataDir, nil)
 
 	body := bytes.NewReader([]byte(`{"embed":{"provider_url":"ollama://localhost:11434/test"}}`))
 	req := httptest.NewRequest("PUT", "/api/admin/plugins/config", body)
@@ -129,7 +129,7 @@ func TestHandlePutPluginConfig_Success_Targeted(t *testing.T) {
 
 func TestRecoveryMiddleware_AbortHandlerRepanics(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	abortHandler := server.recoveryMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		panic(http.ErrAbortHandler)
@@ -159,7 +159,7 @@ func TestHandlePlugins_WithEmbedPlugin(t *testing.T) {
 	}
 
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, registry, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, registry, "", nil)
 	server.embedProvider = "test-provider"
 	server.embedModel = "test-model"
 
@@ -192,7 +192,7 @@ func (p *testEmbedPlugin) Dimension() int { return 2 }
 
 func TestHandleReplicationStatus_Exported(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/v1/replication/status", nil)
 	w := httptest.NewRecorder()
@@ -205,7 +205,7 @@ func TestHandleReplicationStatus_Exported(t *testing.T) {
 
 func TestHandleReplicationLag_Exported(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/v1/replication/lag", nil)
 	w := httptest.NewRecorder()
@@ -224,7 +224,7 @@ func TestHandleReplicationLag_Exported(t *testing.T) {
 
 func TestHandleSubscribe_ContextCancelExit(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest("GET", "/api/subscribe?vault=default", nil)
@@ -250,7 +250,7 @@ func TestHandleSubscribe_ContextCancelExit(t *testing.T) {
 
 func TestHandleSubscribe_WithParams(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	// Test with various query params to cover parameter parsing branches.
@@ -270,7 +270,7 @@ func TestHandleSubscribe_WithParams(t *testing.T) {
 
 func TestHandleSubscribe_InvalidParams(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	// Test with out-of-range threshold, negative ttl, and out-of-range rate.
@@ -290,7 +290,7 @@ func TestHandleSubscribe_InvalidParams(t *testing.T) {
 
 func TestHandlePromoteReplica_Exported(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/replication/promote", nil)
 	w := httptest.NewRecorder()
@@ -332,7 +332,7 @@ func TestCtxVault_WithEmptyContextValue(t *testing.T) {
 
 func TestHandleConsolidate_EmptyVault(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	handler := server.handleConsolidate()
 	req := httptest.NewRequest("POST", "/v1/vaults//consolidate", strings.NewReader(`{}`))
@@ -348,7 +348,7 @@ func TestHandleConsolidate_EmptyVault(t *testing.T) {
 
 func TestHandleConsolidate_InvalidJSON_Targeted(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	handler := server.handleConsolidate()
 	req := httptest.NewRequest("POST", "/v1/vaults/default/consolidate", strings.NewReader("{bad"))
@@ -368,7 +368,7 @@ func TestHandleConsolidate_InvalidJSON_Targeted(t *testing.T) {
 
 func TestHandleEvolve_MissingContent(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := bytes.NewReader([]byte(`{"new_content":"","reason":""}`))
 	req := httptest.NewRequest("PUT", "/api/engrams/some-id/evolve", body)
@@ -431,7 +431,7 @@ func TestSetVaultConfig_InvalidVaultName_Boost(t *testing.T) {
 
 func TestHandleGetSession_WithSinceParam(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	req := httptest.NewRequest("GET", "/api/session?since=2026-01-01T00:00:00Z&limit=10", nil)
 	w := httptest.NewRecorder()
@@ -499,7 +499,7 @@ func TestCreateAPIKey_InvalidMode(t *testing.T) {
 
 func TestHandleMergeVault_InvalidTargetName(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := bytes.NewReader([]byte(`{"target":"INVALID!"}`))
 	req := httptest.NewRequest("POST", "/api/admin/vaults/source/merge-into", body)
@@ -515,7 +515,7 @@ func TestHandleMergeVault_InvalidTargetName(t *testing.T) {
 
 func TestHandleMergeVault_SameSourceTarget_Targeted(t *testing.T) {
 	eng := &MockEngine{}
-	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, nil, "", nil)
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
 	body := bytes.NewReader([]byte(`{"target":"source"}`))
 	req := httptest.NewRequest("POST", "/api/admin/vaults/source/merge-into", body)


### PR DESCRIPTION

<img width="991" height="247" alt="before" src="https://github.com/user-attachments/assets/95f3e1a6-6ed3-4aec-9d70-14d30b13e227" />
<img width="1401" height="403" alt="after" src="https://github.com/user-attachments/assets/ae82d8c8-9c57-4da4-b9de-e8105eef69ef" />

The handlePlugins endpoint only populated Provider and Model fields for embed plugins (tier 2). Added EnrichInfo to NewServer following the same pattern as EmbedInfo, with resolveEnrichInfo extracting provider/model from MUNINN_ENRICH_URL or saved plugin config. The handlePlugins handler now populates these fields for tier 3 (enrich) plugins as well.

