### PR TITLE
docs: GitHub Copilot and Codebuff integration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,50 @@ Omit the `headers` block if you are running MuninnDB without token authenticatio
 > **Note:** OpenCode tools are exposed as `muninn_muninn_remember`, `muninn_muninn_recall`, etc. (server key + tool name prefix). Users preferring shorter names can register the server under the key `memory` instead, which yields `memory_muninn_remember`, `memory_muninn_recall`, etc.
 </details>
 
+<details>
+<summary>GitHub Copilot</summary>
+
+Add to `.vscode/mcp.json` in your workspace:
+
+```json
+{
+  "servers": {
+    "muninn": {
+      "type": "http",
+      "url": "http://127.0.0.1:8750/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_ADMIN_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Replace `YOUR_ADMIN_TOKEN` with the token from your `muninn.env` file. Omit the `headers` block if running without token auth. If Copilot shows an OAuth error, the `headers` block is missing — adding it resolves it. [Full Copilot setup guide →](docs/integrations/github-copilot.md)
+</details>
+
+<details>
+<summary>Codebuff</summary>
+
+Add to your Codebuff MCP config:
+
+```json
+{
+  "mcpServers": {
+    "muninn": {
+      "type": "http",
+      "url": "http://127.0.0.1:8750/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_ADMIN_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For proactive memory behavior — Codebuff storing useful discoveries without being asked — add the memory instructions to your `AGENT.md`. [Full Codebuff setup guide →](docs/integrations/codebuff.md)
+</details>
+
 MuninnDB exposes **35 MCP tools** — store, activate, search, batch insert, get usage guidance, manage vaults, and more. On first connect, call `muninn_guide` for vault-aware instructions. No token required against the default vault. [Full MCP reference →](https://muninndb.com/docs)
 
 ---

--- a/docs/integrations/codebuff.md
+++ b/docs/integrations/codebuff.md
@@ -1,0 +1,107 @@
+# Codebuff + MuninnDB
+
+Codebuff is an AI coding agent that supports MCP servers. Connecting MuninnDB gives Codebuff persistent memory across sessions — it can store decisions, patterns, and context it discovers while working, and recall them automatically in future sessions.
+
+---
+
+## Prerequisites
+
+- MuninnDB running locally (`muninn start`)
+- Codebuff installed and configured
+- Your MuninnDB admin token (printed on first start, or found in `muninn.env`)
+
+---
+
+## MCP configuration
+
+Add MuninnDB as an MCP server in your Codebuff config. The exact config file location depends on your Codebuff version — check the [Codebuff docs](https://codebuff.com/docs) for the current path. The structure is:
+
+```json
+{
+  "mcpServers": {
+    "muninn": {
+      "type": "http",
+      "url": "http://127.0.0.1:8750/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_ADMIN_TOKEN"
+      }
+    }
+  }
+}
+```
+
+**No token configured?** Omit the `headers` block:
+
+```json
+{
+  "mcpServers": {
+    "muninn": {
+      "type": "http",
+      "url": "http://127.0.0.1:8750/mcp"
+    }
+  }
+}
+```
+
+---
+
+## System prompt / AGENT.md
+
+For Codebuff to use memory proactively — storing useful things it discovers, not just when explicitly asked — add this to your project's `AGENT.md` or system prompt:
+
+```markdown
+## Memory (MuninnDB)
+
+You have access to persistent memory via the `muninn_*` MCP tools.
+
+**Store** things worth remembering:
+- Architecture decisions and the reasoning behind them
+- Non-obvious patterns, gotchas, and workarounds discovered while coding
+- User preferences and recurring instructions
+- Important project context (tech stack, deployment setup, constraints)
+
+**Recall** at the start of relevant sessions:
+- Call `muninn_recall` with context about what you're working on
+- Call `muninn_guide` on first connect for vault-specific instructions
+
+**Don't ask** — just store. If you discover something useful, write it to memory without waiting to be told.
+```
+
+This is the key to getting proactive memory behavior. Without it, most agents only use memory when explicitly prompted.
+
+---
+
+## Verify the connection
+
+Start a Codebuff session and ask it to:
+
+```
+Call muninn_guide and tell me what you see.
+```
+
+MuninnDB will return vault-aware usage instructions. If you see tool output, the connection is working.
+
+---
+
+## What Codebuff can remember
+
+Once connected, Codebuff can use MuninnDB to persist:
+
+- **Architectural decisions** — why you chose this structure, what alternatives were rejected
+- **Codebase quirks** — non-obvious patterns, footguns, things that bit you once
+- **Project conventions** — naming, formatting, testing approach
+- **Refactor history** — what was changed and why
+- **Session handoffs** — where you left off on a long-running task
+
+These persist across sessions, across machines (if using a remote MuninnDB instance), and across context resets. The cognitive engine ages them naturally — frequently accessed memories stay sharp, unused ones fade.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `connection refused` | Ensure `muninn start` is running |
+| Tools not appearing | Restart Codebuff after editing the config |
+| Agent not storing proactively | Add the `AGENT.md` / system prompt instructions above |
+| Token not known | Check `~/.muninn/muninn.env` — token is printed on first `muninn start` |

--- a/docs/integrations/github-copilot.md
+++ b/docs/integrations/github-copilot.md
@@ -1,0 +1,104 @@
+# GitHub Copilot + MuninnDB
+
+GitHub Copilot supports MCP servers via VS Code's `.vscode/mcp.json` configuration. This lets Copilot read and write memories through MuninnDB just like any other MCP-capable agent.
+
+---
+
+## Prerequisites
+
+- MuninnDB running locally (`muninn start`) or on a remote host
+- VS Code with the GitHub Copilot extension (v1.250+)
+- Your MuninnDB admin token (printed on first start, or found in `muninn.env`)
+
+---
+
+## Configuration
+
+Add a `.vscode/mcp.json` file to your workspace (or user settings):
+
+```json
+{
+  "servers": {
+    "muninn": {
+      "type": "http",
+      "url": "http://127.0.0.1:8750/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_ADMIN_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Replace `YOUR_ADMIN_TOKEN` with the token from your `muninn.env` file (`MUNINN_ADMIN_TOKEN`).
+
+**No token configured?** If you started MuninnDB without a token, omit the `headers` block entirely:
+
+```json
+{
+  "servers": {
+    "muninn": {
+      "type": "http",
+      "url": "http://127.0.0.1:8750/mcp"
+    }
+  }
+}
+```
+
+---
+
+## Remote host
+
+If MuninnDB is running on a remote server, replace `127.0.0.1` with the server's IP or hostname:
+
+```json
+{
+  "servers": {
+    "muninn": {
+      "type": "http",
+      "url": "http://your-server:8750/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_ADMIN_TOKEN"
+      }
+    }
+  }
+}
+```
+
+> **Tip:** Use `muninn start --listen-host 0.0.0.0` on the remote server so it accepts connections from outside localhost.
+
+---
+
+## Verify the connection
+
+Once configured, open VS Code's Copilot chat panel and ask:
+
+```
+@muninn call muninn_guide
+```
+
+MuninnDB will respond with vault-aware instructions for how to use memory effectively. If you see tool results, you're connected.
+
+---
+
+## OAuth error?
+
+If Copilot shows:
+
+```
+OAuth Client Credentials Required
+This server requires OAuth but doesn't support automatic client registration.
+```
+
+This means Copilot is trying to use OAuth discovery before checking the `Authorization` header. The fix is to ensure the `headers` block is present in your config — Copilot will use the bearer token directly and skip the OAuth flow.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `connection refused` | Make sure `muninn start` is running and port 8750 is reachable |
+| OAuth error | Add the `headers` block with your admin token |
+| Tools not appearing | Restart VS Code after editing `mcp.json` |
+| Token not known | Check `~/.muninn/muninn.env` or re-run `muninn start` — the token is printed on first run |


### PR DESCRIPTION
## Summary

- Adds `docs/integrations/github-copilot.md` — full setup guide covering the bearer token config, OAuth error fix, remote host setup, and troubleshooting
- Adds `docs/integrations/codebuff.md` — setup guide with `AGENT.md` snippet for proactive memory behavior  
- Adds both tools to the README's MCP config section with quickstart snippets

Closes #73, closes #81

## Test Plan
- [x] Docs render correctly (markdown links, code blocks)
- [x] No code changes — docs only