### PR TITLE
fix(ui): fix vault selector staleness, entity graph remote error, and live feed (#127)

### DIFF
--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -437,6 +437,42 @@ func (s *Server) handleMCPInfo(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleEntityGraph returns the entity→relationship graph for the vault.
+// This proxies engine.ExportGraph so the browser does not need to call the MCP
+// server directly — which fails in remote deployments where the MCP address
+// resolves to 127.0.0.1 from the server's perspective but not the browser's.
+func (s *Server) handleEntityGraph(w http.ResponseWriter, r *http.Request) {
+	vault := ctxVault(r)
+	if !isValidVaultName(vault) {
+		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "invalid vault name")
+		return
+	}
+	includeEngrams := r.URL.Query().Get("include_engrams") != "false"
+
+	graph, err := s.engine.ExportGraph(r.Context(), vault, includeEngrams)
+	if err != nil {
+		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
+		return
+	}
+
+	resp := EntityGraphResponse{
+		Nodes: make([]EntityGraphNode, 0, len(graph.Nodes)),
+		Edges: make([]EntityGraphEdge, 0, len(graph.Edges)),
+	}
+	for _, n := range graph.Nodes {
+		resp.Nodes = append(resp.Nodes, EntityGraphNode{ID: n.ID, Type: n.Type})
+	}
+	for _, e := range graph.Edges {
+		resp.Edges = append(resp.Edges, EntityGraphEdge{
+			From:    e.From,
+			To:      e.To,
+			RelType: e.RelType,
+			Weight:  e.Weight,
+		})
+	}
+	s.sendJSON(w, http.StatusOK, resp)
+}
+
 // EmbedStatusResponse is the response for GET /api/admin/embed/status.
 type EmbedStatusResponse struct {
 	Provider      string `json:"provider"`

--- a/internal/transport/rest/engine_adapter.go
+++ b/internal/transport/rest/engine_adapter.go
@@ -523,6 +523,10 @@ Available operations:
 	return guide, nil
 }
 
+func (w *RESTEngineWrapper) ExportGraph(ctx context.Context, vault string, includeEngrams bool) (*engine.ExportGraph, error) {
+	return w.engine.ExportGraph(ctx, vault, includeEngrams)
+}
+
 func (w *RESTEngineWrapper) GetBatchEngramLinks(ctx context.Context, req *BatchGetEngramLinksRequest) (*BatchGetEngramLinksResponse, error) {
 	vault := req.Vault
 	if vault == "" {

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -203,6 +203,7 @@ func NewServer(addr string, engine EngineAPI, authStore *auth.Store, sessionSecr
 	mux.HandleFunc("PUT /api/admin/password", s.withAdminMiddleware(s.handleChangeAdminPassword(authStore)))
 	mux.HandleFunc("GET /api/admin/embed/status", s.withAdminMiddleware(s.handleEmbedStatus))
 	mux.HandleFunc("GET /api/admin/mcp-info", s.withAdminMiddleware(s.handleMCPInfo))
+	mux.HandleFunc("GET /api/admin/entity-graph", s.withAdminMiddleware(s.handleEntityGraph))
 	mux.HandleFunc("GET /api/admin/plugins", s.withAdminMiddleware(s.handlePlugins))
 	mux.HandleFunc("GET /api/admin/vault/{name}/plasticity", s.withAdminMiddleware(s.handleGetVaultPlasticity(authStore)))
 	mux.HandleFunc("PUT /api/admin/vault/{name}/plasticity", s.withAdminMiddleware(s.handlePutVaultPlasticity(authStore)))

--- a/internal/transport/rest/server_test.go
+++ b/internal/transport/rest/server_test.go
@@ -286,6 +286,10 @@ func (m *MockEngine) GetProcessorStats() []plugin.RetroactiveStats {
 	return nil
 }
 
+func (m *MockEngine) ExportGraph(ctx context.Context, vault string, includeEngrams bool) (*engine.ExportGraph, error) {
+	return &engine.ExportGraph{}, nil
+}
+
 // backupMockEngine embeds MockEngine but creates a real Pebble checkpoint so
 // the verification step has something to open.
 type backupMockEngine struct {

--- a/internal/transport/rest/types.go
+++ b/internal/transport/rest/types.go
@@ -133,6 +133,9 @@ type EngineAPI interface {
 	GetContradictions(ctx context.Context, vault string) (*ContradictionsResponse, error)
 	ResolveContradiction(ctx context.Context, vault, idA, idB string) error
 	GetGuide(ctx context.Context, vault string) (string, error)
+	// ExportGraph builds the entity→relationship graph for the vault.
+	// If includeEngrams is true the entity types are enriched from the entity record table.
+	ExportGraph(ctx context.Context, vault string, includeEngrams bool) (*engine.ExportGraph, error)
 }
 
 // ── Web UI types ─────────────────────────────────────────────────────────
@@ -437,4 +440,24 @@ type HealthResponse struct {
 // ReadyResponse is returned by the ready check endpoint.
 type ReadyResponse struct {
 	Status string `json:"status"`
+}
+
+// EntityGraphResponse is returned by GET /api/admin/entity-graph.
+type EntityGraphResponse struct {
+	Nodes []EntityGraphNode `json:"nodes"`
+	Edges []EntityGraphEdge `json:"edges"`
+}
+
+// EntityGraphNode is a node in the entity graph.
+type EntityGraphNode struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+// EntityGraphEdge is an edge in the entity graph.
+type EntityGraphEdge struct {
+	From    string  `json:"from"`
+	To      string  `json:"to"`
+	RelType string  `json:"rel_type"`
+	Weight  float32 `json:"weight"`
 }

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -353,13 +353,13 @@ func (s *Server) broadcaster(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s.broadcastStats(&prevCount)
+			s.broadcastStats(ctx, &prevCount)
 		}
 	}
 }
 
-func (s *Server) broadcastStats(prevCount *int64) {
-	resp, err := s.engine.Stat(context.Background(), &rest.StatRequest{})
+func (s *Server) broadcastStats(ctx context.Context, prevCount *int64) {
+	resp, err := s.engine.Stat(ctx, &rest.StatRequest{})
 	if err != nil {
 		return
 	}
@@ -381,28 +381,49 @@ func (s *Server) broadcastStats(prevCount *int64) {
 
 	// Count-diff: push memory_added if new engrams appeared.
 	if *prevCount > 0 && resp.EngramCount > *prevCount {
-		s.broadcastNewestEngram()
+		s.broadcastNewestEngram(ctx)
 	}
 	*prevCount = resp.EngramCount
 }
 
-func (s *Server) broadcastNewestEngram() {
-	resp, err := s.engine.ListEngrams(context.Background(), &rest.ListEngramsRequest{
-		Vault:  "default",
-		Limit:  1,
-		Offset: 0,
-	})
-	if err != nil || len(resp.Engrams) == 0 {
+func (s *Server) broadcastNewestEngram(ctx context.Context) {
+	// Search all vaults so users who only use non-default vaults see live-feed events.
+	vaults, err := s.engine.ListVaults(ctx)
+	if err != nil || len(vaults) == 0 {
 		return
 	}
-	e := resp.Engrams[0]
+
+	var newestID, newestConcept, newestVault string
+	var newestCreatedAt int64
+	for _, vault := range vaults {
+		resp, listErr := s.engine.ListEngrams(ctx, &rest.ListEngramsRequest{
+			Vault:  vault,
+			Limit:  1,
+			Offset: 0,
+			Sort:   "created",
+		})
+		if listErr != nil || len(resp.Engrams) == 0 {
+			continue
+		}
+		e := resp.Engrams[0]
+		if e.CreatedAt > newestCreatedAt {
+			newestCreatedAt = e.CreatedAt
+			newestID = e.ID
+			newestConcept = e.Concept
+			newestVault = e.Vault
+		}
+	}
+	if newestID == "" {
+		return
+	}
+
 	msg := statsMsg{
 		Type: "memory_added",
 		Data: map[string]interface{}{
-			"id":        e.ID,
-			"concept":   e.Concept,
-			"vault":     e.Vault,
-			"createdAt": e.CreatedAt,
+			"id":        newestID,
+			"concept":   newestConcept,
+			"vault":     newestVault,
+			"createdAt": newestCreatedAt,
 		},
 	}
 	data, err := json.Marshal(msg)

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -184,6 +184,10 @@ func (m *mockEngine) GetProcessorStats() []plugin.RetroactiveStats {
 	return nil
 }
 
+func (m *mockEngine) ExportGraph(ctx context.Context, vault string, includeEngrams bool) (*engine.ExportGraph, error) {
+	return &engine.ExportGraph{}, nil
+}
+
 func makeMockFS() fs.FS {
 	return fstest.MapFS{
 		"static/dist/app.css":   &fstest.MapFile{Data: []byte("/* css */")},

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -22,6 +22,7 @@ document.addEventListener('alpine:init', () => {
     liveFeed: [],
     _activityChart: null,
     _prevEngramCount: 0,
+    _prevVaultCount: 0,
 
     // Memories
     memories: [],
@@ -513,6 +514,14 @@ document.addEventListener('alpine:init', () => {
         if (this._prevEngramCount > 0 && newCount > this._prevEngramCount) {
           this._fetchNewestEngram();
         }
+
+        // Vault count-diff: refresh vault list when a vault is added or removed.
+        // Guard with > 0 on first message (learn current count without triggering a reload).
+        const newVaultCount = msg.data.vaultCount || 0;
+        if (this._prevVaultCount > 0 && newVaultCount !== this._prevVaultCount) {
+          this.loadVaults();
+        }
+        this._prevVaultCount = newVaultCount;
 
         // Re-fetch stats scoped to the selected vault instead of using
         // the global broadcast values.
@@ -1254,88 +1263,48 @@ document.addEventListener('alpine:init', () => {
     async loadEntityGraph() {
       this.entityGraphStatus = 'Loading entity graph…';
       try {
-        // Get MCP info first to find the MCP endpoint
-        const mcpInfo = await this.apiCall('/api/admin/mcp-info');
-        const mcpURL = mcpInfo.url || 'http://localhost:8750/mcp';
+        // Call the REST endpoint directly instead of the MCP server.
+        // The previous approach fetched from http://127.0.0.1:8750/mcp which
+        // is unreachable from remote browsers (127.0.0.1 resolves to the
+        // browser's own loopback, not the server's).
+        const data = await this.apiCall(
+          '/api/admin/entity-graph?vault=' + encodeURIComponent(this.vault) + '&include_engrams=true'
+        );
 
-        // Call muninn_export_graph via MCP
-        const mcpRequest = {
-          jsonrpc: '2.0',
-          id: 1,
-          method: 'tools/call',
-          params: {
-            name: 'muninn_export_graph',
-            arguments: {
-              vault: this.vault,
-              format: 'json-ld',
-              include_engrams: true
-            }
-          }
-        };
-
-        const resp = await fetch(mcpURL, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(mcpRequest)
-        });
-
-        if (!resp.ok) {
-          const text = await resp.text().catch(() => resp.statusText);
-          throw new Error('MCP error: ' + resp.status + ' ' + text);
-        }
-
-        const json = await resp.json();
-        if (json.error) {
-          throw new Error('MCP error: ' + json.error.message);
-        }
-
-        // Parse the result
-        const result = JSON.parse(json.result.content[0].text);
-        const data = JSON.parse(result.data);
-        const graph = data['@graph'] || [];
-
-        // Extract nodes and edges from JSON-LD
         const nodes = [];
         const edges = [];
         const nodeIdSet = new Set();
 
-        graph.forEach(item => {
-          if (item['@type'] === 'muninn:Entity') {
-            const entityId = item['@id'] || '';
-            const entityName = item.name || entityId.replace('muninn:entity/', '');
-            const entityType = (item['muninn:entityType'] || 'other').toLowerCase();
+        (data.nodes || []).forEach(n => {
+          const entityType = (n.type || 'other').toLowerCase();
+          nodeIdSet.add(n.id);
+          nodes.push({
+            id: n.id,
+            label: n.id,
+            type: entityType,
+            title: n.id + ' (' + entityType + ')',
+            shape: 'dot',
+            size: 16,
+            color: this.getEntityTypeColor(entityType),
+            font: { size: 11, color: '#e2e8f0' },
+            borderWidth: 2,
+            borderWidthSelected: 3,
+            borderColor: 'rgba(255,255,255,0.2)'
+          });
+        });
 
-            nodeIdSet.add(entityId);
-            nodes.push({
-              id: entityId,
-              label: entityName,
-              title: entityName + ' (' + entityType + ')',
-              shape: 'dot',
-              size: 16,
-              color: this.getEntityTypeColor(entityType),
-              font: { size: 11, color: '#e2e8f0' },
-              borderWidth: 2,
-              borderWidthSelected: 3,
-              borderColor: 'rgba(255,255,255,0.2)'
+        (data.edges || []).forEach(e => {
+          if (nodeIdSet.has(e.from) && nodeIdSet.has(e.to)) {
+            edges.push({
+              from: e.from,
+              to: e.to,
+              label: e.rel_type,
+              arrows: 'to',
+              color: 'rgba(168,85,247,0.4)',
+              font: { size: 10, color: '#ccc' },
+              width: Math.max(1, (e.weight || 0.5) * 3),
+              smooth: { type: 'continuous' }
             });
-          } else if (item['@type'] === 'muninn:Relationship') {
-            const from = item['muninn:from'] || '';
-            const to = item['muninn:to'] || '';
-            const relType = item['muninn:relType'] || '';
-            const weight = item['muninn:weight'] || 0.5;
-
-            if (nodeIdSet.has(from) && nodeIdSet.has(to)) {
-              edges.push({
-                from: from,
-                to: to,
-                label: relType,
-                arrows: 'to',
-                color: 'rgba(168,85,247,0.4)',
-                font: { size: 10, color: '#ccc' },
-                width: Math.max(1, weight * 3),
-                smooth: { type: 'continuous' }
-              });
-            }
           }
         });
 
@@ -1411,7 +1380,7 @@ document.addEventListener('alpine:init', () => {
         // Add click handler to show entity info
         this._entityCy.on('tap', 'node', (evt) => {
           const node = evt.target;
-          this.addNotification('info', node.data('label') + ' (' + node.data('id').replace('muninn:entity/', '') + ')');
+          this.addNotification('info', node.data('label') + ' (' + node.data('type') + ')');
         });
 
         this.entityGraphLoaded = true;


### PR DESCRIPTION
## Summary

Fixes three UI bugs reported in #127:

- **Vault selector shows only "default"**: Added `_prevVaultCount` tracking in Alpine.js state. When `stats_update` SSE events report a changed vault count the selector is refreshed via `loadVaults()`, so newly created vaults appear without a page reload.

- **Entity Graph shows NetworkError in remote deployments**: The old implementation fetched `http://127.0.0.1:8750/mcp` directly from the browser, which fails when the browser is not co-located with the server. Replaced with a new REST endpoint `GET /api/admin/entity-graph` (protected by `withAdminMiddleware`, vault name validated) that proxies `engine.ExportGraph()`. `EntityGraph*` response types live in `types.go` per project convention.

- **Live Feed empty for non-default vaults**: `broadcastNewestEngram()` previously hardcoded `Vault: "default"`. Rewrote it to iterate all vaults via `engine.ListVaults()`, pick the globally newest engram by `CreatedAt` (explicit `Sort: "created"`), and broadcast it. Broadcaster `context` is now threaded through so storage calls cancel on server shutdown.

- **Bonus**: Fixed stale `muninn:entity/` prefix strip in the entity-graph tap handler (REST endpoint returns plain entity IDs, not MCP URIs); tap notification now shows entity type rather than duplicating the ID.

## Test Plan

- [ ] All existing tests pass (`go test ./...` — zero failures)
- [ ] Build clean (`go build ./...`)
- [ ] Manual: create a new vault → vault selector updates within 5 s without page reload
- [ ] Manual: Entity Graph tab loads without NetworkError when accessing UI from a remote host
- [ ] Manual: write to a non-default vault → Live Feed shows the new entry