### PR TITLE
fix(enrich): fix OpenAI connectivity probe rejecting with 400 on init

### DIFF
--- a/internal/plugin/enrich/openai.go
+++ b/internal/plugin/enrich/openai.go
@@ -69,8 +69,11 @@ func (p *OpenAILLMProvider) Init(ctx context.Context, cfg LLMProviderConfig) err
 		return fmt.Errorf("openai provider requires API key")
 	}
 
-	// Send a probe completion request to validate connectivity
-	_, err := p.Complete(ctx, "You are a helpful assistant.", "Say 'OK' only.")
+	// Send a probe completion request to validate connectivity.
+	// The user message must contain the word "json" because Complete always
+	// sets response_format:json_object — OpenAI rejects requests where none
+	// of the messages mention json when that format is requested.
+	_, err := p.Complete(ctx, "You are a connectivity probe. Respond with valid JSON only.", `{"ok":true}`)
 	if err != nil {
 		return fmt.Errorf("openai connectivity check failed: %w", err)
 	}

--- a/internal/plugin/enrich/providers_test.go
+++ b/internal/plugin/enrich/providers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -263,6 +264,49 @@ func TestOpenAIProvider_Init_Success(t *testing.T) {
 		APIKey:  "key",
 	})
 	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+}
+
+// TestOpenAIProvider_Init_ProbeContainsJSON is a regression test for the bug
+// where the connectivity probe sent "Say 'OK' only." without the word "json",
+// causing OpenAI to reject the request with HTTP 400 when response_format is
+// json_object. Asserts that all probe messages contain "json".
+func TestOpenAIProvider_Init_ProbeContainsJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req openaiChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode request: %v", err)
+		}
+		// OpenAI requires at least one message to contain the word "json"
+		// when response_format=json_object is set.
+		hasJSON := false
+		for _, msg := range req.Messages {
+			if strings.Contains(strings.ToLower(msg.Content), "json") {
+				hasJSON = true
+				break
+			}
+		}
+		if !hasJSON {
+			t.Errorf("no probe message contains 'json' — OpenAI rejects response_format=json_object when 'json' does not appear in any message")
+		}
+		resp := openaiChatResponse{
+			Choices: []struct {
+				Message openaiMessage `json:"message"`
+			}{
+				{Message: openaiMessage{Role: "assistant", Content: `{"ok":true}`}},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	p := NewOpenAILLMProvider()
+	if err := p.Init(context.Background(), LLMProviderConfig{
+		BaseURL: srv.URL,
+		Model:   "test",
+		APIKey:  "key",
+	}); err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #87 — OpenAI enrichment fails on startup with:
```
'messages' must contain the word 'json' in some form, to use 'response_format' of type 'json_object'
```

**Root cause:** `Complete()` always sets `response_format: json_object`. The connectivity probe in `Init()` called it with `"Say 'OK' only."` which contains no mention of "json" — OpenAI rejects this combination with HTTP 400. All real pipeline calls (entities, relationships, classify, summarize) were fine because their system prompts all say "Return ONLY a JSON object."

**Fix:** Updated the probe message to `"You are a connectivity probe. Respond with valid JSON only."` — satisfies the OpenAI requirement, keeps the probe minimal.

**Regression test added:** `TestOpenAIProvider_Init_ProbeContainsJSON` — asserts at least one probe message contains "json" so this can't silently regress.

## Test plan
- [ ] `go test ./internal/plugin/enrich/... -run TestOpenAIProvider` passes
- [ ] OpenAI enrichment initializes without error on `muninn restart`