### PR TITLE
fix(ui): add ?vault= query param to all POST api calls

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -759,7 +759,7 @@ document.addEventListener('alpine:init', () => {
         if (this.searchMode && this.searchMode !== 'balanced') {
             body.mode = this.searchMode;
         }
-        const data = await this.apiCall('/api/activate', {
+        const data = await this.apiCall('/api/activate?vault=' + encodeURIComponent(this.vault), {
           method: 'POST',
           body: JSON.stringify(body),
         });
@@ -798,42 +798,35 @@ document.addEventListener('alpine:init', () => {
       try {
         if (action === 'keep_a') {
           // A supersedes B; archive B
-          await fetch('/api/link', {
+          await this.apiCall('/api/link?vault=' + encodeURIComponent(vault), {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ source_id: idA, target_id: idB, rel_type: 4, weight: 1.0, vault }),
           });
-          await fetch('/api/engrams/' + encodeURIComponent(idB) + '/state', {
+          await this.apiCall('/api/engrams/' + encodeURIComponent(idB) + '/state?vault=' + encodeURIComponent(vault), {
             method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ vault, state: 'archived' }),
           });
-          await fetch('/api/admin/contradictions/resolve', {
+          await this.apiCall('/api/admin/contradictions/resolve', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
           });
         } else if (action === 'keep_b') {
           // B supersedes A; archive A
-          await fetch('/api/link', {
+          await this.apiCall('/api/link?vault=' + encodeURIComponent(vault), {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ source_id: idB, target_id: idA, rel_type: 4, weight: 1.0, vault }),
           });
-          await fetch('/api/engrams/' + encodeURIComponent(idA) + '/state', {
+          await this.apiCall('/api/engrams/' + encodeURIComponent(idA) + '/state?vault=' + encodeURIComponent(vault), {
             method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ vault, state: 'archived' }),
           });
-          await fetch('/api/admin/contradictions/resolve', {
+          await this.apiCall('/api/admin/contradictions/resolve', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
           });
         } else if (action === 'dismiss') {
-          await fetch('/api/admin/contradictions/resolve', {
+          await this.apiCall('/api/admin/contradictions/resolve', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
           });
         } else if (action === 'merge') {
@@ -909,7 +902,7 @@ document.addEventListener('alpine:init', () => {
         : [];
       try {
         // POST /api/engrams → WriteRequest: { concept, content, tags, vault, confidence }
-        await this.apiCall('/api/engrams', {
+        await this.apiCall('/api/engrams?vault=' + encodeURIComponent(this.vault), {
           method: 'POST',
           body: JSON.stringify({
             concept: form.concept,
@@ -996,7 +989,7 @@ document.addEventListener('alpine:init', () => {
       this.editTagsSaving = true;
       try {
         const resp = await this.apiCall(
-          '/api/engrams/' + encodeURIComponent(this.selectedMemory.id) + '/tags',
+          '/api/engrams/' + encodeURIComponent(this.selectedMemory.id) + '/tags?vault=' + encodeURIComponent(this.vault),
           {
             method: 'PUT',
             body: JSON.stringify({ vault: this.vault, tags }),
@@ -1033,7 +1026,7 @@ document.addEventListener('alpine:init', () => {
         return;
       }
       try {
-        await this.apiCall('/api/link', {
+        await this.apiCall('/api/link?vault=' + encodeURIComponent(this.vault), {
           method: 'POST',
           body: JSON.stringify({
             source_id: this.linkModal.sourceId,
@@ -1122,7 +1115,7 @@ document.addEventListener('alpine:init', () => {
 
         // Load all engram links in a single batch call (replaces N+1 pattern).
         const nodeIdSet = new Set(engrams.map(e => e.id));
-        const batchResp = await this.apiCall('/api/engrams/links/batch', {
+        const batchResp = await this.apiCall('/api/engrams/links/batch?vault=' + encodeURIComponent(this.vault), {
           method: 'POST',
           body: JSON.stringify({
             ids: engrams.map(e => e.id),
@@ -2534,15 +2527,10 @@ document.addEventListener('alpine:init', () => {
     // ── Lifecycle state ────────────────────────────────────────────────────
     async updateLifecycleState(id, state) {
       try {
-        const res = await fetch('/api/engrams/' + encodeURIComponent(id) + '/state', {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ vault: this.vault, state }),
-        });
-        if (!res.ok) {
-          const text = await res.text().catch(() => res.statusText);
-          throw new Error(res.status + ': ' + text);
-        }
+        const res = await this.apiCall(
+          '/api/engrams/' + encodeURIComponent(id) + '/state?vault=' + encodeURIComponent(this.vault),
+          { method: 'PUT', body: JSON.stringify({ vault: this.vault, state }) }
+        );
         if (this.selectedMemory && this.selectedMemory.id === id) {
           this.selectedMemory = { ...this.selectedMemory, state };
         }
@@ -2589,7 +2577,7 @@ document.addEventListener('alpine:init', () => {
       if (!this.searchQuery.trim()) return;
       this.explainModal = { show: true, data: null, loading: true };
       try {
-        const data = await this.apiCall('/api/explain', {
+        const data = await this.apiCall('/api/explain?vault=' + encodeURIComponent(this.vault), {
           method: 'POST',
           body: JSON.stringify({
             vault: this.vault,
@@ -2642,7 +2630,7 @@ document.addEventListener('alpine:init', () => {
         return;
       }
       try {
-        const data = await this.apiCall('/api/consolidate', {
+        const data = await this.apiCall('/api/consolidate?vault=' + encodeURIComponent(this.vault), {
           method: 'POST',
           body: JSON.stringify({
             vault: this.vault,
@@ -2682,7 +2670,7 @@ document.addEventListener('alpine:init', () => {
         .map(s => s.trim())
         .filter(Boolean);
       try {
-        const data = await this.apiCall('/api/decide', {
+        const data = await this.apiCall('/api/decide?vault=' + encodeURIComponent(this.vault), {
           method: 'POST',
           body: JSON.stringify({
             vault: this.vault,


### PR DESCRIPTION
## Summary

`VaultAuthWithAdminBypass` reads the vault exclusively from the URL query string when an admin session cookie is present — it does not inspect the request body. Seven POST calls in the web UI passed `vault` only in the JSON body, causing `ctxVault(r)` to resolve to `"default"` instead of the selected vault. `resolveHandlerVault` then rejected the body vault as a mismatch, returning a 400 with error code 4003 (`vault must match the authenticated request vault`).

**Affected callers:**

| Endpoint | Function | Symptom |
|---|---|---|
| `/api/engrams/links/batch` | `loadGraph()` | "Graph failed: 400" |
| `/api/activate` | `searchMemories()` | silent failure on non-default vaults |
| `/api/engrams` | write memory modal | write fails silently |
| `/api/link` | link modal | link fails silently |
| `/api/explain` | explain score | explain fails silently |
| `/api/consolidate` | multi-select consolidate | consolidate fails silently |
| `/api/decide` | decide modal | decide fails silently |

The `fix(ui): replace silent catch blocks` commit (already in main) surfaced these as visible errors; the `loadGraph` failure became the most noticeable symptom.

## Fix

Added `?vault=encodeURIComponent(this.vault)` to the URL for all seven POST calls so the middleware can correctly scope the request before the handler runs. The vault field in the body is unchanged (it is still validated by `resolveHandlerVault` against the context vault for defense-in-depth).

## Test plan

- [ ] Load the memory graph on a non-default vault — should render without "Graph failed" error
- [ ] Search memories on a non-default vault — results should return
- [ ] Write a new memory on a non-default vault — should succeed
- [ ] Create a link on a non-default vault — should succeed
- [ ] Explain score on a non-default vault — should return
- [ ] Consolidate memories on a non-default vault — should succeed
- [ ] Submit a decision on a non-default vault — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)