### PR TITLE
fix(ui): pass active vault on per-engram API calls that require it

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -870,7 +870,10 @@ document.addEventListener('alpine:init', () => {
       const id = this.confirmForgetId;
       this.confirmForgetId = null;
       try {
-        await this.apiCall('/api/engrams/' + encodeURIComponent(id), { method: 'DELETE' });
+        await this.apiCall(
+          '/api/engrams/' + encodeURIComponent(id) + '?vault=' + encodeURIComponent(this.vault),
+          { method: 'DELETE' }
+        );
         this.addNotification('success', 'Memory forgotten');
         if (this.selectedMemory && this.selectedMemory.id === id) {
           this.selectedMemory = null;
@@ -931,7 +934,7 @@ document.addEventListener('alpine:init', () => {
       this.editMemorySaving = true;
       try {
         const resp = await this.apiCall(
-          '/api/engrams/' + encodeURIComponent(this.selectedMemory.id) + '/evolve',
+          '/api/engrams/' + encodeURIComponent(this.selectedMemory.id) + '/evolve?vault=' + encodeURIComponent(this.vault),
           {
             method: 'POST',
             body: JSON.stringify({
@@ -1098,10 +1101,12 @@ document.addEventListener('alpine:init', () => {
           return;
         }
 
-        // Load links for first 20 engrams in parallel
+        // Load links for the listed engrams using the active vault context.
         const nodeIdSet = new Set(engrams.map(e => e.id));
-        const linkPromises = engrams.slice(0, 20).map(e =>
-          this.apiCall('/api/engrams/' + encodeURIComponent(e.id) + '/links')
+        const linkPromises = engrams.map(e =>
+          this.apiCall(
+            '/api/engrams/' + encodeURIComponent(e.id) + '/links?vault=' + encodeURIComponent(this.vault)
+          )
             .then(resp => {
               const links = resp.links || [];
               return links.map(l => ({


### PR DESCRIPTION
### Problem

Three per-engram UI requests didn't pass `?vault=` in the query string, causing them to resolve against the wrong vault context in non-default or API-key-protected setups. The most visible symptom was the Memory Graph rendering nodes with no edges — associations existed but the link requests hit the wrong vault.

Additionally, the graph loader only fetched links for the first 20 engrams despite the UI claiming "Top 50 active engrams + associations."

### Root cause

The backend handlers for `GET /api/engrams/{id}/links`, `DELETE /api/engrams/{id}`, and `POST /api/engrams/{id}/evolve` read vault exclusively from the query string (via the `ctxVault` middleware). The frontend omitted `?vault=<active-vault>`, so the middleware defaulted to `"default"` (or returned `VAULT_KEY_MISMATCH` for scoped API keys).

Other endpoints like `PUT /tags` and `PUT /state` already read vault from the JSON body first, so they were unaffected.

### Changes

- Add `?vault=` query parameter to the 3 endpoints whose handlers only read vault from the query string:
  - `GET /api/engrams/{id}/links` — graph edge loading
  - `DELETE /api/engrams/{id}` — forget memory
  - `POST /api/engrams/{id}/evolve` — edit/evolve memory
- Fetch link data for all 50 graph-listed engrams instead of only the first 20

### Validation

- Verified `GET /api/engrams/{id}/links?vault=<vault>` returns associations; same call without `?vault=` returns `VAULT_KEY_MISMATCH`
- Confirmed graph renders edges correctly for non-default vaults after fix
- Delete and evolve operations confirmed working against non-default vaults

Closes #102