### PR TITLE
feat: replace N+1 links fetch with POST /api/engrams/links/batch, add edge fade-in

### DIFF
--- a/internal/engine/query.go
+++ b/internal/engine/query.go
@@ -48,6 +48,35 @@ func (e *Engine) GetAssociations(ctx context.Context, vault, engramID string, ma
 	return assocMap[id], nil
 }
 
+// GetAssociationsBatch returns forward associations for multiple engrams.
+// The storage layer already supports batching with a single Pebble iterator.
+func (e *Engine) GetAssociationsBatch(ctx context.Context, vault string, engramIDs []string, maxN int) (map[string][]storage.Association, error) {
+	ws := e.store.ResolveVaultPrefix(vault)
+	ids := make([]storage.ULID, len(engramIDs))
+	for i, s := range engramIDs {
+		id, err := storage.ParseULID(s)
+		if err != nil {
+			return nil, fmt.Errorf("parse id at index %d: %w", i, err)
+		}
+		ids[i] = id
+	}
+	assocMap, err := e.store.GetAssociations(ctx, ws, ids, maxN)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string][]storage.Association, len(assocMap))
+	for id, assocs := range assocMap {
+		result[id.String()] = assocs
+	}
+	// Guarantee every requested ID appears in the result map.
+	for _, s := range engramIDs {
+		if _, ok := result[s]; !ok {
+			result[s] = nil
+		}
+	}
+	return result, nil
+}
+
 // GetContradictions returns all contradiction pairs stored in a vault.
 func (e *Engine) GetContradictions(ctx context.Context, vault string) ([][2]storage.ULID, error) {
 	ws := e.store.ResolveVaultPrefix(vault)

--- a/internal/transport/rest/engine_adapter.go
+++ b/internal/transport/rest/engine_adapter.go
@@ -523,7 +523,32 @@ Available operations:
 	return guide, nil
 }
 
-// GetBatchEngramLinks is a stub for Task 1; full implementation added in Task 2.
 func (w *RESTEngineWrapper) GetBatchEngramLinks(ctx context.Context, req *BatchGetEngramLinksRequest) (*BatchGetEngramLinksResponse, error) {
-	return nil, fmt.Errorf("not implemented")
+	vault := req.Vault
+	if vault == "" {
+		vault = "default"
+	}
+	maxPerNode := req.MaxPerNode
+	if maxPerNode <= 0 {
+		maxPerNode = 50
+	}
+	assocMap, err := w.engine.GetAssociationsBatch(ctx, vault, req.IDs, maxPerNode)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string][]AssociationItem, len(assocMap))
+	for srcID, assocs := range assocMap {
+		items := make([]AssociationItem, len(assocs))
+		for i, a := range assocs {
+			items[i] = AssociationItem{
+				TargetID:          a.TargetID.String(),
+				RelType:           uint16(a.RelType),
+				Weight:            a.Weight,
+				CoActivationCount: a.CoActivationCount,
+				RestoredAt:        int64(a.RestoredAt),
+			}
+		}
+		result[srcID] = items
+	}
+	return &BatchGetEngramLinksResponse{Links: result}, nil
 }

--- a/internal/transport/rest/engine_adapter.go
+++ b/internal/transport/rest/engine_adapter.go
@@ -522,3 +522,8 @@ Available operations:
 `, vault, statResp.EngramCount)
 	return guide, nil
 }
+
+// GetBatchEngramLinks is a stub for Task 1; full implementation added in Task 2.
+func (w *RESTEngineWrapper) GetBatchEngramLinks(ctx context.Context, req *BatchGetEngramLinksRequest) (*BatchGetEngramLinksResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/internal/transport/rest/engine_adapter_test.go
+++ b/internal/transport/rest/engine_adapter_test.go
@@ -49,6 +49,9 @@ func (m *mockEngineAPI) ListEngrams(ctx context.Context, req *ListEngramsRequest
 func (m *mockEngineAPI) GetEngramLinks(ctx context.Context, req *GetEngramLinksRequest) (*GetEngramLinksResponse, error) {
 	return nil, nil
 }
+func (m *mockEngineAPI) GetBatchEngramLinks(ctx context.Context, req *BatchGetEngramLinksRequest) (*BatchGetEngramLinksResponse, error) {
+	return &BatchGetEngramLinksResponse{Links: map[string][]AssociationItem{}}, nil
+}
 func (m *mockEngineAPI) ListVaults(ctx context.Context) ([]string, error) {
 	return nil, nil
 }

--- a/internal/transport/rest/markdown_export_test.go
+++ b/internal/transport/rest/markdown_export_test.go
@@ -68,6 +68,10 @@ func (e *markdownExportEngine) GetEngramLinks(_ context.Context, req *GetEngramL
 	return &GetEngramLinksResponse{}, nil
 }
 
+func (e *markdownExportEngine) GetBatchEngramLinks(_ context.Context, _ *BatchGetEngramLinksRequest) (*BatchGetEngramLinksResponse, error) {
+	return &BatchGetEngramLinksResponse{Links: map[string][]AssociationItem{}}, nil
+}
+
 // ---------------------------------------------------------------------------
 // writeVaultMarkdownExport
 // ---------------------------------------------------------------------------

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -174,6 +174,7 @@ func NewServer(addr string, engine EngineAPI, authStore *auth.Store, sessionSecr
 	mux.HandleFunc("GET /api/stats", s.withMiddleware(s.handleStats))
 	mux.HandleFunc("GET /api/engrams", s.withMiddleware(s.handleListEngrams))
 	mux.HandleFunc("GET /api/engrams/{id}/links", s.withMiddleware(s.handleGetEngramLinks))
+	mux.HandleFunc("POST /api/engrams/links/batch", s.withMiddleware(s.handleBatchGetEngramLinks))
 	mux.HandleFunc("GET /api/vaults", s.withMiddleware(s.handleListVaults))
 	mux.HandleFunc("GET /api/vaults/stats", s.withAdminMiddleware(s.handleVaultStats()))
 	mux.HandleFunc("GET /api/session", s.withMiddleware(s.handleGetSession))
@@ -1081,6 +1082,35 @@ func (s *Server) handleGetEngramLinks(w http.ResponseWriter, r *http.Request) {
 	}
 	vault := ctxVault(r)
 	resp, err := s.engine.GetEngramLinks(r.Context(), &GetEngramLinksRequest{ID: id, Vault: vault})
+	if err != nil {
+		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
+		return
+	}
+	s.sendJSON(w, http.StatusOK, resp)
+}
+
+// handleBatchGetEngramLinks returns associations for multiple engrams in one call.
+// POST /api/engrams/links/batch
+// Body: {"ids": ["ulid1", ...], "vault": "x", "max_per_node": 50}
+// Response 200: {"links": {"id1": [{target_id, rel_type, weight, co_activation_count}], ...}}
+func (s *Server) handleBatchGetEngramLinks(w http.ResponseWriter, r *http.Request) {
+	var req BatchGetEngramLinksRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "invalid request body")
+		return
+	}
+	if len(req.IDs) == 0 {
+		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "'ids' array is required and must not be empty")
+		return
+	}
+	if len(req.IDs) > 200 {
+		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "'ids' exceeds maximum batch size of 200")
+		return
+	}
+	if req.Vault == "" {
+		req.Vault = ctxVault(r)
+	}
+	resp, err := s.engine.GetBatchEngramLinks(r.Context(), &req)
 	if err != nil {
 		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
 		return

--- a/internal/transport/rest/server_test.go
+++ b/internal/transport/rest/server_test.go
@@ -119,7 +119,11 @@ func (m *MockEngine) GetEngramLinks(ctx context.Context, req *GetEngramLinksRequ
 }
 
 func (m *MockEngine) GetBatchEngramLinks(ctx context.Context, req *BatchGetEngramLinksRequest) (*BatchGetEngramLinksResponse, error) {
-	return &BatchGetEngramLinksResponse{Links: map[string][]AssociationItem{}}, nil
+	links := make(map[string][]AssociationItem, len(req.IDs))
+	for _, id := range req.IDs {
+		links[id] = []AssociationItem{}
+	}
+	return &BatchGetEngramLinksResponse{Links: links}, nil
 }
 
 func (m *MockEngine) ListVaults(ctx context.Context) ([]string, error) {
@@ -2094,5 +2098,89 @@ func TestHandleVaultStats_RequiresAdminAuth(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401 without auth, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBatchGetEngramLinks_HappyPath(t *testing.T) {
+	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+	body := `{"ids":["01JAAAAAAAAAAAAAAAAAAAAAA1","01JAAAAAAAAAAAAAAAAAAAAAA2"],"vault":"default"}`
+	req := httptest.NewRequest("POST", "/api/engrams/links/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 got %d: %s", w.Code, w.Body.String())
+	}
+	var out BatchGetEngramLinksResponse
+	json.NewDecoder(w.Body).Decode(&out)
+	if out.Links == nil {
+		t.Fatal("Links map must not be nil")
+	}
+	// Both IDs must be present (even with empty slices from MockEngine)
+	for _, id := range []string{"01JAAAAAAAAAAAAAAAAAAAAAA1", "01JAAAAAAAAAAAAAAAAAAAAAA2"} {
+		if _, ok := out.Links[id]; !ok {
+			t.Errorf("Links map missing key %s", id)
+		}
+	}
+}
+
+func TestBatchGetEngramLinks_EmptyIDs(t *testing.T) {
+	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+	req := httptest.NewRequest("POST", "/api/engrams/links/batch", strings.NewReader(`{"ids":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 got %d", w.Code)
+	}
+}
+
+func TestBatchGetEngramLinks_MissingIDs(t *testing.T) {
+	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+	req := httptest.NewRequest("POST", "/api/engrams/links/batch", strings.NewReader(`{"vault":"default"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 got %d", w.Code)
+	}
+}
+
+func TestBatchGetEngramLinks_TooManyIDs(t *testing.T) {
+	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+	ids := make([]string, 201)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("01JAAAAAAAAAAAAAAAAAAAAAA%01d", i%10)
+	}
+	b, _ := json.Marshal(map[string]any{"ids": ids})
+	req := httptest.NewRequest("POST", "/api/engrams/links/batch", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 got %d", w.Code)
+	}
+}
+
+func TestBatchGetEngramLinks_BadJSON(t *testing.T) {
+	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+	req := httptest.NewRequest("POST", "/api/engrams/links/batch", strings.NewReader(`{not json}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 got %d", w.Code)
+	}
+}
+
+func TestBatchGetEngramLinks_EngineError(t *testing.T) {
+	server := NewServer("localhost:8080", &errorEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+	body := `{"ids":["01JAAAAAAAAAAAAAAAAAAAAAA1"],"vault":"default"}`
+	req := httptest.NewRequest("POST", "/api/engrams/links/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500 got %d", w.Code)
 	}
 }

--- a/internal/transport/rest/server_test.go
+++ b/internal/transport/rest/server_test.go
@@ -118,6 +118,10 @@ func (m *MockEngine) GetEngramLinks(ctx context.Context, req *GetEngramLinksRequ
 	return &GetEngramLinksResponse{Links: []AssociationItem{}}, nil
 }
 
+func (m *MockEngine) GetBatchEngramLinks(ctx context.Context, req *BatchGetEngramLinksRequest) (*BatchGetEngramLinksResponse, error) {
+	return &BatchGetEngramLinksResponse{Links: map[string][]AssociationItem{}}, nil
+}
+
 func (m *MockEngine) ListVaults(ctx context.Context) ([]string, error) {
 	return []string{"default"}, nil
 }
@@ -604,6 +608,10 @@ func (e *errorEngine) GetSession(ctx context.Context, req *GetSessionRequest) (*
 }
 func (e *errorEngine) GetEngramLinks(ctx context.Context, req *GetEngramLinksRequest) (*GetEngramLinksResponse, error) {
 	return nil, fmt.Errorf("storage error")
+}
+
+func (e *errorEngine) GetBatchEngramLinks(ctx context.Context, req *BatchGetEngramLinksRequest) (*BatchGetEngramLinksResponse, error) {
+	return nil, fmt.Errorf("engine error")
 }
 
 func TestListEngramsEngineError(t *testing.T) {

--- a/internal/transport/rest/types.go
+++ b/internal/transport/rest/types.go
@@ -75,6 +75,7 @@ type EngineAPI interface {
 	Stat(ctx context.Context, req *StatRequest) (*StatResponse, error)
 	ListEngrams(ctx context.Context, req *ListEngramsRequest) (*ListEngramsResponse, error)
 	GetEngramLinks(ctx context.Context, req *GetEngramLinksRequest) (*GetEngramLinksResponse, error)
+	GetBatchEngramLinks(ctx context.Context, req *BatchGetEngramLinksRequest) (*BatchGetEngramLinksResponse, error)
 	ListVaults(ctx context.Context) ([]string, error)
 	GetSession(ctx context.Context, req *GetSessionRequest) (*GetSessionResponse, error)
 	WorkerStats() cognitive.EngineWorkerStats
@@ -190,6 +191,19 @@ type GetEngramLinksRequest struct {
 // GetEngramLinksResponse returns association edges.
 type GetEngramLinksResponse struct {
 	Links []AssociationItem `json:"links"`
+}
+
+// BatchGetEngramLinksRequest requests associations for multiple engrams in one call.
+type BatchGetEngramLinksRequest struct {
+	IDs        []string `json:"ids"`
+	Vault      string   `json:"vault,omitempty"`
+	MaxPerNode int      `json:"max_per_node,omitempty"`
+}
+
+// BatchGetEngramLinksResponse returns association edges keyed by source engram ID.
+// Every requested ID is present in the map, even if it has zero associations.
+type BatchGetEngramLinksResponse struct {
+	Links map[string][]AssociationItem `json:"links"`
 }
 
 // GetSessionRequest requests recent writes.

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -76,6 +76,10 @@ func (m *mockEngine) GetEngramLinks(ctx context.Context, req *rest.GetEngramLink
 	return &rest.GetEngramLinksResponse{Links: []rest.AssociationItem{}}, nil
 }
 
+func (m *mockEngine) GetBatchEngramLinks(ctx context.Context, req *rest.BatchGetEngramLinksRequest) (*rest.BatchGetEngramLinksResponse, error) {
+	return &rest.BatchGetEngramLinksResponse{Links: map[string][]rest.AssociationItem{}}, nil
+}
+
 func (m *mockEngine) ListVaults(ctx context.Context) ([]string, error) {
 	return []string{"default"}, nil
 }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1101,36 +1101,34 @@ document.addEventListener('alpine:init', () => {
           return;
         }
 
-        // Load links for the listed engrams using the active vault context.
+        // Load all engram links in a single batch call (replaces N+1 pattern).
         const nodeIdSet = new Set(engrams.map(e => e.id));
-        const linkPromises = engrams.map(e =>
-          this.apiCall(
-            '/api/engrams/' + encodeURIComponent(e.id) + '/links?vault=' + encodeURIComponent(this.vault)
-          )
-            .then(resp => {
-              const links = resp.links || [];
-              return links.map(l => ({
-                data: {
-                  id: e.id + '-' + l.target_id,
-                  source: e.id,
-                  target: l.target_id,
-                  weight: l.weight || 0.5,
-                },
-              }));
-            })
-            .catch(() => [])
-        );
-        const edgeBatches = await Promise.all(linkPromises);
+        const batchResp = await this.apiCall('/api/engrams/links/batch', {
+          method: 'POST',
+          body: JSON.stringify({
+            ids: engrams.map(e => e.id),
+            vault: this.vault,
+          }),
+        });
+        const linksMap = batchResp.links || {};
         const edgeSet = new Set();
         const edges = [];
         const connectedNodeIds = new Set();
-        for (const batch of edgeBatches) {
-          for (const edge of batch) {
-            if (nodeIdSet.has(edge.data.target) && !edgeSet.has(edge.data.id)) {
-              edgeSet.add(edge.data.id);
-              edges.push(edge);
-              connectedNodeIds.add(edge.data.source);
-              connectedNodeIds.add(edge.data.target);
+        for (const [srcId, srcLinks] of Object.entries(linksMap)) {
+          for (const l of (srcLinks || [])) {
+            const edgeId = srcId + '-' + l.target_id;
+            if (nodeIdSet.has(l.target_id) && !edgeSet.has(edgeId)) {
+              edgeSet.add(edgeId);
+              edges.push({
+                data: {
+                  id: edgeId,
+                  source: srcId,
+                  target: l.target_id,
+                  weight: l.weight || 0.5,
+                },
+              });
+              connectedNodeIds.add(srcId);
+              connectedNodeIds.add(l.target_id);
             }
           }
         }
@@ -1196,7 +1194,7 @@ document.addEventListener('alpine:init', () => {
                 'line-color': 'rgba(168,85,247,0.4)',
                 'width': 2,
                 'curve-style': 'bezier',
-                'opacity': 0.6,
+                'opacity': 0,
               },
             },
             {
@@ -1206,6 +1204,16 @@ document.addEventListener('alpine:init', () => {
           ],
           layout: { name: 'fcose', animate: true, animationDuration: 600 },
           wheelSensitivity: 0.3,
+        });
+
+        // Fade edges in after nodes settle into position (fcose layout: 600ms).
+        // cy.one() fires once and removes itself — does not re-trigger on layout re-runs.
+        this._cy.one('layoutstop', () => {
+          this._cy.edges().animate({
+            style: { opacity: 0.6 },
+            duration: 250,
+            easing: 'ease-in-out',
+          });
         });
 
         this._cy.on('tap', 'node', (evt) => {


### PR DESCRIPTION
## Summary

- **Eliminates N+1 HTTP pattern** in the Memory Graph: 50 individual `GET /api/engrams/{id}/links` calls replaced by a single `POST /api/engrams/links/batch`
- **New endpoint** `POST /api/engrams/links/batch` accepts up to 200 engram IDs, returns all associations in one response — backed by the storage layer's existing batch-capable `GetAssociations` (single Pebble iterator, no storage changes)
- **Polished edge fade-in animation**: edges start invisible, nodes animate into position via fcose layout, then edges fade in smoothly over 250ms after layout settles

## Changes

- `internal/transport/rest/types.go` — `BatchGetEngramLinksRequest`, `BatchGetEngramLinksResponse` types + `GetBatchEngramLinks` on `EngineAPI` interface
- `internal/engine/query.go` — `Engine.GetAssociationsBatch`: single store call, guarantees every requested ID in result map
- `internal/transport/rest/engine_adapter.go` — `RESTEngineWrapper.GetBatchEngramLinks` adapter
- `internal/transport/rest/server.go` — `handleBatchGetEngramLinks` handler (validates: empty ids → 400, >200 ids → 400, bad JSON → 400) + route registration
- `internal/transport/rest/server_test.go` — 6 handler tests (happy path, empty IDs, missing IDs, too many IDs, bad JSON, engine error)
- Mock stubs updated across 6 test files
- `web/static/js/app.js` — batch call replaces Promise.all of N calls; `cy.one('layoutstop', ...)` edge fade-in

## Test Plan

- [ ] All 45 packages pass `go test -race -count=1 ./...`
- [ ] DevTools Network: single `POST /api/engrams/links/batch`, zero individual `/links` GETs
- [ ] Edge fade-in: nodes settle ~600ms → edges fade in 250ms
- [ ] Orphan nodes still visible/hidden correctly
- [ ] Empty vault: "No engrams to graph" toast still fires
- [ ] Server error: red toast appears, no partial graph rendered