### PR TITLE
fix(init): write type:http in Claude Code MCP config

### DIFF
--- a/cmd/muninn/coverage_test.go
+++ b/cmd/muninn/coverage_test.go
@@ -907,6 +907,10 @@ func TestConfigureClaudeCode(t *testing.T) {
 	if !strings.Contains(string(data), `"muninn"`) {
 		t.Errorf("muninn not in config: %s", data)
 	}
+	// Regression guard for issue #109: Claude Code schema requires "type":"http".
+	if !strings.Contains(string(data), `"type"`) || !strings.Contains(string(data), `"http"`) {
+		t.Errorf(`"type":"http" missing from written config — Claude Code schema will reject it: %s`, data)
+	}
 }
 
 // --- configureNamedTools claude-code alias ---

--- a/cmd/muninn/setup_ai.go
+++ b/cmd/muninn/setup_ai.go
@@ -218,6 +218,33 @@ func mergeOpenCodeMCP(cfg map[string]any, mcpURL, token string) {
 	cfg["mcp"] = mcp
 }
 
+// claudeCodeMCPEntry returns the JSON map for muninn's Claude Code MCP entry.
+// Claude Code requires "type":"http" for schema validation; this is distinct from
+// Claude Desktop which crashes if "type" is present (see mcpServerEntry).
+func claudeCodeMCPEntry(mcpURL, token string) map[string]any {
+	entry := map[string]any{
+		"type": "http",
+		"url":  mcpURL,
+	}
+	if token != "" {
+		entry["headers"] = map[string]any{
+			"Authorization": "Bearer " + token,
+		}
+	}
+	return entry
+}
+
+// mergeClaudeCodeMCP upserts muninn into cfg["mcpServers"] using the Claude
+// Code-specific entry format (includes "type":"http").
+func mergeClaudeCodeMCP(cfg map[string]any, mcpURL, token string) {
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		servers = map[string]any{}
+	}
+	servers["muninn"] = claudeCodeMCPEntry(mcpURL, token)
+	cfg["mcpServers"] = servers
+}
+
 // claudeCodeConfigPath returns the path to Claude Code's (claude CLI) config file.
 // Claude Code reads ~/.claude.json for global MCP server configuration.
 func claudeCodeConfigPath() string {
@@ -229,7 +256,7 @@ func claudeCodeConfigPath() string {
 func configureClaudeCode(mcpURL, token string) error {
 	path := claudeCodeConfigPath()
 	summary, err := writeAIToolConfig(path, func(cfg map[string]any) {
-		mergeMCPServers(cfg, mcpURL, token)
+		mergeClaudeCodeMCP(cfg, mcpURL, token)
 	})
 	if err != nil {
 		return err

--- a/cmd/muninn/setup_ai_test.go
+++ b/cmd/muninn/setup_ai_test.go
@@ -255,6 +255,54 @@ func TestMCPServerEntry_NoToken(t *testing.T) {
 	}
 }
 
+// TestClaudeCodeMCPEntry_HasType verifies that the Claude Code entry includes "type":"http".
+func TestClaudeCodeMCPEntry_HasType(t *testing.T) {
+	entry := claudeCodeMCPEntry("http://localhost:8750/mcp", "")
+	if entry["type"] != "http" {
+		t.Errorf(`type = %v, want "http" — Claude Code schema requires this field`, entry["type"])
+	}
+	if entry["url"] != "http://localhost:8750/mcp" {
+		t.Errorf("url = %v, want http://localhost:8750/mcp", entry["url"])
+	}
+}
+
+// TestClaudeCodeMCPEntry_WithToken verifies token is included under headers.
+func TestClaudeCodeMCPEntry_WithToken(t *testing.T) {
+	entry := claudeCodeMCPEntry("http://localhost:8750/mcp", "mdb_tok")
+	headers, ok := entry["headers"].(map[string]any)
+	if !ok {
+		t.Fatal("headers missing")
+	}
+	if headers["Authorization"] != "Bearer mdb_tok" {
+		t.Errorf("Authorization = %v, want Bearer mdb_tok", headers["Authorization"])
+	}
+}
+
+// TestClaudeCodeMCPEntry_NoToken verifies no headers when token is empty.
+func TestClaudeCodeMCPEntry_NoToken(t *testing.T) {
+	entry := claudeCodeMCPEntry("http://localhost:8750/mcp", "")
+	if _, ok := entry["headers"]; ok {
+		t.Error("headers should not be present when token is empty")
+	}
+}
+
+// TestMergeClaudeCodeMCP_SetsTypeField verifies mergeClaudeCodeMCP writes "type":"http".
+func TestMergeClaudeCodeMCP_SetsTypeField(t *testing.T) {
+	cfg := map[string]any{}
+	mergeClaudeCodeMCP(cfg, "http://localhost:8750/mcp", "tok")
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers missing")
+	}
+	muninn, ok := servers["muninn"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers.muninn missing")
+	}
+	if muninn["type"] != "http" {
+		t.Errorf(`type = %v, want "http"`, muninn["type"])
+	}
+}
+
 // TestParseToolNumbers verifies tool selection parsing.
 func TestParseToolNumbers(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Problem

`muninn init --tool claude-code` wrote `~/.claude.json` using `mcpServerEntry()`, which intentionally omits `"type"` to avoid crashing Claude Desktop v1.1.4010. Claude Code's schema validator requires `"type": "http"` and rejected the config with:

```
[Error] mcpServers.muninn: Does not adhere to MCP server configuration schema
```

Closes #109.

## Solution

Add `claudeCodeMCPEntry()` and `mergeClaudeCodeMCP()` that include `"type":"http"`, matching the config shape documented in the README. Update `configureClaudeCode()` to use these new builders.

All Claude Desktop, Cursor, and Windsurf paths continue to use the Desktop-safe `mcpServerEntry()` (no `"type"` field).

## Test Plan

- [x] `TestClaudeCodeMCPEntry_HasType` — asserts `"type":"http"` present
- [x] `TestClaudeCodeMCPEntry_WithToken` — correct `Authorization` header
- [x] `TestClaudeCodeMCPEntry_NoToken` — no headers when empty
- [x] `TestMergeClaudeCodeMCP_SetsTypeField` — end-to-end merge check
- [x] `TestConfigureClaudeCode` — regression guard: asserts `"type":"http"` in written file (issue #109)
- [x] Existing Desktop/Cursor tests unchanged and still passing
- [x] `go test -race -count=1 ./cmd/muninn/...` → PASS