### PR TITLE
feat(contrib): add systemd service unit for self-hosters

### DIFF
--- a/contrib/muninndb.service
+++ b/contrib/muninndb.service
@@ -21,19 +21,17 @@ After=network.target
 
 [Service]
 Type=forking
+# PIDFile must match your MUNINNDB_DATA path — muninn writes muninn.pid
+# inside the data directory on start and removes it on clean stop.
+PIDFile=/opt/muninndb/data/muninn.pid
 
 # --- Data ---
 # MUNINNDB_DATA overrides the default (~/.muninn/data).
-# Use this env var rather than --data flag — the start subcommand
-# does not forward --data to the daemon correctly.
 Environment=MUNINNDB_DATA=/opt/muninndb/data
 
 # --- Network ---
 Environment=MUNINN_LISTEN_HOST=0.0.0.0
 Environment=MUNINN_CORS_ORIGINS=http://YOUR_SERVER_IP:8476
-
-# --- Auth ---
-Environment=MUNINN_MCP_TOKEN=your-mcp-token-here
 
 # --- Embeddings (choose one, comment out the rest) ---
 # Local Ollama (no API key required):
@@ -51,7 +49,11 @@ Environment=MUNINN_ANTHROPIC_KEY=sk-ant-...
 # Environment=MUNINN_ENRICH_URL=openai://gpt-4o-mini
 # Environment=MUNINN_ENRICH_API_KEY=sk-...
 
-ExecStart=/opt/muninndb-src/muninndb-server start
+# --- Auth ---
+# The MCP bearer token is passed via --mcp-token flag.
+# Alternatively, write your token to ~/.muninn/mcp.token (no flag needed):
+#   echo 'your-token' > ~/.muninn/mcp.token && chmod 600 ~/.muninn/mcp.token
+ExecStart=/opt/muninndb-src/muninndb-server start --mcp-token your-mcp-token-here
 ExecStop=/opt/muninndb-src/muninndb-server stop
 Restart=on-failure
 


### PR DESCRIPTION
## Summary

Adds `contrib/muninndb.service` — a documented systemd unit template for running MuninnDB as a persistent system service on Linux without Docker.

Spun out from #151 per maintainer request.

## What's included

- All provider options documented inline (Ollama, OpenAI, Anthropic, Voyage, Cohere, etc.)
- Install instructions in the file header
- Key gotcha documented: use `MUNINNDB_DATA` env var rather than `--data` flag — the `start` subcommand does not forward `--data` to the daemon correctly

## Verified on

Rocky Linux 8.10 with binary built from source. Service starts on boot, survives restarts, data persists across reboots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)