### PR TITLE
fix(security): remove MCP token from daemon process argv to prevent ps leak

### DIFF
--- a/cmd/muninn/lifecycle.go
+++ b/cmd/muninn/lifecycle.go
@@ -35,13 +35,14 @@ func parseExplicitFlag(name string, osArgs []string) string {
 // It forwards --listen-host when non-default, --cors-origins when non-empty,
 // and any explicitly provided per-service address flags (--rest-addr, --mbp-addr,
 // --grpc-addr, --mcp-addr, --ui-addr) so they take effect in the daemon.
-func buildDaemonArgs(dataDir string, dev bool, mcpToken string, osArgs []string, listenHostEnv, corsOriginsEnv string) []string {
+//
+// The MCP bearer token is intentionally NOT passed as a CLI argument to avoid
+// exposing it in `ps` output. The daemon reads it directly from
+// ~/.muninn/mcp.token at startup via readTokenFile().
+func buildDaemonArgs(dataDir string, dev bool, osArgs []string, listenHostEnv, corsOriginsEnv string) []string {
 	args := []string{"--daemon", "--data", dataDir}
 	if dev {
 		args = append(args, "--dev")
-	}
-	if mcpToken != "" {
-		args = append(args, "--mcp-token", mcpToken)
 	}
 	// --listen-host: forward when non-default
 	listenHost := parseListenHost(osArgs, listenHostEnv)
@@ -101,7 +102,7 @@ func runStart(webEnabled bool) {
 		}
 	}
 
-	args := buildDaemonArgs(dataDir, dev, readTokenFile(), os.Args[1:], os.Getenv("MUNINN_LISTEN_HOST"), os.Getenv("MUNINN_CORS_ORIGINS"))
+	args := buildDaemonArgs(dataDir, dev, os.Args[1:], os.Getenv("MUNINN_LISTEN_HOST"), os.Getenv("MUNINN_CORS_ORIGINS"))
 	if !webEnabled {
 		args = append(args, "--no-web")
 	}

--- a/cmd/muninn/lifecycle_test.go
+++ b/cmd/muninn/lifecycle_test.go
@@ -11,7 +11,6 @@ func TestBuildDaemonArgs(t *testing.T) {
 		name           string
 		dataDir        string
 		dev            bool
-		mcpToken       string
 		osArgs         []string
 		listenHostEnv  string
 		corsOriginsEnv string
@@ -19,21 +18,21 @@ func TestBuildDaemonArgs(t *testing.T) {
 		wantAbsent     []string
 	}{
 		{
-			name:    "default listen-host not forwarded",
-			dataDir: "/tmp/data",
-			osArgs:  []string{},
+			name:       "default listen-host not forwarded",
+			dataDir:    "/tmp/data",
+			osArgs:     []string{},
 			wantAbsent: []string{"--listen-host"},
 		},
 		{
-			name:    "non-default listen-host forwarded",
-			dataDir: "/tmp/data",
-			osArgs:  []string{"--listen-host", "0.0.0.0"},
+			name:         "non-default listen-host forwarded",
+			dataDir:      "/tmp/data",
+			osArgs:       []string{"--listen-host", "0.0.0.0"},
 			wantContains: []string{"--listen-host", "0.0.0.0"},
 		},
 		{
-			name:    "cors-origins flag in osArgs forwarded",
-			dataDir: "/tmp/data",
-			osArgs:  []string{"--cors-origins", "http://flag.local"},
+			name:         "cors-origins flag in osArgs forwarded",
+			dataDir:      "/tmp/data",
+			osArgs:       []string{"--cors-origins", "http://flag.local"},
 			wantContains: []string{"--cors-origins", "http://flag.local"},
 		},
 		{
@@ -52,10 +51,10 @@ func TestBuildDaemonArgs(t *testing.T) {
 			wantAbsent:     []string{"http://env.local"},
 		},
 		{
-			name:         "neither cors flag nor env not forwarded",
-			dataDir:      "/tmp/data",
-			osArgs:       []string{},
-			wantAbsent:   []string{"--cors-origins"},
+			name:       "neither cors flag nor env not forwarded",
+			dataDir:    "/tmp/data",
+			osArgs:     []string{},
+			wantAbsent: []string{"--cors-origins"},
 		},
 		{
 			name:         "dev true forwarded",
@@ -65,17 +64,18 @@ func TestBuildDaemonArgs(t *testing.T) {
 			wantContains: []string{"--dev"},
 		},
 		{
-			name:         "mcpToken set forwarded",
-			dataDir:      "/tmp/data",
-			mcpToken:     "tok123",
-			osArgs:       []string{},
-			wantContains: []string{"--mcp-token", "tok123"},
+			// Token must NEVER appear in daemon argv — it is read from disk by the daemon.
+			// This prevents the token from leaking via `ps ax` or /proc/<pid>/cmdline.
+			name:       "mcp-token never in daemon args",
+			dataDir:    "/tmp/data",
+			osArgs:     []string{},
+			wantAbsent: []string{"--mcp-token"},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildDaemonArgs(tc.dataDir, tc.dev, tc.mcpToken, tc.osArgs, tc.listenHostEnv, tc.corsOriginsEnv)
+			got := buildDaemonArgs(tc.dataDir, tc.dev, tc.osArgs, tc.listenHostEnv, tc.corsOriginsEnv)
 
 			for _, want := range tc.wantContains {
 				found := false

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -612,7 +612,7 @@ func runServer() {
 		uiAddrDefault = v
 	}
 	uiAddr := flag.String("ui-addr", uiAddrDefault, "Web UI HTTP listen address")
-	mcpToken := flag.String("mcp-token", "", "Bearer token for MCP auth (empty = no auth)")
+	mcpToken := flag.String("mcp-token", "", "Bearer token override for MCP auth (leave empty to read from ~/.muninn/mcp.token)")
 	dev := flag.Bool("dev", false, "serve web assets from ./web directory (development mode)")
 	backupInterval := flag.String("backup-interval", "", "Automated backup interval (e.g. 6h, 30m); empty = disabled")
 	backupDir := flag.String("backup-dir", "", "Directory to write automated backups into")
@@ -649,6 +649,12 @@ func runServer() {
 		fmt.Fprintf(os.Stderr, "  MUNINN_BACKUP_RETAIN          Number of automated backups to keep (default: 5)\n")
 	}
 	flag.Parse()
+
+	// MCP token: --mcp-token flag is an explicit override (tests, container entrypoints).
+	// Default path reads from ~/.muninn/mcp.token so the token never appears in `ps` output.
+	if *mcpToken == "" {
+		*mcpToken = readTokenFile()
+	}
 
 	// TLS env fallbacks — flags take priority; env vars are the fallback.
 	if *tlsCert == "" {

--- a/cmd/muninn/server_test.go
+++ b/cmd/muninn/server_test.go
@@ -62,7 +62,7 @@ func TestCORSOriginsResolution(t *testing.T) {
 func TestBuildDaemonArgs_CORSFlagBeatsEnv(t *testing.T) {
 	osArgs := []string{"--cors-origins=http://flag.local"}
 	corsOriginsEnv := "http://env.local"
-	got := buildDaemonArgs("/tmp/data", false, "", osArgs, "", corsOriginsEnv)
+	got := buildDaemonArgs("/tmp/data", false, osArgs, "", corsOriginsEnv)
 
 	foundFlag := false
 	foundEnv := false
@@ -98,7 +98,7 @@ func TestBuildDaemonArgs_PortFlagsForwarded(t *testing.T) {
 	}
 	for _, tc := range cases {
 		osArgs := []string{tc.flag, tc.val}
-		got := buildDaemonArgs("/tmp/data", false, "", osArgs, "", "")
+		got := buildDaemonArgs("/tmp/data", false, osArgs, "", "")
 
 		foundFlag := false
 		foundVal := false
@@ -119,7 +119,7 @@ func TestBuildDaemonArgs_PortFlagsForwarded(t *testing.T) {
 // TestBuildDaemonArgs_PortFlagsEqForm verifies forwarding for --flag=value syntax.
 func TestBuildDaemonArgs_PortFlagsEqForm(t *testing.T) {
 	osArgs := []string{"--rest-addr=127.0.0.1:8485"}
-	got := buildDaemonArgs("/tmp/data", false, "", osArgs, "", "")
+	got := buildDaemonArgs("/tmp/data", false, osArgs, "", "")
 
 	found := false
 	for i, arg := range got {
@@ -136,7 +136,7 @@ func TestBuildDaemonArgs_PortFlagsEqForm(t *testing.T) {
 // address flags produces no --*-addr entries in daemon args (they are redundant
 // since the daemon uses the same defaults).
 func TestBuildDaemonArgs_DefaultAddrNotForwarded(t *testing.T) {
-	got := buildDaemonArgs("/tmp/data", false, "", []string{}, "", "")
+	got := buildDaemonArgs("/tmp/data", false, []string{}, "", "")
 	for _, arg := range got {
 		for _, flag := range []string{"--rest-addr", "--mbp-addr", "--grpc-addr", "--mcp-addr", "--ui-addr"} {
 			if arg == flag {


### PR DESCRIPTION
## Summary

Fixes #169 — MCP bearer token visible in \`ps ax\` and \`/proc/<pid>/cmdline\`.

**Root cause:** \`buildDaemonArgs\` appended \`--mcp-token mdb_...\` to the daemon subprocess argv, exposing the token to any user on the system.

**Fix:** The daemon now reads the token directly from \`~/.muninn/mcp.token\` at startup via \`readTokenFile()\`. This matches the pattern already used for all other secrets (OpenAI key, TLS cert, session secret — all loaded from files/env, never from CLI args). The \`--mcp-token\` flag is retained as an explicit override for tests and container/CI entrypoints.

**Before:** \`ps ax\` showed: \`muninn --daemon --data ~/.muninn/data --mcp-token mdb_abc123...\`  
**After:** \`ps ax\` shows: \`muninn --daemon --data ~/.muninn/data\`

## Test plan

- [x] \`TestBuildDaemonArgs/mcp-token_never_in_daemon_args\` — verifies \`--mcp-token\` is absent from all daemon args
- [x] All existing \`buildDaemonArgs\` tests updated and passing
- [x] \`server_test.go\` call sites updated
- [x] Full package test suite passes