### PR TITLE
fix(storage): harden all goroutines against Pebble closed-DB panics

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -405,6 +405,14 @@ func (e *Engine) runCoherenceFlush() {
 
 // flushCoherence serializes all vault coherence counters to Pebble.
 func (e *Engine) flushCoherence() {
+	defer func() {
+		if r := recover(); r != nil {
+			if storage.IsClosedPanic(r) {
+				return
+			}
+			slog.Error("engine: coherence flush panicked", "panic", r)
+		}
+	}()
 	if e.coherence == nil {
 		return
 	}
@@ -2626,6 +2634,13 @@ func (e *Engine) PruneVault(ctx context.Context, vaultName string) (int64, error
 // MaxEngrams, RetentionDays, and AssocDecayFactor policies. Runs every 60s with ±5s jitter.
 func (e *Engine) runPruneWorker() {
 	defer close(e.pruneDone)
+	defer func() {
+		if r := recover(); r != nil {
+			if !storage.IsClosedPanic(r) {
+				slog.Error("engine: prune worker panicked", "panic", r)
+			}
+		}
+	}()
 	jitter := time.Duration(rand.Intn(10)) * time.Second
 	timer := time.NewTimer(60*time.Second + jitter)
 	defer timer.Stop()
@@ -2667,6 +2682,13 @@ func (e *Engine) runPruneWorker() {
 // startup (to clean up existing accumulation) and then every 24 hours.
 func (e *Engine) runIdempotencySweep() {
 	defer close(e.idempotencySweepDone)
+	defer func() {
+		if r := recover(); r != nil {
+			if !storage.IsClosedPanic(r) {
+				slog.Error("engine: idempotency sweep panicked", "panic", r)
+			}
+		}
+	}()
 	const retention = 30 * 24 * time.Hour
 	sweep := func() {
 		n, err := e.store.PurgeExpiredIdempotency(e.stopCtx, retention)
@@ -2697,6 +2719,13 @@ func (e *Engine) runIdempotencySweep() {
 // daysSinceLastActivation > 1095, and restoredAt == 0 (never restored).
 func (e *Engine) runArchiveGCWorker() {
 	defer close(e.archiveGCDone)
+	defer func() {
+		if r := recover(); r != nil {
+			if !storage.IsClosedPanic(r) {
+				slog.Error("engine: archive GC worker panicked", "panic", r)
+			}
+		}
+	}()
 	ticker := time.NewTicker(7 * 24 * time.Hour)
 	defer ticker.Stop()
 	for {
@@ -2729,6 +2758,13 @@ func (e *Engine) GetNoveltyDrops() int64 {
 // scans and REFINES association writes entirely off the synchronous write hot path.
 func (e *Engine) runNoveltyWorker() {
 	defer close(e.noveltyDone)
+	defer func() {
+		if r := recover(); r != nil {
+			if !storage.IsClosedPanic(r) {
+				slog.Error("engine: novelty worker panicked", "panic", r)
+			}
+		}
+	}()
 	for {
 		select {
 		case <-e.stopCtx.Done():

--- a/internal/engine/engine_clone.go
+++ b/internal/engine/engine_clone.go
@@ -2,11 +2,9 @@ package engine
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 
-	"github.com/cockroachdb/pebble"
 	"github.com/scrypster/muninndb/internal/engine/vaultjob"
 	"github.com/scrypster/muninndb/internal/index/fts"
 	"github.com/scrypster/muninndb/internal/storage"
@@ -88,7 +86,7 @@ func (e *Engine) runClone(job *vaultjob.Job, wsSource, wsTarget [8]byte, newName
 		if r := recover(); r != nil {
 			// Swallow closed-DB panics — can occur if the 30s Stop() timeout
 			// expires and Pebble is closed before this goroutine exits.
-			if err, ok := r.(error); ok && errors.Is(err, pebble.ErrClosed) {
+			if storage.IsClosedPanic(r) {
 				e.jobManager.Fail(job, fmt.Errorf("engine closed during job"))
 				return
 			}
@@ -217,7 +215,7 @@ func (e *Engine) runMerge(job *vaultjob.Job, wsSource, wsTarget [8]byte, sourceV
 		if r := recover(); r != nil {
 			// Swallow closed-DB panics — can occur if the 30s Stop() timeout
 			// expires and Pebble is closed before this goroutine exits.
-			if err, ok := r.(error); ok && errors.Is(err, pebble.ErrClosed) {
+			if storage.IsClosedPanic(r) {
 				e.jobManager.Fail(job, fmt.Errorf("engine closed during job"))
 				return
 			}

--- a/internal/engine/engine_export.go
+++ b/internal/engine/engine_export.go
@@ -1,12 +1,10 @@
 package engine
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 
-	"github.com/cockroachdb/pebble"
 	"github.com/scrypster/muninndb/internal/engine/vaultjob"
 	"github.com/scrypster/muninndb/internal/metrics"
 	"github.com/scrypster/muninndb/internal/storage"
@@ -107,7 +105,7 @@ func (e *Engine) runImport(job *vaultjob.Job, wsTarget [8]byte, vaultName string
 		if rec := recover(); rec != nil {
 			// Swallow closed-DB panics — can occur if the 30s Stop() timeout
 			// expires and Pebble is closed before this goroutine exits.
-			if err, ok := rec.(error); ok && errors.Is(err, pebble.ErrClosed) {
+			if storage.IsClosedPanic(rec) {
 				e.jobManager.Fail(job, fmt.Errorf("engine closed during job"))
 				return
 			}

--- a/internal/engine/engine_reembed.go
+++ b/internal/engine/engine_reembed.go
@@ -2,12 +2,11 @@ package engine
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 
-	"github.com/cockroachdb/pebble"
 	"github.com/scrypster/muninndb/internal/engine/vaultjob"
+	"github.com/scrypster/muninndb/internal/storage"
 )
 
 // StartReembedVault clears stale embeddings and digest flags for the named vault,
@@ -72,7 +71,7 @@ func (e *Engine) runReembed(job *vaultjob.Job, ws [8]byte, vaultName string) {
 		if r := recover(); r != nil {
 			// Swallow closed-DB panics — can occur if the 30s Stop() timeout
 			// expires and Pebble is closed before this goroutine exits.
-			if err, ok := r.(error); ok && errors.Is(err, pebble.ErrClosed) {
+			if storage.IsClosedPanic(r) {
 				e.jobManager.Fail(job, fmt.Errorf("engine closed during job"))
 				return
 			}

--- a/internal/index/fts/worker.go
+++ b/internal/index/fts/worker.go
@@ -1,8 +1,10 @@
 package fts
 
 import (
+	"fmt"
 	"log/slog"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -68,6 +70,16 @@ func NewWorker(idx *Index) *Worker {
 	for range n {
 		go func() {
 			defer w.wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					// Swallow closed-DB panics that surface as panics in the FTS
+					// indexing path when Pebble is torn down before all goroutines exit.
+					if ftsIsClosedPanic(r) || w.stopped.Load() {
+						return
+					}
+					slog.Error("fts: worker goroutine panicked", "panic", r)
+				}
+			}()
 			w.run()
 		}()
 	}
@@ -155,4 +167,13 @@ func (w *Worker) flush(jobs []IndexJob) {
 			)
 		}
 	}
+}
+
+// ftsIsClosedPanic reports whether a recovered panic value represents a
+// closed-DB condition from Pebble. Inlined here to avoid an import cycle
+// with the storage package. Must stay in sync with storage.IsClosedPanic.
+func ftsIsClosedPanic(r any) bool {
+	s := fmt.Sprintf("%v", r)
+	return strings.Contains(s, "pebble: closed") ||
+		strings.Contains(s, "pebble/record: closed")
 }

--- a/internal/storage/pebble_guard.go
+++ b/internal/storage/pebble_guard.go
@@ -1,0 +1,30 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/pebble"
+)
+
+// IsClosedPanic reports whether a recovered panic value represents a
+// closed-DB condition from Pebble. Pebble surfaces this in three ways:
+//
+//   - An error value wrapping pebble.ErrClosed ("pebble: closed")
+//   - A formatted string from applyInternal containing "pebble: closed"
+//   - A raw string from the record package: "pebble/record: closed LogWriter"
+//
+// All three represent the same unrecoverable state: the DB has been closed.
+// This function is intentionally broad — any panic mentioning Pebble being
+// closed is treated as an expected shutdown condition.
+func IsClosedPanic(r any) bool {
+	if err, ok := r.(error); ok {
+		return errors.Is(err, pebble.ErrClosed)
+	}
+	s := fmt.Sprintf("%v", r)
+	// "pebble: closed" — applyInternal / standard ErrClosed string path.
+	// "pebble/record: closed" — LogWriter torn down before the goroutine exits.
+	return strings.Contains(s, pebble.ErrClosed.Error()) ||
+		strings.Contains(s, "pebble/record: closed")
+}

--- a/internal/storage/transition_cache.go
+++ b/internal/storage/transition_cache.go
@@ -197,6 +197,15 @@ func (tc *TransitionCache) flushLoop() {
 
 // flushAndEvict writes dirty sources to Pebble and evicts cold entries.
 func (tc *TransitionCache) flushAndEvict() {
+	defer func() {
+		if r := recover(); r != nil {
+			// Swallow closed-DB panics from Pebble during engine shutdown.
+			if IsClosedPanic(r) {
+				return
+			}
+			slog.Error("transition cache: flush panicked", "panic", r)
+		}
+	}()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := tc.Flush(ctx); err != nil {

--- a/internal/storage/wal_syncer.go
+++ b/internal/storage/wal_syncer.go
@@ -2,33 +2,12 @@ package storage
 
 import (
 	"errors"
-	"fmt"
 	"log/slog"
-	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/pebble"
 )
-
-// isClosedPanic reports whether the recovered panic value represents a
-// closed-DB condition from Pebble. Pebble surfaces this in several ways:
-//
-//   - An error value wrapping pebble.ErrClosed ("pebble: closed")
-//   - A formatted string from applyInternal containing "pebble: closed"
-//   - A string from the record package: "pebble/record: closed LogWriter"
-//
-// All three represent the same unrecoverable state: the DB has been closed.
-func isClosedPanic(r any) bool {
-	if err, ok := r.(error); ok {
-		return errors.Is(err, pebble.ErrClosed)
-	}
-	s := fmt.Sprintf("%v", r)
-	// "pebble: closed" — applyInternal / standard ErrClosed string path.
-	// "pebble/record: closed" — LogWriter torn down before the goroutine exits.
-	return strings.Contains(s, pebble.ErrClosed.Error()) ||
-		strings.Contains(s, "pebble/record: closed")
-}
 
 const walSyncInterval = 10 * time.Millisecond
 
@@ -125,7 +104,7 @@ func (s *walSyncer) doSync() {
 			// closed-db condition as a panic (not an error) when the WAL writer
 			// is already torn down. This is safe to ignore in all cases because
 			// the db is already in an unrecoverable state.
-			if isClosedPanic(r) {
+			if IsClosedPanic(r) {
 				return
 			}
 			if s.stopped.Load() {

--- a/internal/storage/wal_syncer_test.go
+++ b/internal/storage/wal_syncer_test.go
@@ -37,7 +37,7 @@ func TestIsClosedPanic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isClosedPanic(tt.val)
+			got := IsClosedPanic(tt.val)
 			if got != tt.want {
 				t.Errorf("isClosedPanic(%v) = %v, want %v", tt.val, got, tt.want)
 			}


### PR DESCRIPTION
## Summary

- Extract `isClosedPanic` from `wal_syncer.go` into new shared `storage/pebble_guard.go` as exported `IsClosedPanic`
- Fix all engine job goroutine recoveries (`runClone`, `runMerge`, `runImport`, `runReembed`) to use `storage.IsClosedPanic` — previously only caught error-typed panics, missing string panics like `"pebble/record: closed LogWriter"`
- Add `recover()` to `TransitionCache.flushAndEvict()`, `flushCoherence()`, `runNoveltyWorker()`, `runPruneWorker()`, `runIdempotencySweep()`, `runArchiveGCWorker()` — none had any panic guard
- Add `recover()` to FTS worker goroutine launcher with inlined closed-panic check (avoids import cycle with storage package)

Addresses the develop pipeline flake where `walSyncer.doSync` re-panicked with `pebble/record: closed LogWriter` during shutdown stress testing.

## Test Plan

- [x] `go build ./...` — clean
- [x] `TestEngine_StopDrainsJobs` × 20 — all pass
- [x] `internal/storage` × 3 — all pass (including `TestIsClosedPanic` and `TestWALSyncer_CloseBeforeGoroutineExits`)
- [x] `go test ./... -timeout 300s` — all packages pass, zero failures