### PR TITLE
feat(ui): auto-populate Evidence IDs from selected memories (#123)

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -2612,7 +2612,10 @@ document.addEventListener('alpine:init', () => {
 
     // ── Decide ─────────────────────────────────────────────────────────────
     openDecideModal() {
-      this.decideModal = { show: true, decision: '', rationale: '', alternatives: '', evidenceIds: '' };
+      const evidenceIds = this.selectedMemoryIds.length > 0
+        ? this.selectedMemoryIds.join('\n')
+        : '';
+      this.decideModal = { show: true, decision: '', rationale: '', alternatives: '', evidenceIds };
     },
 
     async submitDecide() {


### PR DESCRIPTION
## Summary

- When memories are selected on the Memories page and the user clicks Record Decision, the Evidence Memory IDs field now pre-populates with the selected IDs (one per line)
- If no memories are selected, the field opens empty — existing behaviour preserved
- Follows the same `selectedMemoryIds` pattern as `openConsolidate()`
- User can edit/clear the pre-populated IDs before submitting

## Test plan
- [ ] Select one or more memories using the Select button, click Record Decision — Evidence IDs should be pre-populated
- [ ] Click Record Decision without selecting any memories — Evidence IDs field should be empty (existing behaviour)
- [ ] Submit with pre-populated IDs — decision should record correctly

Closes #123