### PR TITLE
fix(cli): forward per-service addr flags to daemon

### DIFF
--- a/cmd/muninn/lifecycle.go
+++ b/cmd/muninn/lifecycle.go
@@ -11,8 +11,30 @@ import (
 	"time"
 )
 
+// parseExplicitFlag scans osArgs for an explicit --name value or --name=value
+// occurrence and returns the value. Returns "" if the flag is not present.
+// Used to detect user-supplied values that must be forwarded to the daemon.
+func parseExplicitFlag(name string, osArgs []string) string {
+	long := "--" + name
+	short := "-" + name
+	for i, arg := range osArgs {
+		if (arg == long || arg == short) && i+1 < len(osArgs) {
+			return osArgs[i+1]
+		}
+		if after, ok := strings.CutPrefix(arg, long+"="); ok {
+			return after
+		}
+		if after, ok := strings.CutPrefix(arg, short+"="); ok {
+			return after
+		}
+	}
+	return ""
+}
+
 // buildDaemonArgs constructs the argument list for the forked daemon process.
-// It forwards --listen-host when non-default and --cors-origins when non-empty.
+// It forwards --listen-host when non-default, --cors-origins when non-empty,
+// and any explicitly provided per-service address flags (--rest-addr, --mbp-addr,
+// --grpc-addr, --mcp-addr, --ui-addr) so they take effect in the daemon.
 func buildDaemonArgs(dataDir string, dev bool, mcpToken string, osArgs []string, listenHostEnv, corsOriginsEnv string) []string {
 	args := []string{"--daemon", "--data", dataDir}
 	if dev {
@@ -26,24 +48,20 @@ func buildDaemonArgs(dataDir string, dev bool, mcpToken string, osArgs []string,
 	if listenHost != "127.0.0.1" {
 		args = append(args, "--listen-host", listenHost)
 	}
-	// --cors-origins: forward from flag or env
+	// --cors-origins: forward from flag or env (flag wins)
 	corsOrigins := corsOriginsEnv
-	for i, arg := range osArgs {
-		if (arg == "--cors-origins" || arg == "-cors-origins") && i+1 < len(osArgs) {
-			corsOrigins = osArgs[i+1]
-			break
-		}
-		if after, ok := strings.CutPrefix(arg, "--cors-origins="); ok {
-			corsOrigins = after
-			break
-		}
-		if after, ok := strings.CutPrefix(arg, "-cors-origins="); ok {
-			corsOrigins = after
-			break
-		}
+	if v := parseExplicitFlag("cors-origins", osArgs); v != "" {
+		corsOrigins = v
 	}
 	if corsOrigins != "" {
 		args = append(args, "--cors-origins", corsOrigins)
+	}
+	// Per-service address overrides: forward any that the user explicitly set.
+	// These take priority over --listen-host defaults inside the daemon.
+	for _, name := range []string{"rest-addr", "mbp-addr", "grpc-addr", "mcp-addr", "ui-addr", "metrics-addr"} {
+		if v := parseExplicitFlag(name, osArgs); v != "" {
+			args = append(args, "--"+name, v)
+		}
 	}
 	return args
 }

--- a/cmd/muninn/server_test.go
+++ b/cmd/muninn/server_test.go
@@ -82,6 +82,93 @@ func TestBuildDaemonArgs_CORSFlagBeatsEnv(t *testing.T) {
 	}
 }
 
+// TestBuildDaemonArgs_PortFlagsForwarded is a regression test for GitHub
+// issue #100: --mbp-addr, --rest-addr, --grpc-addr, --mcp-addr were silently
+// ignored because buildDaemonArgs never forwarded them to the daemon process.
+func TestBuildDaemonArgs_PortFlagsForwarded(t *testing.T) {
+	cases := []struct {
+		flag string
+		val  string
+	}{
+		{"--rest-addr", "127.0.0.1:8485"},
+		{"--mbp-addr", "127.0.0.1:8494"},
+		{"--grpc-addr", "127.0.0.1:8497"},
+		{"--mcp-addr", "127.0.0.1:8760"},
+		{"--ui-addr", "127.0.0.1:8486"},
+	}
+	for _, tc := range cases {
+		osArgs := []string{tc.flag, tc.val}
+		got := buildDaemonArgs("/tmp/data", false, "", osArgs, "", "")
+
+		foundFlag := false
+		foundVal := false
+		for i, arg := range got {
+			if arg == tc.flag {
+				foundFlag = true
+				if i+1 < len(got) && got[i+1] == tc.val {
+					foundVal = true
+				}
+			}
+		}
+		if !foundFlag || !foundVal {
+			t.Errorf("%s %s not forwarded to daemon: got %v", tc.flag, tc.val, got)
+		}
+	}
+}
+
+// TestBuildDaemonArgs_PortFlagsEqForm verifies forwarding for --flag=value syntax.
+func TestBuildDaemonArgs_PortFlagsEqForm(t *testing.T) {
+	osArgs := []string{"--rest-addr=127.0.0.1:8485"}
+	got := buildDaemonArgs("/tmp/data", false, "", osArgs, "", "")
+
+	found := false
+	for i, arg := range got {
+		if arg == "--rest-addr" && i+1 < len(got) && got[i+1] == "127.0.0.1:8485" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("--rest-addr=127.0.0.1:8485 not forwarded: got %v", got)
+	}
+}
+
+// TestBuildDaemonArgs_DefaultAddrNotForwarded ensures that omitting per-service
+// address flags produces no --*-addr entries in daemon args (they are redundant
+// since the daemon uses the same defaults).
+func TestBuildDaemonArgs_DefaultAddrNotForwarded(t *testing.T) {
+	got := buildDaemonArgs("/tmp/data", false, "", []string{}, "", "")
+	for _, arg := range got {
+		for _, flag := range []string{"--rest-addr", "--mbp-addr", "--grpc-addr", "--mcp-addr", "--ui-addr"} {
+			if arg == flag {
+				t.Errorf("unexpected %s in daemon args when not explicitly set: %v", flag, got)
+			}
+		}
+	}
+}
+
+// TestParseExplicitFlag covers both --flag value and --flag=value forms.
+func TestParseExplicitFlag(t *testing.T) {
+	cases := []struct {
+		args []string
+		name string
+		want string
+	}{
+		{[]string{"--rest-addr", "10.0.0.1:8485"}, "rest-addr", "10.0.0.1:8485"},
+		{[]string{"--rest-addr=10.0.0.1:8485"}, "rest-addr", "10.0.0.1:8485"},
+		{[]string{"-rest-addr", "10.0.0.1:8485"}, "rest-addr", "10.0.0.1:8485"},
+		{[]string{"-rest-addr=10.0.0.1:8485"}, "rest-addr", "10.0.0.1:8485"},
+		{[]string{"--other", "val"}, "rest-addr", ""},
+		{[]string{}, "rest-addr", ""},
+		{[]string{"--rest-addr"}, "rest-addr", ""}, // flag at end of args with no value
+	}
+	for _, tc := range cases {
+		got := parseExplicitFlag(tc.name, tc.args)
+		if got != tc.want {
+			t.Errorf("parseExplicitFlag(%q, %v) = %q, want %q", tc.name, tc.args, got, tc.want)
+		}
+	}
+}
+
 func TestResolveEmbedInfo_EnvOllama(t *testing.T) {
 	clearEmbedEnv(t)
 	t.Setenv("MUNINN_OLLAMA_URL", "ollama://localhost:11434/nomic-embed-text")


### PR DESCRIPTION
## Problem

When a user runs `muninn start --rest-addr 0.0.0.0:9000` (or any of the other per-service addr flags), the flag is silently dropped. `buildDaemonArgs` only forwarded `--listen-host` and `--cors-origins` to the forked daemon subprocess.

Affected flags:
- `--rest-addr`
- `--mbp-addr`
- `--grpc-addr`
- `--mcp-addr`
- `--ui-addr`
- `--metrics-addr`

Closes #100.

## Solution

- Add `parseExplicitFlag(name, osArgs)` helper that handles both `--name value` and `--name=value` forms (and single-dash equivalents).
- Extend `buildDaemonArgs` to iterate over all per-service addr flags and forward them when explicitly set by the user.
- Refactor the existing `--cors-origins` forwarding to use the same helper for consistency.

Flags not supplied by the user are not forwarded — the daemon computes its own defaults from `--listen-host`, so forwarding defaults would cause incorrect precedence.

## Test Plan

- [x] `TestParseExplicitFlag` — unit covers space-sep, eq-form, short-dash, missing, trailing-flag-no-value
- [x] `TestBuildDaemonArgs_PortFlagsForwarded` — regression: each of the 5 addr flags forwarded when supplied
- [x] `TestBuildDaemonArgs_PortFlagsEqForm` — eq-form (`--rest-addr=0.0.0.0:9001`) forwarded correctly
- [x] `TestBuildDaemonArgs_DefaultAddrNotForwarded` — no spurious flags when none supplied
- [x] `go test -race -count=1 ./cmd/muninn/...` — all passing