### PR TITLE
fix(init): use stdio bridge for Claude Desktop MCP config (#117)

### DIFF
--- a/cmd/muninn/setup_ai.go
+++ b/cmd/muninn/setup_ai.go
@@ -164,10 +164,13 @@ func writeAIToolConfig(path string, mergeFn func(cfg map[string]any)) (string, e
 	return "added mcpServers.muninn to config", nil
 }
 
-// mcpServerEntry returns the JSON map for muninn's MCP server entry.
+// mcpServerEntry returns the JSON map for muninn's HTTP MCP server entry.
+// Used by Cursor, Windsurf, and the VS Code manual snippet — clients that
+// natively support HTTP/SSE transport via a url field.
+//
 // Note: "type" is intentionally omitted. Claude Desktop v1.1.4010+ crashes
 // on startup with a TypeError if "type":"http" is present in any mcpServers
-// entry. The MCP client infers transport from the URL schema.
+// entry. Claude Desktop uses the stdio bridge instead (see desktopMCPEntry).
 func mcpServerEntry(mcpURL, token string) map[string]any {
 	entry := map[string]any{
 		"url": mcpURL,
@@ -309,11 +312,50 @@ func openCodeConfigPath() string {
 	}
 }
 
-// configureClaudeDesktop writes the muninn MCP entry into Claude Desktop's config.
-func configureClaudeDesktop(mcpURL, token string) error {
+// desktopMCPEntry returns a stdio MCP entry for Claude Desktop.
+//
+// Claude Desktop's config file (claude_desktop_config.json) only supports stdio
+// transports — any "type":"http" or "type":"sse" field crashes the app on startup.
+// The entry spawns the muninn binary as a subprocess; the built-in mcp proxy
+// bridges stdin/stdout JSON-RPC to the running MuninnDB daemon over HTTP.
+//
+// The Bearer token and server URL are NOT embedded in the config: the proxy
+// reads the token from ~/.muninn/mcp.token and connects to the default daemon
+// port at runtime, so the config never needs to change after daemon restarts.
+//
+// binPath should be the absolute path to the muninn binary (from os.Executable),
+// which avoids PATH lookup failures when Desktop spawns the subprocess.
+func desktopMCPEntry(binPath string) map[string]any {
+	return map[string]any{
+		"command": binPath,
+		"args":    []any{"mcp"},
+	}
+}
+
+// mergeDesktopMCP upserts the muninn stdio entry into cfg["mcpServers"].
+func mergeDesktopMCP(cfg map[string]any, binPath string) {
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		servers = map[string]any{}
+	}
+	servers["muninn"] = desktopMCPEntry(binPath)
+	cfg["mcpServers"] = servers
+}
+
+// configureClaudeDesktop writes the muninn stdio MCP entry into Claude Desktop's config.
+// mcpURL and token are accepted for interface compatibility but are not embedded in the
+// config — the muninn mcp proxy reads them from disk at runtime.
+func configureClaudeDesktop(_, _ string) error {
+	// Resolve the absolute path to this binary so Desktop can spawn it without
+	// relying on PATH, which is often minimal in GUI app environments.
+	binPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve binary path: %w", err)
+	}
+
 	path := claudeDesktopConfigPath()
 	summary, err := writeAIToolConfig(path, func(cfg map[string]any) {
-		mergeMCPServers(cfg, mcpURL, token)
+		mergeDesktopMCP(cfg, binPath)
 	})
 	if err != nil {
 		return err

--- a/cmd/muninn/setup_ai_test.go
+++ b/cmd/muninn/setup_ai_test.go
@@ -746,16 +746,15 @@ func withTempHome(t *testing.T) (string, func()) {
 	}
 }
 
-// TestConfigureClaudeDesktopWritesConfig verifies Claude Desktop config is written at correct path with correct JSON.
+// TestConfigureClaudeDesktopWritesConfig verifies Claude Desktop config is written at the
+// correct path with a stdio entry (command + args), not an HTTP entry (url + headers).
+// Claude Desktop v1.1.4010+ crashes on startup if any mcpServers entry has type:"http".
 func TestConfigureClaudeDesktopWritesConfig(t *testing.T) {
 	home, cleanup := withTempHome(t)
 	defer cleanup()
 
-	mcpURL := "http://localhost:8750/mcp"
-	token := "mdb_testtoken123"
-
 	out := captureStdout(func() {
-		err := configureClaudeDesktop(mcpURL, token)
+		err := configureClaudeDesktop("http://localhost:8750/mcp", "mdb_testtoken123")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -785,15 +784,23 @@ func TestConfigureClaudeDesktopWritesConfig(t *testing.T) {
 	if !ok {
 		t.Fatalf("mcpServers.muninn not found: %s", data)
 	}
-	if muninn["url"] != mcpURL {
-		t.Errorf("url = %v, want %q", muninn["url"], mcpURL)
+
+	// Must be a stdio entry: command + args, no url/headers/type.
+	if muninn["command"] == nil || muninn["command"] == "" {
+		t.Errorf("command field missing or empty — Desktop config must use stdio transport: %s", data)
 	}
-	headers, ok := muninn["headers"].(map[string]any)
-	if !ok {
-		t.Fatalf("headers not found when token supplied: %s", data)
+	args, ok := muninn["args"].([]any)
+	if !ok || len(args) == 0 || args[0] != "mcp" {
+		t.Errorf("args should be [\"mcp\"], got %v: %s", muninn["args"], data)
 	}
-	if headers["Authorization"] != "Bearer "+token {
-		t.Errorf("Authorization = %v, want %q", headers["Authorization"], "Bearer "+token)
+	if muninn["url"] != nil {
+		t.Errorf("url must not be present in Desktop config (causes schema crash): %s", data)
+	}
+	if muninn["headers"] != nil {
+		t.Errorf("headers must not be present in Desktop config: %s", data)
+	}
+	if muninn["type"] != nil {
+		t.Errorf("type must not be present in Desktop config (causes crash): %s", data)
 	}
 
 	// Output should contain success marker
@@ -802,7 +809,8 @@ func TestConfigureClaudeDesktopWritesConfig(t *testing.T) {
 	}
 }
 
-// TestConfigureClaudeDesktopNoToken verifies no auth header is written when token is empty.
+// TestConfigureClaudeDesktopNoToken verifies Desktop config is still stdio even when no token.
+// The token is read at runtime by muninn mcp, so it never appears in the config file.
 func TestConfigureClaudeDesktopNoToken(t *testing.T) {
 	_, cleanup := withTempHome(t)
 	defer cleanup()
@@ -819,8 +827,15 @@ func TestConfigureClaudeDesktopNoToken(t *testing.T) {
 	servers := cfg["mcpServers"].(map[string]any)
 	muninn := servers["muninn"].(map[string]any)
 
-	if _, hasHeaders := muninn["headers"]; hasHeaders {
-		t.Error("headers should not be present when token is empty")
+	// stdio entry: command present, no url/headers regardless of token presence.
+	if muninn["command"] == nil {
+		t.Error("command field missing — Desktop config must use stdio transport")
+	}
+	if muninn["url"] != nil {
+		t.Error("url must not be present in Desktop config")
+	}
+	if muninn["headers"] != nil {
+		t.Error("headers must not be present in Desktop config")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes Claude Desktop MCP setup — users were hitting config failures on newer Desktop versions because there is no safe HTTP config shape for `claude_desktop_config.json`:

- `"type":"http"` → crashes the app on startup (TypeError)
- `"type":"sse"` → same crash
- `url` + `headers` without `type` → passes in old versions, fails schema validation in newer versions

**Solution:** Switch `configureClaudeDesktop()` from an HTTP url/headers entry to a stdio entry using MuninnDB's built-in proxy:

```json
{
  "mcpServers": {
    "muninn": {
      "command": "/usr/local/bin/muninn",
      "args": ["mcp"]
    }
  }
}
```

The `muninn mcp` stdio proxy (already used by OpenClaw) bridges stdin/stdout JSON-RPC to the running MuninnDB daemon. It reads the Bearer token from `~/.muninn/mcp.token` at runtime — no credentials in the config file, no config changes needed after daemon restarts.

`os.Executable()` resolves the absolute binary path to avoid PATH lookup failures in Desktop's GUI subprocess environment.

`mcpServerEntry()` (url/headers) is now used only by Cursor, Windsurf, and VS Code — clients that natively support HTTP transport.

## Test Plan

- [x] `TestConfigureClaudeDesktopWritesConfig` — asserts `command` + `args: ["mcp"]` present; asserts `url`, `headers`, `type` are absent
- [x] `TestConfigureClaudeDesktopNoToken` — same stdio shape regardless of token (token is never in config)
- [x] `TestConfigureClaudeDesktopPreservesExistingKeys` — existing servers still preserved
- [x] All tests pass: `go test -race -count=1 ./cmd/muninn/...`

## Context

Identified from user report showing `mcp-remote` as the only working Desktop config. Research confirmed Desktop natively supports only stdio transports. The built-in `muninn mcp` proxy is the cleaner solution — no `npx` or external tools required.