### PR TITLE
fix: replace localhost with 127.0.0.1 across all ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,19 @@ muninn start
 
 ```bash
 # 3. Store a memory
-curl -sX POST http://localhost:8475/api/engrams \
+curl -sX POST http://127.0.0.1:8475/api/engrams \
   -H 'Content-Type: application/json' \
   -d '{"concept":"payment incident","content":"We switched to idempotency keys after the double-charge incident in Q3"}'
 
 # 4. Ask what is relevant RIGHT NOW
-curl -sX POST http://localhost:8475/api/activate \
+curl -sX POST http://127.0.0.1:8475/api/activate \
   -H 'Content-Type: application/json' \
   -d '{"context":["debugging the payment retry logic"]}'
 ```
 
 That Q3 incident surfaces. You never mentioned it. MuninnDB connected the concepts.
 
-**Web UI:** `http://localhost:8476` · **Admin:** `root` / `password` (change after first login)
+**Web UI:** `http://127.0.0.1:8476` · **Admin:** `root` / `password` (change after first login)
 
 ---
 
@@ -75,7 +75,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 {
   "mcpServers": {
     "muninn": {
-      "url": "http://localhost:8750/mcp"
+      "url": "http://127.0.0.1:8750/mcp"
     }
   }
 }
@@ -94,7 +94,7 @@ Add to `~/.claude.json`:
   "mcpServers": {
     "muninn": {
       "type": "http",
-      "url": "http://localhost:8750/mcp"
+      "url": "http://127.0.0.1:8750/mcp"
     }
   }
 }
@@ -111,7 +111,7 @@ Add to `~/.cursor/mcp.json`:
   "mcpServers": {
     "muninn": {
       "type": "http",
-      "url": "http://localhost:8750/mcp"
+      "url": "http://127.0.0.1:8750/mcp"
     }
   }
 }
@@ -148,7 +148,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
   "mcpServers": {
     "muninn": {
       "type": "http",
-      "url": "http://localhost:8750/mcp"
+      "url": "http://127.0.0.1:8750/mcp"
     }
   }
 }
@@ -165,7 +165,7 @@ Add to `.vscode/mcp.json` in your workspace:
   "servers": {
     "muninn": {
       "type": "http",
-      "url": "http://localhost:8750/mcp"
+      "url": "http://127.0.0.1:8750/mcp"
     }
   }
 }
@@ -182,7 +182,7 @@ Add to `~/.config/opencode/opencode.json` (macOS/Linux) or `%APPDATA%\opencode\o
   "mcp": {
     "muninn": {
       "type": "remote",
-      "url": "http://localhost:8750/mcp",
+      "url": "http://127.0.0.1:8750/mcp",
       "oauth": false,
       "headers": {
         "Authorization": "Bearer {file:~/.muninn/mcp.token}"
@@ -232,7 +232,7 @@ The Q3 incident surfaced because MuninnDB understood that *"payment retry logic"
 
 ```bash
 # Write
-curl -sX POST http://localhost:8475/api/engrams \
+curl -sX POST http://127.0.0.1:8475/api/engrams \
   -H 'Content-Type: application/json' \
   -d '{
     "concept": "auth architecture",
@@ -241,12 +241,12 @@ curl -sX POST http://localhost:8475/api/engrams \
   }'
 
 # Activate by context (returns ranked, time-weighted, associated memories)
-curl -sX POST http://localhost:8475/api/activate \
+curl -sX POST http://127.0.0.1:8475/api/activate \
   -H 'Content-Type: application/json' \
   -d '{"context": ["reviewing the login flow for the mobile app"], "max_results": 5}'
 
 # Search by text
-curl 'http://localhost:8475/api/engrams?q=JWT&vault=default'
+curl 'http://127.0.0.1:8475/api/engrams?q=JWT&vault=default'
 ```
 
 **Python SDK:**
@@ -254,7 +254,7 @@ curl 'http://localhost:8475/api/engrams?q=JWT&vault=default'
 ```python
 from muninn import MuninnClient
 
-async with MuninnClient("http://localhost:8475") as m:
+async with MuninnClient("http://127.0.0.1:8475") as m:
     # Store
     await m.write(vault="default", concept="auth architecture",
                   content="Short-lived JWTs, refresh in HttpOnly cookies")
@@ -287,7 +287,7 @@ chain = ConversationChain(llm=your_llm, memory=memory)
 ```go
 import "github.com/scrypster/muninndb/sdk/go/muninn"
 
-client := muninn.NewClient("http://localhost:8475", "your-api-key")
+client := muninn.NewClient("http://127.0.0.1:8475", "your-api-key")
 id, _ := client.Write(ctx, "default", "auth architecture",
     "Short-lived JWTs, refresh in HttpOnly cookies", []string{"auth"})
 resp, _ := client.Activate(ctx, "default", []string{"login flow"}, 5)
@@ -433,7 +433,7 @@ If your tool reports a schema validation or config parsing error, try removing `
 <details>
 <summary>muninn_remember or muninn_recall hangs</summary>
 
-Check that the server is running: `muninn status`. If the server is running but tools hang, check `muninn logs` for errors. The most common cause is a stale MCP config pointing to the wrong port — verify the URL in your config matches `http://localhost:8750/mcp`.
+Check that the server is running: `muninn status`. If the server is running but tools hang, check `muninn logs` for errors. The most common cause is a stale MCP config pointing to the wrong port — verify the URL in your config matches `http://127.0.0.1:8750/mcp`.
 </details>
 
 <details>

--- a/cmd/eval-semantic/main.go
+++ b/cmd/eval-semantic/main.go
@@ -5,8 +5,8 @@
 //
 // Usage:
 //
-//	go run ./cmd/eval-semantic -url http://localhost:8750 -token mdb_yourtoken
-//	go run ./cmd/eval-semantic -url http://localhost:8750 -token mdb_yourtoken -vault my-eval
+//	go run ./cmd/eval-semantic -url http://127.0.0.1:8750 -token mdb_yourtoken
+//	go run ./cmd/eval-semantic -url http://127.0.0.1:8750 -token mdb_yourtoken -vault my-eval
 //
 // The vault is cleared between runs by default (-clear=true).
 package main
@@ -286,7 +286,7 @@ func snippet(s string, n int) string {
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 func main() {
-	url := flag.String("url", "http://localhost:8475", "MuninnDB server URL")
+	url := flag.String("url", "http://127.0.0.1:8475", "MuninnDB server URL")
 	tok := flag.String("token", "", "API token (Bearer)")
 	vlt := flag.String("vault", "eval-demo", "Vault name")
 	skipSeed := flag.Bool("skip-seed", false, "Skip seeding (reuse existing vault)")

--- a/cmd/muninn/admin.go
+++ b/cmd/muninn/admin.go
@@ -22,7 +22,7 @@ func printAdminUsage() {
 	fmt.Println("  -u <user>         Admin username (default: root)")
 	fmt.Println("  -p                Prompt for current password")
 	fmt.Println("  -p<password>      Inline current password (no space)")
-	fmt.Println("  -h <host:port>    Server host:port (default: localhost:8475)")
+	fmt.Println("  -h <host:port>    Server host:port (default: 127.0.0.1:8475)")
 }
 
 func runAdmin(args []string) {

--- a/cmd/muninn/api_key.go
+++ b/cmd/muninn/api_key.go
@@ -24,7 +24,7 @@ func printAPIKeyUsage() {
 	fmt.Println("  -u <user>         Admin username (default: root)")
 	fmt.Println("  -p                Prompt for password")
 	fmt.Println("  -p<password>      Inline password (no space)")
-	fmt.Println("  -h <host:port>    Server host:port (default: localhost:8475)")
+	fmt.Println("  -h <host:port>    Server host:port (default: 127.0.0.1:8475)")
 }
 
 func runAPIKey(args []string) {

--- a/cmd/muninn/backup.go
+++ b/cmd/muninn/backup.go
@@ -82,7 +82,7 @@ func runBackup(args []string) {
 		fmt.Fprintf(os.Stderr, "error: muninn is running (pid %d) — cannot perform offline backup\n", pid)
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Use the online backup endpoint instead:")
-		fmt.Fprintf(os.Stderr, "  curl -X POST http://localhost:8475/api/admin/backup -d '{\"output_dir\": \"%s\"}'\n", outputDir)
+		fmt.Fprintf(os.Stderr, "  curl -X POST http://127.0.0.1:8475/api/admin/backup -d '{\"output_dir\": \"%s\"}'\n", outputDir)
 		osExit(1)
 		return
 	}

--- a/cmd/muninn/cluster.go
+++ b/cmd/muninn/cluster.go
@@ -57,14 +57,14 @@ func printClusterHelp() {
 	fmt.Println("  disable       Disable cluster mode on the running node")
 	fmt.Println()
 	fmt.Println("Flags:")
-	fmt.Println("  --addr <url>   Server address (default: http://localhost:8475)")
+	fmt.Println("  --addr <url>   Server address (default: http://127.0.0.1:8475)")
 	fmt.Println("  --json         Output raw JSON")
 }
 
 // runClusterInfo displays cluster topology and node status.
 func runClusterInfo(args []string) {
 	fs := flag.NewFlagSet("cluster info", flag.ContinueOnError)
-	addr := fs.String("addr", "http://localhost:8475", "Server address")
+	addr := fs.String("addr", "http://127.0.0.1:8475", "Server address")
 	outputJSON := fs.Bool("json", false, "Output raw JSON")
 	fs.Parse(args)
 
@@ -124,7 +124,7 @@ func runClusterInfo(args []string) {
 // runClusterStatus shows cluster health and per-node replication lag.
 func runClusterStatus(args []string) {
 	fs := flag.NewFlagSet("cluster status", flag.ContinueOnError)
-	addr := fs.String("addr", "http://localhost:8475", "Server address")
+	addr := fs.String("addr", "http://127.0.0.1:8475", "Server address")
 	outputJSON := fs.Bool("json", false, "Output raw JSON")
 	fs.Parse(args)
 
@@ -200,7 +200,7 @@ func runClusterStatus(args []string) {
 // runClusterFailover triggers a manual failover/election.
 func runClusterFailover(args []string) {
 	fs := flag.NewFlagSet("cluster failover", flag.ContinueOnError)
-	addr := fs.String("addr", "http://localhost:8475", "Server address")
+	addr := fs.String("addr", "http://127.0.0.1:8475", "Server address")
 	yes := fs.Bool("yes", false, "Skip confirmation prompt")
 	fs.Parse(args)
 
@@ -303,7 +303,7 @@ func runClusterRemoveNode(args []string) {
 // runClusterEnable enables cluster mode on a running node via the admin API.
 func runClusterEnable(args []string) int {
 	fs := flag.NewFlagSet("cluster enable", flag.ContinueOnError)
-	addr := fs.String("addr", "http://localhost:8475", "MuninnDB admin address")
+	addr := fs.String("addr", "http://127.0.0.1:8475", "MuninnDB admin address")
 	role := fs.String("role", "primary", "Node role: primary|replica|sentinel|observer")
 	bindAddr := fs.String("bind-addr", "", "Cluster bind address (IP:port)")
 	cortexAddr := fs.String("cortex-addr", "", "Cortex address (required for replica/sentinel/observer)")
@@ -365,7 +365,7 @@ func runClusterEnable(args []string) int {
 // runClusterDisable disables cluster mode on a running node via the admin API.
 func runClusterDisable(args []string) int {
 	fs := flag.NewFlagSet("cluster disable", flag.ContinueOnError)
-	addr := fs.String("addr", "http://localhost:8475", "MuninnDB admin address")
+	addr := fs.String("addr", "http://127.0.0.1:8475", "MuninnDB admin address")
 	yes := fs.Bool("yes", false, "Skip confirmation prompt")
 
 	if err := fs.Parse(args); err != nil {

--- a/cmd/muninn/cluster_test.go
+++ b/cmd/muninn/cluster_test.go
@@ -30,7 +30,7 @@ func TestClusterCommands_InfoJSON(t *testing.T) {
 					},
 					{
 						"node_id":  "node-2",
-						"addr":     "localhost:8475",
+						"addr":     "127.0.0.1:8475",
 						"role":     "Lobe",
 						"last_seq": 950,
 					},

--- a/cmd/muninn/coverage_hardening_test.go
+++ b/cmd/muninn/coverage_hardening_test.go
@@ -786,7 +786,7 @@ func TestRunNonInteractiveInit(t *testing.T) {
 	t.Setenv("MUNINNDB_DATA", filepath.Join(home, "data"))
 
 	out := captureStdout(func() {
-		runNonInteractiveInit("http://localhost:8750/mcp", "manual", "", false, true, true)
+		runNonInteractiveInit("http://127.0.0.1:8750/mcp", "manual", "", false, true, true)
 	})
 	if !strings.Contains(out, "Manual") && !strings.Contains(out, "manual") &&
 		!strings.Contains(out, "mcpServers") && !strings.Contains(out, "curl") {
@@ -800,7 +800,7 @@ func TestRunNonInteractiveInit(t *testing.T) {
 
 func TestConfigureTools_Empty(t *testing.T) {
 	out := captureStdout(func() {
-		configureTools(nil, "http://localhost:8750/mcp", "")
+		configureTools(nil, "http://127.0.0.1:8750/mcp", "")
 	})
 	_ = out
 }
@@ -1081,7 +1081,7 @@ func TestRunVaultImport_ResetMetadata(t *testing.T) {
 
 func TestConfigureTools_ManualAndVSCode(t *testing.T) {
 	out := captureStdout(func() {
-		configureTools([]int{3, 5}, "http://localhost:8750/mcp", "tok")
+		configureTools([]int{3, 5}, "http://127.0.0.1:8750/mcp", "tok")
 	})
 	if !strings.Contains(out, "muninn") {
 		t.Errorf("expected instructions: %s", out)
@@ -1094,7 +1094,7 @@ func TestConfigureTools_AllNumbered(t *testing.T) {
 	t.Setenv("USERPROFILE", home)
 
 	out := captureStdout(func() {
-		errs := configureTools([]int{1, 2, 3, 4, 5}, "http://localhost:8750/mcp", "tok")
+		errs := configureTools([]int{1, 2, 3, 4, 5}, "http://127.0.0.1:8750/mcp", "tok")
 		_ = errs
 	})
 	_ = out
@@ -1112,7 +1112,7 @@ func TestConfigureNamedTools_AllNames(t *testing.T) {
 	out := captureStdout(func() {
 		errs := configureNamedTools([]string{
 			"claude", "claude-code", "cursor", "windsurf", "openclaw", "vscode", "manual",
-		}, "http://localhost:8750/mcp", "tok")
+		}, "http://127.0.0.1:8750/mcp", "tok")
 		_ = errs
 	})
 	_ = out
@@ -1396,7 +1396,7 @@ func TestConfigureClaudeCode_Full(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		err := configureClaudeCode("http://localhost:8750/mcp", "tok")
+		err := configureClaudeCode("http://127.0.0.1:8750/mcp", "tok")
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}
@@ -1417,7 +1417,7 @@ func TestRunNonInteractiveInit_WithTools(t *testing.T) {
 	t.Setenv("MUNINNDB_DATA", filepath.Join(home, "data"))
 
 	out := captureStdout(func() {
-		runNonInteractiveInit("http://localhost:8750/mcp", "vscode,manual", "", true, true, true)
+		runNonInteractiveInit("http://127.0.0.1:8750/mcp", "vscode,manual", "", true, true, true)
 	})
 	_ = out
 }
@@ -1429,7 +1429,7 @@ func TestRunNonInteractiveInit_WithToken(t *testing.T) {
 	t.Setenv("MUNINNDB_DATA", filepath.Join(home, "data"))
 
 	out := captureStdout(func() {
-		runNonInteractiveInit("http://localhost:8750/mcp", "", "mdb_customtoken", false, true, true)
+		runNonInteractiveInit("http://127.0.0.1:8750/mcp", "", "mdb_customtoken", false, true, true)
 	})
 	if !strings.Contains(out, "Token") || !strings.Contains(out, "mcp.token") {
 		t.Logf("output: %s", out)
@@ -1444,7 +1444,7 @@ func TestRunNonInteractiveInit_GenerateToken(t *testing.T) {
 	t.Setenv("MUNINNDB_DATA", filepath.Join(home, ".muninn", "data"))
 
 	out := captureStdout(func() {
-		runNonInteractiveInit("http://localhost:8750/mcp", "", "", false, true, true)
+		runNonInteractiveInit("http://127.0.0.1:8750/mcp", "", "", false, true, true)
 	})
 	_ = out
 }
@@ -1946,7 +1946,7 @@ func TestConfigureNamedTools_OpenClaw(t *testing.T) {
 	t.Setenv("USERPROFILE", home)
 
 	out := captureStdout(func() {
-		errs := configureNamedTools([]string{"openclaw"}, "http://localhost:8750/mcp", "tok")
+		errs := configureNamedTools([]string{"openclaw"}, "http://127.0.0.1:8750/mcp", "tok")
 		_ = errs
 	})
 	_ = out
@@ -1961,7 +1961,7 @@ func TestConfigureTools_ClaudeDesktop_Path(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	captureStdout(func() {
-		configureTools([]int{1}, "http://localhost:8750/mcp", "tok")
+		configureTools([]int{1}, "http://127.0.0.1:8750/mcp", "tok")
 	})
 }
 
@@ -1970,7 +1970,7 @@ func TestConfigureTools_Cursor_Path(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	captureStdout(func() {
-		configureTools([]int{2}, "http://localhost:8750/mcp", "tok")
+		configureTools([]int{2}, "http://127.0.0.1:8750/mcp", "tok")
 	})
 }
 
@@ -1979,7 +1979,7 @@ func TestConfigureTools_Windsurf_Path(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	captureStdout(func() {
-		configureTools([]int{4}, "http://localhost:8750/mcp", "tok")
+		configureTools([]int{4}, "http://127.0.0.1:8750/mcp", "tok")
 	})
 }
 

--- a/cmd/muninn/coverage_test.go
+++ b/cmd/muninn/coverage_test.go
@@ -519,7 +519,7 @@ func TestClusterDisable_ServerError(t *testing.T) {
 
 func TestConfigureTools_VSCode(t *testing.T) {
 	out := captureStdout(func() {
-		configureTools([]int{3}, "http://localhost:8750/mcp", "tok")
+		configureTools([]int{3}, "http://127.0.0.1:8750/mcp", "tok")
 	})
 	if !strings.Contains(out, "VS Code") && !strings.Contains(out, "settings.json") {
 		t.Logf("VS Code instructions: %s", out)
@@ -528,7 +528,7 @@ func TestConfigureTools_VSCode(t *testing.T) {
 
 func TestConfigureTools_Manual(t *testing.T) {
 	out := captureStdout(func() {
-		configureTools([]int{5}, "http://localhost:8750/mcp", "tok")
+		configureTools([]int{5}, "http://127.0.0.1:8750/mcp", "tok")
 	})
 	if out == "" {
 		t.Log("manual instructions printed (may be empty depending on implementation)")
@@ -540,7 +540,7 @@ func TestConfigureTools_ClaudeDesktop(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureTools([]int{1}, "http://localhost:8750/mcp", "tok")
+		configureTools([]int{1}, "http://127.0.0.1:8750/mcp", "tok")
 	})
 	if !strings.Contains(out, "✓") {
 		t.Errorf("expected success marker for Claude Desktop, got: %s", out)
@@ -552,7 +552,7 @@ func TestConfigureTools_Cursor(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureTools([]int{2}, "http://localhost:8750/mcp", "tok")
+		configureTools([]int{2}, "http://127.0.0.1:8750/mcp", "tok")
 	})
 	if !strings.Contains(out, "✓") {
 		t.Errorf("expected success marker for Cursor, got: %s", out)
@@ -564,7 +564,7 @@ func TestConfigureTools_Windsurf(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureTools([]int{4}, "http://localhost:8750/mcp", "tok")
+		configureTools([]int{4}, "http://127.0.0.1:8750/mcp", "tok")
 	})
 	if !strings.Contains(out, "✓") {
 		t.Errorf("expected success marker for Windsurf, got: %s", out)
@@ -576,7 +576,7 @@ func TestConfigureTools_Multiple(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureTools([]int{1, 2, 3, 4, 5}, "http://localhost:8750/mcp", "tok")
+		configureTools([]int{1, 2, 3, 4, 5}, "http://127.0.0.1:8750/mcp", "tok")
 	})
 	if !strings.Contains(out, "VS Code") {
 		t.Errorf("expected VS Code instructions in multi-tool output, got: %s", out)
@@ -888,7 +888,7 @@ func TestConfigureClaudeCode(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		if err := configureClaudeCode("http://localhost:8750/mcp", "tok"); err != nil {
+		if err := configureClaudeCode("http://127.0.0.1:8750/mcp", "tok"); err != nil {
 			t.Fatalf("error: %v", err)
 		}
 	})
@@ -920,7 +920,7 @@ func TestConfigureNamedToolsClaudeCode(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureNamedTools([]string{"claude-code"}, "http://localhost:8750/mcp", "tok")
+		configureNamedTools([]string{"claude-code"}, "http://127.0.0.1:8750/mcp", "tok")
 	})
 	if !strings.Contains(out, "✓") {
 		t.Errorf("expected success marker for claude-code: %s", out)
@@ -932,7 +932,7 @@ func TestConfigureNamedToolsClaudeCodeAlias(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureNamedTools([]string{"claudecode"}, "http://localhost:8750/mcp", "tok")
+		configureNamedTools([]string{"claudecode"}, "http://127.0.0.1:8750/mcp", "tok")
 	})
 	if !strings.Contains(out, "✓") {
 		t.Errorf("expected success marker for claudecode alias: %s", out)

--- a/cmd/muninn/help.go
+++ b/cmd/muninn/help.go
@@ -172,7 +172,7 @@ var subcommandHelp = map[string]func(){
 				{"-u <user>", "Admin username (default: root)"},
 				{"-p", "Prompt for password"},
 				{"-p<password>", "Inline password (no space)"},
-				{"-h <host:port>", "Server host:port (default: localhost:8475)"},
+				{"-h <host:port>", "Server host:port (default: 127.0.0.1:8475)"},
 			},
 			[]string{
 				"muninn vault create myproject",
@@ -200,7 +200,7 @@ var subcommandHelp = map[string]func(){
 				{"-u <user>", "Admin username (default: root)"},
 				{"-p", "Prompt for password"},
 				{"-p<password>", "Inline password (no space)"},
-				{"-h <host:port>", "Server host:port (default: localhost:8475)"},
+				{"-h <host:port>", "Server host:port (default: 127.0.0.1:8475)"},
 			},
 			[]string{
 				"muninn api-key create --vault default --label my-agent",
@@ -218,7 +218,7 @@ var subcommandHelp = map[string]func(){
 				{"-u <user>", "Admin username (default: root)"},
 				{"-p", "Prompt for current password"},
 				{"-p<password>", "Inline current password (no space)"},
-				{"-h <host:port>", "Server host:port (default: localhost:8475)"},
+				{"-h <host:port>", "Server host:port (default: 127.0.0.1:8475)"},
 			},
 			[]string{
 				"muninn admin change-password",
@@ -322,7 +322,7 @@ func printHelp() {
 	fmt.Println("  MuninnDB exposes an MCP server that AI tools connect to for memory.")
 	fmt.Println("  Run " + cyan("muninn init") + " to configure Claude Desktop, Cursor, or Windsurf automatically.")
 	fmt.Println()
-	fmt.Println("  MCP endpoint: http://localhost:8750/mcp")
+	fmt.Println("  MCP endpoint: http://127.0.0.1:8750/mcp")
 	fmt.Printf("  %-28s %s\n", "MUNINN_MCP_URL", "Override MCP server URL (also used by 'muninn mcp' proxy)")
 	fmt.Printf("  %-28s %s\n", "MUNINNDB_DATA", "Override default data directory")
 	fmt.Println()
@@ -331,7 +331,7 @@ func printHelp() {
 	fmt.Println()
 	fmt.Printf("  %-8s %s\n", ":8474", "MBP  — binary protocol")
 	fmt.Printf("  %-8s %s\n", ":8475", "REST — JSON API")
-	fmt.Printf("  %-8s %s\n", ":8476", "UI   — web dashboard (http://localhost:8476)")
+	fmt.Printf("  %-8s %s\n", ":8476", "UI   — web dashboard (http://127.0.0.1:8476)")
 	fmt.Printf("  %-8s %s\n", ":8750", "MCP  — AI tool integration")
 	fmt.Println()
 

--- a/cmd/muninn/init.go
+++ b/cmd/muninn/init.go
@@ -71,7 +71,7 @@ func runInit() {
 	}
 	fs.Parse(args)
 
-	mcpURL := "http://localhost:8750/mcp"
+	mcpURL := "http://127.0.0.1:8750/mcp"
 	isInteractive := term.IsTerminal(int(os.Stdin.Fd()))
 
 	if !isInteractive && !*yes && *toolFlag == "" {
@@ -200,7 +200,7 @@ func runInteractiveInit(mcpURL string, tokenFlag *string, noToken *bool, noStart
 	fmt.Println("  Try it → open Claude Code or Cursor and ask:")
 	fmt.Println(`    "What do you remember about me?"`)
 	fmt.Println()
-	fmt.Println("  Browse memories → http://localhost:8476")
+	fmt.Println("  Browse memories → http://127.0.0.1:8476")
 	fmt.Println()
 	fmt.Println("  ────────────────────────────────────────────────────")
 	fmt.Println()
@@ -603,11 +603,11 @@ func runNonInteractiveInit(mcpURL, toolStr, tokenStr string, noToken, noStart, y
 
 	fmt.Println()
 	fmt.Println("muninn is running.")
-	fmt.Println("  MCP endpoint:   http://localhost:8750/mcp")
+	fmt.Println("  MCP endpoint:   http://127.0.0.1:8750/mcp")
 	if token != "" {
 		fmt.Println("  Token:          ~/.muninn/mcp.token")
 	}
-	fmt.Println("  Web UI:         http://localhost:8476")
+	fmt.Println("  Web UI:         http://127.0.0.1:8476")
 	fmt.Println()
 }
 

--- a/cmd/muninn/init_test.go
+++ b/cmd/muninn/init_test.go
@@ -190,7 +190,7 @@ func TestConfigureNamedTools_OpenCode(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		errs := configureNamedTools([]string{"opencode"}, "http://localhost:8750/mcp", "tok123")
+		errs := configureNamedTools([]string{"opencode"}, "http://127.0.0.1:8750/mcp", "tok123")
 		if len(errs) > 0 {
 			t.Errorf("unexpected errors: %v", errs)
 		}
@@ -216,7 +216,7 @@ func TestUnknownToolMessage_IncludesOpenCode(t *testing.T) {
 	_, cleanup := withTempHome(t)
 	defer cleanup()
 	stderr := captureStderr(func() {
-		configureNamedTools([]string{"notarealtool"}, "http://localhost:8750/mcp", "")
+		configureNamedTools([]string{"notarealtool"}, "http://127.0.0.1:8750/mcp", "")
 	})
 	if !strings.Contains(stderr, "opencode") {
 		t.Errorf("unknown-tool error should list 'opencode', got: %s", stderr)
@@ -280,7 +280,7 @@ func TestPrintWelcomeBanner(t *testing.T) {
 
 func TestConfigureNamedToolsUnknownTool(t *testing.T) {
 	out := captureStderr(func() {
-		configureNamedTools([]string{"unknowntool"}, "http://localhost:8750/mcp", "tok123")
+		configureNamedTools([]string{"unknowntool"}, "http://127.0.0.1:8750/mcp", "tok123")
 	})
 	if !strings.Contains(out, "unknown tool") {
 		t.Errorf("expected 'unknown tool' warning, got: %s", out)
@@ -356,7 +356,7 @@ func TestConfigureNamedToolsReturnsErrorsSlice(t *testing.T) {
 	var errs []string
 	captureStderr(func() {
 		captureStdout(func() {
-			errs = configureNamedTools([]string{"claude"}, "http://localhost:8750/mcp", "tok")
+			errs = configureNamedTools([]string{"claude"}, "http://127.0.0.1:8750/mcp", "tok")
 		})
 	})
 

--- a/cmd/muninn/integration_test.go
+++ b/cmd/muninn/integration_test.go
@@ -24,7 +24,7 @@ var muninnBin string
 // since these tests require exclusive use of that port.
 func TestMain(m *testing.M) {
 	// Guard: skip if something is already on the MCP port.
-	if resp, err := http.Get("http://localhost:8750/mcp/health"); err == nil {
+	if resp, err := http.Get("http://127.0.0.1:8750/mcp/health"); err == nil {
 		resp.Body.Close()
 		fmt.Fprintln(os.Stderr, "integration: muninn already running on :8750 — stop it first")
 		os.Exit(0)
@@ -58,11 +58,11 @@ func muninnCmd(dataDir string, args ...string) *exec.Cmd {
 	return cmd
 }
 
-// waitForHealth polls localhost:8750/mcp/health until 200 or timeout.
+// waitForHealth polls 127.0.0.1:8750/mcp/health until 200 or timeout.
 func waitForHealth(timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		resp, err := http.Get("http://localhost:8750/mcp/health")
+		resp, err := http.Get("http://127.0.0.1:8750/mcp/health")
 		if err == nil && resp.StatusCode == 200 {
 			resp.Body.Close()
 			return true
@@ -72,11 +72,11 @@ func waitForHealth(timeout time.Duration) bool {
 	return false
 }
 
-// waitForDead polls until localhost:8750 refuses connections (port is free).
+// waitForDead polls until 127.0.0.1:8750 refuses connections (port is free).
 func waitForDead(timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		resp, err := http.Get("http://localhost:8750/mcp/health")
+		resp, err := http.Get("http://127.0.0.1:8750/mcp/health")
 		if err != nil {
 			return true // connection refused — port is free
 		}
@@ -136,7 +136,7 @@ func TestInitNoStart(t *testing.T) {
 		t.Fatalf("muninn init --yes --no-start --no-token: %v\n%s", err, out)
 	}
 	// Port 8750 must still be closed.
-	resp, hErr := http.Get("http://localhost:8750/mcp/health")
+	resp, hErr := http.Get("http://127.0.0.1:8750/mcp/health")
 	if hErr == nil {
 		resp.Body.Close()
 		t.Error("daemon should not be running after --no-start, but :8750 responded")
@@ -208,7 +208,7 @@ func mcpTool(t *testing.T, token, toolName string, args map[string]any) map[stri
 			"arguments": args,
 		},
 	})
-	req, _ := http.NewRequest("POST", "http://localhost:8750/mcp", bytes.NewReader(body))
+	req, _ := http.NewRequest("POST", "http://127.0.0.1:8750/mcp", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)

--- a/cmd/muninn/lifecycle.go
+++ b/cmd/muninn/lifecycle.go
@@ -152,7 +152,7 @@ func runStart(webEnabled bool) {
 			fmt.Printf("muninn started (pid %d)\n", cmd.Process.Pid)
 			fmt.Println()
 			printStatusDisplay(true)
-			fmt.Println("  Web UI → http://localhost:8476")
+			fmt.Println("  Web UI → http://127.0.0.1:8476")
 			fmt.Println()
 			return
 		}

--- a/cmd/muninn/mcp_stdio.go
+++ b/cmd/muninn/mcp_stdio.go
@@ -29,7 +29,7 @@ var mcpProxyURL = "http://127.0.0.1:" + defaultMCPPort + "/mcp"
 //
 // MUNINN_MCP_URL overrides the target endpoint for non-default port or TLS setups:
 //
-//	MUNINN_MCP_URL=https://localhost:8750/mcp muninn mcp
+//	MUNINN_MCP_URL=https://127.0.0.1:8750/mcp muninn mcp
 func runMCPStdio() {
 	if u := os.Getenv("MUNINN_MCP_URL"); u != "" {
 		mcpProxyURL = u

--- a/cmd/muninn/repl.go
+++ b/cmd/muninn/repl.go
@@ -15,7 +15,7 @@ import (
 
 type replState struct {
 	vault         string // current vault context (empty = no vault selected)
-	mcpURL        string // e.g. "http://localhost:8750"
+	mcpURL        string // e.g. "http://127.0.0.1:8750"
 	cmdCount      int    // total commands run this session (for tip rotation)
 	firstRun      bool   // true if no config file existed at shell start
 	sessionCookie string // for REST API calls requiring admin auth
@@ -63,7 +63,7 @@ func parseReplInput(line string) (string, []string) {
 func runShell() {
 	mcpURL := os.Getenv("MUNINNDB_MCP_URL")
 	if mcpURL == "" {
-		mcpURL = "http://localhost:8750"
+		mcpURL = "http://127.0.0.1:8750"
 	}
 
 	// Detect first run (no config file = user hasn't used 'use <vault>' before)
@@ -84,7 +84,7 @@ func runShell() {
 	}
 
 	// Auto-authenticate with default credentials; prompt only if that fails
-	sessionCookie, authErr := autoAuth("http://localhost:8476")
+	sessionCookie, authErr := autoAuth("http://127.0.0.1:8476")
 	if authErr != nil {
 		// Default creds failed — prompt once
 		fmt.Print("Username: ")
@@ -105,7 +105,7 @@ func runShell() {
 			os.Exit(1)
 		}
 		// Refresh cookie after explicit login
-		sessionCookie, _ = autoAuth("http://localhost:8476")
+		sessionCookie, _ = autoAuth("http://127.0.0.1:8476")
 	}
 
 	r.sessionCookie = sessionCookie
@@ -276,7 +276,7 @@ func (r *replState) printRotatingTip() {
 		"Tip: 'search' uses semantic similarity — try natural language queries.",
 		"Tip: 'show contradictions' surfaces memories that conflict with each other.",
 		"Tip: Switch between projects with 'use <vault-name>'.",
-		"Tip: Open http://localhost:8476 to browse the memory graph visually.",
+		"Tip: Open http://127.0.0.1:8476 to browse the memory graph visually.",
 		"Tip: 'forget' is reversible — restore memories from Settings in the web UI.",
 		"Tip: The web UI shows memory confidence, decay, and association graphs.",
 	}
@@ -286,7 +286,7 @@ func (r *replState) printRotatingTip() {
 }
 
 // shellValidateAdmin validates admin credentials against the running UI server's
-// login endpoint (POST http://localhost:8476/api/auth/login).
+// login endpoint (POST http://127.0.0.1:8476/api/auth/login).
 // Returns nil on success, non-nil on auth failure or network error.
 func shellValidateAdmin(username, password string) error {
 	body, _ := json.Marshal(map[string]string{
@@ -294,7 +294,7 @@ func shellValidateAdmin(username, password string) error {
 		"password": password,
 	})
 	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Post("http://localhost:8476/api/auth/login", "application/json", bytes.NewReader(body))
+	resp, err := client.Post("http://127.0.0.1:8476/api/auth/login", "application/json", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("connect to server: %w", err)
 	}

--- a/cmd/muninn/repl_client.go
+++ b/cmd/muninn/repl_client.go
@@ -50,7 +50,7 @@ func mcpCall(baseURL, toolName string, args map[string]any) (map[string]any, err
 
 func (r *replState) cmdShowVaults() {
 	client := &http.Client{Timeout: 5 * time.Second}
-	req, err := http.NewRequest("GET", "http://localhost:8475/api/vaults", nil)
+	req, err := http.NewRequest("GET", "http://127.0.0.1:8475/api/vaults", nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return
@@ -70,7 +70,7 @@ func (r *replState) cmdShowVaults() {
 		// Fallback: show static message
 		fmt.Println("  default   (built-in)")
 		fmt.Println()
-		fmt.Println("  For full vault list, open: http://localhost:8476")
+		fmt.Println("  For full vault list, open: http://127.0.0.1:8476")
 		return
 	}
 
@@ -350,7 +350,7 @@ func (r *replState) cmdShowStats() {
 	fmt.Println("  MBP  :8474   binary protocol")
 	fmt.Println("  REST :8475   JSON API")
 	fmt.Println("  MCP  :8750   AI tool integration")
-	fmt.Println("  UI   :8476   http://localhost:8476")
+	fmt.Println("  UI   :8476   http://127.0.0.1:8476")
 	if r.vault != "" {
 		fmt.Println()
 		result, err := mcpCall(r.mcpURL, "muninn_status", map[string]any{"vault": r.vault})
@@ -380,7 +380,7 @@ func isEmptyMCPResult(result map[string]any) bool {
 }
 
 func runShowVaults() {
-	r := &replState{mcpURL: "http://localhost:8750"}
+	r := &replState{mcpURL: "http://127.0.0.1:8750"}
 	r.cmdShowVaults()
 }
 

--- a/cmd/muninn/repl_test.go
+++ b/cmd/muninn/repl_test.go
@@ -401,7 +401,7 @@ func TestShellValidateAdminSuccess(t *testing.T) {
 	srv := newAuthServer("session", "abc123")
 	defer srv.Close()
 
-	// This function hardcodes http://localhost:8476, so we can only test
+	// This function hardcodes http://127.0.0.1:8476, so we can only test
 	// the error case when no server is running on that port. We test the
 	// function by verifying it sends POST request to /api/auth/login and
 	// checks the response status. For this test, we verify it returns nil
@@ -421,7 +421,7 @@ func TestShellValidateAdminSuccess(t *testing.T) {
 
 // Test 20: shellValidateAdmin with invalid credentials
 func TestShellValidateAdminInvalidCredentials(t *testing.T) {
-	// Since shellValidateAdmin hardcodes http://localhost:8476,
+	// Since shellValidateAdmin hardcodes http://127.0.0.1:8476,
 	// we can't easily mock the response. Instead, test the error handling
 	// by calling it with wrong credentials when no server is available.
 	err := shellValidateAdmin("wronguser", "wrongpass")

--- a/cmd/muninn/setup_ai_test.go
+++ b/cmd/muninn/setup_ai_test.go
@@ -84,7 +84,7 @@ func TestWriteAIToolConfig_NewFile(t *testing.T) {
 	path := filepath.Join(dir, "claude_desktop_config.json")
 
 	summary, err := writeAIToolConfig(path, func(cfg map[string]any) {
-		mergeMCPServers(cfg, "http://localhost:8750/mcp", "mdb_testtoken")
+		mergeMCPServers(cfg, "http://127.0.0.1:8750/mcp", "mdb_testtoken")
 	})
 	if err != nil {
 		t.Fatalf("writeAIToolConfig: %v", err)
@@ -110,7 +110,7 @@ func TestWriteAIToolConfig_NewFile(t *testing.T) {
 	if !ok {
 		t.Fatal("muninn entry not found in mcpServers")
 	}
-	if entry["url"] != "http://localhost:8750/mcp" {
+	if entry["url"] != "http://127.0.0.1:8750/mcp" {
 		t.Errorf("unexpected URL in config: %v", entry["url"])
 	}
 }
@@ -131,7 +131,7 @@ func TestWriteAIToolConfig_PreservesExistingServers(t *testing.T) {
 	os.WriteFile(path, b, 0600)
 
 	_, err := writeAIToolConfig(path, func(cfg map[string]any) {
-		mergeMCPServers(cfg, "http://localhost:8750/mcp", "")
+		mergeMCPServers(cfg, "http://127.0.0.1:8750/mcp", "")
 	})
 	if err != nil {
 		t.Fatalf("writeAIToolConfig: %v", err)
@@ -161,7 +161,7 @@ func TestWriteAIToolConfig_InvalidExistingJSON(t *testing.T) {
 	os.WriteFile(path, []byte("this is not json {{{{"), 0644)
 
 	_, err := writeAIToolConfig(path, func(cfg map[string]any) {
-		mergeMCPServers(cfg, "http://localhost:8750/mcp", "")
+		mergeMCPServers(cfg, "http://127.0.0.1:8750/mcp", "")
 	})
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
@@ -178,7 +178,7 @@ func TestWriteAIToolConfig_CreatesParentDir(t *testing.T) {
 	// Parent dir does NOT exist yet
 
 	_, err := writeAIToolConfig(path, func(cfg map[string]any) {
-		mergeMCPServers(cfg, "http://localhost:8750/mcp", "")
+		mergeMCPServers(cfg, "http://127.0.0.1:8750/mcp", "")
 	})
 	if err != nil {
 		t.Fatalf("writeAIToolConfig should create parent dirs: %v", err)
@@ -196,7 +196,7 @@ func TestWriteAIToolConfig_BackupCreated(t *testing.T) {
 	os.WriteFile(path, original, 0644)
 
 	writeAIToolConfig(path, func(cfg map[string]any) {
-		mergeMCPServers(cfg, "http://localhost:8750/mcp", "")
+		mergeMCPServers(cfg, "http://127.0.0.1:8750/mcp", "")
 	})
 
 	bak, err := os.ReadFile(path + ".bak")
@@ -214,7 +214,7 @@ func TestWriteAIToolConfig_AtomicTempCleaned(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 
 	writeAIToolConfig(path, func(cfg map[string]any) {
-		mergeMCPServers(cfg, "http://localhost:8750/mcp", "")
+		mergeMCPServers(cfg, "http://127.0.0.1:8750/mcp", "")
 	})
 
 	// No temp files should remain
@@ -228,8 +228,8 @@ func TestWriteAIToolConfig_AtomicTempCleaned(t *testing.T) {
 
 // TestMCPServerEntry_WithToken verifies token is included when provided.
 func TestMCPServerEntry_WithToken(t *testing.T) {
-	entry := mcpServerEntry("http://localhost:8750/mcp", "mdb_abc123")
-	if entry["url"] != "http://localhost:8750/mcp" {
+	entry := mcpServerEntry("http://127.0.0.1:8750/mcp", "mdb_abc123")
+	if entry["url"] != "http://127.0.0.1:8750/mcp" {
 		t.Errorf("unexpected url: %v", entry["url"])
 	}
 	if _, ok := entry["type"]; ok {
@@ -246,7 +246,7 @@ func TestMCPServerEntry_WithToken(t *testing.T) {
 
 // TestMCPServerEntry_NoToken verifies no headers when token is empty.
 func TestMCPServerEntry_NoToken(t *testing.T) {
-	entry := mcpServerEntry("http://localhost:8750/mcp", "")
+	entry := mcpServerEntry("http://127.0.0.1:8750/mcp", "")
 	if _, ok := entry["headers"]; ok {
 		t.Error("headers should not be present when token is empty")
 	}
@@ -257,18 +257,18 @@ func TestMCPServerEntry_NoToken(t *testing.T) {
 
 // TestClaudeCodeMCPEntry_HasType verifies that the Claude Code entry includes "type":"http".
 func TestClaudeCodeMCPEntry_HasType(t *testing.T) {
-	entry := claudeCodeMCPEntry("http://localhost:8750/mcp", "")
+	entry := claudeCodeMCPEntry("http://127.0.0.1:8750/mcp", "")
 	if entry["type"] != "http" {
 		t.Errorf(`type = %v, want "http" — Claude Code schema requires this field`, entry["type"])
 	}
-	if entry["url"] != "http://localhost:8750/mcp" {
-		t.Errorf("url = %v, want http://localhost:8750/mcp", entry["url"])
+	if entry["url"] != "http://127.0.0.1:8750/mcp" {
+		t.Errorf("url = %v, want http://127.0.0.1:8750/mcp", entry["url"])
 	}
 }
 
 // TestClaudeCodeMCPEntry_WithToken verifies token is included under headers.
 func TestClaudeCodeMCPEntry_WithToken(t *testing.T) {
-	entry := claudeCodeMCPEntry("http://localhost:8750/mcp", "mdb_tok")
+	entry := claudeCodeMCPEntry("http://127.0.0.1:8750/mcp", "mdb_tok")
 	headers, ok := entry["headers"].(map[string]any)
 	if !ok {
 		t.Fatal("headers missing")
@@ -280,7 +280,7 @@ func TestClaudeCodeMCPEntry_WithToken(t *testing.T) {
 
 // TestClaudeCodeMCPEntry_NoToken verifies no headers when token is empty.
 func TestClaudeCodeMCPEntry_NoToken(t *testing.T) {
-	entry := claudeCodeMCPEntry("http://localhost:8750/mcp", "")
+	entry := claudeCodeMCPEntry("http://127.0.0.1:8750/mcp", "")
 	if _, ok := entry["headers"]; ok {
 		t.Error("headers should not be present when token is empty")
 	}
@@ -289,7 +289,7 @@ func TestClaudeCodeMCPEntry_NoToken(t *testing.T) {
 // TestMergeClaudeCodeMCP_SetsTypeField verifies mergeClaudeCodeMCP writes "type":"http".
 func TestMergeClaudeCodeMCP_SetsTypeField(t *testing.T) {
 	cfg := map[string]any{}
-	mergeClaudeCodeMCP(cfg, "http://localhost:8750/mcp", "tok")
+	mergeClaudeCodeMCP(cfg, "http://127.0.0.1:8750/mcp", "tok")
 	servers, ok := cfg["mcpServers"].(map[string]any)
 	if !ok {
 		t.Fatal("mcpServers missing")
@@ -422,7 +422,7 @@ func TestConfigureOpenClaw_WritesCorrectSchema(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		if err := configureOpenClaw("http://localhost:8750/mcp", "mdb_testtoken"); err != nil {
+		if err := configureOpenClaw("http://127.0.0.1:8750/mcp", "mdb_testtoken"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -472,7 +472,7 @@ func TestConfigureOpenClaw_NoToken(t *testing.T) {
 	defer cleanup()
 
 	captureStdout(func() {
-		configureOpenClaw("http://localhost:8750/mcp", "")
+		configureOpenClaw("http://127.0.0.1:8750/mcp", "")
 	})
 
 	data, _ := os.ReadFile(openClawConfigPath())
@@ -496,7 +496,7 @@ func TestConfigureOpenClaw_PreservesExistingEntries(t *testing.T) {
 	os.WriteFile(path, []byte(`{"mcpServers":{"other":{"command":"other","transport":"stdio"}},"topKey":"kept"}`), 0644)
 
 	captureStdout(func() {
-		configureOpenClaw("http://localhost:8750/mcp", "tok")
+		configureOpenClaw("http://127.0.0.1:8750/mcp", "tok")
 	})
 
 	data, _ := os.ReadFile(path)
@@ -517,7 +517,7 @@ func TestConfigureOpenClaw_PreservesExistingEntries(t *testing.T) {
 func TestConfigureOpenClaw_SummaryAdded(t *testing.T) {
 	_, cleanup := withTempHome(t)
 	defer cleanup()
-	out := captureStdout(func() { configureOpenClaw("http://localhost:8750/mcp", "tok") })
+	out := captureStdout(func() { configureOpenClaw("http://127.0.0.1:8750/mcp", "tok") })
 	if !strings.Contains(out, "added") {
 		t.Errorf("expected 'added' in output for new config: %s", out)
 	}
@@ -529,7 +529,7 @@ func TestConfigureOpenClaw_SummaryUpdated(t *testing.T) {
 	path := openClawConfigPath()
 	os.MkdirAll(filepath.Dir(path), 0755)
 	os.WriteFile(path, []byte(`{"mcpServers":{"muninn":{"command":"muninn","args":["mcp"],"transport":"stdio"}}}`), 0644)
-	out := captureStdout(func() { configureOpenClaw("http://localhost:8750/mcp", "tok") })
+	out := captureStdout(func() { configureOpenClaw("http://127.0.0.1:8750/mcp", "tok") })
 	if !strings.Contains(out, "updated") {
 		t.Errorf("expected 'updated' in output for existing mcpServers: %s", out)
 	}
@@ -603,7 +603,7 @@ func TestConfigureOpenClawSkill_CreatesDirectory(t *testing.T) {
 }
 
 func TestOpenCodeMCPEntry_WithToken(t *testing.T) {
-	entry := openCodeMCPEntry("http://localhost:8750/mcp", "mdb_testtoken123")
+	entry := openCodeMCPEntry("http://127.0.0.1:8750/mcp", "mdb_testtoken123")
 	if entry["type"] != "remote" {
 		t.Errorf("type = %v, want \"remote\"", entry["type"])
 	}
@@ -624,7 +624,7 @@ func TestOpenCodeMCPEntry_WithToken(t *testing.T) {
 }
 
 func TestOpenCodeMCPEntry_NoToken(t *testing.T) {
-	entry := openCodeMCPEntry("http://localhost:8750/mcp", "")
+	entry := openCodeMCPEntry("http://127.0.0.1:8750/mcp", "")
 	if entry["type"] != "remote" {
 		t.Errorf("type = %v, want \"remote\"", entry["type"])
 	}
@@ -643,7 +643,7 @@ func TestMergeOpenCodeMCP_PreservesOtherEntries(t *testing.T) {
 		},
 		"topKey": "preserved",
 	}
-	mergeOpenCodeMCP(cfg, "http://localhost:8750/mcp", "tok")
+	mergeOpenCodeMCP(cfg, "http://127.0.0.1:8750/mcp", "tok")
 	mcp := cfg["mcp"].(map[string]any)
 	if _, ok := mcp["other-tool"]; !ok {
 		t.Error("other-tool entry removed")
@@ -658,7 +658,7 @@ func TestMergeOpenCodeMCP_PreservesOtherEntries(t *testing.T) {
 
 func TestMergeOpenCodeMCP_EmptyConfig(t *testing.T) {
 	cfg := map[string]any{}
-	mergeOpenCodeMCP(cfg, "http://localhost:8750/mcp", "tok")
+	mergeOpenCodeMCP(cfg, "http://127.0.0.1:8750/mcp", "tok")
 	mcp, ok := cfg["mcp"].(map[string]any)
 	if !ok {
 		t.Fatal("cfg[\"mcp\"] not a map")
@@ -673,7 +673,7 @@ func TestConfigureOpenCode_WritesCorrectSchema(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		if err := configureOpenCode("http://localhost:8750/mcp", "mdb_testtoken"); err != nil {
+		if err := configureOpenCode("http://127.0.0.1:8750/mcp", "mdb_testtoken"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -708,7 +708,7 @@ func TestConfigureOpenCode_NoToken(t *testing.T) {
 	defer cleanup()
 
 	captureStdout(func() {
-		configureOpenCode("http://localhost:8750/mcp", "")
+		configureOpenCode("http://127.0.0.1:8750/mcp", "")
 	})
 
 	data, _ := os.ReadFile(openCodeConfigPath())
@@ -732,7 +732,7 @@ func TestConfigureOpenCode_PreservesExistingEntries(t *testing.T) {
 	os.WriteFile(path, []byte(`{"mcp":{"other":{"type":"remote","url":"http://x"}},"topKey":"kept"}`), 0644)
 
 	captureStdout(func() {
-		configureOpenCode("http://localhost:8750/mcp", "tok")
+		configureOpenCode("http://127.0.0.1:8750/mcp", "tok")
 	})
 
 	data, _ := os.ReadFile(path)
@@ -753,7 +753,7 @@ func TestConfigureOpenCode_PreservesExistingEntries(t *testing.T) {
 func TestConfigureOpenCode_SummaryAdded(t *testing.T) {
 	_, cleanup := withTempHome(t)
 	defer cleanup()
-	out := captureStdout(func() { configureOpenCode("http://localhost:8750/mcp", "tok") })
+	out := captureStdout(func() { configureOpenCode("http://127.0.0.1:8750/mcp", "tok") })
 	if !strings.Contains(out, "added") {
 		t.Errorf("expected 'added' in output for new config: %s", out)
 	}
@@ -764,8 +764,8 @@ func TestConfigureOpenCode_SummaryUpdated(t *testing.T) {
 	defer cleanup()
 	path := openCodeConfigPath()
 	os.MkdirAll(filepath.Dir(path), 0755)
-	os.WriteFile(path, []byte(`{"mcp":{"muninn":{"type":"remote","url":"http://localhost:8750/mcp","oauth":false}}}`), 0644)
-	out := captureStdout(func() { configureOpenCode("http://localhost:8750/mcp", "tok") })
+	os.WriteFile(path, []byte(`{"mcp":{"muninn":{"type":"remote","url":"http://127.0.0.1:8750/mcp","oauth":false}}}`), 0644)
+	out := captureStdout(func() { configureOpenCode("http://127.0.0.1:8750/mcp", "tok") })
 	if !strings.Contains(out, "updated") {
 		t.Errorf("expected 'updated' in output for existing mcp: %s", out)
 	}
@@ -802,7 +802,7 @@ func TestConfigureClaudeDesktopWritesConfig(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		err := configureClaudeDesktop("http://localhost:8750/mcp", "mdb_testtoken123")
+		err := configureClaudeDesktop("http://127.0.0.1:8750/mcp", "mdb_testtoken123")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -864,7 +864,7 @@ func TestConfigureClaudeDesktopNoToken(t *testing.T) {
 	defer cleanup()
 
 	captureStdout(func() {
-		if err := configureClaudeDesktop("http://localhost:8750/mcp", ""); err != nil {
+		if err := configureClaudeDesktop("http://127.0.0.1:8750/mcp", ""); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -899,7 +899,7 @@ func TestConfigureClaudeDesktopPreservesExistingKeys(t *testing.T) {
 	os.WriteFile(path, []byte(existing), 0644)
 
 	captureStdout(func() {
-		configureClaudeDesktop("http://localhost:8750/mcp", "tok123")
+		configureClaudeDesktop("http://127.0.0.1:8750/mcp", "tok123")
 	})
 
 	data, _ := os.ReadFile(path)
@@ -927,7 +927,7 @@ func TestConfigureCursorWritesConfig(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		if err := configureCursor("http://localhost:8750/mcp", "tok"); err != nil {
+		if err := configureCursor("http://127.0.0.1:8750/mcp", "tok"); err != nil {
 			t.Fatalf("error: %v", err)
 		}
 	})
@@ -953,7 +953,7 @@ func TestConfigureWindsurfWritesConfig(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		if err := configureWindsurf("http://localhost:8750/mcp", "tok"); err != nil {
+		if err := configureWindsurf("http://127.0.0.1:8750/mcp", "tok"); err != nil {
 			t.Fatalf("error: %v", err)
 		}
 	})
@@ -980,7 +980,7 @@ func TestConfigureOpenClawWritesConfig(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		if err := configureOpenClaw("http://localhost:8750/mcp", "tok"); err != nil {
+		if err := configureOpenClaw("http://127.0.0.1:8750/mcp", "tok"); err != nil {
 			t.Fatalf("error: %v", err)
 		}
 	})
@@ -1034,7 +1034,7 @@ func TestConfigureCodexWritesConfig(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		if err := configureCodex("http://localhost:8750/mcp", "mdb_testtoken"); err != nil {
+		if err := configureCodex("http://127.0.0.1:8750/mcp", "mdb_testtoken"); err != nil {
 			t.Fatalf("error: %v", err)
 		}
 	})
@@ -1047,7 +1047,7 @@ func TestConfigureCodexWritesConfig(t *testing.T) {
 	if !strings.Contains(content, "muninn") {
 		t.Errorf("muninn not in config: %s", content)
 	}
-	if !strings.Contains(content, "http://localhost:8750/mcp") {
+	if !strings.Contains(content, "http://127.0.0.1:8750/mcp") {
 		t.Errorf("MCP URL not in config: %s", content)
 	}
 	if !strings.Contains(content, "Bearer mdb_testtoken") {
@@ -1064,7 +1064,7 @@ func TestConfigureCodexNoToken(t *testing.T) {
 	defer cleanup()
 
 	captureStdout(func() {
-		if err := configureCodex("http://localhost:8750/mcp", ""); err != nil {
+		if err := configureCodex("http://127.0.0.1:8750/mcp", ""); err != nil {
 			t.Fatalf("error: %v", err)
 		}
 	})
@@ -1077,7 +1077,7 @@ func TestConfigureCodexNoToken(t *testing.T) {
 	if strings.Contains(content, "http_headers") {
 		t.Errorf("should not have http_headers without token: %s", content)
 	}
-	if !strings.Contains(content, "http://localhost:8750/mcp") {
+	if !strings.Contains(content, "http://127.0.0.1:8750/mcp") {
 		t.Errorf("URL missing: %s", content)
 	}
 }
@@ -1097,7 +1097,7 @@ url = "http://other.example"
 	os.WriteFile(path, []byte(existing), 0644)
 
 	captureStdout(func() {
-		configureCodex("http://localhost:8750/mcp", "tok123")
+		configureCodex("http://127.0.0.1:8750/mcp", "tok123")
 	})
 
 	data, _ := os.ReadFile(path)
@@ -1120,7 +1120,7 @@ func TestWriteCodexTOMLConfig_InvalidTOML(t *testing.T) {
 	path := filepath.Join(dir, "config.toml")
 	os.WriteFile(path, []byte("this is not valid toml = = = [[["), 0644)
 
-	_, err := writeCodexTOMLConfig(path, "http://localhost:8750/mcp", "")
+	_, err := writeCodexTOMLConfig(path, "http://127.0.0.1:8750/mcp", "")
 	if err == nil {
 		t.Fatal("expected error for invalid TOML, got nil")
 	}
@@ -1136,7 +1136,7 @@ func TestWriteCodexTOMLConfig_BackupCreated(t *testing.T) {
 	original := []byte("[mcp_servers]\n")
 	os.WriteFile(path, original, 0644)
 
-	writeCodexTOMLConfig(path, "http://localhost:8750/mcp", "")
+	writeCodexTOMLConfig(path, "http://127.0.0.1:8750/mcp", "")
 
 	bak, err := os.ReadFile(path + ".bak")
 	if err != nil {
@@ -1153,7 +1153,7 @@ func TestConfigureNamedToolsCodex(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureNamedTools([]string{"codex"}, "http://localhost:8750/mcp", "tok123")
+		configureNamedTools([]string{"codex"}, "http://127.0.0.1:8750/mcp", "tok123")
 	})
 	if !strings.Contains(out, "✓") {
 		t.Errorf("expected success marker for codex tool, got: %s", out)
@@ -1168,7 +1168,7 @@ func TestConfigureNamedToolsCodex(t *testing.T) {
 // TestPrintVSCodeInstructions verifies VS Code instructions contain required elements.
 func TestPrintVSCodeInstructions(t *testing.T) {
 	out := captureStdout(func() {
-		printVSCodeInstructions("http://localhost:8750/mcp", "mdb_mytoken")
+		printVSCodeInstructions("http://127.0.0.1:8750/mcp", "mdb_mytoken")
 	})
 	if !strings.Contains(out, `"muninn"`) {
 		t.Errorf("missing muninn key: %s", out)
@@ -1191,7 +1191,7 @@ func TestPrintVSCodeInstructions(t *testing.T) {
 // TestPrintVSCodeInstructionsNoToken verifies no auth header without token.
 func TestPrintVSCodeInstructionsNoToken(t *testing.T) {
 	out := captureStdout(func() {
-		printVSCodeInstructions("http://localhost:8750/mcp", "")
+		printVSCodeInstructions("http://127.0.0.1:8750/mcp", "")
 	})
 	if strings.Contains(out, "Bearer") {
 		t.Errorf("should not have auth header without token: %s", out)
@@ -1201,7 +1201,7 @@ func TestPrintVSCodeInstructionsNoToken(t *testing.T) {
 // TestPrintManualInstructions verifies manual instructions contain required elements.
 func TestPrintManualInstructions(t *testing.T) {
 	out := captureStdout(func() {
-		printManualInstructions("http://localhost:8750/mcp", "mdb_secrettoken")
+		printManualInstructions("http://127.0.0.1:8750/mcp", "mdb_secrettoken")
 	})
 	if !strings.Contains(out, "mcpServers") {
 		t.Errorf("missing mcpServers: %s", out)
@@ -1220,7 +1220,7 @@ func TestPrintManualInstructions(t *testing.T) {
 // TestPrintManualInstructionsNoToken verifies curl command appears without token.
 func TestPrintManualInstructionsNoToken(t *testing.T) {
 	out := captureStdout(func() {
-		printManualInstructions("http://localhost:8750/mcp", "")
+		printManualInstructions("http://127.0.0.1:8750/mcp", "")
 	})
 	if strings.Contains(out, "Bearer") {
 		t.Errorf("should not have auth header without token: %s", out)
@@ -1237,7 +1237,7 @@ func TestConfigureNamedToolsClaudeDesktop(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureNamedTools([]string{"claude"}, "http://localhost:8750/mcp", "tok123")
+		configureNamedTools([]string{"claude"}, "http://127.0.0.1:8750/mcp", "tok123")
 	})
 	if !strings.Contains(out, "✓") {
 		t.Errorf("expected success marker for claude tool, got: %s", out)
@@ -1256,7 +1256,7 @@ func TestConfigureNamedToolsClaudeDesktopAlias(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureNamedTools([]string{"claude-desktop"}, "http://localhost:8750/mcp", "tok")
+		configureNamedTools([]string{"claude-desktop"}, "http://127.0.0.1:8750/mcp", "tok")
 	})
 	if !strings.Contains(out, "✓") {
 		t.Errorf("claude-desktop alias should work: %s", out)
@@ -1269,7 +1269,7 @@ func TestConfigureNamedToolsCursor(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureNamedTools([]string{"cursor"}, "http://localhost:8750/mcp", "tok123")
+		configureNamedTools([]string{"cursor"}, "http://127.0.0.1:8750/mcp", "tok123")
 	})
 	if !strings.Contains(out, "✓") {
 		t.Errorf("expected success marker for cursor tool, got: %s", out)
@@ -1287,7 +1287,7 @@ func TestConfigureNamedToolsWindsurf(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureNamedTools([]string{"windsurf"}, "http://localhost:8750/mcp", "tok123")
+		configureNamedTools([]string{"windsurf"}, "http://127.0.0.1:8750/mcp", "tok123")
 	})
 	if !strings.Contains(out, "✓") {
 		t.Errorf("expected success marker for windsurf tool, got: %s", out)
@@ -1305,7 +1305,7 @@ func TestConfigureNamedToolsOpenClaw(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureNamedTools([]string{"openclaw"}, "http://localhost:8750/mcp", "tok123")
+		configureNamedTools([]string{"openclaw"}, "http://127.0.0.1:8750/mcp", "tok123")
 	})
 	if !strings.Contains(out, "✓") {
 		t.Errorf("expected success marker for openclaw tool, got: %s", out)
@@ -1323,7 +1323,7 @@ func TestConfigureNamedToolsVSCode(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureNamedTools([]string{"vscode"}, "http://localhost:8750/mcp", "")
+		configureNamedTools([]string{"vscode"}, "http://127.0.0.1:8750/mcp", "")
 	})
 	if !strings.Contains(out, "VS Code") {
 		t.Errorf("expected VS Code instructions, got: %s", out)
@@ -1339,7 +1339,7 @@ func TestConfigureNamedToolsVSCodeAlias(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureNamedTools([]string{"vs-code"}, "http://localhost:8750/mcp", "")
+		configureNamedTools([]string{"vs-code"}, "http://127.0.0.1:8750/mcp", "")
 	})
 	if !strings.Contains(out, "VS Code") {
 		t.Errorf("expected VS Code instructions with vs-code alias: %s", out)
@@ -1352,7 +1352,7 @@ func TestConfigureNamedToolsManual(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureNamedTools([]string{"manual"}, "http://localhost:8750/mcp", "")
+		configureNamedTools([]string{"manual"}, "http://127.0.0.1:8750/mcp", "")
 	})
 	if !strings.Contains(out, "mcpServers") {
 		t.Errorf("expected manual instructions, got: %s", out)
@@ -1368,7 +1368,7 @@ func TestConfigureNamedToolsOtherAlias(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureNamedTools([]string{"other"}, "http://localhost:8750/mcp", "")
+		configureNamedTools([]string{"other"}, "http://127.0.0.1:8750/mcp", "")
 	})
 	if !strings.Contains(out, "mcpServers") {
 		t.Errorf("expected manual instructions with 'other' alias: %s", out)
@@ -1381,7 +1381,7 @@ func TestConfigureNamedToolsMultiple(t *testing.T) {
 	defer cleanup()
 
 	out := captureStdout(func() {
-		configureNamedTools([]string{"claude", "cursor"}, "http://localhost:8750/mcp", "tok123")
+		configureNamedTools([]string{"claude", "cursor"}, "http://127.0.0.1:8750/mcp", "tok123")
 	})
 
 	// Both should succeed
@@ -1406,7 +1406,7 @@ func TestConfigureNamedToolsUnknownToolSetupAI(t *testing.T) {
 	defer cleanup()
 
 	stderr := captureStderr(func() {
-		configureNamedTools([]string{"nonexistent"}, "http://localhost:8750/mcp", "")
+		configureNamedTools([]string{"nonexistent"}, "http://127.0.0.1:8750/mcp", "")
 	})
 	if !strings.Contains(stderr, "unknown tool") {
 		t.Errorf("expected error for unknown tool, got stderr: %s", stderr)

--- a/cmd/muninn/smoke_exhaustive_test.go
+++ b/cmd/muninn/smoke_exhaustive_test.go
@@ -57,7 +57,7 @@ var allMCPTools = []string{
 func adminLogin(t *testing.T) string {
 	t.Helper()
 	body, _ := json.Marshal(map[string]string{"username": "root", "password": "password"})
-	req, _ := http.NewRequest("POST", "http://localhost:8476/api/auth/login", bytes.NewReader(body))
+	req, _ := http.NewRequest("POST", "http://127.0.0.1:8476/api/auth/login", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	// Use a client that does NOT follow redirects so we can capture the cookie directly.
 	client := &http.Client{
@@ -92,7 +92,7 @@ func mcpToolsList(t *testing.T, token string) []string {
 		"method":  "tools/list",
 		"params":  map[string]any{},
 	})
-	req, _ := http.NewRequest("POST", "http://localhost:8750/mcp", bytes.NewReader(body))
+	req, _ := http.NewRequest("POST", "http://127.0.0.1:8750/mcp", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
@@ -144,7 +144,7 @@ func mcpToolText(t *testing.T, token, toolName string, args map[string]any) stri
 			"arguments": args,
 		},
 	})
-	req, _ := http.NewRequest("POST", "http://localhost:8750/mcp", bytes.NewReader(body))
+	req, _ := http.NewRequest("POST", "http://127.0.0.1:8750/mcp", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
@@ -194,7 +194,7 @@ func mcpToolNoFail(t *testing.T, token, toolName string, args map[string]any) (m
 			"arguments": args,
 		},
 	})
-	req, _ := http.NewRequest("POST", "http://localhost:8750/mcp", bytes.NewReader(body))
+	req, _ := http.NewRequest("POST", "http://127.0.0.1:8750/mcp", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
@@ -799,7 +799,7 @@ func doREST(t *testing.T, method, path string, body []byte, headers map[string]s
 	if body != nil {
 		bodyReader = bytes.NewReader(body)
 	}
-	req, err := http.NewRequest(method, "http://localhost:8475"+path, bodyReader)
+	req, err := http.NewRequest(method, "http://127.0.0.1:8475"+path, bodyReader)
 	if err != nil {
 		t.Fatalf("doREST %s %s: %v", method, path, err)
 	}
@@ -823,7 +823,7 @@ func doRESTWithCookie(t *testing.T, method, path string, body []byte, cookieName
 	if body != nil {
 		bodyReader = bytes.NewReader(body)
 	}
-	req, err := http.NewRequest(method, "http://localhost:8475"+path, bodyReader)
+	req, err := http.NewRequest(method, "http://127.0.0.1:8475"+path, bodyReader)
 	if err != nil {
 		t.Fatalf("doRESTWithCookie %s %s: %v", method, path, err)
 	}

--- a/cmd/muninn/status.go
+++ b/cmd/muninn/status.go
@@ -86,9 +86,9 @@ func probeServicesDefault() []serviceStatus {
 	}
 
 	return []serviceStatus{
-		{name: "database", port: 8475, up: probe("http://localhost:8475/api/health")},
-		{name: "mcp", port: 8750, up: probe("http://localhost:8750/mcp/health")},
-		{name: "web ui", port: 8476, up: probe("http://localhost:8476/")},
+		{name: "database", port: 8475, up: probe("http://127.0.0.1:8475/api/health")},
+		{name: "mcp", port: 8750, up: probe("http://127.0.0.1:8750/mcp/health")},
+		{name: "web ui", port: 8476, up: probe("http://127.0.0.1:8476/")},
 	}
 }
 

--- a/cmd/muninn/vault.go
+++ b/cmd/muninn/vault.go
@@ -37,7 +37,7 @@ func printVaultUsage() {
 	fmt.Println("  -u <user>         Admin username (default: root)")
 	fmt.Println("  -p                Prompt for password")
 	fmt.Println("  -p<password>      Inline password (no space)")
-	fmt.Println("  -h <host:port>    Server host:port (default: localhost:8475)")
+	fmt.Println("  -h <host:port>    Server host:port (default: 127.0.0.1:8475)")
 }
 
 func runVault(args []string) {

--- a/cmd/muninn/vault_auth.go
+++ b/cmd/muninn/vault_auth.go
@@ -14,8 +14,8 @@ import (
 // Package-level session state set by runVault before dispatching subcommands.
 // Tests don't touch these, so doVaultRequestForce and friends work unchanged.
 var (
-	vaultAdminBase = "http://localhost:8475" // REST API
-	vaultUIBase    = "http://localhost:8476" // login endpoint lives here
+	vaultAdminBase = "http://127.0.0.1:8475" // REST API
+	vaultUIBase    = "http://127.0.0.1:8476" // login endpoint lives here
 	vaultCookie    string                   // muninn_session value
 )
 
@@ -29,7 +29,7 @@ var (
 //	-p                prompt for password
 //	-p<password>      inline password (no space, like MySQL)
 //	--password=<pw>   inline password
-//	-h <host:port>    UI host:port (default: localhost:8476)
+//	-h <host:port>    UI host:port (default: 127.0.0.1:8476)
 func parseAdminFlags(args []string) (remaining []string, username, password string, prompted bool) {
 	username = "root"
 

--- a/cmd/muninn/vault_test.go
+++ b/cmd/muninn/vault_test.go
@@ -368,7 +368,7 @@ func TestFetchJobStatus_ReturnsSnapOnOK(t *testing.T) {
 func TestFetchJobStatus_ReturnsNilOnConnectionRefused(t *testing.T) {
 	// Port with nothing listening — fetchJobStatus should return nil.
 	snap := fetchJobStatus("some-job", "some-vault")
-	// It will try localhost:8475 which is likely not running in CI; nil is fine.
+	// It will try 127.0.0.1:8475 which is likely not running in CI; nil is fine.
 	_ = snap // either nil or a real snap — just must not panic
 }
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -83,7 +83,7 @@ Keys are 46 characters. The raw bytes are generated with `crypto/rand`. The toke
 Include the key as a bearer token on every request:
 
 ```bash
-curl http://localhost:8475/api/engrams?vault=default \
+curl http://127.0.0.1:8475/api/engrams?vault=default \
   -H "Authorization: Bearer mk_xK9m..."
 ```
 
@@ -96,7 +96,7 @@ The key implicitly identifies the vault. If the key belongs to `default` and the
 ### Create a key (admin only)
 
 ```bash
-curl -X POST http://localhost:8475/api/admin/keys \
+curl -X POST http://127.0.0.1:8475/api/admin/keys \
   -H "Content-Type: application/json" \
   -d '{
     "vault": "default",
@@ -122,7 +122,7 @@ Response:
 ### List keys for a vault
 
 ```bash
-curl "http://localhost:8475/api/admin/keys?vault=default"
+curl "http://127.0.0.1:8475/api/admin/keys?vault=default"
 ```
 
 Token values are not returned. You see the key metadata (ID, label, mode, created date) only.
@@ -130,7 +130,7 @@ Token values are not returned. You see the key metadata (ID, label, mode, create
 ### Revoke a key
 
 ```bash
-curl -X DELETE "http://localhost:8475/api/admin/keys/A1B2C3D4?vault=default"
+curl -X DELETE "http://127.0.0.1:8475/api/admin/keys/A1B2C3D4?vault=default"
 ```
 
 Revocation is immediate. The token stops working on the next request.
@@ -146,7 +146,7 @@ The `default` vault is created as **public** on first run — no API key require
 To open a vault (allow unauthenticated access):
 
 ```bash
-curl -X PUT http://localhost:8475/api/admin/vaults/config \
+curl -X PUT http://127.0.0.1:8475/api/admin/vaults/config \
   -H "Content-Type: application/json" \
   -d '{"name":"myvault","public":true}'
 ```
@@ -154,7 +154,7 @@ curl -X PUT http://localhost:8475/api/admin/vaults/config \
 To lock a vault (require an API key):
 
 ```bash
-curl -X PUT http://localhost:8475/api/admin/vaults/config \
+curl -X PUT http://127.0.0.1:8475/api/admin/vaults/config \
   -H "Content-Type: application/json" \
   -d '{"name":"default","public":false}'
 ```
@@ -170,7 +170,7 @@ Plasticity controls the cognitive pipeline for a vault — how it learns, forget
 Get the current plasticity configuration for a vault:
 
 ```bash
-curl "http://localhost:8475/api/admin/vault/default/plasticity" \
+curl "http://127.0.0.1:8475/api/admin/vault/default/plasticity" \
   -H "Authorization: Bearer <admin-session>"
 ```
 
@@ -202,7 +202,7 @@ Response includes both the saved configuration and the fully resolved values (pr
 Update plasticity for a vault:
 
 ```bash
-curl -X PUT "http://localhost:8475/api/admin/vault/default/plasticity" \
+curl -X PUT "http://127.0.0.1:8475/api/admin/vault/default/plasticity" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <admin-session>" \
   -d '{

--- a/docs/cluster-operations.md
+++ b/docs/cluster-operations.md
@@ -72,7 +72,7 @@ muninn start
 **Or** enable cluster mode on a running node via REST:
 
 ```sh
-curl -X POST http://localhost:8475/api/admin/cluster/enable \
+curl -X POST http://127.0.0.1:8475/api/admin/cluster/enable \
   -H "Content-Type: application/json" \
   -H "Cookie: <admin-session-cookie>" \
   -d '{
@@ -87,7 +87,7 @@ curl -X POST http://localhost:8475/api/admin/cluster/enable \
 1. On the Cortex, obtain a join token (required when `cluster_secret` is set):
 
 ```sh
-curl http://localhost:8475/api/admin/cluster/token \
+curl http://127.0.0.1:8475/api/admin/cluster/token \
   -H "Cookie: <admin-session-cookie>"
 # {"token":"...", "expires_at":"...", "ttl_seconds":900}
 ```
@@ -95,7 +95,7 @@ curl http://localhost:8475/api/admin/cluster/token \
 2. Register the pending peer on the Cortex:
 
 ```sh
-curl -X POST http://localhost:8475/api/admin/cluster/nodes \
+curl -X POST http://127.0.0.1:8475/api/admin/cluster/nodes \
   -H "Content-Type: application/json" \
   -H "Cookie: <admin-session-cookie>" \
   -d '{"addr": "10.0.1.6:8474", "token": "<token-from-step-1>"}'
@@ -147,8 +147,8 @@ muninn cluster info
 muninn cluster status
 
 # REST (cluster auth: Bearer token = cluster_secret)
-curl -H "Authorization: Bearer <cluster_secret>" http://localhost:8475/v1/cluster/health
-curl -H "Authorization: Bearer <cluster_secret>" http://localhost:8475/v1/cluster/info
+curl -H "Authorization: Bearer <cluster_secret>" http://127.0.0.1:8475/v1/cluster/health
+curl -H "Authorization: Bearer <cluster_secret>" http://127.0.0.1:8475/v1/cluster/info
 ```
 
 Expected: `status: "ok"`, `is_leader: true` on Cortex, `replication_lag: 0` on Cortex, non-zero lag on Lobes until caught up.
@@ -163,7 +163,7 @@ Expected: `status: "ok"`, `is_leader: true` on Cortex, `replication_lag: 0` on C
 
 ```sh
 curl -H "Authorization: Bearer $MUNINN_CLUSTER_SECRET" \
-  http://localhost:8475/v1/cluster/health
+  http://127.0.0.1:8475/v1/cluster/health
 ```
 
 Response: `status` (`ok` | `degraded` | `down`), `role`, `is_leader`, `epoch`, `replication_lag`.
@@ -172,7 +172,7 @@ Response: `status` (`ok` | `degraded` | `down`), `role`, `is_leader`, `epoch`, `
 
 ```sh
 curl -H "Authorization: Bearer $MUNINN_CLUSTER_SECRET" \
-  http://localhost:8475/v1/cluster/info
+  http://127.0.0.1:8475/v1/cluster/info
 ```
 
 ### Checking Replica Lag
@@ -180,7 +180,7 @@ curl -H "Authorization: Bearer $MUNINN_CLUSTER_SECRET" \
 ```sh
 # On a Lobe — returns this node's lag
 curl -H "Authorization: Bearer $MUNINN_CLUSTER_SECRET" \
-  http://localhost:8475/v1/replication/lag
+  http://127.0.0.1:8475/v1/replication/lag
 # {"lag": 42, "role": "replica"}
 
 # Full status
@@ -193,7 +193,7 @@ muninn cluster status
 
 ```sh
 curl -N -H "Cookie: <admin-session>" \
-  http://localhost:8475/api/admin/cluster/events
+  http://127.0.0.1:8475/api/admin/cluster/events
 ```
 
 Use for debugging replication flow. Requires admin session authentication.
@@ -215,7 +215,7 @@ Use for debugging replication flow. Requires admin session authentication.
 
 ```sh
 # Optional: drain=true waits up to 30s for replica to catch up before removal
-curl -X DELETE "http://localhost:8475/api/admin/cluster/nodes/replica-1?drain=true" \
+curl -X DELETE "http://127.0.0.1:8475/api/admin/cluster/nodes/replica-1?drain=true" \
   -H "Cookie: <admin-session>"
 ```
 
@@ -244,7 +244,7 @@ Add sentinel nodes as in §2. They increase quorum size and improve ODOWN detect
 **POST /api/admin/cluster/failover** — Planned handoff to a specific Lobe:
 
 ```sh
-curl -X POST http://localhost:8475/api/admin/cluster/failover \
+curl -X POST http://127.0.0.1:8475/api/admin/cluster/failover \
   -H "Content-Type: application/json" \
   -H "Cookie: <admin-session>" \
   -d '{"target_node_id": "replica-1"}'
@@ -266,7 +266,7 @@ Timeout: 5s for HANDOFF_ACK, 30s for convergence.
 
 ```sh
 curl -X POST -H "Authorization: Bearer $MUNINN_CLUSTER_SECRET" \
-  http://localhost:8475/v1/replication/promote
+  http://127.0.0.1:8475/v1/replication/promote
 ```
 
 Use when the Cortex has failed and you need a new leader elected. The Lobe with quorum votes will become Cortex.
@@ -327,7 +327,7 @@ Use when the Cortex has failed and you need a new leader elected. The Lobe with 
 muninn backup --data-dir ~/.muninn/data --output /backups/muninn-$(date +%Y%m%d)
 
 # Online backup (server running) — via REST API:
-curl -X POST http://localhost:8475/api/admin/backup \
+curl -X POST http://127.0.0.1:8475/api/admin/backup \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"output_dir": "/backups/muninn-online"}'
@@ -339,7 +339,7 @@ The backup creates a Pebble checkpoint (hardlinked, space-efficient) plus copies
 
 ```sh
 curl -H "Cookie: <admin-session>" \
-  "http://localhost:8475/api/admin/vaults/default/export" \
+  "http://127.0.0.1:8475/api/admin/vaults/default/export" \
   -o default.muninn
 ```
 
@@ -359,7 +359,7 @@ Includes: `pebble/`, `wal/`, `auth_secret`, `cluster.yaml`, etc.
 **Vault import** (for vault export):
 
 ```sh
-curl -X POST "http://localhost:8475/api/admin/vaults/import?vault=restored" \
+curl -X POST "http://127.0.0.1:8475/api/admin/vaults/import?vault=restored" \
   -H "Content-Type: application/gzip" \
   -H "Cookie: <admin-session>" \
   --data-binary @default.muninn

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -68,7 +68,7 @@ First run automatically:
 ```bash
 muninn status
 # or
-curl http://localhost:8750/mcp/health
+curl http://127.0.0.1:8750/mcp/health
 ```
 
 **Stop it:**
@@ -92,7 +92,7 @@ muninn stop
 ## 3. Store Your First Memory
 
 ```bash
-curl -sX POST http://localhost:8475/api/engrams \
+curl -sX POST http://127.0.0.1:8475/api/engrams \
   -H 'Content-Type: application/json' \
   -d '{
     "concept": "payment incident",
@@ -109,7 +109,7 @@ You'll get back an engram ID. That memory now exists in MuninnDB with a relevanc
 ## 4. Activate — Retrieve What's Relevant Now
 
 ```bash
-curl -sX POST http://localhost:8475/api/activate \
+curl -sX POST http://127.0.0.1:8475/api/activate \
   -H 'Content-Type: application/json' \
   -d '{
     "context": ["debugging the payment retry logic"],
@@ -140,7 +140,7 @@ muninn init --tool claude --yes
 muninn init --tool cursor,claude --yes
 ```
 
-**Manual MCP config:** Point any MCP client to `http://localhost:8750/mcp`.
+**Manual MCP config:** Point any MCP client to `http://127.0.0.1:8750/mcp`.
 
 ---
 
@@ -188,7 +188,7 @@ import asyncio
 from muninn import MuninnClient
 
 async def main():
-    async with MuninnClient("http://localhost:8475") as m:
+    async with MuninnClient("http://127.0.0.1:8475") as m:
         # Write
         eid = await m.write(
             vault="default",
@@ -217,7 +217,7 @@ asyncio.run(main())
 
 ## 9. Change the Admin Password
 
-Log into the Web UI at `http://localhost:8476` with `root` / `password` and change the password from the settings page. Or via the shell:
+Log into the Web UI at `http://127.0.0.1:8476` with `root` / `password` and change the password from the settings page. Or via the shell:
 
 ```bash
 muninn shell

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -55,7 +55,7 @@ docker run -d \
   ghcr.io/scrypster/muninndb:latest
 ```
 
-Open the Web UI: http://localhost:8476
+Open the Web UI: http://127.0.0.1:8476
 
 ### Docker Compose
 
@@ -175,7 +175,7 @@ Add to your AI tool's MCP config:
   "mcpServers": {
     "muninn": {
       "type": "http",
-      "url": "http://localhost:8750/mcp"
+      "url": "http://127.0.0.1:8750/mcp"
     }
   }
 }
@@ -187,7 +187,7 @@ If you enabled MCP auth (token file at `~/.muninn/mcp.token`):
   "mcpServers": {
     "muninn": {
       "type": "http",
-      "url": "http://localhost:8750/mcp",
+      "url": "http://127.0.0.1:8750/mcp",
       "headers": {
         "Authorization": "Bearer <your-token>"
       }
@@ -202,7 +202,7 @@ If you enabled MCP auth (token file at `~/.muninn/mcp.token`):
   "mcpServers": {
     "muninn": {
       "type": "http",
-      "url": "http://localhost:8750/mcp"
+      "url": "http://127.0.0.1:8750/mcp"
     }
   }
 }
@@ -214,7 +214,7 @@ If you enabled MCP auth (token file at `~/.muninn/mcp.token`):
   "mcpServers": {
     "muninn": {
       "type": "http",
-      "url": "http://localhost:8750/mcp"
+      "url": "http://127.0.0.1:8750/mcp"
     }
   }
 }
@@ -253,7 +253,7 @@ MUNINN_MCP_URL=https://my-server:8750/mcp muninn mcp
   "mcpServers": {
     "muninn": {
       "type": "http",
-      "url": "http://localhost:8750/mcp"
+      "url": "http://127.0.0.1:8750/mcp"
     }
   }
 }
@@ -265,7 +265,7 @@ MUNINN_MCP_URL=https://my-server:8750/mcp muninn mcp
   "servers": {
     "muninn": {
       "type": "http",
-      "url": "http://localhost:8750/mcp"
+      "url": "http://127.0.0.1:8750/mcp"
     }
   }
 }
@@ -276,7 +276,7 @@ Restart your AI tool after editing the config.
 ### Verify the connection
 
 ```sh
-curl http://localhost:8750/mcp/health
+curl http://127.0.0.1:8750/mcp/health
 # → {"status":"ok"}
 ```
 
@@ -500,7 +500,7 @@ Encryption at rest protects data that is **stored on disk while the system is of
 
 All services expose the same health endpoint:
 ```sh
-curl http://localhost:8750/mcp/health
+curl http://127.0.0.1:8750/mcp/health
 ```
 
 Returns `{"status":"ok"}` when the server is ready to accept requests.

--- a/docs/semantic-triggers.md
+++ b/docs/semantic-triggers.md
@@ -91,7 +91,7 @@ Non-blocking async channel per subscriber. If the subscriber's channel is full b
 ### Basic Subscribe (Go SDK)
 
 ```go
-client := muninn.NewClient("http://localhost:8475", token)
+client := muninn.NewClient("http://127.0.0.1:8475", token)
 pushCh, err := client.Subscribe(ctx, "my-project")
 if err != nil {
     log.Fatal(err)
@@ -120,7 +120,7 @@ q.Set("context", "database architecture")
 q.Set("threshold", "0.8")
 q.Set("push_on_write", "true")
 
-url := "http://localhost:8475/api/subscribe?" + q.Encode()
+url := "http://127.0.0.1:8475/api/subscribe?" + q.Encode()
 // Then use client.Subscribe(ctx, vault) which encapsulates this
 
 pushCh, err := client.Subscribe(ctx, "my-project")
@@ -146,7 +146,7 @@ The canonical integration for AI agents looks like this:
 
 ```go
 func RunAgent(ctx context.Context, task string) error {
-    client := muninn.NewClient("http://localhost:8475", token)
+    client := muninn.NewClient("http://127.0.0.1:8475", token)
 
     // Subscribe at session start
     // The DB will push memories as they become relevant — no polling
@@ -183,7 +183,7 @@ import asyncio
 from muninn.client import MuninnClient
 
 async def run_agent(task: str):
-    async with MuninnClient("http://localhost:8475", token=token) as client:
+    async with MuninnClient("http://127.0.0.1:8475", token=token) as client:
         # Subscribe to semantic triggers via SSE
         stream = client.subscribe(vault="agent-session", push_on_write=True, threshold=0.7)
 

--- a/internal/cognitive/mechanics_proof_test.go
+++ b/internal/cognitive/mechanics_proof_test.go
@@ -439,7 +439,7 @@ func cleanupVault(t *testing.T, base, vault string) {
 
 		// Authenticate to get a session cookie.
 		loginBody := strings.NewReader(`{"username":"root","password":"password"}`)
-		loginResp, err := client.Post("http://localhost:8476/api/auth/login", "application/json", loginBody)
+		loginResp, err := client.Post("http://127.0.0.1:8476/api/auth/login", "application/json", loginBody)
 		if err != nil {
 			t.Logf("vault cleanup: login failed: %v", err)
 			return
@@ -471,12 +471,12 @@ func cleanupVault(t *testing.T, base, vault string) {
 }
 
 func TestLiveIntegration_WriteAndActivate(t *testing.T) {
-	base := "http://localhost:8475"
+	base := "http://127.0.0.1:8475"
 
 	// Check server is up
 	resp, err := http.Get(base + "/api/stats")
 	if err != nil || resp.StatusCode != 200 {
-		t.Skip("server not running at localhost:8475 — skipping live test")
+		t.Skip("server not running at 127.0.0.1:8475 — skipping live test")
 	}
 	resp.Body.Close()
 
@@ -817,12 +817,12 @@ func TestProveWorker_DormancyWakeUp(t *testing.T) {
 // TestLiveIntegration_ContradictionDetection verifies that contradicting engrams
 // trigger the contradiction detection worker.
 func TestLiveIntegration_ContradictionDetection(t *testing.T) {
-	base := "http://localhost:8475"
+	base := "http://127.0.0.1:8475"
 
 	// Check server is up
 	resp, err := http.Get(base + "/api/stats")
 	if err != nil || resp.StatusCode != 200 {
-		t.Skip("server not running at localhost:8475 — skipping live test")
+		t.Skip("server not running at 127.0.0.1:8475 — skipping live test")
 	}
 	resp.Body.Close()
 
@@ -981,12 +981,12 @@ func TestLiveIntegration_ContradictionDetection(t *testing.T) {
 
 // TestLiveIntegration_ScoreComposition verifies the breakdown of FTS, Semantic, and Hebbian scores.
 func TestLiveIntegration_ScoreComposition(t *testing.T) {
-	base := "http://localhost:8475"
+	base := "http://127.0.0.1:8475"
 
 	// Check server is up
 	resp, err := http.Get(base + "/api/stats")
 	if err != nil || resp.StatusCode != 200 {
-		t.Skip("server not running at localhost:8475 — skipping live test")
+		t.Skip("server not running at 127.0.0.1:8475 — skipping live test")
 	}
 	resp.Body.Close()
 
@@ -1143,12 +1143,12 @@ func TestLiveIntegration_ScoreComposition(t *testing.T) {
 // TestLiveIntegration_HNSWRetroactiveProcessing verifies that the RetroactiveProcessor
 // embeds engrams asynchronously and SemanticSimilarity becomes non-zero after a delay.
 func TestLiveIntegration_HNSWRetroactiveProcessing(t *testing.T) {
-	base := "http://localhost:8475"
+	base := "http://127.0.0.1:8475"
 
 	// Check server is up
 	resp, err := http.Get(base + "/api/stats")
 	if err != nil || resp.StatusCode != 200 {
-		t.Skip("server not running at localhost:8475 — skipping live test")
+		t.Skip("server not running at 127.0.0.1:8475 — skipping live test")
 	}
 	resp.Body.Close()
 

--- a/internal/transport/rest/admin_coverage_test.go
+++ b/internal/transport/rest/admin_coverage_test.go
@@ -644,8 +644,8 @@ func TestMCPInfo_EmptyAddr(t *testing.T) {
 
 	var resp MCPInfoResponse
 	json.NewDecoder(w.Body).Decode(&resp)
-	if !strings.Contains(resp.URL, "localhost") {
-		t.Errorf("expected localhost in URL for empty addr, got %q", resp.URL)
+	if !strings.Contains(resp.URL, "127.0.0.1") {
+		t.Errorf("expected 127.0.0.1 in URL for empty addr, got %q", resp.URL)
 	}
 }
 
@@ -661,7 +661,7 @@ func TestMCPInfo_IPv6Wildcard(t *testing.T) {
 
 	var resp MCPInfoResponse
 	json.NewDecoder(w.Body).Decode(&resp)
-	if resp.URL != "http://localhost:8750/mcp" {
+	if resp.URL != "http://127.0.0.1:8750/mcp" {
 		t.Errorf("expected localhost for :: wildcard, got %q", resp.URL)
 	}
 }

--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -422,13 +422,13 @@ func (s *Server) handleMCPInfo(w http.ResponseWriter, r *http.Request) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		// Fallback for misconfigured or empty addresses.
-		host = "localhost"
+		host = "127.0.0.1"
 		port = "8750"
 	}
 	// A wildcard listen address (empty string, 0.0.0.0, or ::) means the server
-	// is reachable on any interface; present it as localhost in the UI.
+	// is reachable on any interface; use 127.0.0.1 to avoid IPv6 dual-stack ambiguity.
 	if host == "" || host == "0.0.0.0" || host == "::" {
-		host = "localhost"
+		host = "127.0.0.1"
 	}
 	mcpURL := "http://" + host + ":" + port + "/mcp"
 	s.sendJSON(w, http.StatusOK, MCPInfoResponse{

--- a/internal/transport/rest/admin_handlers_test.go
+++ b/internal/transport/rest/admin_handlers_test.go
@@ -237,7 +237,7 @@ func TestMCPInfo(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.URL != "http://localhost:8750/mcp" {
+	if resp.URL != "http://127.0.0.1:8750/mcp" {
 		t.Errorf("unexpected URL: %q", resp.URL)
 	}
 	if !resp.TokenConfigured {
@@ -278,7 +278,7 @@ func TestMCPInfo_CustomPort(t *testing.T) {
 
 	var resp MCPInfoResponse
 	json.NewDecoder(w.Body).Decode(&resp)
-	if resp.URL != "http://localhost:9999/mcp" {
+	if resp.URL != "http://127.0.0.1:9999/mcp" {
 		t.Errorf("unexpected URL for custom port: %q", resp.URL)
 	}
 }

--- a/internal/transport/rest/server_test.go
+++ b/internal/transport/rest/server_test.go
@@ -1953,7 +1953,7 @@ func TestGuide_EngineError(t *testing.T) {
 // returns correct MCP URL for the UI to call entity graph via MCP.
 func TestEntityGraphVisualization_MCPInfoEndpoint(t *testing.T) {
 	// Create server with MCP address configured
-	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil, MCPInfo{Addr: "localhost:8750", HasToken: false})
+	server := NewServer("localhost:8080", &MockEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil, MCPInfo{Addr: "127.0.0.1:8750", HasToken: false})
 
 	req := httptest.NewRequest("GET", "/api/admin/mcp-info", nil)
 	w := httptest.NewRecorder()

--- a/sdk/go/muninn/examples/cognitive_loop/main.go
+++ b/sdk/go/muninn/examples/cognitive_loop/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	token := os.Getenv("MUNINN_TOKEN")
-	client := muninn.NewClient("http://localhost:8476", token)
+	client := muninn.NewClient("http://127.0.0.1:8476", token)
 	ctx := context.Background()
 
 	vault := "default"

--- a/sdk/go/muninn/examples/lifecycle/main.go
+++ b/sdk/go/muninn/examples/lifecycle/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	token := os.Getenv("MUNINN_TOKEN")
-	client := muninn.NewClient("http://localhost:8476", token)
+	client := muninn.NewClient("http://127.0.0.1:8476", token)
 	ctx := context.Background()
 
 	vault := "default"

--- a/sdk/go/muninn/examples/quickstart/main.go
+++ b/sdk/go/muninn/examples/quickstart/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	token := os.Getenv("MUNINN_TOKEN")
-	client := muninn.NewClient("http://localhost:8476", token)
+	client := muninn.NewClient("http://127.0.0.1:8476", token)
 	ctx := context.Background()
 
 	// Health check

--- a/sdk/muninndb/README.md
+++ b/sdk/muninndb/README.md
@@ -18,7 +18,7 @@ import asyncio
 from muninn import MuninnClient
 
 async def main():
-    async with MuninnClient("http://localhost:8475") as client:
+    async with MuninnClient("http://127.0.0.1:8475") as client:
         eid = await client.write(
             vault="default",
             concept="neural plasticity",

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -24,7 +24,7 @@ import { MuninnClient } from "@muninndb/client";
 
 const client = new MuninnClient({
   token: "your-api-token",
-  // baseUrl defaults to http://localhost:8476
+  // baseUrl defaults to http://127.0.0.1:8476
 });
 
 // Write a memory
@@ -52,7 +52,7 @@ client.close();
 
 ```typescript
 const client = new MuninnClient({
-  baseUrl: "http://localhost:8476", // MuninnDB server URL
+  baseUrl: "http://127.0.0.1:8476", // MuninnDB server URL
   token: "your-api-token",         // Bearer token (required)
   timeout: 30_000,                 // Request timeout in ms (default: 30s)
   maxRetries: 3,                   // Retry attempts (default: 3)

--- a/sdk/php/README.md
+++ b/sdk/php/README.md
@@ -32,7 +32,7 @@ composer require muninndb/client
 use MuninnDB\MuninnClient;
 
 $client = new MuninnClient(
-    baseUrl: 'http://localhost:8476',
+    baseUrl: 'http://127.0.0.1:8476',
     token: 'your-api-token',
 );
 
@@ -123,7 +123,7 @@ $client->write(
 
 ```php
 $client = new MuninnClient(
-    baseUrl: 'http://localhost:8476', // Server URL
+    baseUrl: 'http://127.0.0.1:8476', // Server URL
     token: '',                        // Bearer token
     timeout: 5.0,                     // Request timeout in seconds
     maxRetries: 3,                    // Retry count on 5xx / connection errors
@@ -383,7 +383,7 @@ All configuration is done through the constructor — no config files, no enviro
 
 ```php
 $client = new MuninnClient(
-    baseUrl: getenv('MUNINN_URL') ?: 'http://localhost:8476',
+    baseUrl: getenv('MUNINN_URL') ?: 'http://127.0.0.1:8476',
     token: getenv('MUNINN_TOKEN') ?: '',
     timeout: 10.0,
     maxRetries: 5,

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -30,7 +30,7 @@ import asyncio
 from muninn import MuninnClient
 
 async def main():
-    async with MuninnClient("http://localhost:8476") as client:
+    async with MuninnClient("http://127.0.0.1:8476") as client:
         # Write a memory
         engram_id = await client.write(
             vault="default",
@@ -210,7 +210,7 @@ Create a client with custom settings:
 
 ```python
 client = MuninnClient(
-    base_url="http://localhost:8476",      # Server address
+    base_url="http://127.0.0.1:8476",      # Server address
     token="your-bearer-token",              # Optional auth token
     timeout=5.0,                            # Request timeout (seconds)
     max_retries=3,                          # Max retry attempts
@@ -287,7 +287,7 @@ Example with custom retry settings:
 
 ```python
 async with MuninnClient(
-    base_url="http://localhost:8476",
+    base_url="http://127.0.0.1:8476",
     max_retries=5,
     retry_backoff=1.0
 ) as client:


### PR DESCRIPTION
## Summary

- Replaces all `localhost:8750`, `localhost:8475`, and `localhost:8476` with `127.0.0.1:XXXX` across the entire codebase
- Covers runtime code, tests, docs, SDK examples, and the MCP info endpoint handler
- The MCP info endpoint now returns `127.0.0.1` for wildcard bind addresses (`""`, `0.0.0.0`, `::`) instead of `localhost`, avoiding IPv6 dual-stack ambiguity

**Root cause:** On systems with IPv6 dual-stack, `localhost` may resolve to `::1` while the daemon only binds to `127.0.0.1` (IPv4), causing connection failures.

**Files changed:** 41 files (runtime, tests, docs, SDK examples)

## Test Plan
- [x] All tests pass (`go test ./... -short`)
- [x] Build succeeds (`go build ./...`)
- [x] No remaining `localhost:8750/8475/8476` references in non-plan files