### PR TITLE
fix(ui): remove duplicate const — Safari black page (v0.3.14-alpha-1 hotfix)

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -527,14 +527,6 @@ document.addEventListener('alpine:init', () => {
         }
         this._prevVaultCount = newVaultCount;
 
-        // Vault count-diff: refresh vault list when a vault is added or removed.
-        // Guard with > 0 on first message (learn current count without triggering a reload).
-        const newVaultCount = msg.data.vaultCount || 0;
-        if (this._prevVaultCount > 0 && newVaultCount !== this._prevVaultCount) {
-          this.loadVaults();
-        }
-        this._prevVaultCount = newVaultCount;
-
         // Re-fetch stats scoped to the selected vault instead of using
         // the global broadcast values.
         this.loadStats();


### PR DESCRIPTION
## Critical hotfix — Safari users see a black page on v0.3.14-alpha

### Root cause

A bad merge conflict resolution in PR #163 left a **duplicate** `const newVaultCount` declaration in `web/static/js/app.js`:

```js
// Lines 524–536 in v0.3.14-alpha (broken):
const newVaultCount = msg.data.vaultCount || 0;  // first
...
const newVaultCount = msg.data.vaultCount || 0;  // duplicate — SyntaxError in Safari
```

**Safari's JavaScriptCore** treats duplicate `const` in the same block scope as a hard `SyntaxError`, aborting `app.js` execution entirely. Alpine.js never registers `muninnApp`, every UI variable is undefined, and the page is black.

**Chrome/V8** silently accepts the re-declaration — which is why the bug wasn't caught in local testing.

### Fix

Remove the duplicate block. Single declaration remains at line 524.

### Test Plan
- [ ] Open http://localhost:8476 in **Safari** — loads correctly
- [ ] Open in Chrome — loads correctly
- [ ] `node --check web/static/js/app.js` passes