### PR TITLE
Fix enrich retry persistence, parser handling, and reasoning fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Enrich now accepts OpenAI-compatible JSON responses returned in `message.reasoning` when `message.content` is empty, including structured reasoning payloads.
+- Retry and retroactive enrichment now only mark entity and relationship stages complete after successful persistence, avoiding partial-state retries, nil-result crashes, and silent graph-write failures.
+- Entity and relationship response parsing now rejects nested wrapper keys like `meta.entities` / `meta.relationships` instead of treating them as valid empty results.
+
 ---
 
 ## [0.2.6] - 2026-02-28

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -180,6 +180,10 @@ Provider comparison:
 | Anthropic | claude-haiku-4-5 | Low | Very good | Cost-sensitive production |
 | Anthropic | claude-sonnet-4-6 | Medium | Excellent | Quality-critical production |
 
+For OpenAI-compatible gateways, MuninnDB accepts enrich JSON returned in either
+`message.content` or `message.reasoning`. Some gateways emit structured JSON in
+`reasoning` while leaving `content` empty.
+
 ### Retroactive Enrichment
 
 Same guarantee as Tier 2: enable the plugin, walk away. The retroactive processor enriches existing engrams in the background — highest relevance first, zero impact on the read/write path.
@@ -198,6 +202,11 @@ Enrichment jobs are tracked. If an LLM call fails — rate limit, timeout, provi
 You can also check enrichment status via the REST admin endpoint `/api/admin/embed/status`, which includes tier information and plugin registration status.
 
 The retry mechanism means a temporary provider outage does not result in permanently un-enriched engrams. When the provider recovers, the queue processes automatically.
+
+Retry and retroactive enrichment only mark entity and relationship stages complete
+after the corresponding graph writes succeed. If persistence fails partway
+through, MuninnDB leaves the stage incomplete so the work can be retried instead
+of silently treating a partial write as finished.
 
 ---
 

--- a/internal/plugin/admin_test.go
+++ b/internal/plugin/admin_test.go
@@ -25,15 +25,20 @@ type mockPluginStore struct {
 	updateDigestErr error
 	upsertEntityErr error
 	linkErr         error
+	coOccurErr      error
 	upsertRelErr    error
 	hnswInsertErr   error
 	autoLinkErr     error
 
 	setFlagCalls      int
+	setFlags          []uint8
 	updateEmbedCalls  int
 	hnswInsertCalls   int
 	autoLinkCalls     int
 	upsertEntityCalls int
+	linkCalls         int
+	upsertRelCalls    int
+	coOccurCalls      int
 }
 
 func (m *mockPluginStore) CountWithoutFlag(_ context.Context, _ uint8) (int64, error) {
@@ -44,8 +49,9 @@ func (m *mockPluginStore) ScanWithoutFlag(_ context.Context, _ uint8) EngramIter
 	return m.scanResult
 }
 
-func (m *mockPluginStore) SetDigestFlag(_ context.Context, _ ULID, _ uint8) error {
+func (m *mockPluginStore) SetDigestFlag(_ context.Context, _ ULID, flag uint8) error {
 	m.setFlagCalls++
+	m.setFlags = append(m.setFlags, flag)
 	return m.setFlagErr
 }
 
@@ -68,10 +74,12 @@ func (m *mockPluginStore) UpsertEntity(_ context.Context, _ ExtractedEntity) err
 }
 
 func (m *mockPluginStore) LinkEngramToEntity(_ context.Context, _ ULID, _ string) error {
+	m.linkCalls++
 	return m.linkErr
 }
 
 func (m *mockPluginStore) UpsertRelationship(_ context.Context, _ ULID, _ ExtractedRelation) error {
+	m.upsertRelCalls++
 	return m.upsertRelErr
 }
 
@@ -86,7 +94,8 @@ func (m *mockPluginStore) AutoLinkByEmbedding(_ context.Context, _ ULID, _ []flo
 }
 
 func (m *mockPluginStore) IncrementEntityCoOccurrence(_ context.Context, _ ULID, _, _ string) error {
-	return nil
+	m.coOccurCalls++
+	return m.coOccurErr
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/plugin/enrich/parse.go
+++ b/internal/plugin/enrich/parse.go
@@ -1,6 +1,7 @@
 package enrich
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -51,20 +52,15 @@ func ParseEntityResponse(raw string) ([]plugin.ExtractedEntity, error) {
 	raw = strings.TrimSpace(raw)
 	jsonStr := extractJSON(raw)
 
-	// Try to parse as wrapper object with "entities" key
-	var wrapper struct {
-		Entities []plugin.ExtractedEntity `json:"entities"`
-	}
-	if err := json.Unmarshal([]byte(jsonStr), &wrapper); err == nil {
-		if wrapper.Entities == nil && strings.Contains(jsonStr, `"entities"`) {
+	if rawEntities, ok, err := extractTopLevelField(jsonStr, "entities"); err == nil && ok {
+		if isJSONNull(rawEntities) {
 			return nil, nil
 		}
-		if wrapper.Entities != nil {
-			// Validate and deduplicate
-			return validateAndDedupeEntities(wrapper.Entities), nil
+		var entities []plugin.ExtractedEntity
+		if err := json.Unmarshal(rawEntities, &entities); err != nil {
+			return nil, fmt.Errorf("invalid entity response JSON: %s", truncateForError(jsonStr))
 		}
-	} else {
-		// Fall through to direct-array parsing before surfacing the error.
+		return validateAndDedupeEntities(entities), nil
 	}
 
 	// Try to parse as direct array
@@ -81,33 +77,29 @@ func ParseRelationshipResponse(raw string) ([]plugin.ExtractedRelation, error) {
 	raw = strings.TrimSpace(raw)
 	jsonStr := extractJSON(raw)
 
-	// Try to parse as wrapper object with "relationships" key
-	// Use intermediate struct with "type" field for JSON parsing
-	var wrapper struct {
-		Relationships []struct {
+	if rawRelationships, ok, err := extractTopLevelField(jsonStr, "relationships"); err == nil && ok {
+		if isJSONNull(rawRelationships) {
+			return nil, nil
+		}
+		var wrapper []struct {
 			From   string  `json:"from"`
 			To     string  `json:"to"`
 			Type   string  `json:"type"`
 			Weight float32 `json:"weight"`
-		} `json:"relationships"`
-	}
-
-	if err := json.Unmarshal([]byte(jsonStr), &wrapper); err == nil {
-		if wrapper.Relationships == nil && strings.Contains(jsonStr, `"relationships"`) {
-			return nil, nil
 		}
-		if wrapper.Relationships != nil {
-			var result []plugin.ExtractedRelation
-			for _, rel := range wrapper.Relationships {
-				result = append(result, plugin.ExtractedRelation{
-					FromEntity: rel.From,
-					ToEntity:   rel.To,
-					RelType:    rel.Type,
-					Weight:     rel.Weight,
-				})
-			}
-			return validateRelationships(result), nil
+		if err := json.Unmarshal(rawRelationships, &wrapper); err != nil {
+			return nil, fmt.Errorf("invalid relationship response JSON: %s", truncateForError(jsonStr))
 		}
+		var result []plugin.ExtractedRelation
+		for _, rel := range wrapper {
+			result = append(result, plugin.ExtractedRelation{
+				FromEntity: rel.From,
+				ToEntity:   rel.To,
+				RelType:    rel.Type,
+				Weight:     rel.Weight,
+			})
+		}
+		return validateRelationships(result), nil
 	}
 
 	// Try to parse as direct array
@@ -131,6 +123,19 @@ func ParseRelationshipResponse(raw string) ([]plugin.ExtractedRelation, error) {
 	}
 
 	return nil, fmt.Errorf("invalid relationship response JSON: %s", truncateForError(jsonStr))
+}
+
+func extractTopLevelField(jsonStr, field string) (json.RawMessage, bool, error) {
+	var wrapper map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(jsonStr), &wrapper); err != nil {
+		return nil, false, err
+	}
+	value, ok := wrapper[field]
+	return value, ok, nil
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
 }
 
 // ParseClassificationResponse parses the JSON response from the classification call.

--- a/internal/plugin/enrich/parse_test.go
+++ b/internal/plugin/enrich/parse_test.go
@@ -258,6 +258,28 @@ func TestParseRelationshipResponse_BadJSON(t *testing.T) {
 	}
 }
 
+func TestParseEntityResponse_NestedWrapperKeyReturnsError(t *testing.T) {
+	raw := `{"meta":{"entities":[]}}`
+	entities, err := ParseEntityResponse(raw)
+	if err == nil {
+		t.Fatal("expected parse error for nested entities wrapper")
+	}
+	if len(entities) != 0 {
+		t.Fatalf("expected 0 entities, got %d", len(entities))
+	}
+}
+
+func TestParseRelationshipResponse_NestedWrapperKeyReturnsError(t *testing.T) {
+	raw := `{"meta":{"relationships":[]}}`
+	rels, err := ParseRelationshipResponse(raw)
+	if err == nil {
+		t.Fatal("expected parse error for nested relationships wrapper")
+	}
+	if len(rels) != 0 {
+		t.Fatalf("expected 0 relationships, got %d", len(rels))
+	}
+}
+
 func TestParseClassification_BadJSON(t *testing.T) {
 	raw := `totally broken {{{`
 	memType, typeLabel, cat, subcat, tags, err := ParseClassificationResponse(raw)

--- a/internal/plugin/enrichment_persistence.go
+++ b/internal/plugin/enrichment_persistence.go
@@ -1,0 +1,106 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// PersistEnrichmentResult writes an enrichment result and marks per-stage flags
+// only after the corresponding stage data has been stored successfully.
+func PersistEnrichmentResult(ctx context.Context, store PluginStore, id ULID, result *EnrichmentResult) error {
+	if result == nil {
+		return fmt.Errorf("enrich returned nil result")
+	}
+	if err := store.UpdateDigest(ctx, id, result); err != nil {
+		return fmt.Errorf("persist enriched digest: %w", err)
+	}
+
+	var stageErrs []string
+	if result.Entities != nil {
+		if err := persistEntityStage(ctx, store, id, result.Entities); err != nil {
+			stageErrs = append(stageErrs, err.Error())
+		}
+	}
+
+	switch {
+	case result.Relationships != nil:
+		if err := persistRelationshipStage(ctx, store, id, result.Relationships); err != nil {
+			stageErrs = append(stageErrs, err.Error())
+		}
+	case result.Entities != nil && len(result.Entities) == 0:
+		// An entity pass that found nothing also implies there can be no
+		// relationship records for this engram.
+		if err := store.SetDigestFlag(ctx, id, DigestRelationships); err != nil {
+			stageErrs = append(stageErrs, fmt.Sprintf("set DigestRelationships flag: %v", err))
+		}
+	}
+
+	if len(stageErrs) > 0 {
+		return fmt.Errorf("persist enrich graph: %s", strings.Join(stageErrs, "; "))
+	}
+	return nil
+}
+
+func persistEntityStage(ctx context.Context, store PluginStore, id ULID, entities []ExtractedEntity) error {
+	var linkedEntityNames []string
+	var errs []string
+
+	for _, entity := range entities {
+		if err := store.UpsertEntity(ctx, entity); err != nil {
+			slog.Warn("enrich: failed to upsert entity", "id", id.String(), "name", entity.Name, "err", err)
+			errs = append(errs, fmt.Sprintf("upsert entity %q: %v", entity.Name, err))
+			continue
+		}
+		if err := store.LinkEngramToEntity(ctx, id, entity.Name); err != nil {
+			slog.Warn("enrich: failed to link engram to entity", "id", id.String(), "name", entity.Name, "err", err)
+			errs = append(errs, fmt.Sprintf("link entity %q: %v", entity.Name, err))
+			continue
+		}
+		linkedEntityNames = append(linkedEntityNames, entity.Name)
+	}
+
+	for i := 0; i < len(linkedEntityNames); i++ {
+		for j := i + 1; j < len(linkedEntityNames); j++ {
+			if err := store.IncrementEntityCoOccurrence(ctx, id, linkedEntityNames[i], linkedEntityNames[j]); err != nil {
+				slog.Warn("enrich: failed to increment entity co-occurrence",
+					"id", id.String(),
+					"name_a", linkedEntityNames[i],
+					"name_b", linkedEntityNames[j],
+					"err", err)
+				errs = append(errs, fmt.Sprintf("increment entity co-occurrence %q/%q: %v", linkedEntityNames[i], linkedEntityNames[j], err))
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("entities: %s", strings.Join(errs, "; "))
+	}
+	if err := store.SetDigestFlag(ctx, id, DigestEntities); err != nil {
+		return fmt.Errorf("set DigestEntities flag: %w", err)
+	}
+	return nil
+}
+
+func persistRelationshipStage(ctx context.Context, store PluginStore, id ULID, relationships []ExtractedRelation) error {
+	var errs []string
+	for _, rel := range relationships {
+		if err := store.UpsertRelationship(ctx, id, rel); err != nil {
+			slog.Warn("enrich: failed to upsert relationship",
+				"id", id.String(),
+				"from", rel.FromEntity,
+				"to", rel.ToEntity,
+				"type", rel.RelType,
+				"err", err)
+			errs = append(errs, fmt.Sprintf("upsert relationship %q->%q (%s): %v", rel.FromEntity, rel.ToEntity, rel.RelType, err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("relationships: %s", strings.Join(errs, "; "))
+	}
+	if err := store.SetDigestFlag(ctx, id, DigestRelationships); err != nil {
+		return fmt.Errorf("set DigestRelationships flag: %w", err)
+	}
+	return nil
+}

--- a/internal/plugin/enrichment_persistence_test.go
+++ b/internal/plugin/enrichment_persistence_test.go
@@ -1,0 +1,114 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestPersistEnrichmentResult_NilResult(t *testing.T) {
+	store := &mockPluginStore{}
+
+	err := PersistEnrichmentResult(context.Background(), store, ULID{}, nil)
+	if err == nil {
+		t.Fatal("expected error for nil enrichment result")
+	}
+	if !strings.Contains(err.Error(), "nil result") {
+		t.Fatalf("expected nil result error, got %v", err)
+	}
+}
+
+func TestPersistEnrichmentResult_EntityFailureDoesNotSetDigestEntities(t *testing.T) {
+	store := &mockPluginStore{
+		linkErr: errors.New("link fail"),
+	}
+	result := &EnrichmentResult{
+		Summary: "summary",
+		Entities: []ExtractedEntity{
+			{Name: "postgres", Type: "database", Confidence: 0.9},
+		},
+	}
+
+	err := PersistEnrichmentResult(context.Background(), store, ULID{}, result)
+	if err == nil {
+		t.Fatal("expected entity persistence error")
+	}
+	if !strings.Contains(err.Error(), `link entity "postgres"`) {
+		t.Fatalf("expected link failure in error, got %v", err)
+	}
+	if hasSetFlag(store, DigestEntities) {
+		t.Fatalf("DigestEntities flag should not be set after entity persistence failure; flags=%v", store.setFlags)
+	}
+}
+
+func TestPersistEnrichmentResult_CoOccurrenceFailureDoesNotSetDigestEntities(t *testing.T) {
+	store := &mockPluginStore{
+		coOccurErr: errors.New("co-occurrence fail"),
+	}
+	result := &EnrichmentResult{
+		Entities: []ExtractedEntity{
+			{Name: "postgres", Type: "database", Confidence: 0.9},
+			{Name: "redis", Type: "database", Confidence: 0.8},
+		},
+	}
+
+	err := PersistEnrichmentResult(context.Background(), store, ULID{}, result)
+	if err == nil {
+		t.Fatal("expected co-occurrence persistence error")
+	}
+	if !strings.Contains(err.Error(), `increment entity co-occurrence "postgres"/"redis"`) {
+		t.Fatalf("expected co-occurrence failure in error, got %v", err)
+	}
+	if hasSetFlag(store, DigestEntities) {
+		t.Fatalf("DigestEntities flag should not be set after co-occurrence failure; flags=%v", store.setFlags)
+	}
+}
+
+func TestPersistEnrichmentResult_RelationshipFailureDoesNotSetDigestRelationships(t *testing.T) {
+	store := &mockPluginStore{
+		upsertRelErr: errors.New("relationship fail"),
+	}
+	result := &EnrichmentResult{
+		Relationships: []ExtractedRelation{
+			{FromEntity: "postgres", ToEntity: "redis", RelType: "depends_on", Weight: 0.8},
+		},
+	}
+
+	err := PersistEnrichmentResult(context.Background(), store, ULID{}, result)
+	if err == nil {
+		t.Fatal("expected relationship persistence error")
+	}
+	if !strings.Contains(err.Error(), `upsert relationship "postgres"->"redis" (depends_on)`) {
+		t.Fatalf("expected relationship failure in error, got %v", err)
+	}
+	if hasSetFlag(store, DigestRelationships) {
+		t.Fatalf("DigestRelationships flag should not be set after relationship persistence failure; flags=%v", store.setFlags)
+	}
+}
+
+func TestPersistEnrichmentResult_EmptyEntityStageMarksEntityAndRelationshipFlags(t *testing.T) {
+	store := &mockPluginStore{}
+	result := &EnrichmentResult{
+		Entities: []ExtractedEntity{},
+	}
+
+	if err := PersistEnrichmentResult(context.Background(), store, ULID{}, result); err != nil {
+		t.Fatalf("PersistEnrichmentResult: %v", err)
+	}
+	if !hasSetFlag(store, DigestEntities) {
+		t.Fatalf("expected DigestEntities flag, got %v", store.setFlags)
+	}
+	if !hasSetFlag(store, DigestRelationships) {
+		t.Fatalf("expected DigestRelationships flag when entity extraction found no entities, got %v", store.setFlags)
+	}
+}
+
+func hasSetFlag(store *mockPluginStore, flag uint8) bool {
+	for _, got := range store.setFlags {
+		if got == flag {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugin/retroactive.go
+++ b/internal/plugin/retroactive.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"runtime"
 	"sync"
@@ -443,6 +444,9 @@ func (rp *RetroactiveProcessor) processEngram(ctx context.Context, eng *Engram) 
 		if err != nil {
 			return err
 		}
+		if result == nil {
+			return fmt.Errorf("enrich returned nil result")
+		}
 
 		// Only overwrite fields the caller didn't provide.
 		// hasSummary covers both eng.Summary != "" and DigestSummarized flag;
@@ -454,45 +458,15 @@ func (rp *RetroactiveProcessor) processEngram(ctx context.Context, eng *Engram) 
 			}
 		}
 
-		// Store the enrichment result
-		if err := rp.store.UpdateDigest(ctx, eng.ID, result); err != nil {
+		if hasEntities {
+			result.Entities = nil
+		}
+		if hasRelationships {
+			result.Relationships = nil
+		}
+
+		if err := PersistEnrichmentResult(ctx, rp.store, eng.ID, result); err != nil {
 			return err
-		}
-
-		// Upsert entities (only if caller didn't provide them)
-		if !hasEntities {
-			var linkedEntityNames []string
-			for _, entity := range result.Entities {
-				if err := rp.store.UpsertEntity(ctx, entity); err != nil {
-					slog.Warn("enrich: failed to upsert entity", "id", eng.ID.String(), "name", entity.Name, "err", err)
-					continue
-				}
-				if err := rp.store.LinkEngramToEntity(ctx, eng.ID, entity.Name); err != nil {
-					slog.Warn("enrich: failed to link engram to entity", "id", eng.ID.String(), "name", entity.Name, "err", err)
-					continue
-				}
-				linkedEntityNames = append(linkedEntityNames, entity.Name)
-			}
-			// Write co-occurrence pairs for entities co-appearing in this engram.
-			for i := 0; i < len(linkedEntityNames); i++ {
-				for j := i + 1; j < len(linkedEntityNames); j++ {
-					_ = rp.store.IncrementEntityCoOccurrence(ctx, eng.ID, linkedEntityNames[i], linkedEntityNames[j])
-				}
-			}
-		}
-
-		// Mark entity extraction complete so subsequent polls skip this stage.
-		if !hasEntities && len(result.Entities) > 0 {
-			if err := rp.store.SetDigestFlag(ctx, eng.ID, DigestEntities); err != nil {
-				slog.Warn("enrich: failed to set DigestEntities flag", "id", eng.ID.String(), "err", err)
-			}
-		}
-
-		// Upsert relationships
-		for _, rel := range result.Relationships {
-			if err := rp.store.UpsertRelationship(ctx, eng.ID, rel); err != nil {
-				slog.Warn("failed to upsert relationship", "error", err)
-			}
 		}
 
 		return nil

--- a/internal/plugin/retroactive_test.go
+++ b/internal/plugin/retroactive_test.go
@@ -314,6 +314,63 @@ func TestRetroactiveProcessor_ProcessBatchEnrichError(t *testing.T) {
 	}
 }
 
+func TestRetroactiveProcessor_ProcessBatchEnrichNilResult(t *testing.T) {
+	eng := &Engram{Concept: "nil", Content: "content"}
+	iter := &mockIterator{engrams: []*Engram{eng}}
+
+	store := &mockPluginStore{countResult: 1, scanResult: iter}
+	enrichPlugin := &enrichMockForRetro{
+		mockPlugin: mockPlugin{name: "enrich-nil", tier: TierEnrich},
+	}
+	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
+
+	ok := rp.processBatch(context.Background())
+	if !ok {
+		t.Error("processBatch should return true even with enrich errors")
+	}
+
+	stats := rp.Stats()
+	if stats.Errors != 1 {
+		t.Errorf("expected Errors=1, got %d", stats.Errors)
+	}
+	if store.setFlagCalls != 0 {
+		t.Errorf("expected no digest flags to be set on nil result, got %d calls", store.setFlagCalls)
+	}
+}
+
+func TestRetroactiveProcessor_ProcessBatchEntityPersistenceError(t *testing.T) {
+	eng := &Engram{Concept: "retry", Content: "uses postgres"}
+	iter := &mockIterator{engrams: []*Engram{eng}}
+
+	store := &mockPluginStore{
+		countResult: 1,
+		scanResult:  iter,
+		linkErr:     errors.New("link fail"),
+	}
+	enrichPlugin := &enrichMockForRetro{
+		mockPlugin: mockPlugin{name: "enrich-entity-fail", tier: TierEnrich},
+		enrichResult: &EnrichmentResult{
+			Entities: []ExtractedEntity{
+				{Name: "postgres", Type: "database", Confidence: 0.9},
+			},
+		},
+	}
+	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
+
+	ok := rp.processBatch(context.Background())
+	if !ok {
+		t.Error("processBatch should return true even with enrich errors")
+	}
+
+	stats := rp.Stats()
+	if stats.Errors != 1 {
+		t.Errorf("expected Errors=1, got %d", stats.Errors)
+	}
+	if store.setFlagCalls != 0 {
+		t.Errorf("expected no digest flags to be set on entity persistence failure, got %v", store.setFlags)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // processBatch — SetDigestFlag error on enrich path
 // ---------------------------------------------------------------------------

--- a/internal/plugin/store_adapter.go
+++ b/internal/plugin/store_adapter.go
@@ -51,6 +51,9 @@ func (a *pluginStoreAdapter) UpdateEmbedding(ctx context.Context, id ULID, vec [
 }
 
 func (a *pluginStoreAdapter) UpdateDigest(ctx context.Context, id ULID, result *EnrichmentResult) error {
+	if result == nil {
+		return fmt.Errorf("UpdateDigest: nil enrichment result")
+	}
 	return a.store.UpdateDigest(ctx, storage.ULID(id), result.Summary, result.KeyPoints, result.MemoryType, result.TypeLabel)
 }
 

--- a/internal/plugin/store_adapter_test.go
+++ b/internal/plugin/store_adapter_test.go
@@ -133,6 +133,15 @@ func TestStoreAdapter_UpsertRelationship_NotFound(t *testing.T) {
 	}
 }
 
+func TestStoreAdapter_UpdateDigest_NilResult(t *testing.T) {
+	store := openTestStore(t)
+	adapter := &pluginStoreAdapter{store: store}
+
+	if err := adapter.UpdateDigest(context.Background(), ULID{}, nil); err == nil {
+		t.Fatal("expected error for nil enrichment result")
+	}
+}
+
 func TestNewStoreAdapter(t *testing.T) {
 	adapter := NewStoreAdapter(nil, nil)
 	if adapter == nil {

--- a/internal/transport/rest/engine_adapter.go
+++ b/internal/transport/rest/engine_adapter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 	"time"
 
 	"github.com/scrypster/muninndb/internal/cognitive"
@@ -459,45 +458,13 @@ func (w *RESTEngineWrapper) RetryEnrich(ctx context.Context, vault, engramID str
 	if enrichErr != nil {
 		return nil, fmt.Errorf("enrich: %w", enrichErr)
 	}
+	if result == nil {
+		return nil, fmt.Errorf("enrich returned nil result")
+	}
 
 	pStore := plugin.NewStoreAdapter(w.engine.Store(), w.hnswReg)
-
-	if err := pStore.UpdateDigest(ctx, plugin.ULID(ulid), result); err != nil {
-		return nil, fmt.Errorf("persist enriched digest: %w", err)
-	}
-
-	var linkedEntityNames []string
-	for _, entity := range result.Entities {
-		if err := pStore.UpsertEntity(ctx, entity); err != nil {
-			slog.Warn("retry enrich: failed to upsert entity", "id", engramID, "name", entity.Name, "err", err)
-			continue
-		}
-		if err := pStore.LinkEngramToEntity(ctx, plugin.ULID(ulid), entity.Name); err != nil {
-			slog.Warn("retry enrich: failed to link engram to entity", "id", engramID, "name", entity.Name, "err", err)
-			continue
-		}
-		linkedEntityNames = append(linkedEntityNames, entity.Name)
-	}
-	for i := 0; i < len(linkedEntityNames); i++ {
-		for j := i + 1; j < len(linkedEntityNames); j++ {
-			_ = pStore.IncrementEntityCoOccurrence(ctx, plugin.ULID(ulid), linkedEntityNames[i], linkedEntityNames[j])
-		}
-	}
-	if len(result.Entities) > 0 {
-		if err := pStore.SetDigestFlag(ctx, plugin.ULID(ulid), plugin.DigestEntities); err != nil {
-			slog.Warn("retry enrich: failed to set DigestEntities flag", "id", engramID, "err", err)
-		}
-	}
-
-	for _, rel := range result.Relationships {
-		if err := pStore.UpsertRelationship(ctx, plugin.ULID(ulid), rel); err != nil {
-			slog.Warn("retry enrich: failed to upsert relationship", "id", engramID, "err", err)
-		}
-	}
-	if len(result.Relationships) > 0 {
-		if err := pStore.SetDigestFlag(ctx, plugin.ULID(ulid), plugin.DigestRelationships); err != nil {
-			slog.Warn("retry enrich: failed to set DigestRelationships flag", "id", engramID, "err", err)
-		}
+	if err := plugin.PersistEnrichmentResult(ctx, pStore, plugin.ULID(ulid), result); err != nil {
+		return nil, err
 	}
 	return &RetryEnrichResponse{
 		EngramID:      engramID,

--- a/internal/transport/rest/engine_adapter_retry_enrich_test.go
+++ b/internal/transport/rest/engine_adapter_retry_enrich_test.go
@@ -243,3 +243,24 @@ func TestRESTEngineWrapperRetryEnrich_PersistsDigestAndGraphData(t *testing.T) {
 		t.Fatalf("expected entity/relationship persistence without engram-association side effects, got %+v", links.Links)
 	}
 }
+
+func TestRESTEngineWrapperRetryEnrich_NilResultReturnsError(t *testing.T) {
+	eng, cleanup := newRESTRetryEnrichEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	vault := "rest-retry-enrich-nil"
+	writeResp, err := eng.Write(ctx, &WriteRequest{
+		Vault:   vault,
+		Concept: "retry enrich nil result",
+		Content: "plugin returned nil",
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	wrapper := &RESTEngineWrapper{engine: eng, enricher: &restTestEnrichPlugin{}}
+	if _, err := wrapper.RetryEnrich(ctx, vault, writeResp.ID); err == nil {
+		t.Fatal("expected RetryEnrich to reject nil enrichment result")
+	}
+}


### PR DESCRIPTION
## Forward

This is a 2nd PR to append to the already merged work on these issues


## Summary

  This fixes several enrich-path failures observed in a live deployment using an OpenAI-compatible gateway.

  The core problem was not a single bug. Enrich had a few separate failure modes that compounded into the same user-visible symptom: memories either failed to enrich,
  got stuck in retry loops, or were left in a partially persisted state that looked complete enough to suppress later repair.

  This PR hardens that path in three ways:
  1. accept the response shapes real OpenAI-compatible gateways are returning
  2. make retry and retroactive enrichment share the same persistence rules
  3. only mark enrich sub-stages complete after the corresponding data has actually been written successfully

  ## Changes

  - accept enrich JSON from `choices[0].message.reasoning` when `message.content` is empty
  - support both string and structured `reasoning` payloads
  - preserve canonical `memory_type` separately from free-form `type_label`
  - centralize enrich persistence so REST `retry-enrich` and retroactive enrichment use the same write/flagging path
  - reject nil enrichment results instead of panicking during retry or retroactive processing
  - only set `DigestEntities` and `DigestRelationships` after successful persistence of those stages
  - surface entity co-occurrence and other partial graph-write failures instead of silently swallowing them
  - preserve digest metadata correctly during digest rewrites
  - treat missing digest-flag rows as unset during retroactive enrichment
  - tighten entity/relationship parser handling so nested `meta.entities` / `meta.relationships` keys do not get treated as valid empty wrappers
  - improve regression coverage for reasoning fallback, retry-enrich persistence, nil results, partial persistence failures, missing digest flags, and parser edge cases

  - `message.reasoning` fallback:
    some OpenAI-compatible gateways return valid JSON there instead of in `message.content`. Without this fallback, enrich treats a valid model response as empty

  - stage flags only after successful writes:
    the digest flags are effectively the scheduler’s source of truth. If they are set after partial failure, Muninn stops retrying work that never actually completed.
  That is worse than a visible failure because it leaves corrupted progress state behind.

  - nil-result rejection:
    a plugin returning `(nil, nil)` should be treated as a bad enrich result, not as a panic path.

  - stricter parser behavior:
    nested wrapper keys like `{"meta":{"entities":[]}}` should not be accepted as a valid empty entity pass. Returning a parse error here is safer and makes failures
  observable.

  ## Tests

  Added or updated tests for:

  - OpenAI reasoning fallback
  - enrich pipeline aggregation and classification/type handling
  - digest persistence and digest-flag behavior
  - embed-dimension preservation during digest updates
  - REST `retry-enrich` persistence flow
  - REST `retry-enrich` nil-result handling
  - retroactive enrich behavior when digest flags are missing
  - retroactive enrich behavior when persistence partially fails
  - parser rejection of nested `meta.entities` / `meta.relationships` wrapper keys
  ## Validation

  Validated with focused Go test suites and live local verification against an AIC-managed MuninnDB instance.

  - `go test ./internal/plugin/... ./internal/transport/rest`
  - `go test ./internal/storage ./internal/engine ./internal/mcp`
  ## Release Checklist

  - [x] `CHANGELOG.md` updated with changes
  - [x] OpenAPI spec (`internal/transport/rest/openapi.yaml`) updated if API routes changed (not applicable: no API route/schema changes)
  - [x] SDK types updated if request/response schemas changed (Python, Node, PHP) (not applicable: no request/response schema changes)
  - [x] `docs/` updated if user-facing behavior changed
  - [x] `go build ./...` clean
  - [x] `go vet ./...` clean
  - [x] `go test ./...` passes
  
  Closes #137 