### PR TITLE
fix(upgrade): stop/restart daemon around brew upgrade, show Web UI URL

### DIFF
--- a/cmd/muninn/status.go
+++ b/cmd/muninn/status.go
@@ -161,6 +161,8 @@ func printStatusDisplay(compact bool) runState {
 			fmt.Println("  muninn help   →  see all commands")
 		}
 		if state == stateRunning {
+			fmt.Println()
+			fmt.Println("  Web UI → http://127.0.0.1:8476")
 			checkVersionHint()
 		}
 	}

--- a/cmd/muninn/upgrade.go
+++ b/cmd/muninn/upgrade.go
@@ -184,6 +184,7 @@ func runUpgrade(args []string) {
 	if usingBrew {
 		fmt.Println("  Detected Homebrew install.")
 		fmt.Println("  This will run: brew upgrade scrypster/tap/muninn")
+		fmt.Println("  The daemon will be stopped before upgrading and restarted after.")
 	} else {
 		fmt.Println("  Your data is safe. Only the binary will be replaced.")
 		fmt.Println("  The daemon will restart automatically.")
@@ -208,9 +209,30 @@ func runUpgrade(args []string) {
 		}
 	}
 
-	// Homebrew: delegate to brew
+	// Homebrew: stop daemon → brew upgrade → restart daemon
 	if usingBrew {
 		fmt.Println()
+
+		daemonWasRunning := isDaemonRunning()
+
+		if daemonWasRunning {
+			fmt.Printf("  %-28s", "Stopping daemon...")
+			pidPath := filepath.Join(defaultDataDir(), "muninn.pid")
+			if pid, err := readPID(pidPath); err == nil {
+				if proc, err := os.FindProcess(pid); err == nil {
+					_ = stopProcess(proc)
+					for i := 0; i < 30; i++ {
+						if !isProcessRunning(pid) {
+							break
+						}
+						time.Sleep(100 * time.Millisecond)
+					}
+				}
+			}
+			os.Remove(pidPath)
+			fmt.Println(" ✓")
+		}
+
 		fmt.Println("  Running brew upgrade...")
 		fmt.Println()
 		cmd := exec.Command("brew", "upgrade", "scrypster/tap/muninn")
@@ -221,6 +243,17 @@ func runUpgrade(args []string) {
 			fmt.Fprintf(os.Stderr, "  brew upgrade failed: %v\n", err)
 			osExit(1)
 		}
+
+		if daemonWasRunning {
+			fmt.Println()
+			fmt.Printf("  %-28s", "Restarting daemon...")
+			runStart(true)
+			fmt.Println(" ✓")
+			fmt.Println()
+			fmt.Printf("  Web UI → http://127.0.0.1:8476\n")
+			fmt.Println()
+		}
+
 		return
 	}
 


### PR DESCRIPTION
## Summary

- **Brew upgrade left old daemon running**: `muninn upgrade` on Homebrew installs ran `brew upgrade` without stopping the daemon first. The old binary kept running in memory indefinitely — users saw stale UI until they manually restarted.
- **Fixed**: Brew upgrade path now stops the daemon before `brew upgrade`, then restarts it after (same behaviour as the self-update/curl path).
- **`muninn status` now shows the Web UI URL**: Adds `Web UI → http://127.0.0.1:8476` to running status output so users know the correct URL to visit (not port 8475 which is the API).

## Root cause of the "black page" report

Joe hit `localhost:8475` (REST API) instead of `localhost:8476` (Web UI) — the API root returns 404. The status output didn't show the URL, making it easy to guess wrong. Both issues are now fixed.

## Test Plan
- [ ] `muninn upgrade` on a Brew install stops old daemon, runs brew upgrade, restarts daemon on same ports
- [ ] `muninn status` shows `Web UI → http://127.0.0.1:8476` when running
- [ ] All existing tests pass