### PR TITLE
feat(ui): memory graph UX — label toggle, layout spacing, resize handling

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1235,9 +1235,25 @@ document.addEventListener('alpine:init', () => {
           wheelSensitivity: 0.3,
         });
 
-        // Fade edges in after nodes settle into position (fcose layout: 600ms).
-        // cy.one() fires once and removes itself — does not re-trigger on layout re-runs.
+        // Resize Cytoscape when the container changes size (sidebar collapse,
+        // window resize, etc). Only resize() here — fit() is handled by layoutstop.
+        if (this._cyResizeObserver) this._cyResizeObserver.disconnect();
+        const cyContainer = document.getElementById('cy');
+        if (cyContainer && typeof ResizeObserver !== 'undefined') {
+          let _cyResizeTimer = null;
+          this._cyResizeObserver = new ResizeObserver(() => {
+            clearTimeout(_cyResizeTimer);
+            _cyResizeTimer = setTimeout(() => {
+              if (this._cy) this._cy.resize();
+            }, 150);
+          });
+          this._cyResizeObserver.observe(cyContainer);
+        }
+
+        // Fade edges in and fit view after nodes settle (fcose layout: 600ms).
+        // cy.one() fires once and removes itself — does not re-trigger on re-runs.
         this._cy.one('layoutstop', () => {
+          this._cy.fit(undefined, 40);
           this._cy.edges().animate({
             style: { opacity: 0.6 },
             duration: 250,


### PR DESCRIPTION
## Summary

Improve the memory graph visualization:

- **Label toggle** — cycle node labels between full, short (18 chars), and hidden via `graphCycleLabel()`. Uses a `displayLabel` data field bound in the Cytoscape stylesheet so mode changes persist across zoom/pan re-renders
- **Layout spacing** — tune fcose params (node repulsion, ideal edge length, tiling padding) so nodes don't overlap on dense graphs
- **Resize handling** — use ResizeObserver to resize the Cytoscape canvas when the container changes (sidebar collapse, window resize). Fit viewport with padding after layout settles

## Test plan

- [x] Label toggle cycles full → short → none correctly
- [x] Labels persist after zoom/pan (no revert to full)
- [x] Graph nodes are visually spaced and readable
- [ ] Resize browser window — graph canvas adjusts without clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)