### PR TITLE
fix(mcp): recall prefers summary, read returns full content

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1624,6 +1624,7 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 			ID:          scored.Engram.ID.String(),
 			Concept:     scored.Engram.Concept,
 			Content:     scored.Engram.Content,
+			Summary:     scored.Engram.Summary,
 			Score:       float32(scored.Score),
 			Confidence:  scored.Engram.Confidence,
 			Why:         scored.Why,

--- a/internal/mcp/convert.go
+++ b/internal/mcp/convert.go
@@ -7,19 +7,25 @@ import (
 	"github.com/scrypster/muninndb/internal/transport/mbp"
 )
 
-const contentMaxLen = 500
+const contentPreviewLen = 500
 
 // activationToMemory converts an mbp.ActivationItem to an MCP Memory for recall responses.
-// Truncates Content to contentMaxLen chars if over limit.
+// Prefers Summary when available; falls back to a content preview (500 chars) so that
+// recall returns discovery-oriented data rather than a raw content slice.
 func activationToMemory(item *mbp.ActivationItem) Memory {
-	content := item.Content
-	if len(content) > contentMaxLen {
-		content = content[:contentMaxLen] + "..."
+	// Use the enrichment-generated summary when present; otherwise preview content.
+	displayContent := item.Summary
+	if displayContent == "" {
+		displayContent = item.Content
+		if len(displayContent) > contentPreviewLen {
+			displayContent = displayContent[:contentPreviewLen] + "..."
+		}
 	}
 	return Memory{
 		ID:          item.ID,
 		Concept:     item.Concept,
-		Content:     content,
+		Content:     displayContent,
+		Summary:     item.Summary,
 		Score:       float64(item.Score),
 		VectorScore: float64(item.ScoreComponents.SemanticSimilarity),
 		Confidence:  item.Confidence,
@@ -33,20 +39,18 @@ func activationToMemory(item *mbp.ActivationItem) Memory {
 }
 
 // readResponseToMemory converts a ReadResponse to a Memory for the muninn_read tool.
+// Returns the full content without truncation, and maps Summary when present.
 func readResponseToMemory(r *mbp.ReadResponse) Memory {
-	content := r.Content
-	if len(content) > contentMaxLen {
-		content = content[:contentMaxLen] + "..."
-	}
 	return Memory{
-		ID:         r.ID,
-		Concept:    r.Concept,
-		Content:    content,
-		Confidence: r.Confidence,
-		Tags:       r.Tags,
-		State:       fmt.Sprintf("%d", r.State),
-		CreatedAt:   time.Unix(0, r.CreatedAt), // r.CreatedAt is nanoseconds since epoch
-		LastAccess:  time.Unix(0, int64(r.LastAccess)).UTC(),
+		ID:          r.ID,
+		Concept:     r.Concept,
+		Content:     r.Content, // full content, no truncation
+		Summary:     r.Summary,
+		Confidence:  r.Confidence,
+		Tags:        r.Tags,
+		State:      fmt.Sprintf("%d", r.State),
+		CreatedAt:  time.Unix(0, r.CreatedAt).UTC(),
+		LastAccess: time.Unix(0, r.LastAccess).UTC(),
 		AccessCount: r.AccessCount,
 		Relevance:   r.Relevance,
 	}

--- a/internal/mcp/convert_test.go
+++ b/internal/mcp/convert_test.go
@@ -246,3 +246,80 @@ func TestConvertReadResponseToMemory(t *testing.T) {
 		t.Errorf("tags len = %d, want 2", len(m.Tags))
 	}
 }
+
+// TestReadResponseToMemory_FullContent verifies muninn_read returns full content
+// without truncation — regression guard for issue #112.
+func TestReadResponseToMemory_FullContent(t *testing.T) {
+	long := make([]byte, 2000)
+	for i := range long {
+		long[i] = 'y'
+	}
+	resp := &mbp.ReadResponse{
+		ID:      "full-read",
+		Content: string(long),
+	}
+	m := readResponseToMemory(resp)
+	if len(m.Content) != 2000 {
+		t.Errorf("readResponseToMemory truncated content: got len %d, want 2000", len(m.Content))
+	}
+}
+
+// TestReadResponseToMemory_MapsummaryField verifies that Summary from the read
+// response is propagated to the Memory.
+func TestReadResponseToMemory_MapsSummaryField(t *testing.T) {
+	resp := &mbp.ReadResponse{
+		ID:      "sum-read",
+		Content: "full content here",
+		Summary: "short summary",
+	}
+	m := readResponseToMemory(resp)
+	if m.Summary != "short summary" {
+		t.Errorf("Summary = %q, want %q", m.Summary, "short summary")
+	}
+	if m.Content != "full content here" {
+		t.Errorf("Content = %q, want full content", m.Content)
+	}
+}
+
+// TestActivationToMemory_PrefersSummary verifies that muninn_recall uses the
+// enrichment summary when present instead of the truncated content preview.
+func TestActivationToMemory_PrefersSummary(t *testing.T) {
+	item := &mbp.ActivationItem{
+		ID:      "recall-with-summary",
+		Concept: "concept",
+		Content: "this is the full long content that goes well beyond any preview limit",
+		Summary: "short enriched summary",
+	}
+	m := activationToMemory(item)
+	if m.Summary != "short enriched summary" {
+		t.Errorf("Summary = %q, want %q", m.Summary, "short enriched summary")
+	}
+	// Content field should carry the summary as the display value when present.
+	if m.Content != "short enriched summary" {
+		t.Errorf("Content (display) = %q, want summary %q", m.Content, "short enriched summary")
+	}
+}
+
+// TestActivationToMemory_FallsBackToTruncated verifies that when no summary
+// exists, muninn_recall falls back to a truncated content preview.
+func TestActivationToMemory_FallsBackToTruncated(t *testing.T) {
+	long := make([]byte, 800)
+	for i := range long {
+		long[i] = 'z'
+	}
+	item := &mbp.ActivationItem{
+		ID:      "recall-no-summary",
+		Content: string(long),
+		Summary: "",
+	}
+	m := activationToMemory(item)
+	if m.Summary != "" {
+		t.Errorf("Summary should be empty, got %q", m.Summary)
+	}
+	if len(m.Content) > contentPreviewLen+3 {
+		t.Errorf("Content not truncated: len=%d", len(m.Content))
+	}
+	if m.Content[len(m.Content)-3:] != "..." {
+		t.Error("truncated content must end with '...'")
+	}
+}

--- a/internal/mcp/server_coverage_test.go
+++ b/internal/mcp/server_coverage_test.go
@@ -276,6 +276,8 @@ func TestResolveVault_NoSession_NoArg(t *testing.T) {
 
 // ── convert.go: readResponseToMemory long content ─────────────────────────────
 
+// TestReadResponseToMemory_LongContent verifies that muninn_read returns the
+// full content without truncation — issue #112 behavior change.
 func TestReadResponseToMemory_LongContent(t *testing.T) {
 	longContent := strings.Repeat("x", 501)
 	resp := &mbp.ReadResponse{
@@ -283,11 +285,11 @@ func TestReadResponseToMemory_LongContent(t *testing.T) {
 		Content: longContent,
 	}
 	mem := readResponseToMemory(resp)
-	if len(mem.Content) > contentMaxLen+3 { // +3 for "..."
-		t.Errorf("content should be truncated, got len=%d", len(mem.Content))
+	if len(mem.Content) != 501 {
+		t.Errorf("readResponseToMemory should return full content: got len=%d, want 501", len(mem.Content))
 	}
-	if !strings.HasSuffix(mem.Content, "...") {
-		t.Error("truncated content should end with '...'")
+	if strings.HasSuffix(mem.Content, "...") {
+		t.Error("readResponseToMemory must not truncate content (issue #112)")
 	}
 }
 

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -56,7 +56,7 @@ type WriteResult struct {
 type Memory struct {
 	ID          string    `json:"id"`
 	Concept     string    `json:"concept"`
-	Content     string    `json:"content"` // truncated to 500 chars if no Summary
+	Content     string    `json:"content"` // recall: summary or 500-char preview; read: full content
 	Summary     string    `json:"summary,omitempty"`
 	Score       float64   `json:"score,omitempty"`
 	VectorScore float64   `json:"vector_score,omitempty"`

--- a/internal/transport/mbp/types.go
+++ b/internal/transport/mbp/types.go
@@ -201,6 +201,7 @@ type ActivationItem struct {
 	ID              string          `msgpack:"id"                          json:"id"`
 	Concept         string          `msgpack:"concept"                     json:"concept"`
 	Content         string          `msgpack:"content"                     json:"content"`
+	Summary         string          `msgpack:"summary,omitempty"           json:"summary,omitempty"`
 	Score           float32         `msgpack:"score"                       json:"score"`
 	Confidence      float32         `msgpack:"confidence"                  json:"confidence"`
 	ScoreComponents ScoreComponents `msgpack:"score_components,omitempty"  json:"score_components,omitempty"`


### PR DESCRIPTION
## Problem

Both `muninn_recall` and `muninn_read` returned truncated content (500 chars). The `Summary` field existed as a first-class field on `Memory` and `ReadResponse`, and was even referenced in a comment, but was never populated or used.

Closes #112.

## Changes

### Transport
- `ActivationItem` gains a `Summary` field (so recall results can carry enrichment summaries)

### Engine
- `Activate()` populates `Summary` from `scored.Engram.Summary`

### MCP converters (`internal/mcp/convert.go`)
- `activationToMemory` (recall path): prefers `Summary` when present; falls back to a 500-char content preview when no summary exists. Renames `contentMaxLen` → `contentPreviewLen` for intent clarity.
- `readResponseToMemory` (read path): returns full `Content` without truncation; maps `Summary`; normalizes `CreatedAt` to UTC (was missing `.UTC()`); removes a no-op `int64` cast

### Comment update
- `Memory.Content` comment updated: `"recall: summary or 500-char preview; read: full content"`

## Test Plan

- [x] `TestActivationToMemory_PrefersSummary` — display Content == Summary when present
- [x] `TestActivationToMemory_FallsBackToTruncated` — 800-char, no summary → truncated preview with `...`
- [x] `TestReadResponseToMemory_FullContent` — 2000-char content returned intact
- [x] `TestReadResponseToMemory_MapsSummaryField` — Summary field populated on read
- [x] `TestReadResponseToMemory_LongContent` updated — now asserts full content (was asserting truncation)
- [x] `go test -race -count=1 ./internal/...` — all 44 packages pass