### PR TITLE
fix(retroactive): prevent infinite retry loops and improve observability

### DIFF
--- a/internal/mcp/engine_adapter_test.go
+++ b/internal/mcp/engine_adapter_test.go
@@ -19,8 +19,8 @@ type mockPluginStore struct {
 	incrementCoOccurrenceCalls int
 }
 
-func (m *mockPluginStore) CountWithoutFlag(_ context.Context, _ uint8) (int64, error) { return 0, nil }
-func (m *mockPluginStore) ScanWithoutFlag(_ context.Context, _ uint8) plugin.EngramIterator {
+func (m *mockPluginStore) CountWithoutFlag(_ context.Context, _, _ uint8) (int64, error) { return 0, nil }
+func (m *mockPluginStore) ScanWithoutFlag(_ context.Context, _, _ uint8) plugin.EngramIterator {
 	return nil
 }
 func (m *mockPluginStore) SetDigestFlag(_ context.Context, _ plugin.ULID, _ uint8) error {

--- a/internal/plugin/admin.go
+++ b/internal/plugin/admin.go
@@ -175,7 +175,11 @@ func (h *AdminHandler) handleAdd(w http.ResponseWriter, ctx context.Context, req
 		flagBit = DigestEnrich
 	}
 
-	total, err := h.store.CountWithoutFlag(ctx, flagBit)
+	skipFlags := uint8(0)
+	if flagBit == DigestEmbed {
+		skipFlags = DigestEmbedFailed
+	}
+	total, err := h.store.CountWithoutFlag(ctx, flagBit, skipFlags)
 	if err != nil {
 		slog.Warn("failed to count unprocessed engrams", "error", err)
 		total = 0

--- a/internal/plugin/admin_test.go
+++ b/internal/plugin/admin_test.go
@@ -41,11 +41,11 @@ type mockPluginStore struct {
 	coOccurCalls      int
 }
 
-func (m *mockPluginStore) CountWithoutFlag(_ context.Context, _ uint8) (int64, error) {
+func (m *mockPluginStore) CountWithoutFlag(_ context.Context, _, _ uint8) (int64, error) {
 	return m.countResult, m.countErr
 }
 
-func (m *mockPluginStore) ScanWithoutFlag(_ context.Context, _ uint8) EngramIterator {
+func (m *mockPluginStore) ScanWithoutFlag(_ context.Context, _, _ uint8) EngramIterator {
 	return m.scanResult
 }
 

--- a/internal/plugin/embed/ollama.go
+++ b/internal/plugin/embed/ollama.go
@@ -26,6 +26,14 @@ type ollamaEmbedResponse struct {
 	Embedding []float64 `json:"embedding"`
 }
 
+type ollamaShowRequest struct {
+	Name string `json:"name"`
+}
+
+type ollamaShowResponse struct {
+	ModelInfo map[string]any `json:"model_info"`
+}
+
 func (p *OllamaProvider) Name() string {
 	return "ollama"
 }
@@ -60,6 +68,10 @@ func (p *OllamaProvider) Init(ctx context.Context, cfg ProviderHTTPConfig) (int,
 		return 0, fmt.Errorf("cannot connect to Ollama at %s — is it running? (%w)", p.baseURL, err)
 	}
 	resp.Body.Close()
+
+	// Probe model info to warn about small context windows.
+	// A short context window causes long engrams to be silently truncated.
+	p.probeContextLength(ctx)
 
 	// Embed probe text to detect dimension
 	embedCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -147,6 +159,58 @@ func (p *OllamaProvider) EmbedBatch(ctx context.Context, texts []string) ([]floa
 func (p *OllamaProvider) MaxBatchSize() int {
 	// Ollama embeds one at a time
 	return 1
+}
+
+// probeContextLength queries /api/show for model info and logs a warning when
+// the model's context window is below 2048 tokens, which risks silent truncation
+// of longer engram content.
+func (p *OllamaProvider) probeContextLength(ctx context.Context) {
+	showCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	body, _ := json.Marshal(ollamaShowRequest{Name: p.model})
+	req, err := http.NewRequestWithContext(showCtx, "POST", p.baseURL+"/api/show", bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return
+	}
+
+	var show ollamaShowResponse
+	if err := json.NewDecoder(resp.Body).Decode(&show); err != nil {
+		return
+	}
+
+	// The context length is stored under a model-family-specific key in model_info.
+	// Common keys: "llama.context_length", "bert.context_length", etc.
+	const warnThreshold = 2048
+	for k, v := range show.ModelInfo {
+		if k != "llama.context_length" && k != "bert.context_length" &&
+			k != "nomic_bert.context_length" && k != "qwen2.context_length" {
+			continue
+		}
+		switch n := v.(type) {
+		case float64:
+			if int(n) < warnThreshold {
+				slog.Warn("Ollama model has a small context window — long engrams may be truncated",
+					"model", p.model,
+					"context_length", int(n),
+					"recommended_minimum", warnThreshold)
+			} else {
+				slog.Info("Ollama context length", "model", p.model, "context_length", int(n))
+			}
+		}
+		return
+	}
 }
 
 func (p *OllamaProvider) Close() error {

--- a/internal/plugin/enrich/entities_test.go
+++ b/internal/plugin/enrich/entities_test.go
@@ -55,8 +55,8 @@ func (m *mockPluginStore) UpsertRelationship(_ context.Context, id plugin.ULID, 
 }
 
 // Unused interface methods
-func (m *mockPluginStore) CountWithoutFlag(context.Context, uint8) (int64, error)           { return 0, nil }
-func (m *mockPluginStore) ScanWithoutFlag(context.Context, uint8) plugin.EngramIterator     { return nil }
+func (m *mockPluginStore) CountWithoutFlag(context.Context, uint8, uint8) (int64, error)        { return 0, nil }
+func (m *mockPluginStore) ScanWithoutFlag(context.Context, uint8, uint8) plugin.EngramIterator  { return nil }
 func (m *mockPluginStore) SetDigestFlag(context.Context, plugin.ULID, uint8) error          { return nil }
 func (m *mockPluginStore) GetDigestFlags(context.Context, plugin.ULID) (uint8, error)       { return 0, nil }
 func (m *mockPluginStore) UpdateEmbedding(context.Context, plugin.ULID, []float32) error    { return nil }

--- a/internal/plugin/retroactive.go
+++ b/internal/plugin/retroactive.go
@@ -96,6 +96,15 @@ func (rp *RetroactiveProcessor) Mode() string {
 	return "enrich"
 }
 
+// skipFlags returns the digest flags that should be excluded from scanning.
+// Embed processors skip DigestEmbedFailed engrams to avoid infinite retry loops.
+func (rp *RetroactiveProcessor) skipFlags() uint8 {
+	if rp.flagBit == DigestEmbed {
+		return DigestEmbedFailed
+	}
+	return 0
+}
+
 func (rp *RetroactiveProcessor) run(ctx context.Context) {
 	defer rp.wg.Done()
 
@@ -172,7 +181,8 @@ func (rp *RetroactiveProcessor) backoff(ctx context.Context, consecutiveErrors i
 // inference call per micro-batch, then scatters vectors back individually.
 // For EnrichPlugin: processes one engram at a time (LLM call per engram).
 func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
-	total, err := rp.store.CountWithoutFlag(ctx, rp.flagBit)
+	skipFlags := rp.skipFlags()
+	total, err := rp.store.CountWithoutFlag(ctx, rp.flagBit, skipFlags)
 	if err != nil {
 		slog.Error("retroactive processor: count failed", "plugin", rp.plugin.Name(), "error", err)
 		return false
@@ -188,7 +198,7 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 	rp.stats.Total += total
 	rp.statsMu.Unlock()
 
-	iter := rp.store.ScanWithoutFlag(ctx, rp.flagBit)
+	iter := rp.store.ScanWithoutFlag(ctx, rp.flagBit, skipFlags)
 	if iter == nil {
 		slog.Error("retroactive processor: failed to create iterator", "plugin", rp.plugin.Name())
 		return false
@@ -215,10 +225,24 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 		}
 		vecs, embedErr := embedPlugin.Embed(ctx, microTexts)
 		if embedErr != nil {
+			ids := make([]string, len(microEngrams))
+			for i, e := range microEngrams {
+				ids[i] = e.ID.String()
+			}
 			slog.Warn("retroactive processor: embed batch failed",
 				"plugin", rp.plugin.Name(),
 				"batch_size", len(microEngrams),
+				"engram_ids", ids,
 				"error", embedErr)
+			// Mark each engram with DigestEmbedFailed so the processor does not
+			// retry them indefinitely. If the underlying provider recovers, an
+			// operator can clear the flag manually or via the admin API.
+			for _, e := range microEngrams {
+				if flagErr := rp.store.SetDigestFlag(ctx, e.ID, DigestEmbedFailed); flagErr != nil {
+					slog.Warn("retroactive processor: failed to set DigestEmbedFailed",
+						"plugin", rp.plugin.Name(), "engram_id", e.ID.String(), "error", flagErr)
+				}
+			}
 			rp.statsMu.Lock()
 			rp.stats.Errors += int64(len(microEngrams))
 			rp.statsMu.Unlock()

--- a/internal/plugin/store.go
+++ b/internal/plugin/store.go
@@ -6,13 +6,17 @@ import "context"
 // A subset of EngineStore — plugins never see the full store surface.
 type PluginStore interface {
 	// CountWithoutFlag returns the number of engrams missing the given digest flag.
+	// skipFlags causes engrams that have any of those bits set to be excluded
+	// from the count (e.g. pass DigestEmbedFailed to exclude permanently-failed engrams).
 	// Used by RetroactiveProcessor to calculate total work.
-	CountWithoutFlag(ctx context.Context, flag uint8) (int64, error)
+	CountWithoutFlag(ctx context.Context, flag, skipFlags uint8) (int64, error)
 
 	// ScanWithoutFlag returns an iterator over engrams missing the given digest flag.
+	// skipFlags causes engrams that have any of those bits set to be skipped
+	// (e.g. pass DigestEmbedFailed to skip permanently-failed engrams).
 	// Iterates in ULID order (oldest first). Must be resumable: if the server
 	// restarts, calling ScanWithoutFlag again yields only unprocessed engrams.
-	ScanWithoutFlag(ctx context.Context, flag uint8) EngramIterator
+	ScanWithoutFlag(ctx context.Context, flag, skipFlags uint8) EngramIterator
 
 	// SetDigestFlag sets a digest flag bit on an engram's metadata.
 	// Atomic: uses Pebble Merge to set the bit without read-modify-write.

--- a/internal/plugin/store_adapter.go
+++ b/internal/plugin/store_adapter.go
@@ -20,12 +20,12 @@ func NewStoreAdapter(store *storage.PebbleStore, hnsw *hnswpkg.Registry) PluginS
 	return &pluginStoreAdapter{store: store, hnsw: hnsw}
 }
 
-func (a *pluginStoreAdapter) CountWithoutFlag(ctx context.Context, flag uint8) (int64, error) {
-	return a.store.CountWithoutFlag(ctx, flag)
+func (a *pluginStoreAdapter) CountWithoutFlag(ctx context.Context, flag, skipFlags uint8) (int64, error) {
+	return a.store.CountWithoutFlag(ctx, flag, skipFlags)
 }
 
-func (a *pluginStoreAdapter) ScanWithoutFlag(ctx context.Context, flag uint8) EngramIterator {
-	iter := a.store.ScanWithoutFlag(ctx, flag)
+func (a *pluginStoreAdapter) ScanWithoutFlag(ctx context.Context, flag, skipFlags uint8) EngramIterator {
+	iter := a.store.ScanWithoutFlag(ctx, flag, skipFlags)
 	if iter == nil {
 		// Prevent a typed-nil concrete pointer from being wrapped in a non-nil
 		// interface value, which would cause a nil-dereference panic in the caller.

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -56,6 +56,11 @@ const (
 	DigestRelationships uint8 = 0x10 // relationship extraction complete
 	DigestClassified    uint8 = 0x20 // classification complete
 	DigestSummarized    uint8 = 0x40 // summarization complete
+
+	// DigestEmbedFailed is set when an embed batch permanently fails for an engram.
+	// Engrams with this flag are skipped by the embed retroactive processor so
+	// they are not retried indefinitely.
+	DigestEmbedFailed uint8 = 0x80
 )
 
 // PluginStatus represents the runtime state of a registered plugin.

--- a/internal/storage/plugin_store.go
+++ b/internal/storage/plugin_store.go
@@ -13,8 +13,9 @@ import (
 )
 
 // CountWithoutFlag returns the number of engrams across all vaults that are
-// missing the given digest flag bit.
-func (ps *PebbleStore) CountWithoutFlag(ctx context.Context, flag uint8) (int64, error) {
+// missing the given digest flag bit. Engrams that have any skipFlags bit set
+// are excluded from the count (e.g. permanently-failed engrams).
+func (ps *PebbleStore) CountWithoutFlag(ctx context.Context, flag, skipFlags uint8) (int64, error) {
 	lowerBound := []byte{0x01}
 	upperBound := []byte{0x02}
 
@@ -37,7 +38,7 @@ func (ps *PebbleStore) CountWithoutFlag(ctx context.Context, flag uint8) (int64,
 		copy(id[:], k[9:25])
 
 		raw, err := ps.getDigestFlagsRaw(id)
-		if err != nil || (raw&flag == 0) {
+		if (err != nil || raw&flag == 0) && (skipFlags == 0 || raw&skipFlags == 0) {
 			count++
 		}
 	}
@@ -71,8 +72,9 @@ func (ps *PebbleStore) CountWithFlag(ctx context.Context, flag uint8) (int64, er
 }
 
 // ScanWithoutFlag returns a forward-only iterator over all engrams that are
-// missing the given digest flag bit.
-func (ps *PebbleStore) ScanWithoutFlag(ctx context.Context, flag uint8) *PluginEngramIterator {
+// missing the given digest flag bit. Engrams that have any skipFlags bit set
+// are skipped during iteration.
+func (ps *PebbleStore) ScanWithoutFlag(ctx context.Context, flag, skipFlags uint8) *PluginEngramIterator {
 	lowerBound := []byte{0x01}
 	upperBound := []byte{0x02}
 
@@ -88,12 +90,13 @@ func (ps *PebbleStore) ScanWithoutFlag(ctx context.Context, flag uint8) *PluginE
 	}
 
 	return &PluginEngramIterator{
-		ps:      ps,
-		iter:    iter,
-		flag:    flag,
-		started: false,
-		current: nil,
-		wsCache: make(map[ULID][8]byte),
+		ps:        ps,
+		iter:      iter,
+		flag:      flag,
+		skipFlags: skipFlags,
+		started:   false,
+		current:   nil,
+		wsCache:   make(map[ULID][8]byte),
 	}
 }
 
@@ -220,12 +223,13 @@ func (ps *PebbleStore) FindVaultPrefix(id ULID) ([8]byte, bool) {
 // PluginEngramIterator is a forward-only iterator over engrams missing a digest flag.
 // It implements plugin.EngramIterator.
 type PluginEngramIterator struct {
-	ps      *PebbleStore
-	iter    *pebble.Iterator
-	iterErr error // set when NewIter failed; Next() immediately returns false
-	flag    uint8
-	started bool
-	current *Engram
+	ps        *PebbleStore
+	iter      *pebble.Iterator
+	iterErr   error // set when NewIter failed; Next() immediately returns false
+	flag      uint8
+	skipFlags uint8 // skip engrams that have any of these bits set (e.g. DigestEmbedFailed)
+	started   bool
+	current   *Engram
 	// wsCache maps ULID -> vault prefix so callers can retrieve it.
 	wsCache   map[ULID][8]byte
 	currentWS [8]byte
@@ -266,6 +270,10 @@ func (it *PluginEngramIterator) Next() bool {
 			// Already has this flag, skip
 			continue
 		}
+		// Skip engrams that have a permanent failure flag set (e.g. DigestEmbedFailed).
+		if it.skipFlags != 0 && err == nil && raw&it.skipFlags != 0 {
+			continue
+		}
 
 		// Decode engram
 		val := make([]byte, len(it.iter.Value()))
@@ -276,6 +284,12 @@ func (it *PluginEngramIterator) Next() bool {
 		}
 
 		eng := fromERFEngram(erfEng)
+
+		// Skip soft-deleted and archived engrams — they are not candidates for processing.
+		if eng.State == StateSoftDeleted || eng.State == StateArchived {
+			continue
+		}
+
 		it.current = eng
 		it.currentWS = ws
 		it.wsCache[ULID(id)] = ws

--- a/internal/storage/plugin_store_test.go
+++ b/internal/storage/plugin_store_test.go
@@ -37,7 +37,7 @@ func TestCountWithoutFlag(t *testing.T) {
 		t.Fatalf("SetDigestFlag: %v", err)
 	}
 
-	count, err := store.CountWithoutFlag(ctx, flag)
+	count, err := store.CountWithoutFlag(ctx, flag, 0)
 	if err != nil {
 		t.Fatalf("CountWithoutFlag: %v", err)
 	}


### PR DESCRIPTION
## Summary

Fixes issue #133 — three bugs in the retroactive embed processor plus one enhancement.

- **Bug 1 (missing IDs in error log):** `flushMicroBatch` now logs the full list of engram IDs alongside the embed failure error, so operators can identify stuck engrams.
- **Bug 2 (infinite retry loop):** A new `DigestEmbedFailed` flag (`0x80`) is set on each engram whose embed batch permanently fails. The embed retroactive processor passes this as `skipFlags` to `CountWithoutFlag` / `ScanWithoutFlag`, so permanently-failed engrams are excluded from future scans without needing external intervention.
- **Bug 3 (soft-deleted/archived retried):** `PluginEngramIterator.Next()` now skips engrams with `State == StateSoftDeleted` or `StateArchived`.
- **Enhancement (Ollama context warning):** `OllamaProvider.Init()` probes `/api/show` after the connectivity check and logs a warning when the model's context length is below 2048 tokens, surfacing the silent-truncation risk at startup rather than silently producing poor embeddings.

## Interface changes

`CountWithoutFlag` and `ScanWithoutFlag` both gain a `skipFlags uint8` parameter. All implementations and mocks updated accordingly.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/plugin/... ./internal/storage/... ./internal/mcp/...` — all pass
- [x] `go test ./...` — all 40 packages pass