### PR TITLE
fix(mcp-proxy): return JSON-RPC errors for HTTP failures instead of silent drops

### DIFF
--- a/cmd/muninn/mcp_stdio.go
+++ b/cmd/muninn/mcp_stdio.go
@@ -18,7 +18,64 @@ import (
 // Overridable in tests via direct assignment.
 var mcpProxyURL = "http://127.0.0.1:" + defaultMCPPort + "/mcp"
 
-// runMCPStdio is the stdio→HTTP MCP proxy used by OpenClaw and other clients
+// mcpStderr is the writer for proxy diagnostic messages. Package-level so
+// tests can redirect it without forking a process.
+var mcpStderr io.Writer = os.Stderr
+
+// jsonRPCErrorResponse is a JSON-RPC 2.0 error response structure.
+type jsonRPCErrorResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Error   jsonRPCErrorObj `json:"error"`
+}
+
+// jsonRPCErrorObj holds the error code and message for a JSON-RPC error.
+type jsonRPCErrorObj struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// writeJSONRPCError writes a JSON-RPC 2.0 error response to out.
+// rpcID is the id from the originating request; nil is treated as null.
+// This ensures MCP clients receive a structured error instead of silence,
+// which would cause them to hang or report "Server disconnected".
+//
+// Note: for JSON-RPC notifications (requests without an id), emitting an
+// error response with id:null is a spec deviation — the spec says servers
+// MUST NOT reply to notifications. However, silence causes MCP clients to
+// disconnect, so we prefer the explicit error. A code comment explains this
+// tradeoff at the call site.
+func writeJSONRPCError(out io.Writer, rpcID json.RawMessage, code int, msg string) {
+	if rpcID == nil {
+		rpcID = json.RawMessage("null")
+	}
+	resp := jsonRPCErrorResponse{
+		JSONRPC: "2.0",
+		ID:      rpcID,
+		Error:   jsonRPCErrorObj{Code: code, Message: msg},
+	}
+	b, _ := json.Marshal(resp) // struct contains only primitive types; Marshal cannot fail
+	fmt.Fprintf(out, "%s\n", b)
+}
+
+// httpStatusToRPCError maps an HTTP status code to a JSON-RPC error code and message.
+// Codes are in the implementation-defined range (-32000 to -32099) per JSON-RPC 2.0 spec.
+func httpStatusToRPCError(status int) (code int, msg string) {
+	switch status {
+	case http.StatusUnauthorized:
+		return -32001, "MuninnDB: authentication required — verify ~/.muninn/mcp.token matches the running daemon"
+	case http.StatusNotFound:
+		return -32004, "MuninnDB: MCP endpoint not found"
+	case http.StatusTooManyRequests:
+		return -32029, "MuninnDB: rate limit exceeded"
+	case http.StatusServiceUnavailable:
+		return -32000, "MuninnDB: daemon unavailable"
+	default:
+		return -32000, fmt.Sprintf("MuninnDB: HTTP %d from daemon", status)
+	}
+}
+
+// runMCPStdio is the stdio→HTTP MCP proxy used by Claude Desktop and other clients
 // that spawn MCP servers as local subprocesses. It bridges:
 //
 //	stdin  (newline-delimited JSON-RPC)  →  MuninnDB HTTP MCP endpoint
@@ -42,7 +99,7 @@ func runMCPStdio() {
 // Session handling: the proxy is MCP session-aware. After forwarding an
 // "initialize" request, it captures the Mcp-Session-Id response header and
 // includes it in all subsequent requests. This keeps the daemon's per-session
-// state consistent across the lifetime of a single OpenClaw session.
+// state consistent across the lifetime of a single client session.
 func runMCPStdioWith(in io.Reader, out io.Writer) {
 	client := &http.Client{Timeout: 35 * time.Second}
 	scanner := bufio.NewScanner(in)
@@ -56,10 +113,11 @@ func runMCPStdioWith(in io.Reader, out io.Writer) {
 			continue
 		}
 
-		// Best-effort parse to detect the "initialize" method so we can
-		// capture the Mcp-Session-Id from its response.
+		// Best-effort parse to detect the "initialize" method and extract the
+		// request ID for error responses. Malformed lines are still forwarded.
 		var rpcEnvelope struct {
-			Method string `json:"method"`
+			Method string          `json:"method"`
+			ID     json.RawMessage `json:"id"`
 		}
 		json.Unmarshal([]byte(line), &rpcEnvelope) //nolint:errcheck // ignored intentionally; malformed lines still forwarded
 
@@ -67,7 +125,7 @@ func runMCPStdioWith(in io.Reader, out io.Writer) {
 
 		req, err := http.NewRequest(http.MethodPost, mcpProxyURL, bytes.NewBufferString(line))
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "muninn mcp: build request: %v\n", err)
+			fmt.Fprintf(mcpStderr, "muninn mcp: build request: %v\n", err)
 			continue
 		}
 		req.Header.Set("Content-Type", "application/json")
@@ -81,7 +139,11 @@ func runMCPStdioWith(in io.Reader, out io.Writer) {
 
 		resp, err := client.Do(req)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "muninn mcp: daemon unreachable — is muninn running? (%v)\n", err)
+			// Emit a JSON-RPC error so the client receives a structured failure
+			// instead of silence (which causes MCP clients to disconnect).
+			// See writeJSONRPCError for the notification id:null spec note.
+			fmt.Fprintf(mcpStderr, "muninn mcp: daemon unreachable — is muninn running? (%v)\n", err)
+			writeJSONRPCError(out, rpcEnvelope.ID, -32000, "MuninnDB: daemon unreachable — is muninn running?")
 			continue
 		}
 
@@ -95,12 +157,22 @@ func runMCPStdioWith(in io.Reader, out io.Writer) {
 		body, readErr := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if readErr != nil {
-			fmt.Fprintf(os.Stderr, "muninn mcp: read response: %v\n", readErr)
+			fmt.Fprintf(mcpStderr, "muninn mcp: read response: %v\n", readErr)
+			writeJSONRPCError(out, rpcEnvelope.ID, -32000, "MuninnDB: failed to read daemon response")
 			continue
 		}
 
 		// HTTP 202 Accepted = MCP notification (fire-and-forget); no stdout output.
 		if resp.StatusCode == http.StatusAccepted {
+			continue
+		}
+
+		if resp.StatusCode >= 400 {
+			code, msg := httpStatusToRPCError(resp.StatusCode)
+			if resp.StatusCode == http.StatusUnauthorized {
+				fmt.Fprintf(mcpStderr, "muninn mcp: 401 Unauthorized — token mismatch; verify ~/.muninn/mcp.token and restart the daemon if the token changed\n")
+			}
+			writeJSONRPCError(out, rpcEnvelope.ID, code, msg)
 			continue
 		}
 
@@ -111,7 +183,7 @@ func runMCPStdioWith(in io.Reader, out io.Writer) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		fmt.Fprintf(os.Stderr, "muninn mcp: stdin: %v\n", err)
+		fmt.Fprintf(mcpStderr, "muninn mcp: stdin: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/muninn/mcp_stdio_test.go
+++ b/cmd/muninn/mcp_stdio_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -116,16 +117,151 @@ func TestRunMCPStdioWith_EmptyLinesSkipped(t *testing.T) {
 	}
 }
 
-func TestRunMCPStdioWith_DaemonUnreachableNoOutput(t *testing.T) {
+// withMCPStderr redirects mcpStderr for the duration of a test.
+func withMCPStderr(t *testing.T, w io.Writer) {
+	t.Helper()
+	orig := mcpStderr
+	mcpStderr = w
+	t.Cleanup(func() { mcpStderr = orig })
+}
+
+func TestRunMCPStdioWith_DaemonUnreachable_JSONRPCError(t *testing.T) {
 	withMCPProxyURL(t, "http://127.0.0.1:1") // nothing listening
 
-	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":42,"method":"ping"}` + "\n")
 	var out bytes.Buffer
-	// Must not panic — error goes to stderr, stdout stays empty.
+	var errBuf bytes.Buffer
+	withMCPStderr(t, &errBuf)
 	runMCPStdioWith(in, &out)
 
-	if out.Len() != 0 {
-		t.Errorf("expected no stdout when daemon unreachable, got %q", out.String())
+	// Must produce a valid JSON-RPC error, not silence.
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &resp); err != nil {
+		t.Fatalf("expected valid JSON-RPC error response, got: %q — parse error: %v", out.String(), err)
+	}
+	errObj, _ := resp["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatalf("expected error field in response, got %v", resp)
+	}
+	if code, _ := errObj["code"].(float64); code != -32000 {
+		t.Errorf("expected error code -32000, got %v", code)
+	}
+	if id, _ := resp["id"].(float64); id != 42 {
+		t.Errorf("expected id=42 in error response, got %v", resp["id"])
+	}
+	// Diagnostic message must go to stderr.
+	if !strings.Contains(errBuf.String(), "daemon unreachable") {
+		t.Errorf("expected stderr diagnostic about daemon unreachable, got %q", errBuf.String())
+	}
+}
+
+// TestRunMCPStdioWith_401_JSONRPCError verifies that an HTTP 401 is converted to
+// a proper JSON-RPC error with code -32001 and a diagnostic on stderr.
+func TestRunMCPStdioWith_401_JSONRPCError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+
+	var errBuf bytes.Buffer
+	withMCPStderr(t, &errBuf)
+
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/list"}` + "\n")
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &resp); err != nil {
+		t.Fatalf("expected valid JSON-RPC error response, got: %q — parse error: %v", out.String(), err)
+	}
+	errObj, _ := resp["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatalf("expected error field in response, got %v", resp)
+	}
+	if code, _ := errObj["code"].(float64); code != -32001 {
+		t.Errorf("expected error code -32001, got %v", code)
+	}
+	if id, _ := resp["id"].(float64); id != 7 {
+		t.Errorf("expected id=7 in error response, got %v", resp["id"])
+	}
+	msg, _ := errObj["message"].(string)
+	if !strings.Contains(msg, "authentication") {
+		t.Errorf("expected auth message, got %q", msg)
+	}
+	if !strings.Contains(errBuf.String(), "401") {
+		t.Errorf("expected 401 diagnostic on stderr, got %q", errBuf.String())
+	}
+}
+
+// TestRunMCPStdioWith_404_JSONRPCError verifies HTTP 404 → JSON-RPC error -32004.
+func TestRunMCPStdioWith_404_JSONRPCError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+	withMCPStderr(t, &bytes.Buffer{})
+
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":3,"method":"ping"}` + "\n")
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &resp); err != nil {
+		t.Fatalf("expected valid JSON, got: %q — %v", out.String(), err)
+	}
+	errObj, _ := resp["error"].(map[string]any)
+	if code, _ := errObj["code"].(float64); code != -32004 {
+		t.Errorf("expected -32004, got %v", code)
+	}
+}
+
+// TestRunMCPStdioWith_500_JSONRPCError verifies HTTP 500 → JSON-RPC error -32000.
+func TestRunMCPStdioWith_500_JSONRPCError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+	withMCPStderr(t, &bytes.Buffer{})
+
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":9,"method":"ping"}` + "\n")
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &resp); err != nil {
+		t.Fatalf("expected valid JSON, got: %q — %v", out.String(), err)
+	}
+	errObj, _ := resp["error"].(map[string]any)
+	if code, _ := errObj["code"].(float64); code != -32000 {
+		t.Errorf("expected -32000, got %v", code)
+	}
+}
+
+// TestRunMCPStdioWith_ErrorNullIDWhenNoIDInRequest verifies that errors for
+// requests without an id field use id:null in the response.
+func TestRunMCPStdioWith_ErrorNullIDWhenNoIDInRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+	withMCPStderr(t, &bytes.Buffer{})
+
+	// Notification: no "id" field
+	in := strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n")
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &resp); err != nil {
+		t.Fatalf("expected valid JSON, got: %q — %v", out.String(), err)
+	}
+	if resp["id"] != nil {
+		t.Errorf("expected id:null for request with no id, got %v", resp["id"])
 	}
 }
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -140,7 +140,7 @@ muninn init --tool claude --yes
 muninn init --tool cursor,claude --yes
 ```
 
-**Manual MCP config:** Point any MCP client to `http://127.0.0.1:8750/mcp`.
+**Manual MCP config:** HTTP clients (Cursor, Codex, OpenCode) can connect to `http://127.0.0.1:8750/mcp`. If MCP auth is enabled, include the token in the `Authorization` header: `Authorization: Bearer $(cat ~/.muninn/mcp.token)`. Claude Desktop uses the built-in stdio bridge — run `muninn init` instead of pointing it at the URL directly.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #170 — Claude Desktop showing "MCP server disconnected" with no actionable error when auth is enabled or daemon is unreachable.

**Root cause:** The stdio proxy (`muninn mcp`) was passing raw HTTP error bodies (401, 404, etc.) to stdout — not valid JSON-RPC — so Claude Desktop disconnected silently. Same issue for connection-refused and body-read failures.

**Fix:**
- HTTP 4xx/5xx responses are now wrapped in valid JSON-RPC 2.0 error responses with appropriate codes
- Connection failures and body-read errors also produce JSON-RPC errors instead of silently dropping the request
- 401 specifically writes a diagnostic to stderr pointing to `~/.muninn/mcp.token`
- `var mcpStderr io.Writer` makes stderr testable
- Quickstart docs updated to clarify Claude Desktop needs `muninn init` (stdio bridge), not the bare URL

**Error code mapping:**
| HTTP | JSON-RPC code |
|------|--------------|
| 401 | -32001 (auth required) |
| 404 | -32004 (endpoint not found) |
| 429 | -32029 (rate limited) |
| 503 / other | -32000 (server error) |
| connection refused | -32000 |

## Test plan

- [x] `TestRunMCPStdioWith_DaemonUnreachable_JSONRPCError` — connection refused → valid JSON-RPC error
- [x] `TestRunMCPStdioWith_401_JSONRPCError` — 401 → code -32001, auth message, stderr diagnostic
- [x] `TestRunMCPStdioWith_404_JSONRPCError` — 404 → code -32004
- [x] `TestRunMCPStdioWith_500_JSONRPCError` — 500 → code -32000
- [x] `TestRunMCPStdioWith_ErrorNullIDWhenNoIDInRequest` — notifications get id:null in error
- [x] All existing proxy tests continue to pass
- [x] Verified locally against a mock 401 server — stdout is valid JSON-RPC, stderr shows token hint