### PR TITLE
fix(sdk): send vault as query param on all POST/PUT endpoints

### DIFF
--- a/sdk/go/muninn/client.go
+++ b/sdk/go/muninn/client.go
@@ -64,8 +64,11 @@ func (c *Client) Write(ctx context.Context, vault, concept, content string, tags
 		return "", fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	q := url.Values{}
+	q.Set("vault", vault)
+
 	var resp WriteResponse
-	if err := c.request(ctx, "POST", "/api/engrams", body, &resp); err != nil {
+	if err := c.request(ctx, "POST", "/api/engrams?"+q.Encode(), body, &resp); err != nil {
 		return "", err
 	}
 
@@ -86,8 +89,11 @@ func (c *Client) WriteWithOptions(ctx context.Context, req WriteRequest) (*Write
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	q := url.Values{}
+	q.Set("vault", req.Vault)
+
 	var resp WriteResponse
-	if err := c.request(ctx, "POST", "/api/engrams", body, &resp); err != nil {
+	if err := c.request(ctx, "POST", "/api/engrams?"+q.Encode(), body, &resp); err != nil {
 		return nil, err
 	}
 
@@ -118,8 +124,11 @@ func (c *Client) WriteBatch(ctx context.Context, vault string, engrams []WriteRe
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	q := url.Values{}
+	q.Set("vault", vault)
+
 	var resp BatchWriteResponse
-	if err := c.request(ctx, "POST", "/api/engrams/batch", body, &resp); err != nil {
+	if err := c.request(ctx, "POST", "/api/engrams/batch?"+q.Encode(), body, &resp); err != nil {
 		return nil, err
 	}
 
@@ -155,8 +164,11 @@ func (c *Client) Activate(ctx context.Context, vault string, context []string, m
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	q := url.Values{}
+	q.Set("vault", vault)
+
 	resp := &ActivateResponse{}
-	if err := c.request(ctx, "POST", "/api/activate", body, resp); err != nil {
+	if err := c.request(ctx, "POST", "/api/activate?"+q.Encode(), body, resp); err != nil {
 		return nil, err
 	}
 
@@ -178,7 +190,10 @@ func (c *Client) Link(ctx context.Context, vault, sourceID, targetID string, rel
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	return c.request(ctx, "POST", "/api/link", body, nil)
+	q := url.Values{}
+	q.Set("vault", vault)
+
+	return c.request(ctx, "POST", "/api/link?"+q.Encode(), body, nil)
 }
 
 // Forget forgets an engram.
@@ -269,8 +284,11 @@ func (c *Client) ActivateWithOptions(ctx context.Context, req ActivateRequest) (
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	q := url.Values{}
+	q.Set("vault", req.Vault)
+
 	resp := &ActivateResponse{}
-	if err := c.request(ctx, "POST", "/api/activate", body, resp); err != nil {
+	if err := c.request(ctx, "POST", "/api/activate?"+q.Encode(), body, resp); err != nil {
 		return nil, err
 	}
 
@@ -290,8 +308,11 @@ func (c *Client) Evolve(ctx context.Context, vault, engramID, newContent, reason
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	q := url.Values{}
+	q.Set("vault", vault)
+
 	resp := &EvolveResponse{}
-	if err := c.request(ctx, "POST", fmt.Sprintf("/api/engrams/%s/evolve", engramID), body, resp); err != nil {
+	if err := c.request(ctx, "POST", fmt.Sprintf("/api/engrams/%s/evolve?%s", engramID, q.Encode()), body, resp); err != nil {
 		return nil, err
 	}
 
@@ -311,8 +332,11 @@ func (c *Client) Consolidate(ctx context.Context, vault string, ids []string, me
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	q := url.Values{}
+	q.Set("vault", vault)
+
 	resp := &ConsolidateResponse{}
-	if err := c.request(ctx, "POST", "/api/consolidate", body, resp); err != nil {
+	if err := c.request(ctx, "POST", "/api/consolidate?"+q.Encode(), body, resp); err != nil {
 		return nil, err
 	}
 
@@ -334,8 +358,11 @@ func (c *Client) Decide(ctx context.Context, vault, decision, rationale string, 
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	q := url.Values{}
+	q.Set("vault", vault)
+
 	resp := &DecideResponse{}
-	if err := c.request(ctx, "POST", "/api/decide", body, resp); err != nil {
+	if err := c.request(ctx, "POST", "/api/decide?"+q.Encode(), body, resp); err != nil {
 		return nil, err
 	}
 
@@ -371,8 +398,11 @@ func (c *Client) Traverse(ctx context.Context, vault, startID string, maxHops, m
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	q := url.Values{}
+	q.Set("vault", vault)
+
 	resp := &TraverseResponse{}
-	if err := c.request(ctx, "POST", "/api/traverse", body, resp); err != nil {
+	if err := c.request(ctx, "POST", "/api/traverse?"+q.Encode(), body, resp); err != nil {
 		return nil, err
 	}
 
@@ -392,8 +422,11 @@ func (c *Client) Explain(ctx context.Context, vault, engramID string, query []st
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	q := url.Values{}
+	q.Set("vault", vault)
+
 	resp := &ExplainResponse{}
-	if err := c.request(ctx, "POST", "/api/explain", body, resp); err != nil {
+	if err := c.request(ctx, "POST", "/api/explain?"+q.Encode(), body, resp); err != nil {
 		return nil, err
 	}
 
@@ -413,8 +446,11 @@ func (c *Client) SetState(ctx context.Context, vault, engramID, state, reason st
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	q := url.Values{}
+	q.Set("vault", vault)
+
 	resp := &SetStateResponse{}
-	if err := c.request(ctx, "PUT", fmt.Sprintf("/api/engrams/%s/state", engramID), body, resp); err != nil {
+	if err := c.request(ctx, "PUT", fmt.Sprintf("/api/engrams/%s/state?%s", engramID, q.Encode()), body, resp); err != nil {
 		return nil, err
 	}
 

--- a/sdk/node/src/client.ts
+++ b/sdk/node/src/client.ts
@@ -82,11 +82,13 @@ export class MuninnClient {
 
   /** Write a single engram. */
   async write(options: WriteOptions): Promise<WriteResponse> {
-    const body = { ...options, vault: options.vault ?? this.defaultVault };
+    const vault = options.vault ?? this.defaultVault;
+    const body = { ...options, vault };
     return this.request<WriteResponse>({
       method: "POST",
       path: "/api/engrams",
       body,
+      query: { vault },
     });
   }
 
@@ -101,16 +103,19 @@ export class MuninnClient {
       body: {
         engrams: engrams.map((e) => ({ ...e, vault: e.vault ?? vault })),
       },
+      query: { vault },
     });
   }
 
   /** Semantic recall / activation query. */
   async activate(options: ActivateOptions): Promise<ActivateResponse> {
-    const body = { ...options, vault: options.vault ?? this.defaultVault };
+    const vault = options.vault ?? this.defaultVault;
+    const body = { ...options, vault };
     return this.request<ActivateResponse>({
       method: "POST",
       path: "/api/activate",
       body,
+      query: { vault },
     });
   }
 
@@ -134,8 +139,9 @@ export class MuninnClient {
 
   /** Create an association between two engrams. */
   async link(options: LinkOptions): Promise<void> {
-    const body = { ...options, vault: options.vault ?? this.defaultVault };
-    await this.request<unknown>({ method: "POST", path: "/api/link", body });
+    const vault = options.vault ?? this.defaultVault;
+    const body = { ...options, vault };
+    await this.request<unknown>({ method: "POST", path: "/api/link", body, query: { vault } });
   }
 
   // -----------------------------------------------------------------------
@@ -161,21 +167,25 @@ export class MuninnClient {
   async consolidate(
     options: ConsolidateOptions,
   ): Promise<ConsolidateResponse> {
-    const body = { ...options, vault: options.vault ?? this.defaultVault };
+    const vault = options.vault ?? this.defaultVault;
+    const body = { ...options, vault };
     return this.request<ConsolidateResponse>({
       method: "POST",
       path: "/api/consolidate",
       body,
+      query: { vault },
     });
   }
 
   /** Record a decision. */
   async decide(options: DecideOptions): Promise<DecideResponse> {
-    const body = { ...options, vault: options.vault ?? this.defaultVault };
+    const vault = options.vault ?? this.defaultVault;
+    const body = { ...options, vault };
     return this.request<DecideResponse>({
       method: "POST",
       path: "/api/decide",
       body,
+      query: { vault },
     });
   }
 
@@ -190,21 +200,25 @@ export class MuninnClient {
 
   /** Traverse the association graph from a starting engram. */
   async traverse(options: TraverseOptions): Promise<TraverseResponse> {
-    const body = { ...options, vault: options.vault ?? this.defaultVault };
+    const vault = options.vault ?? this.defaultVault;
+    const body = { ...options, vault };
     return this.request<TraverseResponse>({
       method: "POST",
       path: "/api/traverse",
       body,
+      query: { vault },
     });
   }
 
   /** Get a scoring breakdown for an engram against a query. */
   async explain(options: ExplainOptions): Promise<ExplainResponse> {
-    const body = { ...options, vault: options.vault ?? this.defaultVault };
+    const vault = options.vault ?? this.defaultVault;
+    const body = { ...options, vault };
     return this.request<ExplainResponse>({
       method: "POST",
       path: "/api/explain",
       body,
+      query: { vault },
     });
   }
 

--- a/sdk/php/src/MuninnClient.php
+++ b/sdk/php/src/MuninnClient.php
@@ -79,7 +79,7 @@ class MuninnClient
         ], fn(mixed $v) => $v !== '' && $v !== [] && $v !== null);
 
         return WriteResponse::fromArray(
-            $this->request('POST', '/api/engrams', $body),
+            $this->request('POST', '/api/engrams?vault=' . urlencode($vault), $body),
         );
     }
 
@@ -96,7 +96,7 @@ class MuninnClient
         }, $engrams);
 
         return BatchWriteResponse::fromArray(
-            $this->request('POST', '/api/engrams/batch', ['engrams' => $prepared]),
+            $this->request('POST', '/api/engrams/batch?vault=' . urlencode($vault), ['engrams' => $prepared]),
         );
     }
 
@@ -156,7 +156,7 @@ class MuninnClient
         $body['limit']   = $limit;
 
         return ActivateResponse::fromArray(
-            $this->request('POST', '/api/activate', $body),
+            $this->request('POST', '/api/activate?vault=' . urlencode($vault), $body),
         );
     }
 
@@ -168,7 +168,7 @@ class MuninnClient
         float $weight = 1.0,
         string $vault = 'default',
     ): void {
-        $this->request('POST', '/api/link', [
+        $this->request('POST', '/api/link?vault=' . urlencode($vault), [
             'vault'     => $vault,
             'source_id' => $sourceId,
             'target_id' => $targetId,
@@ -183,7 +183,7 @@ class MuninnClient
     public function evolve(string $id, string $newContent, string $reason, string $vault = 'default'): EvolveResponse
     {
         return EvolveResponse::fromArray(
-            $this->request('POST', "/api/engrams/$id/evolve", [
+            $this->request('POST', "/api/engrams/$id/evolve?vault=" . urlencode($vault), [
                 'new_content' => $newContent,
                 'reason'      => $reason,
                 'vault'       => $vault,
@@ -199,7 +199,7 @@ class MuninnClient
     public function consolidate(array $ids, string $mergedContent, string $vault = 'default'): ConsolidateResponse
     {
         return ConsolidateResponse::fromArray(
-            $this->request('POST', '/api/consolidate', [
+            $this->request('POST', '/api/consolidate?vault=' . urlencode($vault), [
                 'vault'          => $vault,
                 'ids'            => $ids,
                 'merged_content' => $mergedContent,
@@ -221,7 +221,7 @@ class MuninnClient
         string $vault = 'default',
     ): DecideResponse {
         return DecideResponse::fromArray(
-            $this->request('POST', '/api/decide', array_filter([
+            $this->request('POST', '/api/decide?vault=' . urlencode($vault), array_filter([
                 'vault'        => $vault,
                 'decision'     => $decision,
                 'rationale'    => $rationale,
@@ -235,7 +235,7 @@ class MuninnClient
     public function restore(string $id, string $vault = 'default'): RestoreResponse
     {
         return RestoreResponse::fromArray(
-            $this->request('POST', "/api/engrams/$id/restore", ['vault' => $vault]),
+            $this->request('POST', "/api/engrams/$id/restore?vault=" . urlencode($vault), ['vault' => $vault]),
         );
     }
 
@@ -252,7 +252,7 @@ class MuninnClient
         string $vault = 'default',
     ): TraverseResponse {
         return TraverseResponse::fromArray(
-            $this->request('POST', '/api/traverse', array_filter([
+            $this->request('POST', '/api/traverse?vault=' . urlencode($vault), array_filter([
                 'vault'     => $vault,
                 'start_id'  => $startId,
                 'max_hops'  => $maxHops,
@@ -270,7 +270,7 @@ class MuninnClient
     public function explain(string $engramId, array $query, string $vault = 'default'): ExplainResponse
     {
         return ExplainResponse::fromArray(
-            $this->request('POST', '/api/explain', [
+            $this->request('POST', '/api/explain?vault=' . urlencode($vault), [
                 'vault'     => $vault,
                 'engram_id' => $engramId,
                 'query'     => $query,
@@ -287,7 +287,7 @@ class MuninnClient
         }
 
         return SetStateResponse::fromArray(
-            $this->request('PUT', "/api/engrams/$id/state", $body),
+            $this->request('PUT', "/api/engrams/$id/state?vault=" . urlencode($vault), $body),
         );
     }
 
@@ -303,7 +303,7 @@ class MuninnClient
     public function retryEnrich(string $id, string $vault = 'default'): RetryEnrichResponse
     {
         return RetryEnrichResponse::fromArray(
-            $this->request('POST', "/api/engrams/$id/retry-enrich", ['vault' => $vault]),
+            $this->request('POST', "/api/engrams/$id/retry-enrich?vault=" . urlencode($vault), ['vault' => $vault]),
         );
     }
 

--- a/sdk/python/examples/langchain_demo.py
+++ b/sdk/python/examples/langchain_demo.py
@@ -35,7 +35,7 @@ from muninn import MuninnClient
 from muninn.langchain import MuninnDBMemory
 
 MUNINN_URL = "http://localhost:8475"
-VAULT = "langchain-demo"
+VAULT = "default"
 
 
 # ── Part 1: Seed some memories directly via the SDK ─────────────────────────

--- a/sdk/python/examples/write_activate.py
+++ b/sdk/python/examples/write_activate.py
@@ -51,7 +51,7 @@ async def main():
         ids = []
         for mem in memories:
             eid = await client.write(
-                vault="demo",
+                vault="default",
                 concept=mem["concept"],
                 content=mem["content"],
                 tags=mem["tags"],
@@ -65,7 +65,7 @@ async def main():
         # Activate memory with a semantic query
         print("Activating memory with query: 'how does learning work in the brain?'")
         result = await client.activate(
-            vault="demo",
+            vault="default",
             context=["how does learning work", "neural mechanisms", "memory formation"],
             max_results=10,
             threshold=0.0,

--- a/sdk/python/muninn/client.py
+++ b/sdk/python/muninn/client.py
@@ -172,7 +172,7 @@ class MuninnClient:
         if relationships is not None:
             body["relationships"] = relationships
 
-        response = await self._request("POST", "/api/engrams", json=body)
+        response = await self._request("POST", "/api/engrams", json=body, params={"vault": vault})
         return WriteResponse(
             id=response.get("id", ""),
             created_at=response.get("created_at", 0),
@@ -213,7 +213,7 @@ class MuninnClient:
             items.append(item)
 
         response = await self._request(
-            "POST", "/api/engrams/batch", json={"engrams": items}
+            "POST", "/api/engrams/batch", json={"engrams": items}, params={"vault": vault}
         )
 
         results = [
@@ -267,7 +267,7 @@ class MuninnClient:
             "brief_mode": brief_mode,
         }
 
-        response = await self._request("POST", "/api/activate", json=body)
+        response = await self._request("POST", "/api/activate", json=body, params={"vault": vault})
 
         activations = [
             ActivationItem(
@@ -395,7 +395,7 @@ class MuninnClient:
             "rel_type": rel_type,
             "weight": weight,
         }
-        await self._request("POST", "/api/link", json=body)
+        await self._request("POST", "/api/link", json=body, params={"vault": vault})
         return True
 
     async def stats(self, vault: str = "default") -> StatResponse:
@@ -487,7 +487,7 @@ class MuninnClient:
             EvolveResponse with the new engram ID
         """
         body = {"new_content": new_content, "reason": reason, "vault": vault}
-        response = await self._request("POST", f"/api/engrams/{id}/evolve", json=body)
+        response = await self._request("POST", f"/api/engrams/{id}/evolve", json=body, params={"vault": vault})
         return EvolveResponse(id=response.get("id", ""))
 
     async def consolidate(
@@ -507,7 +507,7 @@ class MuninnClient:
             ConsolidateResponse with new ID, archived IDs, and any warnings
         """
         body = {"vault": vault, "ids": ids, "merged_content": merged_content}
-        response = await self._request("POST", "/api/consolidate", json=body)
+        response = await self._request("POST", "/api/consolidate", json=body, params={"vault": vault})
         return ConsolidateResponse(
             id=response.get("id", ""),
             archived=response.get("archived", []),
@@ -539,7 +539,7 @@ class MuninnClient:
             body["alternatives"] = alternatives
         if evidence_ids:
             body["evidence_ids"] = evidence_ids
-        response = await self._request("POST", "/api/decide", json=body)
+        response = await self._request("POST", "/api/decide", json=body, params={"vault": vault})
         return DecideResponse(id=response.get("id", ""))
 
     async def restore(self, id: str, vault: str = "default") -> RestoreResponse:
@@ -590,7 +590,7 @@ class MuninnClient:
         }
         if rel_types:
             body["rel_types"] = rel_types
-        response = await self._request("POST", "/api/traverse", json=body)
+        response = await self._request("POST", "/api/traverse", json=body, params={"vault": vault})
         nodes = [
             TraversalNode(
                 id=n.get("id", ""),
@@ -633,7 +633,7 @@ class MuninnClient:
             ExplainResponse with scoring breakdown
         """
         body = {"vault": vault, "engram_id": engram_id, "query": query}
-        response = await self._request("POST", "/api/explain", json=body)
+        response = await self._request("POST", "/api/explain", json=body, params={"vault": vault})
         comp = response.get("components", {})
         return ExplainResponse(
             engram_id=response.get("engram_id", ""),
@@ -674,7 +674,7 @@ class MuninnClient:
         body: dict = {"state": state, "vault": vault}
         if reason:
             body["reason"] = reason
-        response = await self._request("PUT", f"/api/engrams/{id}/state", json=body)
+        response = await self._request("PUT", f"/api/engrams/{id}/state", json=body, params={"vault": vault})
         return SetStateResponse(
             id=response.get("id", ""),
             state=response.get("state", ""),


### PR DESCRIPTION
## Summary

- `VaultAuthMiddleware` reads vault exclusively from `?vault=` — never from the JSON body
- All four SDKs (Python, Go, PHP, Node) were only sending vault in the request body on POST/PUT endpoints, causing `VAULT_KEY_MISMATCH` for any non-default vault API key
- Fixed by adding vault as a URL query param to every affected POST/PUT method across all SDKs

## Affected methods (all SDKs)

`write`, `write_batch`, `activate`, `link`, `evolve`, `consolidate`, `decide`, `traverse`, `explain`, `set_state` — plus `restore` and `retry_enrich` in PHP (were missing it too)

GET/DELETE methods were already correct and untouched.

## Test Plan

- [ ] Non-default vault API key can call write, activate, link, evolve, consolidate, decide, traverse, explain, setState without VAULT_KEY_MISMATCH
- [ ] Default vault behavior unchanged
- [ ] Go SDK compiles cleanly (`go build ./...`)