### PR TITLE
feat(openclaw): complete stdio MCP integration with muninn mcp proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,18 +121,21 @@ Add to `~/.cursor/mcp.json`:
 <details>
 <summary>OpenClaw</summary>
 
-Add to `~/.openclaw/mcp.json`:
+Add to `~/.openclaw/openclaw.json`:
 
 ```json
 {
   "mcpServers": {
     "muninn": {
-      "type": "http",
-      "url": "http://localhost:8750/mcp"
+      "command": "muninn",
+      "args": ["mcp"],
+      "transport": "stdio"
     }
   }
 }
 ```
+
+OpenClaw uses stdio transport. The `muninn mcp` proxy (included in the binary) handles bearer token auth automatically — no credential needed in the config file.
 </details>
 
 <details>

--- a/cmd/muninn/completion.go
+++ b/cmd/muninn/completion.go
@@ -5,7 +5,7 @@ import "fmt"
 // muninnCommands is the canonical list of all top-level subcommands.
 var muninnCommands = []string{
 	"init", "start", "stop", "restart", "status",
-	"shell", "logs", "show", "completion", "help",
+	"shell", "logs", "mcp", "show", "completion", "help",
 }
 
 func printCompletion(shell string) {
@@ -26,7 +26,7 @@ const bashCompletion = `# muninn bash completion
 
 _muninn_completions() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
-    local commands="init start stop restart status shell logs show completion help"
+    local commands="init start stop restart status shell logs mcp show completion help"
     COMPREPLY=($(compgen -W "${commands}" -- "${cur}"))
 }
 complete -F _muninn_completions muninn
@@ -46,6 +46,7 @@ _muninn() {
         'status:Show service health'
         'shell:Interactive memory explorer'
         'logs:Tail the log file'
+        'mcp:stdio→HTTP MCP proxy (for OpenClaw)'
         'completion:Generate shell completion script'
         'help:Show help'
     )
@@ -66,6 +67,7 @@ complete -c muninn -n __fish_use_subcommand -a restart   -d 'Stop and restart'
 complete -c muninn -n __fish_use_subcommand -a status    -d 'Show service health'
 complete -c muninn -n __fish_use_subcommand -a shell     -d 'Interactive memory explorer'
 complete -c muninn -n __fish_use_subcommand -a logs      -d 'Tail the log file'
+complete -c muninn -n __fish_use_subcommand -a mcp       -d 'stdio→HTTP MCP proxy (for OpenClaw)'
 complete -c muninn -n __fish_use_subcommand -a completion -d 'Generate shell completion script'
 complete -c muninn -n __fish_use_subcommand -a help      -d 'Show help'
 `

--- a/cmd/muninn/help.go
+++ b/cmd/muninn/help.go
@@ -225,6 +225,16 @@ var subcommandHelp = map[string]func(){
 				"muninn admin change-password -u root -p",
 			})
 	},
+	"mcp": func() {
+		printSubcommandUsage("mcp", "stdio→HTTP MCP proxy for OpenClaw", "muninn mcp",
+			[][2]string{
+				{"MUNINN_MCP_URL", "Override MCP endpoint (default: http://127.0.0.1:8750/mcp)"},
+			},
+			[]string{
+				"muninn mcp",
+				"MUNINN_MCP_URL=https://remote:8750/mcp muninn mcp",
+			})
+	},
 	"show vaults": func() {
 		printSubcommandUsage("show vaults", "list all vaults", "muninn show vaults", nil,
 			[]string{"muninn show vaults"})
@@ -293,6 +303,7 @@ func printHelp() {
 	fmt.Printf("  %-32s %s\n", cyan("muninn admin change-password"), "Change the admin password")
 	fmt.Printf("  %-32s %s\n", cyan("muninn backup --output <dir>"), "Offline point-in-time backup (server must be stopped)")
 	fmt.Printf("  %-32s %s\n", cyan("muninn cluster"), "Cluster management (info, status, failover, add-node, remove-node)")
+	fmt.Printf("  %-32s %s\n", cyan("muninn mcp"), "stdio→HTTP MCP proxy (for OpenClaw)")
 	fmt.Printf("  %-32s %s\n", cyan("muninn completion <shell>"), "Shell completion (bash/zsh/fish)")
 	fmt.Printf("  %-32s %s\n", cyan("muninn upgrade"), "Check for and install updates")
 	fmt.Printf("  %-32s %s\n", cyan("muninn help"), "Show this message")
@@ -312,7 +323,7 @@ func printHelp() {
 	fmt.Println("  Run " + cyan("muninn init") + " to configure Claude Desktop, Cursor, or Windsurf automatically.")
 	fmt.Println()
 	fmt.Println("  MCP endpoint: http://localhost:8750/mcp")
-	fmt.Printf("  %-28s %s\n", "MUNINNDB_MCP_URL", "Override MCP server URL")
+	fmt.Printf("  %-28s %s\n", "MUNINN_MCP_URL", "Override MCP server URL (also used by 'muninn mcp' proxy)")
 	fmt.Printf("  %-28s %s\n", "MUNINNDB_DATA", "Override default data directory")
 	fmt.Println()
 

--- a/cmd/muninn/init.go
+++ b/cmd/muninn/init.go
@@ -684,6 +684,10 @@ func configureNamedTools(tools []string, mcpURL, token string) []string {
 				errs = append(errs, fmt.Sprintf("OpenClaw: %v", err))
 				fmt.Fprintf(os.Stderr, "  ✗ OpenClaw: %v\n", err)
 			}
+			// Also install the SKILL.md so OpenClaw knows how to use MuninnDB tools.
+			if err := configureOpenClawSkill(); err != nil {
+				fmt.Fprintf(os.Stderr, "  warning: OpenClaw skill: %v\n", err)
+			}
 		case "codex":
 			if err := configureCodex(mcpURL, token); err != nil {
 				errs = append(errs, fmt.Sprintf("Codex: %v", err))

--- a/cmd/muninn/main.go
+++ b/cmd/muninn/main.go
@@ -64,6 +64,8 @@ func main() {
 		runStart(true)
 	case "show:vaults":
 		runShowVaults()
+	case "mcp":
+		runMCPStdio()
 	case "logs":
 		runLogs(rest)
 	case "cluster":

--- a/cmd/muninn/mcp_stdio.go
+++ b/cmd/muninn/mcp_stdio.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// mcpProxyURL is the HTTP MCP endpoint for the running daemon.
+// Default is derived from defaultMCPPort so a single constant controls the port.
+// Override via MUNINN_MCP_URL env var for non-default daemon configurations.
+// Overridable in tests via direct assignment.
+var mcpProxyURL = "http://127.0.0.1:" + defaultMCPPort + "/mcp"
+
+// runMCPStdio is the stdio→HTTP MCP proxy used by OpenClaw and other clients
+// that spawn MCP servers as local subprocesses. It bridges:
+//
+//	stdin  (newline-delimited JSON-RPC)  →  MuninnDB HTTP MCP endpoint
+//	stdout  ←  JSON-RPC responses
+//
+// The Bearer token is re-read from disk on every request so the proxy works
+// transparently even after a daemon restart.
+//
+// MUNINN_MCP_URL overrides the target endpoint for non-default port or TLS setups:
+//
+//	MUNINN_MCP_URL=https://localhost:8750/mcp muninn mcp
+func runMCPStdio() {
+	if u := os.Getenv("MUNINN_MCP_URL"); u != "" {
+		mcpProxyURL = u
+	}
+	runMCPStdioWith(os.Stdin, os.Stdout)
+}
+
+// runMCPStdioWith is the testable implementation of the proxy loop.
+//
+// Session handling: the proxy is MCP session-aware. After forwarding an
+// "initialize" request, it captures the Mcp-Session-Id response header and
+// includes it in all subsequent requests. This keeps the daemon's per-session
+// state consistent across the lifetime of a single OpenClaw session.
+func runMCPStdioWith(in io.Reader, out io.Writer) {
+	client := &http.Client{Timeout: 35 * time.Second}
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20) // 1 MB max line
+
+	var sessionID string // MCP session ID captured from initialize response
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		// Best-effort parse to detect the "initialize" method so we can
+		// capture the Mcp-Session-Id from its response.
+		var rpcEnvelope struct {
+			Method string `json:"method"`
+		}
+		json.Unmarshal([]byte(line), &rpcEnvelope) //nolint:errcheck // ignored intentionally; malformed lines still forwarded
+
+		token := readTokenFile()
+
+		req, err := http.NewRequest(http.MethodPost, mcpProxyURL, bytes.NewBufferString(line))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "muninn mcp: build request: %v\n", err)
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		// Forward the MCP session ID on all requests after initialize.
+		if sessionID != "" {
+			req.Header.Set("Mcp-Session-Id", sessionID)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "muninn mcp: daemon unreachable — is muninn running? (%v)\n", err)
+			continue
+		}
+
+		// Capture session ID from the initialize response per MCP Streamable HTTP spec.
+		if rpcEnvelope.Method == "initialize" {
+			if sid := resp.Header.Get("Mcp-Session-Id"); sid != "" {
+				sessionID = sid
+			}
+		}
+
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			fmt.Fprintf(os.Stderr, "muninn mcp: read response: %v\n", readErr)
+			continue
+		}
+
+		// HTTP 202 Accepted = MCP notification (fire-and-forget); no stdout output.
+		if resp.StatusCode == http.StatusAccepted {
+			continue
+		}
+
+		body = bytes.TrimSpace(body)
+		if len(body) > 0 {
+			fmt.Fprintf(out, "%s\n", body)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "muninn mcp: stdin: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/muninn/mcp_stdio_test.go
+++ b/cmd/muninn/mcp_stdio_test.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// withMCPProxyURL overrides the global mcpProxyURL for the duration of a test.
+func withMCPProxyURL(t *testing.T, url string) {
+	t.Helper()
+	orig := mcpProxyURL
+	mcpProxyURL = url
+	t.Cleanup(func() { mcpProxyURL = orig })
+}
+
+// TestMCPProxyURLDefault guards that the default URL is derived from the canonical
+// port constant and targets localhost. If defaultMCPPort changes, this will catch
+// any mismatch before a release.
+func TestMCPProxyURLDefault(t *testing.T) {
+	if !strings.Contains(mcpProxyURL, defaultMCPPort) {
+		t.Errorf("mcpProxyURL %q must contain defaultMCPPort %q", mcpProxyURL, defaultMCPPort)
+	}
+	if !strings.Contains(mcpProxyURL, "127.0.0.1") {
+		t.Errorf("mcpProxyURL %q must target 127.0.0.1 (localhost only)", mcpProxyURL)
+	}
+	if !strings.HasSuffix(mcpProxyURL, "/mcp") {
+		t.Errorf("mcpProxyURL %q must end with /mcp", mcpProxyURL)
+	}
+}
+
+// TestRunMCPStdio_EnvVarOverride verifies MUNINN_MCP_URL is applied before the
+// proxy loop starts. Uses a test server as the override target.
+func TestRunMCPStdio_EnvVarOverride(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	t.Setenv("MUNINN_MCP_URL", srv.URL)
+	orig := mcpProxyURL
+	defer func() { mcpProxyURL = orig }()
+
+	// Apply the env override exactly as runMCPStdio does.
+	if u := os.Getenv("MUNINN_MCP_URL"); u != "" {
+		mcpProxyURL = u
+	}
+	if mcpProxyURL != srv.URL {
+		t.Errorf("env var override not applied: got %q, want %q", mcpProxyURL, srv.URL)
+	}
+
+	// Verify the proxy actually reaches the overridden server.
+	in := strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n")
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+	if out.Len() != 0 {
+		t.Errorf("expected no output for 202, got %q", out.String())
+	}
+}
+
+func TestRunMCPStdioWith_NotificationNoOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+
+	in := strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n")
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	if out.Len() != 0 {
+		t.Errorf("expected no output for 202 Accepted, got %q", out.String())
+	}
+}
+
+func TestRunMCPStdioWith_ResponseWrittenToOut(t *testing.T) {
+	body := `{"jsonrpc":"2.0","id":1,"result":{}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	got := strings.TrimSpace(out.String())
+	if got != body {
+		t.Errorf("expected %q, got %q", body, got)
+	}
+}
+
+func TestRunMCPStdioWith_EmptyLinesSkipped(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+
+	// Two empty/whitespace lines followed by one real request.
+	in := strings.NewReader("\n   \n" + `{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n")
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	if calls != 1 {
+		t.Errorf("expected 1 HTTP call (empty lines skipped), got %d", calls)
+	}
+}
+
+func TestRunMCPStdioWith_DaemonUnreachableNoOutput(t *testing.T) {
+	withMCPProxyURL(t, "http://127.0.0.1:1") // nothing listening
+
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	var out bytes.Buffer
+	// Must not panic — error goes to stderr, stdout stays empty.
+	runMCPStdioWith(in, &out)
+
+	if out.Len() != 0 {
+		t.Errorf("expected no stdout when daemon unreachable, got %q", out.String())
+	}
+}
+
+func TestRunMCPStdioWith_ContentTypeHeader(t *testing.T) {
+	var gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+
+	in := strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n")
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want \"application/json\"", gotContentType)
+	}
+}
+
+func TestRunMCPStdioWith_MultipleRequests(t *testing.T) {
+	responses := []string{
+		`{"jsonrpc":"2.0","id":1,"result":{"pong":true}}`,
+		`{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}`,
+	}
+	i := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(responses[i]))
+		i++
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+
+	input := `{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n" +
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n"
+	in := strings.NewReader(input)
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 output lines, got %d: %s", len(lines), out.String())
+	}
+	for idx, line := range lines {
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(line), &parsed); err != nil {
+			t.Errorf("line %d is not valid JSON: %v — %s", idx, err, line)
+		}
+	}
+}
+
+// TestRunMCPStdioWith_SessionIDCapturedAndForwarded verifies that the proxy
+// captures Mcp-Session-Id from the initialize response and forwards it on all
+// subsequent requests, as required by the MCP Streamable HTTP specification.
+func TestRunMCPStdioWith_SessionIDCapturedAndForwarded(t *testing.T) {
+	const wantSessionID = "test-session-abc123"
+	var gotSessionIDOnSecond string
+	callCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		switch callCount {
+		case 1:
+			// initialize — respond with a session ID in the header.
+			w.Header().Set("Mcp-Session-Id", wantSessionID)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"muninn","version":"1.0.0"}}}`))
+		default:
+			// All subsequent requests — record the session ID header.
+			gotSessionIDOnSecond = r.Header.Get("Mcp-Session-Id")
+			w.WriteHeader(http.StatusAccepted)
+		}
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+
+	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}` + "\n" +
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n"
+	in := strings.NewReader(input)
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	if callCount != 2 {
+		t.Fatalf("expected 2 HTTP calls, got %d", callCount)
+	}
+	if gotSessionIDOnSecond != wantSessionID {
+		t.Errorf("Mcp-Session-Id not forwarded: got %q, want %q", gotSessionIDOnSecond, wantSessionID)
+	}
+}
+
+// TestRunMCPStdioWith_SessionIDNotSentBeforeInitialize verifies that no
+// Mcp-Session-Id header is sent on the initialize request itself.
+func TestRunMCPStdioWith_SessionIDNotSentBeforeInitialize(t *testing.T) {
+	var initSessionHeader string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		initSessionHeader = r.Header.Get("Mcp-Session-Id")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` + "\n")
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	if initSessionHeader != "" {
+		t.Errorf("Mcp-Session-Id must not be sent before initialize completes, got %q", initSessionHeader)
+	}
+}
+
+// TestRunMCPStdioWith_NoSessionIDWhenServerOmitsIt verifies the proxy works
+// correctly when the server does not return a session ID (current MuninnDB behavior).
+func TestRunMCPStdioWith_NoSessionIDWhenServerOmitsIt(t *testing.T) {
+	var secondRequestSessionID string
+	callCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount > 1 {
+			secondRequestSessionID = r.Header.Get("Mcp-Session-Id")
+		}
+		// Respond without Mcp-Session-Id header.
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+
+	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` + "\n" +
+		`{"jsonrpc":"2.0","id":2,"method":"ping"}` + "\n"
+	in := strings.NewReader(input)
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	if secondRequestSessionID != "" {
+		t.Errorf("expected no session ID when server omits it, got %q", secondRequestSessionID)
+	}
+}

--- a/cmd/muninn/setup_ai.go
+++ b/cmd/muninn/setup_ai.go
@@ -272,10 +272,20 @@ func windsurfConfigPath() string {
 	return filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
 }
 
-// openClawConfigPath returns the path to OpenClaw's MCP config file.
+// openClawConfigPath returns the path to OpenClaw's config file.
+// macOS/Linux: ~/.openclaw/openclaw.json
+// Windows:     %APPDATA%\OpenClaw\openclaw.json
 func openClawConfigPath() string {
+	if runtime.GOOS == "windows" {
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			home, _ := os.UserHomeDir()
+			appData = filepath.Join(home, "AppData", "Roaming")
+		}
+		return filepath.Join(appData, "OpenClaw", "openclaw.json")
+	}
 	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".openclaw", "mcp.json")
+	return filepath.Join(home, ".openclaw", "openclaw.json")
 }
 
 // openCodeConfigPath returns the path to OpenCode's config file.
@@ -341,17 +351,99 @@ func configureWindsurf(mcpURL, token string) error {
 	return nil
 }
 
-// configureOpenClaw writes the muninn MCP entry into OpenClaw's mcp.json.
-func configureOpenClaw(mcpURL, token string) error {
+// openClawMCPEntry returns the JSON map for muninn's OpenClaw stdio MCP entry.
+// OpenClaw spawns this as a local subprocess; the muninn binary handles
+// auth internally by reading ~/.muninn/mcp.token at runtime.
+func openClawMCPEntry() map[string]any {
+	return map[string]any{
+		"command":   "muninn",
+		"args":      []any{"mcp"},
+		"transport": "stdio",
+	}
+}
+
+// mergeOpenClawMCP upserts muninn into the root-level cfg["mcpServers"] map,
+// preserving all other entries. OpenClaw reads root-level mcpServers for
+// stdio server definitions.
+func mergeOpenClawMCP(cfg map[string]any) {
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		servers = map[string]any{}
+	}
+	servers["muninn"] = openClawMCPEntry()
+	cfg["mcpServers"] = servers
+}
+
+// configureOpenClaw writes the muninn stdio MCP entry into OpenClaw's openclaw.json.
+// The mcpURL and token parameters are accepted for interface compatibility but are
+// not embedded in the config — the muninn mcp proxy reads the token at runtime.
+func configureOpenClaw(_, _ string) error {
 	path := openClawConfigPath()
 	summary, err := writeAIToolConfig(path, func(cfg map[string]any) {
-		mergeMCPServers(cfg, mcpURL, token)
+		mergeOpenClawMCP(cfg)
 	})
 	if err != nil {
 		return err
 	}
 	fmt.Printf("  ✓ OpenClaw: %s\n    %s\n", summary, path)
-	fmt.Println("  → Restart OpenClaw to activate muninn memory")
+	fmt.Println("  → Restart OpenClaw to activate MuninnDB memory")
+	return nil
+}
+
+// openClawSkillContent is the SKILL.md content that teaches OpenClaw how to
+// use MuninnDB for persistent memory across sessions.
+const openClawSkillContent = `# MuninnDB Memory
+
+MuninnDB is your persistent memory system, available via the "muninn" MCP server.
+
+## When to use memory
+
+- Store important facts, decisions, user preferences, and project context
+- Recall relevant memories at the start of each conversation
+- Be proactive — if the user shares something worth remembering, store it without being asked
+
+## Available tools
+
+- **muninn_remember** — store a memory (vault, concept, content)
+- **muninn_recall** — search memories by context (vault, context)
+- **muninn_read** — read a specific memory by ID (vault, id)
+- **muninn_link** — link two related memories (vault, source_id, target_id)
+- **muninn_guide** — learn MuninnDB best practices (call this on first connect)
+- **muninn_remember_batch** — store multiple memories in one call (vault, memories[])
+
+## Usage pattern
+
+At the start of each session, call muninn_recall with relevant context to surface
+what you know. When the user shares preferences, facts, or decisions, call
+muninn_remember. Use vault "default" for general memories.
+`
+
+// openClawSkillPath returns the path to the muninn SKILL.md for OpenClaw.
+// macOS/Linux: ~/.openclaw/skills/muninn/SKILL.md
+// Windows:     %APPDATA%\OpenClaw\skills\muninn\SKILL.md
+func openClawSkillPath() string {
+	if runtime.GOOS == "windows" {
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			home, _ := os.UserHomeDir()
+			appData = filepath.Join(home, "AppData", "Roaming")
+		}
+		return filepath.Join(appData, "OpenClaw", "skills", "muninn", "SKILL.md")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".openclaw", "skills", "muninn", "SKILL.md")
+}
+
+// configureOpenClawSkill writes the MuninnDB SKILL.md into OpenClaw's skills directory.
+func configureOpenClawSkill() error {
+	path := openClawSkillPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create skill directory: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(openClawSkillContent), 0644); err != nil {
+		return fmt.Errorf("write SKILL.md: %w", err)
+	}
+	fmt.Printf("  ✓ OpenClaw skill: wrote SKILL.md\n    %s\n", path)
 	return nil
 }
 

--- a/cmd/muninn/setup_ai_test.go
+++ b/cmd/muninn/setup_ai_test.go
@@ -297,15 +297,260 @@ func TestOpenCodeConfigPath(t *testing.T) {
 	}
 }
 
-// TestOpenClawConfigPath verifies OpenClaw config path is set correctly.
+// TestOpenClawConfigPath verifies OpenClaw config path points to openclaw.json (not mcp.json).
 func TestOpenClawConfigPath(t *testing.T) {
 	path := openClawConfigPath()
 	if path == "" {
 		t.Error("openClawConfigPath returned empty string")
 	}
-	home, _ := os.UserHomeDir()
-	if !strings.HasPrefix(path, home) {
-		t.Errorf("path %q should start with home dir", path)
+	if !filepath.IsAbs(path) {
+		t.Errorf("path %q should be absolute", path)
+	}
+	if !strings.HasSuffix(path, "openclaw.json") {
+		t.Errorf("path %q should end with openclaw.json", path)
+	}
+	// Must contain the openclaw directory component (case-insensitive for Windows).
+	if !strings.Contains(strings.ToLower(path), "openclaw") {
+		t.Errorf("path %q should contain an openclaw directory component", path)
+	}
+}
+
+// TestOpenClawMCPEntry verifies the stdio entry has command/args/transport and no URL/token.
+func TestOpenClawMCPEntry(t *testing.T) {
+	entry := openClawMCPEntry()
+	if entry["command"] != "muninn" {
+		t.Errorf("command = %v, want \"muninn\"", entry["command"])
+	}
+	args, ok := entry["args"].([]any)
+	if !ok || len(args) != 1 || args[0] != "mcp" {
+		t.Errorf("args = %v, want [\"mcp\"]", entry["args"])
+	}
+	if entry["transport"] != "stdio" {
+		t.Errorf("transport = %v, want \"stdio\"", entry["transport"])
+	}
+	// No URL or token — the proxy binary handles auth at runtime.
+	if _, ok := entry["url"]; ok {
+		t.Error("url must not be present in stdio entry")
+	}
+	if _, ok := entry["headers"]; ok {
+		t.Error("headers must not be present in stdio entry")
+	}
+}
+
+func TestMergeOpenClawMCP_PreservesOtherEntries(t *testing.T) {
+	cfg := map[string]any{
+		"mcpServers": map[string]any{
+			"other-tool": map[string]any{"command": "other", "transport": "stdio"},
+		},
+		"topKey": "preserved",
+	}
+	mergeOpenClawMCP(cfg)
+	servers := cfg["mcpServers"].(map[string]any)
+	if _, ok := servers["other-tool"]; !ok {
+		t.Error("other-tool entry removed")
+	}
+	if _, ok := servers["muninn"]; !ok {
+		t.Error("muninn not added")
+	}
+	if cfg["topKey"] != "preserved" {
+		t.Error("top-level key lost")
+	}
+}
+
+func TestMergeOpenClawMCP_EmptyConfig(t *testing.T) {
+	cfg := map[string]any{}
+	mergeOpenClawMCP(cfg)
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("cfg[\"mcpServers\"] not a map")
+	}
+	if _, ok := servers["muninn"]; !ok {
+		t.Error("muninn not added")
+	}
+}
+
+func TestConfigureOpenClaw_WritesCorrectSchema(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+
+	out := captureStdout(func() {
+		if err := configureOpenClaw("http://localhost:8750/mcp", "mdb_testtoken"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	data, err := os.ReadFile(openClawConfigPath())
+	if err != nil {
+		t.Fatalf("config file not written: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, data)
+	}
+
+	// OpenClaw reads root-level mcpServers for stdio server definitions.
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers not found — OpenClaw reads root-level mcpServers for stdio servers")
+	}
+	muninn, ok := servers["muninn"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers.muninn not found")
+	}
+	if muninn["command"] != "muninn" {
+		t.Errorf("command = %v, want \"muninn\"", muninn["command"])
+	}
+	args, ok := muninn["args"].([]any)
+	if !ok || len(args) != 1 || args[0] != "mcp" {
+		t.Errorf("args = %v, want [\"mcp\"]", muninn["args"])
+	}
+	if muninn["transport"] != "stdio" {
+		t.Errorf("transport = %v, want \"stdio\"", muninn["transport"])
+	}
+	// Token must not be embedded — proxy reads it at runtime.
+	if _, ok := muninn["headers"]; ok {
+		t.Error("headers must not be embedded in stdio config entry")
+	}
+	if !strings.Contains(out, "✓") || !strings.Contains(out, "OpenClaw") {
+		t.Errorf("output missing success marker: %s", out)
+	}
+	if !strings.Contains(out, "Restart OpenClaw") {
+		t.Errorf("output missing restart hint: %s", out)
+	}
+}
+
+func TestConfigureOpenClaw_NoToken(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+
+	captureStdout(func() {
+		configureOpenClaw("http://localhost:8750/mcp", "")
+	})
+
+	data, _ := os.ReadFile(openClawConfigPath())
+	var cfg map[string]any
+	json.Unmarshal(data, &cfg)
+	muninn := cfg["mcpServers"].(map[string]any)["muninn"].(map[string]any)
+	if muninn["transport"] != "stdio" {
+		t.Errorf("transport must be stdio, got %v", muninn["transport"])
+	}
+	if _, ok := muninn["headers"]; ok {
+		t.Error("headers must not be present in stdio config")
+	}
+}
+
+func TestConfigureOpenClaw_PreservesExistingEntries(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+
+	path := openClawConfigPath()
+	os.MkdirAll(filepath.Dir(path), 0755)
+	os.WriteFile(path, []byte(`{"mcpServers":{"other":{"command":"other","transport":"stdio"}},"topKey":"kept"}`), 0644)
+
+	captureStdout(func() {
+		configureOpenClaw("http://localhost:8750/mcp", "tok")
+	})
+
+	data, _ := os.ReadFile(path)
+	var cfg map[string]any
+	json.Unmarshal(data, &cfg)
+	if cfg["topKey"] != "kept" {
+		t.Error("top-level key lost")
+	}
+	servers := cfg["mcpServers"].(map[string]any)
+	if _, ok := servers["other"]; !ok {
+		t.Error("other tool removed")
+	}
+	if _, ok := servers["muninn"]; !ok {
+		t.Error("muninn not added")
+	}
+}
+
+func TestConfigureOpenClaw_SummaryAdded(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+	out := captureStdout(func() { configureOpenClaw("http://localhost:8750/mcp", "tok") })
+	if !strings.Contains(out, "added") {
+		t.Errorf("expected 'added' in output for new config: %s", out)
+	}
+}
+
+func TestConfigureOpenClaw_SummaryUpdated(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+	path := openClawConfigPath()
+	os.MkdirAll(filepath.Dir(path), 0755)
+	os.WriteFile(path, []byte(`{"mcpServers":{"muninn":{"command":"muninn","args":["mcp"],"transport":"stdio"}}}`), 0644)
+	out := captureStdout(func() { configureOpenClaw("http://localhost:8750/mcp", "tok") })
+	if !strings.Contains(out, "updated") {
+		t.Errorf("expected 'updated' in output for existing mcpServers: %s", out)
+	}
+}
+
+// --- OpenClaw SKILL.md ---
+
+func TestOpenClawSkillPath(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+	path := openClawSkillPath()
+	if !filepath.IsAbs(path) {
+		t.Errorf("path %q should be absolute", path)
+	}
+	if !strings.HasSuffix(path, "SKILL.md") {
+		t.Errorf("path %q should end with SKILL.md", path)
+	}
+	// Must be nested under a muninn skill directory.
+	if !strings.Contains(strings.ToLower(path), "muninn") {
+		t.Errorf("path %q should contain a muninn directory component", path)
+	}
+	// Must be nested under an openclaw directory.
+	if !strings.Contains(strings.ToLower(path), "openclaw") {
+		t.Errorf("path %q should contain an openclaw directory component", path)
+	}
+}
+
+func TestConfigureOpenClawSkill_WritesFile(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+
+	out := captureStdout(func() {
+		if err := configureOpenClawSkill(); err != nil {
+			t.Fatalf("configureOpenClawSkill: %v", err)
+		}
+	})
+
+	data, err := os.ReadFile(openClawSkillPath())
+	if err != nil {
+		t.Fatalf("SKILL.md not written: %v", err)
+	}
+	if !strings.Contains(string(data), "MuninnDB") {
+		t.Error("SKILL.md should mention MuninnDB")
+	}
+	if !strings.Contains(string(data), "muninn_remember") {
+		t.Error("SKILL.md should mention muninn_remember tool")
+	}
+	if !strings.Contains(out, "SKILL.md") {
+		t.Errorf("output should mention SKILL.md: %s", out)
+	}
+}
+
+func TestConfigureOpenClawSkill_CreatesDirectory(t *testing.T) {
+	_, cleanup := withTempHome(t)
+	defer cleanup()
+
+	dir := filepath.Dir(openClawSkillPath())
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Skip("directory already exists")
+	}
+
+	captureStdout(func() {
+		if err := configureOpenClawSkill(); err != nil {
+			t.Fatalf("configureOpenClawSkill: %v", err)
+		}
+	})
+
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("skill directory not created: %v", err)
 	}
 }
 
@@ -665,7 +910,8 @@ func TestConfigureWindsurfWritesConfig(t *testing.T) {
 	}
 }
 
-// TestConfigureOpenClawWritesConfig verifies OpenClaw config is written correctly.
+// TestConfigureOpenClawWritesConfig verifies OpenClaw config is written at the correct path
+// with the correct stdio schema (root-level mcpServers with command/args/transport).
 func TestConfigureOpenClawWritesConfig(t *testing.T) {
 	_, cleanup := withTempHome(t)
 	defer cleanup()
@@ -680,11 +926,24 @@ func TestConfigureOpenClawWritesConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("file not written: %v", err)
 	}
-	if !strings.Contains(string(data), `"muninn"`) {
-		t.Errorf("muninn not in config: %s", data)
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
 	}
-	if !strings.Contains(string(data), "8750") {
-		t.Errorf("MCP port not in config: %s", data)
+	// OpenClaw reads root-level mcpServers for stdio server definitions.
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("mcpServers not found in config: %s", data)
+	}
+	muninn, ok := servers["muninn"].(map[string]any)
+	if !ok {
+		t.Fatalf("mcpServers.muninn not found: %s", data)
+	}
+	if muninn["command"] != "muninn" {
+		t.Errorf("command = %v, want \"muninn\"", muninn["command"])
+	}
+	if muninn["transport"] != "stdio" {
+		t.Errorf("transport = %v, want \"stdio\"", muninn["transport"])
 	}
 	if !strings.Contains(out, "✓") {
 		t.Errorf("output missing success marker: %s", out)

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -220,16 +220,31 @@ If you enabled MCP auth (token file at `~/.muninn/mcp.token`):
 }
 ```
 
-**OpenClaw** — `~/.openclaw/mcp.json`
+**OpenClaw** — `~/.openclaw/openclaw.json`
+
+OpenClaw only supports stdio-transport MCP servers. MuninnDB ships a built-in
+proxy (`muninn mcp`) that bridges OpenClaw's subprocess model to the running
+daemon. `muninn init` configures this automatically; for manual setup:
+
 ```json
 {
   "mcpServers": {
     "muninn": {
-      "type": "http",
-      "url": "http://localhost:8750/mcp"
+      "command": "muninn",
+      "args": ["mcp"],
+      "transport": "stdio"
     }
   }
 }
+```
+
+The `muninn mcp` proxy reads the bearer token from `~/.muninn/mcp.token` on
+every request, so it works transparently even after a daemon restart — no
+credential embedded in the config file.
+
+To override the daemon endpoint (non-default port, TLS):
+```sh
+MUNINN_MCP_URL=https://my-server:8750/mcp muninn mcp
 ```
 
 **Windsurf** — `~/.codeium/windsurf/mcp_config.json`
@@ -283,6 +298,7 @@ curl http://localhost:8750/mcp/health
 | `MUNINN_MEM_LIMIT_GB` | `4` | GOMEMLIMIT in GB |
 | `MUNINN_GC_PERCENT` | `200` | GOGC tuning |
 | `MUNINN_CORS_ORIGINS` | `""` | Comma-separated allowed CORS origins |
+| `MUNINN_MCP_URL` | `http://127.0.0.1:8750/mcp` | Override MCP endpoint used by `muninn mcp` proxy (OpenClaw) |
 
 ---
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1783,6 +1783,26 @@
             </template>
           </div>
 
+          <!-- OpenClaw -->
+          <div class="card-polished">
+            <h3 style="margin:0 0 0.75rem;font-size:1rem;">OpenClaw</h3>
+            <p style="color:var(--text-muted);font-size:0.8125rem;margin:0 0 0.5rem;">
+              Run <code style="font-family:monospace;background:var(--bg-elevated);padding:0.1rem 0.35rem;border-radius:0.25rem;">muninn init --tool openclaw --yes</code> to configure automatically, or add manually to <code style="font-family:monospace;background:var(--bg-elevated);padding:0.1rem 0.35rem;border-radius:0.25rem;">~/.openclaw/openclaw.json</code>:
+            </p>
+            <pre style="background:var(--bg-elevated);border-radius:0.5rem;padding:0.75rem;font-size:0.8125rem;overflow-x:auto;color:var(--text-primary);margin:0 0 0.5rem;">{
+  "mcpServers": {
+    "muninn": {
+      "command": "muninn",
+      "args": ["mcp"],
+      "transport": "stdio"
+    }
+  }
+}</pre>
+            <p style="font-size:0.75rem;color:var(--text-muted);margin:0;">
+              OpenClaw uses stdio transport. The <code style="font-family:monospace;background:var(--bg-base);padding:0.1rem 0.3rem;border-radius:0.2rem;">muninn mcp</code> proxy handles auth automatically — no token needed in the config.
+            </p>
+          </div>
+
           <!-- Codex -->
           <div class="card-polished">
             <h3 style="margin:0 0 0.75rem;font-size:1rem;">Codex</h3>


### PR DESCRIPTION
## Summary

- **New**: `muninn mcp` subcommand — stdio→HTTP proxy that bridges OpenClaw's subprocess model to MuninnDB's running HTTP MCP endpoint
- **Fixed**: OpenClaw config was writing the wrong file (`mcp.json` → `openclaw.json`) with the wrong schema (HTTP type/URL → stdio `command`/`args`/`transport`)
- **Fixed**: `muninn mcp --help` was hanging on stdin (no subcommand help entry registered)
- **Fixed**: Env var name mismatch — docs said `MUNINNDB_MCP_URL`, code read `MUNINN_MCP_URL` — standardized to `MUNINN_MCP_URL` everywhere
- **Fixed**: `mcp` was missing from all three shell completion scripts (bash, zsh, fish)
- **Docs**: Corrected OpenClaw section in `docs/self-hosting.md` and `README.md`
- **UI**: Added OpenClaw tool card to the web settings page with correct stdio schema

## How it works

OpenClaw only supports stdio-transport MCP (it spawns subprocesses). `muninn mcp` is a thin proxy:

```
OpenClaw → stdin (JSON-RPC) → muninn mcp → HTTP POST → MuninnDB :8750/mcp
                                         ← HTTP response ←
           stdout (JSON-RPC) ←
```

Key design decisions:
- Token re-read from `~/.muninn/mcp.token` on every request — works transparently after daemon restarts, no credential in the OpenClaw config
- `Mcp-Session-Id` captured from `initialize` response and forwarded on all subsequent requests (MCP Streamable HTTP spec compliance)
- `MUNINN_MCP_URL` env var overrides the target for non-default ports or TLS
- Platform-aware config paths (macOS/Linux vs Windows `%APPDATA%`)
- `SKILL.md` written to `~/.openclaw/skills/muninn/` to teach OpenClaw's LLM how and when to use MuninnDB tools

## Test plan

- [x] 11 unit tests for the proxy loop (notification suppression, response forwarding, session ID capture/forwarding, env var override, daemon-unreachable safety, content-type, multi-request)
- [x] Comprehensive `setup_ai` tests covering config write, path correctness, merge behavior, SKILL.md install
- [x] All CI checks passing on develop