### PR TITLE
fix(mcp): concept in remember response, rel_type in traverse, max_results after entity boost

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1624,6 +1624,11 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 	// top-N result receives a small boost. This surfaces entity-linked engrams
 	// that have no direct association edge to the query-matching engrams.
 	result.Activations = e.applyEntityBoost(ctx, wsPrefix, result.Activations)
+	// Re-apply MaxResults: entity boost may have appended engrams beyond the limit.
+	// applyEntityBoost re-sorts by score descending, so truncation preserves top-K.
+	if actReq.MaxResults > 0 && len(result.Activations) > actReq.MaxResults {
+		result.Activations = result.Activations[:actReq.MaxResults]
+	}
 
 	// Convert result.Activations to []mbp.ActivationItem
 	items := make([]mbp.ActivationItem, len(result.Activations))

--- a/internal/engine/engine_entity_boost_test.go
+++ b/internal/engine/engine_entity_boost_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -179,4 +180,59 @@ func TestEntityBoost_ApplyEntityBoostDirect(t *testing.T) {
 	// Engram C must NOT be in results (different entity, no entity link written).
 	_, cFound := idSet[idC]
 	require.False(t, cFound, "engram C (different entity) should not be in boosted results")
+}
+
+// TestEntityBoost_MaxResultsRespectedAfterBoost verifies that max_results is
+// enforced even when the entity boost phase appends additional engrams beyond
+// the limit. Regression test for issue #171.
+func TestEntityBoost_MaxResultsRespectedAfterBoost(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "max-results-test"
+
+	// Write one strong-match engram tagged with entity "PostgreSQL".
+	_, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   vault,
+		Concept: "primary database",
+		Content: "PostgreSQL primary relational database for transactional workloads",
+		Entities: []mbp.InlineEntity{
+			{Name: "PostgreSQL", Type: "database"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Write many additional entity-linked engrams; the entity boost phase may
+	// append these to results after the BFS limit has been applied.
+	for i := range 8 {
+		_, err := eng.Write(ctx, &mbp.WriteRequest{
+			Vault:   vault,
+			Concept: "related config",
+			Content: fmt.Sprintf("PostgreSQL related engram %d configuration details", i),
+			Entities: []mbp.InlineEntity{
+				{Name: "PostgreSQL", Type: "database"},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	const maxResults = 3
+	resp, err := eng.Activate(ctx, &mbp.ActivateRequest{
+		Vault:      vault,
+		Context:    []string{"PostgreSQL database"},
+		MaxResults: maxResults,
+	})
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(resp.Activations), maxResults,
+		"expected at most %d activations after entity boost, got %d", maxResults, len(resp.Activations))
+
+	// Verify descending score order — entity boost re-sorts, truncation must preserve it.
+	for i := 1; i < len(resp.Activations); i++ {
+		if resp.Activations[i].Score > resp.Activations[i-1].Score {
+			t.Errorf("activations not sorted descending at index %d: %.3f > %.3f",
+				i, resp.Activations[i].Score, resp.Activations[i-1].Score)
+		}
+	}
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -2067,3 +2067,34 @@ func TestStat_DefaultVaultMinimum(t *testing.T) {
 		t.Errorf("expected VaultCount >= 1 (minimum floor), got %d", resp.VaultCount)
 	}
 }
+
+// TestEngineTraverse_EdgeRelTypePopulated verifies that TraversalEdge.RelType
+// is populated from the storage.Association when traversing a typed edge.
+// Regression test for issue #173 (rel_type always empty in muninn_traverse).
+func TestEngineTraverse_EdgeRelTypePopulated(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	r1, _ := eng.Write(ctx, &mbp.WriteRequest{Vault: "test", Concept: "src", Content: "source engram"})
+	r2, _ := eng.Write(ctx, &mbp.WriteRequest{Vault: "test", Concept: "dst", Content: "destination engram"})
+
+	_, _ = eng.Link(ctx, &mbp.LinkRequest{
+		SourceID: r1.ID,
+		TargetID: r2.ID,
+		RelType:  uint16(storage.RelSupports),
+		Weight:   0.9,
+		Vault:    "test",
+	})
+
+	_, edges, err := eng.Traverse(ctx, "test", r1.ID, 1, 50, false)
+	if err != nil {
+		t.Fatalf("Traverse: %v", err)
+	}
+	if len(edges) == 0 {
+		t.Fatal("expected at least one edge")
+	}
+	if edges[0].RelType != storage.RelSupports {
+		t.Errorf("edge RelType = %v (%d), want storage.RelSupports (%d)", edges[0].RelType, edges[0].RelType, storage.RelSupports)
+	}
+}

--- a/internal/engine/query.go
+++ b/internal/engine/query.go
@@ -19,9 +19,10 @@ type TraversalNode struct {
 
 // TraversalEdge is an association edge returned during graph traversal.
 type TraversalEdge struct {
-	From   storage.ULID
-	To     storage.ULID
-	Weight float32
+	From    storage.ULID
+	To      storage.ULID
+	RelType storage.RelType // zero for synthetic entity-hop edges
+	Weight  float32
 }
 
 // ExplainData is the engine-level score explanation for a specific engram + query.
@@ -155,7 +156,7 @@ func (e *Engine) Traverse(ctx context.Context, vault, startID string, maxHops, m
 				}
 			}
 			for _, assoc := range assocMap[src] {
-				edges = append(edges, TraversalEdge{From: src, To: assoc.TargetID, Weight: assoc.Weight})
+				edges = append(edges, TraversalEdge{From: src, To: assoc.TargetID, RelType: assoc.RelType, Weight: assoc.Weight})
 				if _, seen := visited[assoc.TargetID]; !seen {
 					visited[assoc.TargetID] = struct{}{}
 					hopMap[assoc.TargetID] = hop + 1

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -137,9 +137,10 @@ func (a *mcpEngineAdapter) Traverse(ctx context.Context, vault string, req *Trav
 	}
 	for _, e := range edges {
 		result.Edges = append(result.Edges, TraversalEdge{
-			FromID: e.From.String(),
-			ToID:   e.To.String(),
-			Weight: e.Weight,
+			FromID:  e.From.String(),
+			ToID:    e.To.String(),
+			RelType: relTypeToString(e.RelType),
+			Weight:  e.Weight,
 		})
 	}
 	return result, nil

--- a/internal/mcp/engine_adapter_test.go
+++ b/internal/mcp/engine_adapter_test.go
@@ -276,3 +276,31 @@ func TestMCPEngineAdapterTraverseExplicitMaxHops(t *testing.T) {
 		t.Errorf("expected maxNodes=100, got %d", maxNodes)
 	}
 }
+
+// TestRelTypeToString_SupportsRoundTrip verifies that relTypeToString is the
+// correct inverse of relTypeFromString for all known relation types.
+// Regression guard for issue #173 (rel_type always empty in muninn_traverse).
+func TestRelTypeToString_AllKnownTypes(t *testing.T) {
+	// All canonical string names that appear in relTypeMap.
+	knownTypes := []string{
+		"supports", "contradicts", "depends_on", "supersedes", "relates_to",
+		"is_part_of", "causes", "preceded_by", "followed_by", "created_by_person",
+		"belongs_to_project", "references", "implements", "blocks", "resolves", "refines",
+	}
+	for _, name := range knownTypes {
+		code := storage.RelType(relTypeFromString(name))
+		got := relTypeToString(code)
+		if got != name {
+			t.Errorf("round-trip failed for %q: relTypeToString(%d) = %q", name, code, got)
+		}
+	}
+}
+
+// TestRelTypeToString_ZeroValueEmpty verifies that RelType(0) — used by
+// synthetic entity-hop edges — returns an empty string (not a panic or "relates_to").
+func TestRelTypeToString_ZeroValueEmpty(t *testing.T) {
+	got := relTypeToString(storage.RelType(0))
+	if got != "" {
+		t.Errorf("relTypeToString(0) = %q, want empty string", got)
+	}
+}

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -90,7 +90,7 @@ func (s *MCPServer) handleRemember(ctx context.Context, w http.ResponseWriter, i
 			slog.Warn("mcp: failed to record idempotency receipt", "op_id", opID, "engram_id", resp.ID, "err", err)
 		}
 	}
-	result := WriteResult{ID: resp.ID}
+	result := WriteResult{ID: resp.ID, Concept: req.Concept}
 	if len(content) > 500 {
 		result.Hint = "Tip: memories work best when each one captures a single concept. For future writes, consider using muninn_remember_batch to store multiple focused memories at once."
 	}
@@ -169,18 +169,19 @@ func (s *MCPServer) handleRememberBatch(ctx context.Context, w http.ResponseWrit
 	responses, errs := s.engine.WriteBatch(ctx, reqs)
 
 	type batchItemResult struct {
-		Index  int    `json:"index"`
-		ID     string `json:"id,omitempty"`
-		Status string `json:"status"`
-		Error  string `json:"error,omitempty"`
-		Hint   string `json:"hint,omitempty"`
+		Index   int    `json:"index"`
+		ID      string `json:"id,omitempty"`
+		Concept string `json:"concept,omitempty"`
+		Status  string `json:"status"`
+		Error   string `json:"error,omitempty"`
+		Hint    string `json:"hint,omitempty"`
 	}
 	results := make([]batchItemResult, len(reqs))
 	for i := range reqs {
 		if errs[i] != nil {
 			results[i] = batchItemResult{Index: i, Status: "error", Error: errs[i].Error()}
 		} else {
-			results[i] = batchItemResult{Index: i, ID: responses[i].ID, Status: "ok"}
+			results[i] = batchItemResult{Index: i, ID: responses[i].ID, Concept: reqs[i].Concept, Status: "ok"}
 		}
 		if malformedCounts[i] > 0 {
 			results[i].Hint = fmt.Sprintf("%d entity item(s) were malformed (expected {\"name\":\"...\",\"type\":\"...\"} objects) and were skipped.", malformedCounts[i])
@@ -1167,6 +1168,25 @@ func relTypeFromString(rel string) uint16 {
 		return uint16(v)
 	}
 	return uint16(storage.RelRelatesTo) // default
+}
+
+// relTypeReverseMap is the inverse of relTypeMap, built once at package init.
+// Used by relTypeToString for O(1) deterministic lookup.
+var relTypeReverseMap = func() map[storage.RelType]string {
+	m := make(map[storage.RelType]string, len(relTypeMap))
+	for s, v := range relTypeMap {
+		m[v] = s
+	}
+	return m
+}()
+
+// relTypeToString converts a storage.RelType to its canonical string name.
+// Returns "" for unknown or zero-value types (e.g. synthetic entity-hop edges).
+func relTypeToString(r storage.RelType) string {
+	if s, ok := relTypeReverseMap[r]; ok {
+		return s
+	}
+	return ""
 }
 
 func (s *MCPServer) handleSimilarEntities(ctx context.Context, w http.ResponseWriter, id json.RawMessage, vault string, args map[string]any) {

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -2343,3 +2343,52 @@ func TestHandleReplayEnrichment_WithStages(t *testing.T) {
 		t.Error("response missing 'processed' field")
 	}
 }
+
+// ── Issue #172: concept in muninn_remember / muninn_remember_batch response ──
+
+// TestHandleRemember_ConceptInResponse verifies that the concept sent in a
+// muninn_remember request is echoed back in the response.
+// Regression test for issue #172 (concept always empty in response).
+func TestHandleRemember_ConceptInResponse(t *testing.T) {
+	srv := newTestServer()
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_remember","arguments":{"vault":"default","content":"test content","concept":"my-concept"}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	content := extractInnerJSON(t, resp)
+	concept, ok := content["concept"].(string)
+	if !ok || concept != "my-concept" {
+		t.Errorf("expected concept='my-concept', got %v", content["concept"])
+	}
+}
+
+// TestHandleRememberBatch_ConceptInResponse verifies that each batch item's
+// concept is echoed back in the response.
+// Regression test for issue #172 (concept always empty in response).
+func TestHandleRememberBatch_ConceptInResponse(t *testing.T) {
+	srv := newTestServer()
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_remember_batch","arguments":{"vault":"default","memories":[{"content":"memory one","concept":"concept-a"},{"content":"memory two","concept":"concept-b"}]}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	inner := extractInnerJSON(t, resp)
+	results, ok := inner["results"].([]any)
+	if !ok || len(results) != 2 {
+		t.Fatalf("expected 2 results, got %v", inner["results"])
+	}
+	wantConcepts := []string{"concept-a", "concept-b"}
+	for i, r := range results {
+		item, ok := r.(map[string]any)
+		if !ok {
+			t.Fatalf("results[%d] is not an object", i)
+		}
+		got, _ := item["concept"].(string)
+		if got != wantConcepts[i] {
+			t.Errorf("results[%d].concept = %q, want %q", i, got, wantConcepts[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **#172** — `muninn_remember` response always had empty `concept` field. `WriteResult.Concept` was never set from `req.Concept`. Same omission fixed in `muninn_remember_batch` batch item results.

- **#173** — `muninn_traverse` edges always had empty `rel_type`. Root cause was two-level: `engine.TraversalEdge` struct had no `RelType` field, and `Traverse()` wasn't copying `assoc.RelType`. Fixed by adding the field, populating it in `Traverse()`, and adding `relTypeReverseMap` + `relTypeToString()` in the mcp package for O(1) deterministic string conversion.

- **#171** — `max_results` was ignored when `applyEntityBoost()` appended engrams beyond the BFS limit. Added a re-apply of the `MaxResults` truncation immediately after the boost phase (which already re-sorts by score descending, so truncation preserves top-K order).

## Test plan

- [ ] `TestHandleRemember_ConceptInResponse` — single remember echoes concept
- [ ] `TestHandleRememberBatch_ConceptInResponse` — batch remember echoes per-item concept
- [ ] `TestRelTypeToString_AllKnownTypes` — all 16 rel types round-trip through relTypeFromString/relTypeToString
- [ ] `TestRelTypeToString_ZeroValueEmpty` — entity-hop zero-value RelType returns empty string
- [ ] `TestEngineTraverse_EdgeRelTypePopulated` — engine Traverse() returns correct RelType on edges
- [ ] `TestEntityBoost_MaxResultsRespectedAfterBoost` — activation count ≤ max_results after entity boost, sorted descending by score