### PR TITLE
fix(ui): clear memory graph when vault is switched (#125)

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -423,7 +423,14 @@ document.addEventListener('alpine:init', () => {
         // Always load these for settings
         this.loadVaults();
       }
-      // Graph loads on explicit button click
+      } else if (view === 'graph') {
+        // Clear graph state on vault change so stale nodes from the previous
+        // vault are not shown. User must click Load Graph again for the new vault.
+        if (this._cy) { this._cy.destroy(); this._cy = null; }
+        if (this._entityCy) { this._entityCy.destroy(); this._entityCy = null; }
+        this.graphLoaded = false;
+        this.entityGraphLoaded = false;
+      }
       if (view === 'cluster') {
         this.loadClusterDashboard();
       } else {

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -422,7 +422,6 @@ document.addEventListener('alpine:init', () => {
 
         // Always load these for settings
         this.loadVaults();
-      }
       } else if (view === 'graph') {
         // Clear graph state on vault change so stale nodes from the previous
         // vault are not shown. User must click Load Graph again for the new vault.


### PR DESCRIPTION
## Summary

- When the user switched vaults while on the Graph view, the old vault's nodes remained on screen
- Root cause: `_onViewEnter()` had no handler for `view === 'graph'`, making `onVaultChange()` a no-op on that view
- Fix: add graph case that destroys both cytoscape instances and resets `graphLoaded`/`entityGraphLoaded` — user clicks Load Graph to fetch the new vault's data

## Test plan
- [ ] Load the Memory Graph for vault A
- [ ] Switch vaults via the selector — graph should clear immediately
- [ ] Click Load Graph — new vault's data loads correctly
- [ ] Repeat for Entity Graph tab

Closes #125