### PR TITLE
feat(graph): memory graph UX — spacing, resize, label toggle

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -63,6 +63,7 @@ document.addEventListener('alpine:init', () => {
     // Graph
     graphLoaded: false,
     graphTab: 'memory',
+    graphLabelMode: 'full', // 'full' | 'short' | 'none'
     _cy: null,
     entityGraphLoaded: false,
     entityGraphStatus: '',
@@ -1156,18 +1157,22 @@ document.addEventListener('alpine:init', () => {
         const nodesToRender = filteredEngrams.length > 0 ? filteredEngrams : engrams;
 
         // Build node elements
-        const nodeElements = nodesToRender.map(e => ({
-          data: {
-            id: e.id,
-            label: e.concept || e.id.slice(0, 8),
-            size: connectedNodeIds.has(e.id) ? 20 + (e.confidence || 0.5) * 20 : 12,
-            color: !connectedNodeIds.has(e.id) ? '#64748b'
-                 : (e.confidence || 0) > 0.7 ? '#06b6d4'
-                 : (e.confidence || 0) > 0.4 ? '#a855f7' : '#eab308',
-            orphan: !connectedNodeIds.has(e.id),
-            snippet: (e.content || '').slice(0, 80),
-          },
-        }));
+        const nodeElements = nodesToRender.map(e => {
+          const fullLabel = e.concept || e.id.slice(0, 8);
+          return {
+            data: {
+              id: e.id,
+              label: fullLabel,
+              shortLabel: fullLabel.length > 20 ? fullLabel.slice(0, 18) + '…' : fullLabel,
+              size: connectedNodeIds.has(e.id) ? 20 + (e.confidence || 0.5) * 20 : 12,
+              color: !connectedNodeIds.has(e.id) ? '#64748b'
+                   : (e.confidence || 0) > 0.7 ? '#06b6d4'
+                   : (e.confidence || 0) > 0.4 ? '#a855f7' : '#eab308',
+              orphan: !connectedNodeIds.has(e.id),
+              snippet: (e.content || '').slice(0, 80),
+            },
+          };
+        });
 
         const elements = [...nodeElements, ...edges];
 
@@ -1215,13 +1220,47 @@ document.addEventListener('alpine:init', () => {
               style: { 'border-width': 3, 'border-color': '#06b6d4' },
             },
           ],
-          layout: { name: 'fcose', animate: true, animationDuration: 600 },
+          layout: {
+            name: 'fcose',
+            animate: true,
+            animationDuration: 600,
+            randomize: true,
+            padding: 40,
+            idealEdgeLength: 120,
+            nodeRepulsion: 6500,
+            edgeElasticity: 0.45,
+            gravity: 0.2,
+            numIter: 2500,
+            tile: true,
+            tilingPaddingVertical: 30,
+            tilingPaddingHorizontal: 30,
+          },
           wheelSensitivity: 0.3,
         });
 
-        // Fade edges in after nodes settle into position (fcose layout: 600ms).
-        // cy.one() fires once and removes itself — does not re-trigger on layout re-runs.
+        // Apply current label mode to the freshly initialised graph.
+        this._applyGraphLabelStyle();
+
+        // Resize Cytoscape when the container changes size (sidebar collapse,
+        // window resize, etc). Only resize() here — fit() is handled by layoutstop
+        // to avoid zooming in on pre-layout node positions.
+        if (this._cyResizeObserver) this._cyResizeObserver.disconnect();
+        const cyContainer = document.getElementById('cy');
+        if (cyContainer && typeof ResizeObserver !== 'undefined') {
+          let _cyResizeTimer = null;
+          this._cyResizeObserver = new ResizeObserver(() => {
+            clearTimeout(_cyResizeTimer);
+            _cyResizeTimer = setTimeout(() => {
+              if (this._cy) this._cy.resize();
+            }, 150);
+          });
+          this._cyResizeObserver.observe(cyContainer);
+        }
+
+        // Fade edges in and fit view after nodes settle (fcose layout: 600ms).
+        // cy.one() fires once and removes itself — does not re-trigger on re-runs.
         this._cy.one('layoutstop', () => {
+          this._cy.fit(undefined, 40);
           this._cy.edges().animate({
             style: { opacity: 0.6 },
             duration: 250,
@@ -1255,6 +1294,22 @@ document.addEventListener('alpine:init', () => {
     },
     graphFit() {
       if (this._cy) { this._cy.fit(); }
+    },
+    graphCycleLabel() {
+      const modes = ['full', 'short', 'none'];
+      const next = modes[(modes.indexOf(this.graphLabelMode) + 1) % modes.length];
+      this.graphLabelMode = next;
+      this._applyGraphLabelStyle();
+    },
+    _applyGraphLabelStyle() {
+      if (!this._cy) return;
+      const mode = this.graphLabelMode;
+      this._cy.nodes().forEach(node => {
+        const lbl = mode === 'full' ? node.data('label')
+                  : mode === 'short' ? node.data('shortLabel')
+                  : '';
+        node.style('label', lbl);
+      });
     },
 
     // ── Entity Graph ───────────────────────────────────────────────────────

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -634,7 +634,8 @@
             </label>
             <span x-show="graphLoaded" class="badge-success">Loaded</span>
             <!-- Zoom controls -->
-            <div x-show="graphLoaded" style="display:flex;gap:0.375rem;margin-left:auto;">
+            <div x-show="graphLoaded" style="display:flex;gap:0.375rem;margin-left:auto;align-items:center;">
+              <button class="btn-secondary" style="padding:0.25rem 0.625rem;font-size:0.8125rem;" title="Cycle label display: full → short → none" @click="graphCycleLabel()" x-text="graphLabelMode === 'full' ? 'Labels: Full' : graphLabelMode === 'short' ? 'Labels: Short' : 'Labels: Off'"></button>
               <button class="btn-secondary" style="padding:0.25rem 0.625rem;font-size:0.875rem;" title="Zoom in" @click="graphZoomIn()">+</button>
               <button class="btn-secondary" style="padding:0.25rem 0.625rem;font-size:0.875rem;" title="Zoom out" @click="graphZoomOut()">−</button>
               <button class="btn-secondary" style="padding:0.25rem 0.75rem;font-size:0.8125rem;" title="Fit all nodes in view" @click="graphFit()">Fit</button>


### PR DESCRIPTION
Addresses #124 — memory graph UX improvements.

## What changed

**Node spacing:** fCoSE layout tuned — `nodeRepulsion: 6500`, `idealEdgeLength: 120`, `tile: true` with 30px padding. Nodes load spread out and grouped by association instead of clustering at center.

**Graph fills available space:** `ResizeObserver` on `#cy` calls `cy.resize()` on container size changes (debounced 150ms). Fit is handled by `layoutstop` event to avoid zooming on pre-layout positions.

**Label toggle:** Button in toolbar cycles **Full → Short (20 chars with ellipsis) → Off**. State persists while graph is loaded. Uses per-element `node.style('label', …)` bypass for instant response without re-rendering.

## Notes

- Rebased onto current `develop`
- Verified on Rocky Linux 8.10, muninndb vault (451 entities / 624 relationships)

🤖 Generated with [Claude Code](https://claude.com/claude-code)