### PR TITLE
fix(enrich): wire enrichPlugin into engine for replay_enrichment

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -987,6 +987,7 @@ func runServer() {
 		if err := pluginRegistry.Register(enrichPlugin); err != nil {
 			slog.Warn("failed to register enrich plugin in registry", "err", err)
 		}
+		eng.SetEnrichPlugin(enrichPlugin)
 		if rew, ok := restWrapper.(*rest.RESTEngineWrapper); ok {
 			rew.SetEnricher(enrichPlugin)
 		}


### PR DESCRIPTION
replay_enrichment failed with "no enrich plugin available" because
server.go never called eng.SetEnrichPlugin() during initialization.
The plugin was only passed to the MCP adapter (for retry_enrich) and
the REST wrapper, but not to the Engine struct that replay_enrichment
delegates to. Add the missing SetEnrichPlugin call in the startup
wiring block.