### PR TITLE
fix(cluster): apply defaults before persisting cluster config on enable

### DIFF
--- a/internal/config/cluster.go
+++ b/internal/config/cluster.go
@@ -53,6 +53,12 @@ type muninnYAML struct {
 	Cluster ClusterConfig `yaml:"cluster"`
 }
 
+// ClusterDefaults returns a ClusterConfig with all default values applied.
+// Use this as the base when constructing a new cluster config programmatically
+// to avoid accidentally persisting zero-values for required fields such as
+// LeaseTTL and HeartbeatMS.
+func ClusterDefaults() ClusterConfig { return clusterDefaults() }
+
 // clusterDefaults returns a ClusterConfig with default values applied.
 func clusterDefaults() ClusterConfig {
 	return ClusterConfig{

--- a/internal/transport/rest/admin_cluster_handlers.go
+++ b/internal/transport/rest/admin_cluster_handlers.go
@@ -95,12 +95,13 @@ func (s *Server) handleAdminClusterEnable(w http.ResponseWriter, r *http.Request
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "cortex_addr is required for non-primary roles")
 		return
 	}
-	cfg := config.ClusterConfig{
-		Enabled:       true,
-		Role:          req.Role,
-		BindAddr:      req.BindAddr,
-		ClusterSecret: req.ClusterSecret,
-	}
+	// Start from defaults so fields like LeaseTTL and HeartbeatMS are never
+	// persisted as zero (which would cause a crash on the next restart).
+	cfg := config.ClusterDefaults()
+	cfg.Enabled = true
+	cfg.Role = req.Role
+	cfg.BindAddr = req.BindAddr
+	cfg.ClusterSecret = req.ClusterSecret
 	if req.CortexAddr != "" {
 		cfg.Seeds = []string{req.CortexAddr}
 	}

--- a/internal/transport/rest/admin_cluster_handlers_test.go
+++ b/internal/transport/rest/admin_cluster_handlers_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/scrypster/muninndb/internal/config"
 )
 
 func TestAdminCluster_GetToken_NoCoordinator(t *testing.T) {
@@ -47,6 +49,55 @@ func TestAdminCluster_Settings_Validation_HeartbeatNegative(t *testing.T) {
 	s.mux.ServeHTTP(w, r)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestAdminCluster_Enable_DefaultsWrittenToDisk is a regression test for
+// GitHub issue #101: the cluster enable handler was writing lease_ttl: 0 and
+// heartbeat_ms: 0 to cluster.yaml, causing a crash on the next restart.
+func TestAdminCluster_Enable_DefaultsWrittenToDisk(t *testing.T) {
+	dataDir := t.TempDir()
+	s := NewServer("localhost:0", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, dataDir, nil)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api/admin/cluster/enable",
+		strings.NewReader(`{"role":"primary","bind_addr":"127.0.0.1:8474"}`))
+	r.Header.Set("Content-Type", "application/json")
+	s.mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Read back the persisted config and verify no zero-value timing fields.
+	saved, err := config.LoadClusterConfig(dataDir)
+	if err != nil {
+		t.Fatalf("LoadClusterConfig: %v", err)
+	}
+	if !saved.Enabled {
+		t.Error("cluster should be enabled in saved config")
+	}
+	if saved.LeaseTTL <= 0 {
+		t.Errorf("LeaseTTL = %d, want > 0 (regression: issue #101)", saved.LeaseTTL)
+	}
+	if saved.HeartbeatMS <= 0 {
+		t.Errorf("HeartbeatMS = %d, want > 0 (regression: issue #101)", saved.HeartbeatMS)
+	}
+	// Spot-check other timing defaults are also non-zero.
+	if saved.QuorumLossTimeoutSec <= 0 {
+		t.Errorf("QuorumLossTimeoutSec = %d, want > 0", saved.QuorumLossTimeoutSec)
+	}
+}
+
+// TestClusterDefaults_NonZero verifies that ClusterDefaults returns sensible
+// non-zero timing values so callers can use it as a safe base.
+func TestClusterDefaults_NonZero(t *testing.T) {
+	d := config.ClusterDefaults()
+	if d.LeaseTTL <= 0 {
+		t.Errorf("ClusterDefaults().LeaseTTL = %d, want > 0", d.LeaseTTL)
+	}
+	if d.HeartbeatMS <= 0 {
+		t.Errorf("ClusterDefaults().HeartbeatMS = %d, want > 0", d.HeartbeatMS)
 	}
 }
 


### PR DESCRIPTION
Fixes #101.

## Problem

Enabling cluster mode via the Web UI wrote `lease_ttl: 0` and `heartbeat_ms: 0` to `cluster.yaml`. On the next restart, startup validation rejected those zero values:

```
level=ERROR msg="invalid cluster config" err="cluster: lease_ttl must be > 0"
```

The server refused to start, requiring manual YAML editing to recover.

## Root Cause

`handleAdminClusterEnable` constructed a `ClusterConfig{}` literal with only 4 fields. All integer timing fields defaulted to Go zero values and were persisted as-is.

## Changes

- `internal/config/cluster.go` — Export `ClusterDefaults()` as a documented thin wrapper so callers can safely use it as a base
- `internal/transport/rest/admin_cluster_handlers.go` — Start from `config.ClusterDefaults()` and override only user-supplied fields (role, bind_addr, cluster_secret, seeds)
- `internal/transport/rest/admin_cluster_handlers_test.go` — Regression tests: `TestAdminCluster_Enable_DefaultsWrittenToDisk` reads cluster.yaml back and asserts `LeaseTTL > 0` + `HeartbeatMS > 0`; `TestClusterDefaults_NonZero` guards the exported function

## Test Plan

- [ ] `go test -race -count=1 ./internal/transport/rest/... ./internal/config/...` — all pass
- [ ] Enable cluster via UI → restart → server starts normally
- [ ] `cluster.yaml` shows `lease_ttl: 10`, `heartbeat_ms: 1000` (not 0)