### PR TITLE
Hotfix v0.3.14-alpha-1: fix Safari black page + brew upgrade daemon restart

### DIFF
--- a/cmd/muninn/status.go
+++ b/cmd/muninn/status.go
@@ -161,6 +161,8 @@ func printStatusDisplay(compact bool) runState {
 			fmt.Println("  muninn help   →  see all commands")
 		}
 		if state == stateRunning {
+			fmt.Println()
+			fmt.Println("  Web UI → http://127.0.0.1:8476")
 			checkVersionHint()
 		}
 	}

--- a/cmd/muninn/upgrade.go
+++ b/cmd/muninn/upgrade.go
@@ -184,6 +184,7 @@ func runUpgrade(args []string) {
 	if usingBrew {
 		fmt.Println("  Detected Homebrew install.")
 		fmt.Println("  This will run: brew upgrade scrypster/tap/muninn")
+		fmt.Println("  The daemon will be stopped before upgrading and restarted after.")
 	} else {
 		fmt.Println("  Your data is safe. Only the binary will be replaced.")
 		fmt.Println("  The daemon will restart automatically.")
@@ -208,9 +209,30 @@ func runUpgrade(args []string) {
 		}
 	}
 
-	// Homebrew: delegate to brew
+	// Homebrew: stop daemon → brew upgrade → restart daemon
 	if usingBrew {
 		fmt.Println()
+
+		daemonWasRunning := isDaemonRunning()
+
+		if daemonWasRunning {
+			fmt.Printf("  %-28s", "Stopping daemon...")
+			pidPath := filepath.Join(defaultDataDir(), "muninn.pid")
+			if pid, err := readPID(pidPath); err == nil {
+				if proc, err := os.FindProcess(pid); err == nil {
+					_ = stopProcess(proc)
+					for i := 0; i < 30; i++ {
+						if !isProcessRunning(pid) {
+							break
+						}
+						time.Sleep(100 * time.Millisecond)
+					}
+				}
+			}
+			os.Remove(pidPath)
+			fmt.Println(" ✓")
+		}
+
 		fmt.Println("  Running brew upgrade...")
 		fmt.Println()
 		cmd := exec.Command("brew", "upgrade", "scrypster/tap/muninn")
@@ -221,6 +243,17 @@ func runUpgrade(args []string) {
 			fmt.Fprintf(os.Stderr, "  brew upgrade failed: %v\n", err)
 			osExit(1)
 		}
+
+		if daemonWasRunning {
+			fmt.Println()
+			fmt.Printf("  %-28s", "Restarting daemon...")
+			runStart(true)
+			fmt.Println(" ✓")
+			fmt.Println()
+			fmt.Printf("  Web UI → http://127.0.0.1:8476\n")
+			fmt.Println()
+		}
+
 		return
 	}
 


### PR DESCRIPTION
## Critical Fix

**Safari users see a black page on v0.3.14-alpha.** Root cause: a bad merge conflict resolution in PR #163 left a duplicate `const newVaultCount` declaration in `app.js`. Safari's JavaScriptCore throws a hard `SyntaxError: Cannot declare a const variable twice: 'newVaultCount'` which prevents `app.js` from executing entirely — meaning Alpine.js never registers the `muninnApp` component, and all UI variables are undefined.

Chrome/V8 is lenient about this in some contexts and doesn't throw, which is why we couldn't reproduce it locally.

## Also includes

- `muninn upgrade` on Brew now stops the old daemon before `brew upgrade`, then restarts it after — old daemon was kept alive in memory, new binary never loaded until manual restart.
- `muninn status` now prints `Web UI → http://127.0.0.1:8476` when running.

## Test Plan
- [ ] Open http://localhost:8476 in **Safari** — should load the UI correctly
- [ ] `muninn upgrade` on Brew install stops old daemon and restarts new one
- [ ] `muninn status` shows Web UI URL