### PR TITLE
fix(rest): close auth bypass on body vault override and fix memory_type omission (#145)

### DIFF
--- a/internal/transport/mbp/types.go
+++ b/internal/transport/mbp/types.go
@@ -86,7 +86,7 @@ type WriteRequest struct {
 	Embedding    []float32     `msgpack:"embedding,omitempty" json:"embedding,omitempty"`
 	Vault        string        `msgpack:"vault,omitempty" json:"vault,omitempty"`
 	IdempotentID string        `msgpack:"idempotent_id,omitempty" json:"idempotent_id,omitempty"`
-	MemoryType   uint8         `msgpack:"memory_type,omitempty" json:"memory_type,omitempty"`
+	MemoryType   uint8         `msgpack:"memory_type,omitempty" json:"memory_type"`
 	TypeLabel    string        `msgpack:"type_label,omitempty" json:"type_label,omitempty"`
 
 	// Inline enrichment: caller-provided data that bypasses background enrichment.
@@ -124,7 +124,7 @@ type ReadResponse struct {
 	LastAccess     int64    `msgpack:"last_access"           json:"last_access"`
 	Summary        string   `msgpack:"summary,omitempty"     json:"summary,omitempty"`
 	KeyPoints      []string `msgpack:"key_points,omitempty"  json:"key_points,omitempty"`
-	MemoryType     uint8    `msgpack:"memory_type,omitempty" json:"memory_type,omitempty"`
+	MemoryType     uint8    `msgpack:"memory_type,omitempty" json:"memory_type"`
 	TypeLabel      string   `msgpack:"type_label,omitempty"  json:"type_label,omitempty"`
 	Classification uint16   `msgpack:"classification,omitempty" json:"classification,omitempty"`
 	// EmbedDim is the stored embedding dimensionality code (0 = no embedding).

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -568,9 +568,7 @@ func (s *Server) handleCreateEngram(w http.ResponseWriter, r *http.Request) {
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "invalid request body")
 		return
 	}
-	if req.Vault == "" {
-		req.Vault = ctxVault(r)
-	}
+	req.Vault = ctxVault(r)
 	resp, err := s.engine.Write(r.Context(), &req)
 	if err != nil {
 		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
@@ -597,10 +595,9 @@ func (s *Server) handleBatchCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	reqs := make([]*WriteRequest, len(body.Engrams))
+	vault := ctxVault(r)
 	for i := range body.Engrams {
-		if body.Engrams[i].Vault == "" {
-			body.Engrams[i].Vault = ctxVault(r)
-		}
+		body.Engrams[i].Vault = vault
 		reqs[i] = &body.Engrams[i]
 	}
 
@@ -665,9 +662,7 @@ func (s *Server) handleActivate(w http.ResponseWriter, r *http.Request) {
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "invalid request body")
 		return
 	}
-	if req.Vault == "" {
-		req.Vault = ctxVault(r)
-	}
+	req.Vault = ctxVault(r)
 	// Apply recall mode preset if provided.
 	if req.Mode != "" {
 		preset, err := auth.LookupRecallMode(req.Mode)
@@ -728,9 +723,7 @@ func (s *Server) handleLink(w http.ResponseWriter, r *http.Request) {
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "invalid request body")
 		return
 	}
-	if req.Vault == "" {
-		req.Vault = ctxVault(r)
-	}
+	req.Vault = ctxVault(r)
 	mbpReq := &mbp.LinkRequest{
 		SourceID: req.SourceID,
 		TargetID: req.TargetID,
@@ -1108,9 +1101,7 @@ func (s *Server) handleBatchGetEngramLinks(w http.ResponseWriter, r *http.Reques
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "'ids' exceeds maximum batch size of 200")
 		return
 	}
-	if req.Vault == "" {
-		req.Vault = ctxVault(r)
-	}
+	req.Vault = ctxVault(r)
 	resp, err := s.engine.GetBatchEngramLinks(r.Context(), &req)
 	if err != nil {
 		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())

--- a/internal/transport/rest/server_test.go
+++ b/internal/transport/rest/server_test.go
@@ -2188,3 +2188,46 @@ func TestBatchGetEngramLinks_EngineError(t *testing.T) {
 		t.Fatalf("want 500 got %d", w.Code)
 	}
 }
+
+// --- Bug #145: memory_type omitempty ---
+
+// memoryTypeZeroEngine returns a ReadResponse where MemoryType is 0 (fact — the default).
+type memoryTypeZeroEngine struct{ MockEngine }
+
+func (e *memoryTypeZeroEngine) Read(ctx context.Context, req *ReadRequest) (*ReadResponse, error) {
+	return &ReadResponse{
+		ID:         "test-id",
+		Concept:    "test",
+		Content:    "test content",
+		Confidence: 0.9,
+		MemoryType: 0, // fact type — zero value that omitempty would suppress
+	}, nil
+}
+
+// TestReadResponse_MemoryTypeZeroIncludedInJSON verifies that memory_type=0 (fact)
+// is always present in the JSON response body. Previously, json:"memory_type,omitempty"
+// caused the field to be silently omitted for fact memories, making them
+// indistinguishable from responses that don't carry a memory type at all.
+func TestReadResponse_MemoryTypeZeroIncludedInJSON(t *testing.T) {
+	server := NewServer("localhost:8080", &memoryTypeZeroEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+
+	req := httptest.NewRequest("GET", "/api/engrams/test-id?vault=default", nil)
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Decode into a raw map to verify presence of the key (not just its value).
+	var raw map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := raw["memory_type"]; !ok {
+		t.Error("memory_type missing from JSON response — zero value (fact type) must always be serialized")
+	}
+	if val, _ := raw["memory_type"].(float64); val != 0 {
+		t.Errorf("memory_type: want 0, got %v", raw["memory_type"])
+	}
+}

--- a/internal/transport/rest/vault_routing_test.go
+++ b/internal/transport/rest/vault_routing_test.go
@@ -769,3 +769,103 @@ func TestVaultRouting_ResolveContradiction_ExplicitVault(t *testing.T) {
 		t.Errorf("engine ResolveContradiction vault: want %q, got %q", "myvault", eng.lastResolveContradictionVault)
 	}
 }
+
+// --- Bug #145: body vault bypass ---
+
+// TestVaultRouting_Write_BodyVaultIgnored verifies that a "vault" field in the
+// POST /api/engrams request body cannot override the auth-middleware vault.
+// A key scoped to "default" must not be able to write to "othervault" by
+// setting "vault":"othervault" in the JSON body.
+func TestVaultRouting_Write_BodyVaultIgnored(t *testing.T) {
+	srv, eng, _ := newVaultTrackingServer(t)
+
+	// Body contains vault:"othervault" but the auth middleware resolves "default".
+	body := strings.NewReader(`{"concept":"test","content":"hello","vault":"othervault"}`)
+	req := httptest.NewRequest("POST", "/api/engrams", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if eng.lastWriteVault != "default" {
+		t.Errorf("body vault must be ignored: engine Write vault = %q, want %q", eng.lastWriteVault, "default")
+	}
+}
+
+// TestVaultRouting_BatchCreate_BodyVaultIgnored verifies that per-item "vault"
+// fields in POST /api/engrams/batch cannot override the auth-middleware vault.
+func TestVaultRouting_BatchCreate_BodyVaultIgnored(t *testing.T) {
+	srv, eng, _ := newVaultTrackingServer(t)
+
+	body := strings.NewReader(`{"engrams":[{"concept":"a","content":"b","vault":"othervault"},{"concept":"c","content":"d","vault":"thirdfault"}]}`)
+	req := httptest.NewRequest("POST", "/api/engrams/batch", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if eng.lastWriteBatchVault != "default" {
+		t.Errorf("per-item body vault must be ignored: engine WriteBatch vault = %q, want %q", eng.lastWriteBatchVault, "default")
+	}
+}
+
+// TestVaultRouting_Activate_BodyVaultIgnored verifies that a "vault" field in
+// the POST /api/activate body cannot override the auth-middleware vault.
+func TestVaultRouting_Activate_BodyVaultIgnored(t *testing.T) {
+	srv, eng, _ := newVaultTrackingServer(t)
+
+	body := strings.NewReader(`{"context":["something"],"vault":"othervault"}`)
+	req := httptest.NewRequest("POST", "/api/activate", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if eng.lastActivateVault != "default" {
+		t.Errorf("body vault must be ignored: engine Activate vault = %q, want %q", eng.lastActivateVault, "default")
+	}
+}
+
+// TestVaultRouting_Link_BodyVaultIgnored verifies that a "vault" field in
+// the POST /api/link body cannot override the auth-middleware vault.
+func TestVaultRouting_Link_BodyVaultIgnored(t *testing.T) {
+	srv, eng, _ := newVaultTrackingServer(t)
+
+	body := strings.NewReader(`{"source_id":"a","target_id":"b","vault":"othervault"}`)
+	req := httptest.NewRequest("POST", "/api/link", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if eng.lastLinkVault != "default" {
+		t.Errorf("body vault must be ignored: engine Link vault = %q, want %q", eng.lastLinkVault, "default")
+	}
+}
+
+// TestVaultRouting_BatchGetEngramLinks_BodyVaultIgnored verifies that a "vault"
+// field in the POST /api/engrams/links/batch body cannot override the auth-middleware vault.
+func TestVaultRouting_BatchGetEngramLinks_BodyVaultIgnored(t *testing.T) {
+	srv, eng, _ := newVaultTrackingServer(t)
+
+	body := strings.NewReader(`{"ids":["01JAAAAAAAAAAAAAAAAAAAAAA1"],"vault":"othervault"}`)
+	req := httptest.NewRequest("POST", "/api/engrams/links/batch", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if eng.lastGetBatchEngramLinksVault != "default" {
+		t.Errorf("body vault must be ignored: engine GetBatchEngramLinks vault = %q, want %q", eng.lastGetBatchEngramLinksVault, "default")
+	}
+}


### PR DESCRIPTION
## Summary

- **Auth bypass (write/read)**: `POST /api/engrams`, `POST /api/engrams/batch`, `POST /api/activate`, `POST /api/link`, and `POST /api/engrams/links/batch` all had `if req.Vault == ""` guards that let a client override the auth-middleware-resolved vault by supplying a different vault in the JSON body. A key scoped to vault A could operate on vault B. Fixed by unconditionally assigning `req.Vault = ctxVault(r)`.
- **`memory_type` serialization**: `MemoryType uint8` was tagged `json:"memory_type,omitempty"`, silently dropping zero-value (fact type = 0) from JSON responses. Fixed by removing `omitempty` from the json tag (msgpack tag unchanged).

## Test Plan
- [ ] `TestVaultRouting_Write_BodyVaultIgnored` — body vault cannot override auth vault on write
- [ ] `TestVaultRouting_BatchCreate_BodyVaultIgnored` — per-item body vault ignored in batch create
- [ ] `TestVaultRouting_Activate_BodyVaultIgnored` — body vault ignored on activate
- [ ] `TestVaultRouting_Link_BodyVaultIgnored` — body vault ignored on link
- [ ] `TestVaultRouting_BatchGetEngramLinks_BodyVaultIgnored` — body vault ignored on batch link fetch
- [ ] `TestReadResponse_MemoryTypeZeroIncludedInJSON` — `memory_type: 0` present in JSON response
- [ ] Full REST and mbp test suites pass
- [ ] CI green

Closes #145