### PR TITLE
fix(backup): wait for scheduler goroutine before temp dir cleanup

### DIFF
--- a/internal/backup/scheduler.go
+++ b/internal/backup/scheduler.go
@@ -66,8 +66,14 @@ func New(cfg Config, eng Checkpointer) *Scheduler {
 }
 
 // Start launches the backup goroutine. It respects context cancellation.
-func (s *Scheduler) Start(ctx context.Context) {
-	go s.run(ctx)
+// The returned channel is closed when the goroutine has fully stopped.
+func (s *Scheduler) Start(ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.run(ctx)
+	}()
+	return done
 }
 
 // GetStatus returns a thread-safe snapshot of the scheduler's current state.

--- a/internal/backup/scheduler_test.go
+++ b/internal/backup/scheduler_test.go
@@ -212,8 +212,9 @@ func TestScheduler_Start(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
-	sched.Start(ctx)
+	done := sched.Start(ctx)
 	<-ctx.Done()
+	<-done // wait for the goroutine to finish any in-progress runOnce before temp dir cleanup
 
 	if stub.called.Load() == 0 {
 		t.Fatal("expected Checkpoint to be called at least once by the scheduler goroutine")


### PR DESCRIPTION
## Problem

`TestScheduler_Start` was flaky on Linux CI. The test waited for `ctx.Done()` then immediately returned, but the scheduler goroutine could still be mid-`runOnce()` writing checkpoint files to the temp dir. Go's `TempDir` `RemoveAll` cleanup then failed with:

```
TempDir RemoveAll cleanup: unlinkat .../backup-.../pebble: directory not empty
```

This was causing the `Go build & test` job to fail on `main`.

## Fix

- `Start()` now returns a `<-chan struct{}` that closes when the goroutine fully exits
- `TestScheduler_Start` waits on this channel after `ctx.Done()` before returning, ensuring the temp dir is idle before cleanup
- Production call site in `server.go` ignores the return value — no behavior change

## Verified

`go test ./internal/backup/... -run TestScheduler_Start -count=10` — 10/10 PASS