### PR TITLE
fix(ui): live feed detection, vault modal refresh, Alpine crash guards

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -306,9 +306,15 @@ document.addEventListener('alpine:init', () => {
       // Load initial data (gated on auth check)
       await this.checkAuth();
 
-      // Fetch vault engram counts whenever the vault picker modal opens.
+      // Fetch vault list and engram counts whenever the vault picker modal opens.
+      // loadVaults() was previously missing here — the vault list would only
+      // refresh at login/auth-check, so newly created vaults wouldn't appear
+      // until page reload.
       this.$watch('vaultModalOpen', (open) => {
-        if (open) this.loadVaultStats();
+        if (open) {
+          this.loadVaults();
+          this.loadVaultStats();
+        }
       });
     },
 
@@ -508,13 +514,13 @@ document.addEventListener('alpine:init', () => {
 
     _handleLiveMessage(msg) {
       if (msg.type === 'stats_update') {
-        // Vault count-diff: refresh vault list when a vault is added or removed.
-        // Guard with > 0 on first message (learn current count without triggering a reload).
-        const newVaultCount = msg.data.vaultCount || 0;
-        if (this._prevVaultCount > 0 && newVaultCount !== this._prevVaultCount) {
-          this.loadVaults();
+        const newCount = msg.data.engramCount || 0;
+
+        // Count-diff: if engrams increased, fetch newest as live feed entry
+        if (this._prevEngramCount > 0 && newCount > this._prevEngramCount) {
+          this._fetchNewestEngram();
         }
-        this._prevVaultCount = newVaultCount;
+        this._prevEngramCount = newCount;
 
         // Vault count-diff: refresh vault list when a vault is added or removed.
         // Guard with > 0 on first message (learn current count without triggering a reload).
@@ -528,6 +534,13 @@ document.addEventListener('alpine:init', () => {
         // the global broadcast values.
         this.loadStats();
       } else if (msg.type === 'memory_added') {
+        // Guard: skip malformed events missing required fields.
+        // A missing or undefined id causes Alpine x-for to use 'undefined' as
+        // a key, corrupting DOM anchor tracking and producing the
+        // "can't access property 'after', v is undefined" crash.
+        if (!msg.data || !msg.data.id) {
+          return;
+        }
         // Deduplicate: guard against double-delivery of the same engram ID.
         // Replace the array reference (instead of in-place unshift+pop) so that
         // Alpine.js x-for can perform a clean diff — in-place mutations of both
@@ -537,6 +550,26 @@ document.addEventListener('alpine:init', () => {
           const next = [msg.data, ...this.liveFeed];
           this.liveFeed = next.length > 20 ? next.slice(0, 20) : next;
         }
+      }
+    },
+
+    async _fetchNewestEngram() {
+      try {
+        const data = await this.apiCall(
+          '/api/engrams?vault=' + encodeURIComponent(this.vault) + '&limit=1&offset=0'
+        );
+        const e = (data.engrams || [])[0];
+        if (e && !this.liveFeed.some(item => item.id === e.id)) {
+          const next = [{
+            id: e.id,
+            concept: e.concept,
+            vault: e.vault || this.vault,
+            createdAt: e.createdAt,
+          }, ...this.liveFeed];
+          this.liveFeed = next.length > 20 ? next.slice(0, 20) : next;
+        }
+      } catch (err) {
+        console.warn('[muninn] fetchNewestEngram failed:', err);
       }
     },
 


### PR DESCRIPTION
## Summary

- **Remove duplicate `const newVaultCount`** that crashed strict-mode runtimes (redeclared in same scope)
- **Add engram count-diff tracking** (`_prevEngramCount`) so `_fetchNewestEngram` fires when new memories are stored via MCP or API
- **Restore `_fetchNewestEngram` method** lost during prior refactors — was called but never defined
- **Add `loadVaults()` call** when vault modal opens so newly created vaults appear without a page reload
- **Guard `memory_added` events** with missing `id` to prevent Alpine x-for `"can't access property 'after', v is undefined"` crash cascade

## Test plan

- [x] Store a memory via MCP — confirm it appears in live feed without page refresh
- [x] Create a new vault — confirm it appears in vault picker modal without page refresh
- [x] Unit tests pass (`make test` — 4 pre-existing `TestLiveIntegration_*` failures are auth-config issues on `upstream/main`, unrelated to this change)
- [ ] Verify no console errors on dashboard load
- [ ] Verify live feed handles rapid successive writes without duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)