### PR TITLE
fix(ui): logs clear button now clears server-side ring buffer

### DIFF
--- a/internal/logging/ring.go
+++ b/internal/logging/ring.go
@@ -62,6 +62,14 @@ func (rb *RingBuffer) Add(e LogEntry) {
 	}
 }
 
+// Clear removes all entries from the ring buffer.
+func (rb *RingBuffer) Clear() {
+	rb.mu.Lock()
+	rb.head = 0
+	rb.count = 0
+	rb.mu.Unlock()
+}
+
 // Snapshot returns all current entries in insertion order (oldest first).
 func (rb *RingBuffer) Snapshot() []LogEntry {
 	rb.mu.Lock()

--- a/internal/logging/ring_test.go
+++ b/internal/logging/ring_test.go
@@ -156,3 +156,24 @@ func TestRingHandler_EnabledDelegatesToBase(t *testing.T) {
 		t.Error("ERROR should be enabled when base is Warn+")
 	}
 }
+
+func TestRingBuffer_Clear(t *testing.T) {
+	rb := logging.NewRingBuffer(5, nil)
+	rb.Add(logging.LogEntry{Msg: "a"})
+	rb.Add(logging.LogEntry{Msg: "b"})
+	rb.Add(logging.LogEntry{Msg: "c"})
+
+	rb.Clear()
+
+	snap := rb.Snapshot()
+	if len(snap) != 0 {
+		t.Fatalf("expected 0 entries after Clear, got %d", len(snap))
+	}
+
+	// Verify the buffer is usable after clearing.
+	rb.Add(logging.LogEntry{Msg: "d"})
+	snap = rb.Snapshot()
+	if len(snap) != 1 || snap[0].Msg != "d" {
+		t.Errorf("expected [d] after Clear + Add, got %+v", snap)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -113,10 +113,12 @@ func NewServer(webFS fs.FS, engine rest.EngineAPI, apiHandler http.Handler, auth
 	if s.authStore != nil && len(s.sessionSecret) > 0 {
 		mux.HandleFunc("GET /api/auth/check", s.authStore.AdminAPIMiddleware(s.sessionSecret, authCheckHandler))
 		mux.HandleFunc("GET /logs", s.authStore.AdminAPIMiddleware(s.sessionSecret, s.handleLogs))
+		mux.HandleFunc("DELETE /logs", s.authStore.AdminAPIMiddleware(s.sessionSecret, s.handleClearLogs))
 		mux.HandleFunc("/events", s.authStore.AdminAPIMiddleware(s.sessionSecret, s.handleSSE))
 	} else {
 		mux.HandleFunc("GET /api/auth/check", authCheckHandler)
 		mux.HandleFunc("GET /logs", s.handleLogs)
+		mux.HandleFunc("DELETE /logs", s.handleClearLogs)
 		mux.HandleFunc("/events", s.handleSSE)
 	}
 	mux.Handle("/api/", apiHandler)
@@ -204,6 +206,14 @@ func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	json.NewEncoder(w).Encode(out)
+}
+
+// handleClearLogs empties the in-memory ring buffer so the Logs page starts fresh.
+func (s *Server) handleClearLogs(w http.ResponseWriter, r *http.Request) {
+	if s.ring != nil {
+		s.ring.Clear()
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // setCORSIfAllowed sets Access-Control-Allow-Origin + Vary: Origin if the

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -724,3 +724,57 @@ func TestSessionCookie_NoSecureFlagWithoutTLS(t *testing.T) {
 		t.Errorf("expected Set-Cookie to NOT contain Secure flag, got: %q", setCookie)
 	}
 }
+
+func TestClearLogs_EmptiesRing(t *testing.T) {
+	ring := logging.NewRingBuffer(10, nil)
+	ring.Add(logging.LogEntry{Msg: "entry1"})
+	ring.Add(logging.LogEntry{Msg: "entry2"})
+
+	webFS := makeMockFS()
+	eng := &mockEngine{}
+	srv, err := ui.NewServer(webFS, eng, http.NotFoundHandler(), nil, nil, ring, nil, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := httptest.NewRequest("DELETE", "/logs", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+	if len(ring.Snapshot()) != 0 {
+		t.Error("expected ring buffer to be empty after DELETE /logs")
+	}
+}
+
+func TestClearLogs_RequiresAuth(t *testing.T) {
+	srv, _, _ := newAuthServer(t, nil)
+
+	req := httptest.NewRequest("DELETE", "/logs", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without session cookie, got %d", w.Code)
+	}
+}
+
+func TestClearLogs_AllowedWithValidSession(t *testing.T) {
+	srv, _, secret := newAuthServer(t, nil)
+
+	token, err := auth.NewSessionToken("admin", secret)
+	if err != nil {
+		t.Fatalf("NewSessionToken: %v", err)
+	}
+
+	req := httptest.NewRequest("DELETE", "/logs", nil)
+	req.AddCookie(&http.Cookie{Name: "muninn_session", Value: token})
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 with valid session, got %d", w.Code)
+	}
+}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1938,7 +1938,7 @@ Authorization = "Bearer &lt;token from %USERPROFILE%\.muninn\mcp.token&gt;"</pre
           <input type="checkbox" x-model="autoScroll" style="accent-color:#3b82f6;">
           Auto-scroll
         </label>
-        <button @click="entries = []" style="font-size:0.75rem;color:var(--text-muted);background:none;border:none;cursor:pointer;margin-left:auto;" onmouseover="this.style.color='var(--text-secondary)'" onmouseout="this.style.color='var(--text-muted)'">Clear</button>
+        <button @click="clearLogs()" style="font-size:0.75rem;color:var(--text-muted);background:none;border:none;cursor:pointer;margin-left:auto;" onmouseover="this.style.color='var(--text-secondary)'" onmouseout="this.style.color='var(--text-muted)'">Clear</button>
       </div>
       <!-- Log container — fills remaining height, newest entry at top -->
       <div id="log-container" style="font-family:monospace;font-size:0.75rem;background:var(--bg-elevated);border-radius:0.375rem;padding:0.5rem;flex:1;min-height:0;overflow-y:auto;">
@@ -3078,6 +3078,15 @@ function logsTab() {
                     } catch (_) {}
                 });
             }
+        },
+
+        clearLogs() {
+            fetch('/logs', { method: 'DELETE', credentials: 'same-origin' })
+                .catch(() => {})
+                .finally(() => {
+                    this.entries = [];
+                    this._applyFilters();
+                });
         },
 
         scrollToTop() {


### PR DESCRIPTION
## Summary

Fixes #134 — the Clear button on the Logs page was only clearing the Alpine.js local `entries[]` array. On refresh or SSE reconnect, all old logs reappeared from the server's ring buffer.

- Added `RingBuffer.Clear()` — resets `head` and `count` under mutex (O(1), thread-safe, buffer stays allocated for reuse)
- Added `DELETE /logs` endpoint (`handleClearLogs`) behind admin session auth, mirroring `GET /logs`
- Updated the Clear button to call `fetch('/logs', {method:'DELETE', credentials:'same-origin'})` and clear local state in `.finally()` so the UI clears even on transient errors

## Test Plan
- [ ] `TestRingBuffer_Clear` — clears, asserts empty, verifies buffer usable after
- [ ] `TestClearLogs_EmptiesRing` — 204 + ring empty after DELETE /logs
- [ ] `TestClearLogs_RequiresAuth` — 401 without session cookie
- [ ] `TestClearLogs_AllowedWithValidSession` — 204 with valid cookie