### PR TITLE
fix(mcp): populate CreatedAt in ActivationItem so recall returns correct timestamps

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1628,6 +1628,7 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 			Confidence:  scored.Engram.Confidence,
 			Why:         scored.Why,
 			Dormant:     scored.Dormant,
+			CreatedAt:   scored.Engram.CreatedAt.UnixNano(),
 			LastAccess:  scored.Engram.LastAccess.UnixNano(),
 			AccessCount: scored.Engram.AccessCount,
 			Relevance:   scored.Engram.Relevance,

--- a/internal/mcp/convert.go
+++ b/internal/mcp/convert.go
@@ -24,6 +24,7 @@ func activationToMemory(item *mbp.ActivationItem) Memory {
 		VectorScore: float64(item.ScoreComponents.SemanticSimilarity),
 		Confidence:  item.Confidence,
 		Why:         item.Why,
+		CreatedAt:   time.Unix(0, item.CreatedAt).UTC(),
 		LastAccess:  time.Unix(0, item.LastAccess).UTC(),
 		AccessCount: item.AccessCount,
 		Relevance:   item.Relevance,

--- a/internal/mcp/convert_test.go
+++ b/internal/mcp/convert_test.go
@@ -186,6 +186,46 @@ func TestActivationToMemoryEmptySourceType(t *testing.T) {
 	}
 }
 
+// TestActivationToMemoryCreatedAt is a regression test for GitHub issue #97:
+// muninn_recall returned created_at: 0001-01-01T00:00:00Z (Go zero-value) for
+// all engrams because CreatedAt was not mapped through the ActivationItem pipeline.
+func TestActivationToMemoryCreatedAt(t *testing.T) {
+	// Use a well-known timestamp to avoid test fragility.
+	want := time.Date(2026, 3, 6, 20, 15, 29, 0, time.UTC)
+	item := &mbp.ActivationItem{
+		ID:        "engram-abc",
+		Concept:   "test",
+		Content:   "content",
+		CreatedAt: want.UnixNano(),
+	}
+	m := activationToMemory(item)
+
+	if m.CreatedAt.IsZero() {
+		t.Fatal("CreatedAt is zero — regression: issue #97 not fixed")
+	}
+	if !m.CreatedAt.Equal(want) {
+		t.Errorf("CreatedAt = %v, want %v", m.CreatedAt, want)
+	}
+	if m.CreatedAt.Location() != time.UTC {
+		t.Errorf("CreatedAt location = %v, want UTC", m.CreatedAt.Location())
+	}
+}
+
+// TestActivationToMemoryCreatedAtZero verifies that a zero CreatedAt (not yet
+// persisted, or old data) maps to the Unix epoch, not a Go zero time.
+func TestActivationToMemoryCreatedAtZero(t *testing.T) {
+	item := &mbp.ActivationItem{
+		ID:        "engram-zero",
+		CreatedAt: 0,
+	}
+	m := activationToMemory(item)
+
+	want := time.Unix(0, 0).UTC()
+	if !m.CreatedAt.Equal(want) {
+		t.Errorf("CreatedAt with 0 input = %v, want %v", m.CreatedAt, want)
+	}
+}
+
 func TestConvertReadResponseToMemory(t *testing.T) {
 	resp := &mbp.ReadResponse{
 		ID:         "read-123",

--- a/internal/transport/mbp/types.go
+++ b/internal/transport/mbp/types.go
@@ -207,6 +207,7 @@ type ActivationItem struct {
 	Why             string          `msgpack:"why,omitempty"               json:"why,omitempty"`
 	HopPath         []string        `msgpack:"hop_path,omitempty"          json:"hop_path,omitempty"`
 	Dormant         bool            `msgpack:"dormant,omitempty"           json:"dormant,omitempty"`
+	CreatedAt       int64           `msgpack:"created_at,omitempty"        json:"created_at,omitempty"`
 	LastAccess      int64           `msgpack:"last_access,omitempty"       json:"last_access,omitempty"`
 	AccessCount     uint32          `msgpack:"access_count,omitempty"      json:"access_count,omitempty"`
 	Relevance       float32         `msgpack:"relevance,omitempty"         json:"relevance,omitempty"`


### PR DESCRIPTION
Fixes #97.

## Problem

`muninn_recall` returned `created_at: 0001-01-01T00:00:00Z` (Go zero-value) for all engrams. `muninn_read` returned the correct timestamp.

## Root Cause

`CreatedAt` was absent from `mbp.ActivationItem`. The field existed in `storage.Engram` and was correctly mapped in `readResponseToMemory`, but the recall pipeline (`activationToMemory`) had no `CreatedAt` to copy.

## Changes

- `internal/transport/mbp/types.go` — Add `CreatedAt int64` to `ActivationItem` (between `Dormant` and `LastAccess`, consistent field ordering and `omitempty` tags)
- `internal/engine/engine.go` — Populate `CreatedAt: scored.Engram.CreatedAt.UnixNano()` when building `ActivationItem`
- `internal/mcp/convert.go` — Map `CreatedAt: time.Unix(0, item.CreatedAt).UTC()` in `activationToMemory`, mirroring `LastAccess` pattern
- `internal/mcp/convert_test.go` — Two regression tests: real timestamp round-trip + zero input → Unix epoch (not Go zero time)

## Test Plan

- [ ] `go test -race -count=1 ./internal/mcp/... ./internal/engine/... ./internal/transport/mbp/...` — all pass
- [ ] `muninn_recall` returns correct `created_at` for newly stored engrams
- [ ] `muninn_read` result still matches