### PR TITLE
fix(lifecycle): fix restart race condition — proper stop wait and timeout handling

### DIFF
--- a/cmd/muninn/lifecycle.go
+++ b/cmd/muninn/lifecycle.go
@@ -165,11 +165,11 @@ func runStop() {
 		os.Exit(1)
 	}
 
-	// Wait for the process to actually exit (up to 15s) so that restart
-	// doesn't race with the old process still holding the Pebble DB lock.
-	// Pebble's graceful shutdown (WAL flush + fsync) can take several seconds,
-	// so 15s gives ample headroom for slow disks or large write buffers.
-	deadline := time.Now().Add(15 * time.Second)
+	// Wait for the process to actually exit before returning. The timeout is
+	// 35s — 5s beyond the daemon's own 30s internal shutdown deadline — so the
+	// CLI always outlasts the daemon's worst-case graceful shutdown, including
+	// Pebble WAL flush and fsync on slow disks.
+	deadline := time.Now().Add(35 * time.Second)
 	for time.Now().Before(deadline) {
 		if !isProcessRunning(pid) {
 			break
@@ -177,9 +177,20 @@ func runStop() {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	// Brief pause after process exit to allow the OS to fully release file
-	// handles (including the Pebble lock file) before the next instance opens
-	// the same database directory.
+	// If the process is still alive after 35s, do not silently proceed.
+	// Starting a new instance while the old one holds the Pebble lock will
+	// fail with "resource temporarily unavailable". Bail out explicitly so
+	// the user knows to investigate rather than seeing a confusing start failure.
+	if isProcessRunning(pid) {
+		fmt.Fprintf(os.Stderr, "muninn (pid %d) did not stop within 35s — aborting\n", pid)
+		fmt.Fprintf(os.Stderr, "Check 'muninn logs' for details. You can force-kill with: kill -9 %d\n", pid)
+		os.Exit(1)
+	}
+
+	// 300ms buffer after process exit before returning. kill(pid,0) returning
+	// ESRCH means the process is gone from the kernel table, but flock(2) lock
+	// release is not guaranteed to be visible to other processes at exactly
+	// that instant. This covers the brief kernel cleanup window.
 	time.Sleep(300 * time.Millisecond)
 
 	fmt.Printf("muninn stopped (pid %d)\n", pid)


### PR DESCRIPTION
## Summary

Fixes #88 — `muninn restart` fails with Pebble "resource temporarily unavailable" when the old instance hasn't fully released its DB lock before the new one starts.

**Root causes (from Opus architectural review):**
- Stop wait was only 5s, but the daemon's own internal shutdown timeout is 30s — Pebble WAL flush can easily exceed 5s under load
- **Critical:** when the wait timeout expired, the code silently fell through and removed the PID file even if the old process was *still running*, guaranteeing a lock race on the next `runStart`

**Changes:**
- Stop wait: 5s (previous branch had 15s) → **35s** — 5s beyond the daemon's 30s internal shutdown deadline
- After the wait loop, explicitly check `isProcessRunning` again. If still alive, print a clear error with kill hint and `os.Exit(1)` instead of silently racing into a locked DB
- 300ms post-exit buffer retained — covers the brief kernel `flock` cleanup window between `kill(pid,0)` returning ESRCH and lock visibility to other processes

## Test plan
- [ ] `muninn restart` succeeds cleanly (covered by existing `TestRestartNoRace` integration test)
- [ ] If daemon takes >35s to stop, CLI prints clear error and exits 1 rather than starting a racing new instance