### PR TITLE
fix(ui): fix credentials, live feed dedup, and entity-graph vault param

### DIFF
--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -442,7 +442,10 @@ func (s *Server) handleMCPInfo(w http.ResponseWriter, r *http.Request) {
 // server directly — which fails in remote deployments where the MCP address
 // resolves to 127.0.0.1 from the server's perspective but not the browser's.
 func (s *Server) handleEntityGraph(w http.ResponseWriter, r *http.Request) {
-	vault := ctxVault(r)
+	vault := r.URL.Query().Get("vault")
+	if vault == "" {
+		vault = "default"
+	}
 	if !isValidVaultName(vault) {
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "invalid vault name")
 		return

--- a/internal/transport/rest/admin_handlers_test.go
+++ b/internal/transport/rest/admin_handlers_test.go
@@ -675,3 +675,98 @@ func TestHandleRenameVault_DuplicateDetection(t *testing.T) {
 		t.Errorf("expected conflict=my-vault, got %q", resp["conflict"])
 	}
 }
+
+// TestEntityGraph_EmptyVaultDefaultsToDefault verifies that omitting the vault
+// query parameter defaults to the "default" vault.
+func TestEntityGraph_EmptyVaultDefaultsToDefault(t *testing.T) {
+	srv := newTestServer(t, newTestAuthStore(t))
+
+	req := httptest.NewRequest("GET", "/api/admin/entity-graph", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with no vault param, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestEntityGraph returns nodes/edges from the mock engine.
+func TestEntityGraph(t *testing.T) {
+	srv := newTestServer(t, newTestAuthStore(t))
+
+	req := httptest.NewRequest("GET", "/api/admin/entity-graph?vault=default", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp EntityGraphResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// MockEngine.ExportGraph returns empty graph — just verify the shape.
+	if resp.Nodes == nil {
+		t.Error("expected non-nil nodes slice")
+	}
+	if resp.Edges == nil {
+		t.Error("expected non-nil edges slice")
+	}
+}
+
+// TestEntityGraph_InvalidVault returns 400 for an invalid vault name.
+func TestEntityGraph_InvalidVault(t *testing.T) {
+	srv := newTestServer(t, newTestAuthStore(t))
+
+	req := httptest.NewRequest("GET", "/api/admin/entity-graph?vault=../../etc/passwd", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid vault, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestEntityGraph_RequiresAdminAuth verifies 401 is returned when auth is
+// configured and no session cookie is present.
+func TestEntityGraph_RequiresAdminAuth(t *testing.T) {
+	store := newTestAuthStore(t)
+	secret := []byte("test-session-secret-32bytes-ok!!")
+	srv := NewServer("localhost:0", &MockEngine{}, store, secret, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+
+	req := httptest.NewRequest("GET", "/api/admin/entity-graph?vault=default", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without session cookie, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestEntityGraph_AllowedWithValidSession verifies 200 with a valid session cookie.
+func TestEntityGraph_AllowedWithValidSession(t *testing.T) {
+	store := newTestAuthStore(t)
+	secret := []byte("test-session-secret-32bytes-ok!!")
+	srv := NewServer("localhost:0", &MockEngine{}, store, secret, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+
+	token, err := auth.NewSessionToken("admin", secret)
+	if err != nil {
+		t.Fatalf("NewSessionToken: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/admin/entity-graph?vault=default", nil)
+	req.AddCookie(&http.Cookie{Name: "muninn_session", Value: token})
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with valid session cookie, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp EntityGraphResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Nodes == nil || resp.Edges == nil {
+		t.Error("expected non-nil nodes and edges")
+	}
+}

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -21,7 +21,6 @@ document.addEventListener('alpine:init', () => {
     workerStats: [],
     liveFeed: [],
     _activityChart: null,
-    _prevEngramCount: 0,
     _prevVaultCount: 0,
 
     // Memories
@@ -508,13 +507,6 @@ document.addEventListener('alpine:init', () => {
 
     _handleLiveMessage(msg) {
       if (msg.type === 'stats_update') {
-        const newCount = msg.data.engramCount || 0;
-
-        // Count-diff: if engrams increased, fetch newest as live feed entry
-        if (this._prevEngramCount > 0 && newCount > this._prevEngramCount) {
-          this._fetchNewestEngram();
-        }
-
         // Vault count-diff: refresh vault list when a vault is added or removed.
         // Guard with > 0 on first message (learn current count without triggering a reload).
         const newVaultCount = msg.data.vaultCount || 0;
@@ -527,32 +519,19 @@ document.addEventListener('alpine:init', () => {
         // the global broadcast values.
         this.loadStats();
       } else if (msg.type === 'memory_added') {
-        this.liveFeed.unshift(msg.data);
-        if (this.liveFeed.length > 20) this.liveFeed.pop();
-      }
-    },
-
-    async _fetchNewestEngram() {
-      try {
-        const data = await this.apiCall(
-          '/api/engrams?vault=' + encodeURIComponent(this.vault) + '&limit=1&offset=0'
-        );
-        const e = (data.engrams || [])[0];
-        if (e) {
-          this.liveFeed.unshift({
-            id: e.id,
-            concept: e.concept,
-            vault: e.vault || this.vault,
-            createdAt: e.created_at,
-          });
+        // Deduplicate: the server broadcasts memory_added for new engrams across all
+        // vaults. Guard against any edge-case double-delivery by ID.
+        if (!this.liveFeed.some(item => item.id === msg.data.id)) {
+          this.liveFeed.unshift(msg.data);
           if (this.liveFeed.length > 20) this.liveFeed.pop();
         }
-      } catch (_) {}
+      }
     },
 
     // ── API helpers ────────────────────────────────────────────────────────
     async apiCall(url, opts = {}) {
       const res = await fetch(url, {
+        credentials: 'same-origin', // always send session cookie for admin endpoints
         headers: { 'Content-Type': 'application/json', ...(opts.headers || {}) },
         ...opts,
       });
@@ -573,7 +552,6 @@ document.addEventListener('alpine:init', () => {
           storageBytes: data.storage_bytes  || data.storageBytes || 0,
           indexSize:    data.index_size     || data.indexSize    || 0,
         };
-        this._prevEngramCount = this.stats.engramCount;
       } catch (err) {
         this.addNotification('error', 'Stats: ' + err.message);
       }


### PR DESCRIPTION
## Summary

- **Entity graph credentials**: Added `credentials: 'same-origin'` to `apiCall()` so the `muninn_session` cookie is included on all fetch requests. Without this, admin endpoints returned 401, surfaced as NetworkError in the browser.
- **Live feed duplicate keys**: Removed the `_fetchNewestEngram()` / `_prevEngramCount` count-diff code path. Since PR #131 fixed the server to broadcast `memory_added` for all vaults, this second path caused duplicate entries and Alpine.js `x-for` key warnings. Added a belt-and-suspenders dedup guard by ID.
- **Entity graph vault param not validated**: `handleEntityGraph` was calling `ctxVault(r)` which reads from auth middleware context, but `AdminAPIMiddleware` only validates the session cookie and never sets `auth.ContextVault`. The `?vault=` query parameter was silently ignored — the endpoint always queried `"default"`. Fixed to read from `r.URL.Query().Get("vault")` directly, then validated with `isValidVaultName()` to block path traversal.

## Tests

Added 5 new tests for `/api/admin/entity-graph`:
- `TestEntityGraph_EmptyVaultDefaultsToDefault` — no `?vault=` param → 200
- `TestEntityGraph` — explicit `?vault=default` → 200 with correct response shape
- `TestEntityGraph_InvalidVault` — `?vault=../../etc/passwd` → 400
- `TestEntityGraph_RequiresAdminAuth` — no session cookie when auth configured → 401
- `TestEntityGraph_AllowedWithValidSession` — valid `muninn_session` cookie → 200

## Test Plan
- [ ] All 5 new tests pass (`go test ./internal/transport/rest/... -run "^TestEntityGraph"`)
- [ ] Full suite passes (`go test ./...`)
- [ ] Entity graph loads in browser (requires `muninn_session` cookie to be sent)
- [ ] Live feed shows entries without duplicate keys