### PR TITLE
fix(#168): restore plugin config in Web UI on settings tab load

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -13,10 +13,10 @@
   },
   "devDependencies": {
     "vite": "^6.0.0",
+    "vitest": "^2.0.0",
     "tailwindcss": "^3.4.0",
     "postcss": "^8.4.0",
     "autoprefixer": "^10.4.0",
-    "vitest": "^2.0.0",
     "@playwright/test": "^1.44.0"
   }
 }

--- a/web/plugin-config-utils.test.js
+++ b/web/plugin-config-utils.test.js
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { parsePluginConfigResponse } from './static/js/plugin-config-utils.js';
+
+describe('parsePluginConfigResponse', () => {
+
+    it('returns null for null input', () => {
+        expect(parsePluginConfigResponse(null)).toBeNull();
+    });
+
+    it('returns null for undefined input', () => {
+        expect(parsePluginConfigResponse(undefined)).toBeNull();
+    });
+
+    it('returns none providers for empty config object', () => {
+        const r = parsePluginConfigResponse({});
+        expect(r.embedProvider).toBe('none');
+        expect(r.enrichProvider).toBe('none');
+        expect(r.embedOllamaModel).toBeNull();
+        expect(r.embedUrl).toBeNull();
+        expect(r.embedApiKey).toBeNull();
+        expect(r.enrichOllamaModel).toBeNull();
+        expect(r.enrichModel).toBeNull();
+        expect(r.enrichApiKey).toBeNull();
+    });
+
+    it('maps empty-string provider to none', () => {
+        const r = parsePluginConfigResponse({ embed_provider: '', enrich_provider: '' });
+        expect(r.embedProvider).toBe('none');
+        expect(r.enrichProvider).toBe('none');
+    });
+
+    // ── Embed section ────────────────────────────────────────────────────────
+
+    it('parses ollama embed URL to model name', () => {
+        const r = parsePluginConfigResponse({
+            embed_provider: 'ollama',
+            embed_url: 'ollama://localhost:11434/nomic-embed-text',
+        });
+        expect(r.embedProvider).toBe('ollama');
+        expect(r.embedOllamaModel).toBe('nomic-embed-text');
+        expect(r.embedUrl).toBeNull();
+    });
+
+    it('parses openai embed with custom https base URL', () => {
+        const r = parsePluginConfigResponse({
+            embed_provider: 'openai',
+            embed_url: 'https://api.openai.com/v1',
+            embed_api_key: 'sk-test-key',
+        });
+        expect(r.embedProvider).toBe('openai');
+        expect(r.embedUrl).toBe('https://api.openai.com/v1');
+        expect(r.embedApiKey).toBe('sk-test-key');
+        expect(r.embedOllamaModel).toBeNull();
+    });
+
+    it('parses openai embed with http base URL', () => {
+        const r = parsePluginConfigResponse({
+            embed_provider: 'openai',
+            embed_url: 'http://localhost:8080/v1',
+        });
+        expect(r.embedUrl).toBe('http://localhost:8080/v1');
+    });
+
+    it('parses voyage embed (api key only, no embed_url)', () => {
+        const r = parsePluginConfigResponse({
+            embed_provider: 'voyage',
+            embed_url: '',
+            embed_api_key: 'pa-voyage-key',
+        });
+        expect(r.embedProvider).toBe('voyage');
+        expect(r.embedApiKey).toBe('pa-voyage-key');
+        expect(r.embedUrl).toBeNull();
+        expect(r.embedOllamaModel).toBeNull();
+    });
+
+    // ── Enrich section ───────────────────────────────────────────────────────
+
+    it('parses anthropic enrich URL to model name', () => {
+        const r = parsePluginConfigResponse({
+            enrich_provider: 'anthropic',
+            enrich_url: 'anthropic://claude-haiku-4-5-20251001',
+            enrich_api_key: 'sk-ant-test',
+        });
+        expect(r.enrichProvider).toBe('anthropic');
+        expect(r.enrichModel).toBe('claude-haiku-4-5-20251001');
+        expect(r.enrichApiKey).toBe('sk-ant-test');
+        expect(r.enrichOllamaModel).toBeNull();
+    });
+
+    it('parses openai enrich URL to model name', () => {
+        const r = parsePluginConfigResponse({
+            enrich_provider: 'openai',
+            enrich_url: 'openai://gpt-4o-mini',
+            enrich_api_key: 'sk-openai-test',
+        });
+        expect(r.enrichProvider).toBe('openai');
+        expect(r.enrichModel).toBe('gpt-4o-mini');
+        expect(r.enrichApiKey).toBe('sk-openai-test');
+    });
+
+    it('parses ollama enrich URL to model name', () => {
+        const r = parsePluginConfigResponse({
+            enrich_provider: 'ollama',
+            enrich_url: 'ollama://localhost:11434/llama3.2',
+        });
+        expect(r.enrichProvider).toBe('ollama');
+        expect(r.enrichOllamaModel).toBe('llama3.2');
+        expect(r.enrichModel).toBeNull();
+    });
+
+    // ── Provider guard tests ─────────────────────────────────────────────────
+
+    it('does not parse ollama embed URL when embed_provider is not ollama', () => {
+        const r = parsePluginConfigResponse({
+            embed_provider: 'openai',
+            embed_url: 'ollama://localhost:11434/stale-model',
+        });
+        expect(r.embedProvider).toBe('openai');
+        expect(r.embedOllamaModel).toBeNull();  // guard prevents stale parse
+        expect(r.embedUrl).toBeNull();           // not http/https either
+    });
+
+    it('does not parse anthropic enrich URL when enrich_provider is not anthropic', () => {
+        const r = parsePluginConfigResponse({
+            enrich_provider: 'openai',
+            enrich_url: 'anthropic://claude-haiku-4-5-20251001',
+        });
+        expect(r.enrichProvider).toBe('openai');
+        expect(r.enrichModel).toBeNull();
+    });
+
+    it('does not parse openai enrich URL when enrich_provider is not openai', () => {
+        const r = parsePluginConfigResponse({
+            enrich_provider: 'anthropic',
+            enrich_url: 'openai://gpt-4o-mini',
+        });
+        expect(r.enrichProvider).toBe('anthropic');
+        expect(r.enrichModel).toBeNull();
+    });
+
+    // ── Full round-trip scenarios ────────────────────────────────────────────
+
+    it('full anthropic enrich + ollama embed round-trip', () => {
+        const r = parsePluginConfigResponse({
+            embed_provider: 'ollama',
+            embed_url: 'ollama://localhost:11434/nomic-embed-text',
+            embed_api_key: '',
+            enrich_provider: 'anthropic',
+            enrich_url: 'anthropic://claude-haiku-4-5-20251001',
+            enrich_api_key: 'sk-ant-real-key',
+        });
+        expect(r.embedProvider).toBe('ollama');
+        expect(r.embedOllamaModel).toBe('nomic-embed-text');
+        expect(r.enrichProvider).toBe('anthropic');
+        expect(r.enrichModel).toBe('claude-haiku-4-5-20251001');
+        expect(r.enrichApiKey).toBe('sk-ant-real-key');
+    });
+});

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -381,7 +381,7 @@ document.addEventListener('alpine:init', () => {
       }
     },
 
-    _onViewEnter(view) {
+    async _onViewEnter(view) {
       // Stop observability polling when leaving the tab
       if (this._obsInterval) {
         clearInterval(this._obsInterval);
@@ -422,6 +422,7 @@ document.addEventListener('alpine:init', () => {
         } else if (this.settingsTab === 'plugins') {
           this.loadPlugins();
           this.loadEmbedStatus();
+          await this.loadSavedPluginConfig();  // must resolve before probeOllama reads model state
           this.probeOllama();
         } else if (this.settingsTab === 'keys') {
           this.loadApiKeys();
@@ -1601,14 +1602,19 @@ document.addEventListener('alpine:init', () => {
     async loadSavedPluginConfig() {
         try {
             const data = await this.apiCall('/api/admin/plugin-config');
-            const embedUrl = data.embed_url || '';
-            // Only populate the Base URL field when it's an HTTP/HTTPS URL.
-            // ollama:// and other scheme URLs encode a model name, not a base URL.
-            if (embedUrl.startsWith('http://') || embedUrl.startsWith('https://')) {
-                this.pluginCfg.embedUrl = embedUrl;
-            }
-        } catch (_) {
-            // Non-critical — leave embedUrl at default
+            const parsed = MuninnPluginCfg.parsePluginConfigResponse(data);
+            if (!parsed) return;
+            const c = this.pluginCfg;
+            c.embedProvider  = parsed.embedProvider;
+            if (parsed.embedOllamaModel  !== null) c.embedOllamaModel  = parsed.embedOllamaModel;
+            if (parsed.embedUrl          !== null) c.embedUrl          = parsed.embedUrl;
+            if (parsed.embedApiKey       !== null) c.embedApiKey       = parsed.embedApiKey;
+            c.enrichProvider = parsed.enrichProvider;
+            if (parsed.enrichOllamaModel !== null) c.enrichOllamaModel = parsed.enrichOllamaModel;
+            if (parsed.enrichModel       !== null) c.enrichModel       = parsed.enrichModel;
+            if (parsed.enrichApiKey      !== null) c.enrichApiKey      = parsed.enrichApiKey;
+        } catch (e) {
+            console.warn('loadSavedPluginConfig failed:', e);
         }
     },
     async loadWorkers() {

--- a/web/static/js/plugin-config-utils.js
+++ b/web/static/js/plugin-config-utils.js
@@ -1,0 +1,79 @@
+/**
+ * plugin-config-utils.js — pure plugin config parsing utilities.
+ *
+ * Loaded as a <script type="module"> so it can be imported by Vitest with ES
+ * module syntax. The globalThis assignment at the bottom exposes MuninnPluginCfg
+ * as a browser global so the non-module app.js can call it after Alpine init.
+ *
+ * Execution order in index.html:
+ *   1. app.js  (sync/blocking — defines Alpine data component, does NOT call methods)
+ *   2. plugin-config-utils.js  (module — sets globalThis.MuninnPluginCfg)
+ *   3. alpine.js  (defer — initializes Alpine; methods are now callable)
+ *
+ * Because Alpine.js is deferred and runs after step 2, MuninnPluginCfg is always
+ * defined before any component method (e.g. loadSavedPluginConfig) is invoked.
+ */
+
+/**
+ * Parse a GET /api/admin/plugin-config response into Alpine-ready plugin state.
+ *
+ * Returns an object where null fields mean "leave Alpine default unchanged".
+ * Provider fields always return a string ('none' when empty/absent).
+ *
+ * URL decoding mirrors the save conventions in savePluginConfig (app.js):
+ *   embed_url  "ollama://localhost:11434/{model}" → embedOllamaModel
+ *   embed_url  "http(s)://..."                   → embedUrl (custom base URL)
+ *   enrich_url "ollama://localhost:11434/{model}" → enrichOllamaModel
+ *   enrich_url "anthropic://{model}"              → enrichModel
+ *   enrich_url "openai://{model}"                 → enrichModel
+ *
+ * @param {object|null} data - raw API response object
+ * @returns {object|null} parsed state, or null when data is falsy
+ */
+export function parsePluginConfigResponse(data) {
+    if (!data) return null;
+
+    const result = {
+        embedProvider:     data.embed_provider  || 'none',
+        embedOllamaModel:  null,
+        embedUrl:          null,
+        embedApiKey:       data.embed_api_key   || null,
+        enrichProvider:    data.enrich_provider || 'none',
+        enrichOllamaModel: null,
+        enrichModel:       null,
+        enrichApiKey:      data.enrich_api_key  || null,
+    };
+
+    // ── Embed URL parsing ─────────────────────────────────────────────────────
+    const embedUrl = data.embed_url || '';
+    if (result.embedProvider === 'ollama' && embedUrl.startsWith('ollama://')) {
+        // "ollama://localhost:11434/nomic-embed-text" → "nomic-embed-text"
+        const model = embedUrl.split('/').pop();
+        if (model) result.embedOllamaModel = model;
+    } else if (embedUrl.startsWith('http://') || embedUrl.startsWith('https://')) {
+        result.embedUrl = embedUrl;
+    }
+
+    // ── Enrich URL parsing ────────────────────────────────────────────────────
+    const enrichUrl = data.enrich_url || '';
+    if (result.enrichProvider === 'ollama' && enrichUrl.startsWith('ollama://')) {
+        // "ollama://localhost:11434/llama3.2" → "llama3.2"
+        const model = enrichUrl.split('/').pop();
+        if (model) result.enrichOllamaModel = model;
+    } else if (result.enrichProvider === 'anthropic' && enrichUrl.startsWith('anthropic://')) {
+        // "anthropic://claude-haiku-4-5-20251001" → "claude-haiku-4-5-20251001"
+        const model = enrichUrl.replace('anthropic://', '');
+        if (model) result.enrichModel = model;
+    } else if (result.enrichProvider === 'openai' && enrichUrl.startsWith('openai://')) {
+        // "openai://gpt-4o-mini" → "gpt-4o-mini"
+        const model = enrichUrl.replace('openai://', '');
+        if (model) result.enrichModel = model;
+    }
+
+    return result;
+}
+
+// Expose as a browser global so the non-module app.js can access it after Alpine
+// initializes. Module scripts execute before Alpine's deferred init, so this is
+// always set by the time any component method runs.
+globalThis.MuninnPluginCfg = { parsePluginConfigResponse };

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -25,6 +25,9 @@
 
   <!-- App JS (must load before Alpine deferred init) -->
   <script src="/static/js/app.js"></script>
+  <!-- plugin-config-utils: loaded as module after app.js sync execution,
+       before Alpine's deferred init — sets globalThis.MuninnPluginCfg -->
+  <script type="module" src="/static/js/plugin-config-utils.js"></script>
 
   <!-- Alpine.js (deferred — initializes after DOM + app.js registers components) -->
   <script defer src="/static/vendor/alpine-3.14.9.min.js"></script>

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -24,4 +24,9 @@ export default defineConfig({
       '/events': { target: 'http://localhost:8476', changeOrigin: true },
     },
   },
+  test: {
+    root: resolve(__dirname),  // look for tests in web/ not web/static/
+    environment: 'node',
+    globals: false,
+  },
 })


### PR DESCRIPTION
## Summary

- `loadSavedPluginConfig()` was defined in `app.js` but **never called**, and its existing stub only loaded `embed_url` — all enrichment fields were silently ignored on page load
- The GET/PUT API and disk persistence were working correctly; this was a pure UI loading bug

## Changes

### Bug fix (`web/static/js/app.js`)
- Complete `loadSavedPluginConfig()` to restore all 6 config fields by reverse-parsing stored URL schemes (`ollama://`, `anthropic://`, `openai://`, `http(s)://`)
- Call `loadSavedPluginConfig()` when entering the plugins tab, sequenced with `await` before `probeOllama()` to eliminate a race condition where Ollama probe would clobber saved model names with detected defaults
- Make `_onViewEnter()` async to support the await; all three call sites are fire-and-forget so this is backward compatible

### Pure utility extraction (`web/static/js/plugin-config-utils.js`)
- Extract `parsePluginConfigResponse(data)` as a pure ES module function
- Loaded as `<script type="module">` — executes after synchronous `app.js` definition but before Alpine's deferred init, so `globalThis.MuninnPluginCfg` is always set when any component method runs
- Provider guards on all URL-scheme parsing branches prevent stale URL values from polluting the wrong provider state

### Test infrastructure (`web/plugin-config-utils.test.js`, Vitest)
- Add Vitest (`^2.0.0`) — zero friction since Vite was already present
- 15 unit tests covering: null/undefined input, empty config, all 4 embed providers (ollama/openai/voyage/none), all 3 enrich providers (ollama/anthropic/openai), provider guards (stale URL mismatch), empty-string-as-none, full round-trip scenario

## Test plan

- [ ] `cd web && npm test` → 15/15 passing
- [ ] `go test ./...` → all pass (cognitive live-integration tests require a running daemon, pre-existing)
- [ ] Manual: configure Anthropic enrich + Ollama embed → save → reload page → navigate to plugins tab → verify all fields pre-populated
- [ ] Manual: verify Ollama model selection not clobbered when saved model is in the detected Ollama list