### PR TITLE
fix(mcp): use RWMutex for SSE session reads, fixes #174

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -26,7 +26,7 @@ type MCPServer struct {
 	srv       *http.Server
 	tlsConfig *tls.Config // nil = plain TCP
 
-	sseSessionsMu sync.Mutex
+	sseSessionsMu sync.RWMutex
 	sseSessions   map[string]*sseSession // sessionID → session
 	// NOTE: idempotencyLocks grows by one entry per unique op_id seen during the
 	// process lifetime. In practice op_id cardinality is low (client-generated,
@@ -331,9 +331,9 @@ func (s *MCPServer) handleSSEMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.sseSessionsMu.Lock()
+	s.sseSessionsMu.RLock()
 	sess, exists := s.sseSessions[sessionID]
-	s.sseSessionsMu.Unlock()
+	s.sseSessionsMu.RUnlock()
 	if !exists {
 		http.Error(w, "unknown session", http.StatusNotFound)
 		return
@@ -384,8 +384,8 @@ func (s *MCPServer) handleStreamablePost(w http.ResponseWriter, r *http.Request)
 
 // findSSEChannelsByToken returns all SSE channels matching the given auth token.
 func (s *MCPServer) findSSEChannelsByToken(token string) []chan []byte {
-	s.sseSessionsMu.Lock()
-	defer s.sseSessionsMu.Unlock()
+	s.sseSessionsMu.RLock()
+	defer s.sseSessionsMu.RUnlock()
 	var channels []chan []byte
 	for _, sess := range s.sseSessions {
 		if sess.authToken == token {

--- a/internal/mcp/server_sse_test.go
+++ b/internal/mcp/server_sse_test.go
@@ -1,0 +1,138 @@
+package mcp
+
+// server_sse_test.go — concurrency tests for SSE session mutex (#174).
+//
+// Root cause: sseSessionsMu was sync.Mutex; findSSEChannelsByToken and
+// handleSSEMessage held an exclusive write lock during read-only map
+// operations. Under rapid consecutive stores (e.g. Claude Code batch
+// remember calls), concurrent POST goroutines serialized at the mutex,
+// causing temporary MCP server unresponsiveness.
+//
+// Fix: sync.Mutex → sync.RWMutex; read paths use RLock/RUnlock.
+//
+// Run with -race to verify correctness under concurrent read/write access.
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSSESessions_ConcurrentReadWrite is a race-detector test that exercises
+// concurrent reads (findSSEChannelsByToken) and writes (add/delete sessions)
+// simultaneously. Run with: go test -race ./internal/mcp/...
+func TestSSESessions_ConcurrentReadWrite(t *testing.T) {
+	srv := newTestServer()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	// Writer: continuously add and remove sessions, simulating SSE stream
+	// connect/disconnect events.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ctx.Err() == nil; i++ {
+			id := fmt.Sprintf("sess%d", i%10)
+			ch := make(chan []byte, 64)
+
+			srv.sseSessionsMu.Lock()
+			srv.sseSessions[id] = &sseSession{ch: ch, authToken: "tok"}
+			srv.sseSessionsMu.Unlock()
+
+			runtime.Gosched()
+
+			srv.sseSessionsMu.Lock()
+			delete(srv.sseSessions, id)
+			srv.sseSessionsMu.Unlock()
+		}
+	}()
+
+	// Readers: simulate concurrent POST /mcp requests each calling
+	// findSSEChannelsByToken. With the old sync.Mutex, these serialized.
+	// With sync.RWMutex, they run concurrently.
+	for r := 0; r < 10; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ctx.Err() == nil {
+				_ = srv.findSSEChannelsByToken("tok")
+				runtime.Gosched()
+			}
+		}()
+	}
+
+	wg.Wait()
+	// If this completes without -race warnings, lock discipline is correct.
+}
+
+// TestFindSSEChannelsByToken_ReturnsCorrectChannels verifies that
+// findSSEChannelsByToken returns only channels for the matching token.
+func TestFindSSEChannelsByToken_ReturnsCorrectChannels(t *testing.T) {
+	srv := newTestServer()
+
+	ch1 := make(chan []byte, 4)
+	ch2 := make(chan []byte, 4)
+	ch3 := make(chan []byte, 4)
+
+	srv.sseSessionsMu.Lock()
+	srv.sseSessions["s1"] = &sseSession{ch: ch1, authToken: "token-a"}
+	srv.sseSessions["s2"] = &sseSession{ch: ch2, authToken: "token-b"}
+	srv.sseSessions["s3"] = &sseSession{ch: ch3, authToken: "token-a"}
+	srv.sseSessionsMu.Unlock()
+
+	got := srv.findSSEChannelsByToken("token-a")
+	if len(got) != 2 {
+		t.Errorf("expected 2 channels for token-a, got %d", len(got))
+	}
+
+	got = srv.findSSEChannelsByToken("token-b")
+	if len(got) != 1 {
+		t.Errorf("expected 1 channel for token-b, got %d", len(got))
+	}
+
+	got = srv.findSSEChannelsByToken("no-such-token")
+	if len(got) != 0 {
+		t.Errorf("expected 0 channels for unknown token, got %d", len(got))
+	}
+}
+
+// TestFindSSEChannelsByToken_EmptyMap verifies correct behavior when no
+// sessions exist.
+func TestFindSSEChannelsByToken_EmptyMap(t *testing.T) {
+	srv := newTestServer()
+	got := srv.findSSEChannelsByToken("any-token")
+	if len(got) != 0 {
+		t.Errorf("expected 0 channels from empty map, got %d", len(got))
+	}
+}
+
+// BenchmarkFindSSEChannelsByToken_Parallel measures throughput of concurrent
+// readers. With sync.Mutex (bug), goroutines serialize. With sync.RWMutex
+// (fix), readers run in parallel — throughput should scale with GOMAXPROCS.
+//
+// Run: go test -bench=BenchmarkFindSSEChannelsByToken_Parallel ./internal/mcp/...
+func BenchmarkFindSSEChannelsByToken_Parallel(b *testing.B) {
+	srv := newTestServer()
+
+	// Populate with 5 sessions (typical Claude Code usage: 1-3 SSE streams).
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("sess%d", i)
+		srv.sseSessions[id] = &sseSession{
+			ch:        make(chan []byte, 64),
+			authToken: "bench-token",
+		}
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = srv.findSSEChannelsByToken("bench-token")
+		}
+	})
+}


### PR DESCRIPTION
## Root Cause

`sseSessionsMu` was declared as `sync.Mutex`. Two read-only operations held an exclusive write lock:

- `findSSEChannelsByToken` — iterates `sseSessions` map to find channels by token
- `handleSSEMessage` — looks up a single session by ID

Under rapid consecutive stores (e.g. Claude Code `muninn_remember_batch` or sequential `muninn_remember` calls), every inbound POST goroutine called `findSSEChannelsByToken` and contended for the same exclusive lock. This serialized all concurrent reads, causing request queuing and temporary MCP server unresponsiveness.

## Fix

- Change `sseSessionsMu sync.Mutex` → `sseSessionsMu sync.RWMutex`
- `findSSEChannelsByToken`: `Lock` → `RLock`, `Unlock` → `RUnlock`
- `handleSSEMessage`: `Lock` → `RLock`, `Unlock` → `RUnlock`
- Write paths in `handleSSE` (add/delete session) unchanged — correctly keep `Lock`/`Unlock`

Note: existing `pushToAll` already uses non-blocking `select { case ch <- data: default: }`, so the TOCTOU between session lookup and channel send is already safely handled (dropped message, not panic or goroutine leak).

## Tests

- `TestSSESessions_ConcurrentReadWrite` — race-detector test (concurrent readers + writers over 2s); run with `go test -race`
- `TestFindSSEChannelsByToken_ReturnsCorrectChannels` — correctness under multi-session map
- `TestFindSSEChannelsByToken_EmptyMap` — empty map edge case
- `BenchmarkFindSSEChannelsByToken_Parallel` — parallel throughput benchmark (~146 ns/op on M4)

## Checklist

- [x] All 45 packages pass (`go test -race ./...`)
- [x] Race detector clean
- [x] Opus architecture review: confirmed fix is correct and minimal