### PR TITLE
fix(plugin): retroactive embed processor respects provider MaxBatchSize()

### DIFF
--- a/internal/plugin/embed/adapters_test.go
+++ b/internal/plugin/embed/adapters_test.go
@@ -19,8 +19,9 @@ func (s *stubEmbedPlugin) Tier() plugin.PluginTier { return plugin.TierEmbed }
 func (s *stubEmbedPlugin) Init(_ context.Context, _ plugin.PluginConfig) error {
 	return nil
 }
-func (s *stubEmbedPlugin) Close() error    { return nil }
-func (s *stubEmbedPlugin) Dimension() int  { return s.dim }
+func (s *stubEmbedPlugin) Close() error       { return nil }
+func (s *stubEmbedPlugin) Dimension() int     { return s.dim }
+func (s *stubEmbedPlugin) MaxBatchSize() int  { return 32 }
 func (s *stubEmbedPlugin) Embed(_ context.Context, _ []string) ([]float32, error) {
 	return s.embedResult, s.embedErr
 }

--- a/internal/plugin/embed/embed.go
+++ b/internal/plugin/embed/embed.go
@@ -178,6 +178,11 @@ func (s *EmbedService) Dimension() int {
 	return s.dim
 }
 
+// MaxBatchSize delegates to the underlying provider's optimal batch size.
+func (s *EmbedService) MaxBatchSize() int {
+	return s.provider.MaxBatchSize()
+}
+
 // Close releases external connections.
 func (s *EmbedService) Close() error {
 	s.mu.Lock()

--- a/internal/plugin/health_test.go
+++ b/internal/plugin/health_test.go
@@ -25,6 +25,7 @@ func (m *healthMockEmbed) Tier() PluginTier                                     
 func (m *healthMockEmbed) Init(_ context.Context, _ PluginConfig) error          { return nil }
 func (m *healthMockEmbed) Close() error                                          { return nil }
 func (m *healthMockEmbed) Dimension() int                                        { return m.dim }
+func (m *healthMockEmbed) MaxBatchSize() int                                     { return 32 }
 func (m *healthMockEmbed) Embed(_ context.Context, texts []string) ([]float32, error) {
 	m.callCount.Add(1)
 	if m.embedErr != nil {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -44,6 +44,12 @@ type EmbedPlugin interface {
 	// Dimension returns the embedding vector dimension (384, 768, 1024, 1536).
 	// Detected at Init time by sending a probe text to the provider.
 	Dimension() int
+
+	// MaxBatchSize returns the maximum number of texts per Embed call.
+	// The retroactive processor uses this to size micro-batches, so embeddings
+	// are generated at the provider's optimal batch size rather than a
+	// hardcoded constant.
+	MaxBatchSize() int
 }
 
 // EnrichPlugin generates summaries, entities, and relationships via LLM.

--- a/internal/plugin/registry_test.go
+++ b/internal/plugin/registry_test.go
@@ -25,7 +25,8 @@ type mockEmbedPlugin struct {
 func (m *mockEmbedPlugin) Embed(ctx context.Context, texts []string) ([]float32, error) {
 	return make([]float32, len(texts)*384), nil
 }
-func (m *mockEmbedPlugin) Dimension() int { return 384 }
+func (m *mockEmbedPlugin) Dimension() int    { return 384 }
+func (m *mockEmbedPlugin) MaxBatchSize() int { return 32 }
 
 // mockEnrichPlugin is a mock enrich plugin
 type mockEnrichPlugin struct {

--- a/internal/plugin/retroactive.go
+++ b/internal/plugin/retroactive.go
@@ -16,10 +16,6 @@ const pollInterval = 3 * time.Second
 // responsive; any remaining unprocessed engrams are picked up on the next tick.
 const maxBatchSize = 1000
 
-// embedMicroBatch is the number of engrams embedded in one ORT inference call.
-// Matches localMaxBatch in the embed package so the provider runs at full batch.
-const embedMicroBatch = 32
-
 // maxBackoff is the upper bound for exponential back-off when the store
 // returns persistent errors on CountWithoutFlag / ScanWithoutFlag.
 const maxBackoff = 5 * time.Minute
@@ -168,7 +164,7 @@ func (rp *RetroactiveProcessor) backoff(ctx context.Context, consecutiveErrors i
 // in one pass. Returns true on success (including zero-work passes), false if
 // a store-level error prevents processing (used by run() for backoff decisions).
 //
-// For EmbedPlugin: accumulates embedMicroBatch engrams and issues one ORT
+// For EmbedPlugin: accumulates up to MaxBatchSize() engrams and issues one
 // inference call per micro-batch, then scatters vectors back individually.
 // For EnrichPlugin: processes one engram at a time (LLM call per engram).
 func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
@@ -199,9 +195,15 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 	batchCount := 0
 
 	// For embed plugins, accumulate a micro-batch and embed in one ORT call.
+	// The batch size is determined by the plugin's MaxBatchSize() so the provider
+	// runs at its optimal throughput rather than a hardcoded constant.
 	embedPlugin, isEmbedPlugin := rp.plugin.(EmbedPlugin)
-	microEngrams := make([]*Engram, 0, embedMicroBatch)
-	microTexts := make([]string, 0, embedMicroBatch)
+	microBatchSize := 32 // fallback for the non-embed path (never used there)
+	if isEmbedPlugin {
+		microBatchSize = embedPlugin.MaxBatchSize()
+	}
+	microEngrams := make([]*Engram, 0, microBatchSize)
+	microTexts := make([]string, 0, microBatchSize)
 
 	flushMicroBatch := func() {
 		if !isEmbedPlugin || len(microEngrams) == 0 {
@@ -301,7 +303,7 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 			microEngrams = append(microEngrams, eng)
 			microTexts = append(microTexts, eng.Concept+" "+eng.Content)
 			batchCount++
-			if len(microEngrams) >= embedMicroBatch {
+			if len(microEngrams) >= microBatchSize {
 				flushMicroBatch()
 			}
 			if batchCount%100 == 0 {

--- a/internal/transport/rest/targeted_boost_test.go
+++ b/internal/transport/rest/targeted_boost_test.go
@@ -184,7 +184,8 @@ func (p *testEmbedPlugin) Close() error                                        {
 func (p *testEmbedPlugin) Embed(_ context.Context, _ []string) ([]float32, error) {
 	return []float32{0.1, 0.2}, nil
 }
-func (p *testEmbedPlugin) Dimension() int { return 2 }
+func (p *testEmbedPlugin) Dimension() int    { return 2 }
+func (p *testEmbedPlugin) MaxBatchSize() int { return 32 }
 
 // ---------------------------------------------------------------------------
 // HandleReplicationStatus/Lag/Promote — exported wrappers (0% → covered)


### PR DESCRIPTION
## Summary

- The retroactive embed processor was hardcoded to batch in groups of 32, ignoring the provider's `MaxBatchSize()`. Ollama caps at 1, OpenAI at 2048, Voyage at 128 — none were honoured.
- Added `MaxBatchSize() int` to the `EmbedPlugin` interface.
- Implemented on `EmbedService`, delegating to the underlying provider.
- Replaced `const embedMicroBatch = 32` in `retroactive.go` with `embedPlugin.MaxBatchSize()` at runtime.
- Updated four mock/stub implementations (`mockEmbedPlugin`, `healthMockEmbed`, `testEmbedPlugin`, `stubEmbedPlugin`) to satisfy the new interface.

Resolves #122

## Test Plan
- [x] `go build ./...` clean
- [x] `go test ./... -short` all pass
- [x] Opus code review approved (stale comment fixed)