### PR TITLE
fix: return 404 for missing engrams instead of 500/wrong-code

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1380,6 +1380,9 @@ func (e *Engine) Read(ctx context.Context, req *mbp.ReadRequest) (*mbp.ReadRespo
 
 	eng, err := e.store.GetEngram(ctx, wsPrefix, id)
 	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, ErrEngramNotFound
+		}
 		return nil, fmt.Errorf("get engram: %w", err)
 	}
 
@@ -1988,6 +1991,9 @@ func (e *Engine) Forget(ctx context.Context, req *mbp.ForgetRequest) (*mbp.Forge
 
 	if req.Hard {
 		if err := e.store.DeleteEngram(ctx, wsPrefix, id); err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return nil, ErrEngramNotFound
+			}
 			return nil, fmt.Errorf("hard delete: %w", err)
 		}
 		// Mark the node as deleted in the HNSW index so it is skipped in
@@ -2010,6 +2016,9 @@ func (e *Engine) Forget(ctx context.Context, req *mbp.ForgetRequest) (*mbp.Forge
 		// Read the engram before soft-deleting so we can clean up FTS index entries.
 		eng, readErr := e.store.GetEngram(ctx, wsPrefix, id)
 		if err := e.store.SoftDelete(ctx, wsPrefix, id); err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return nil, ErrEngramNotFound
+			}
 			return nil, fmt.Errorf("soft delete: %w", err)
 		}
 		// Remove FTS posting-list entries so soft-deleted engrams do not appear in search.
@@ -2164,6 +2173,9 @@ func (e *Engine) Restore(ctx context.Context, vault, id string) (*storage.Engram
 	}
 	eng, err := e.store.GetEngram(ctx, ws, ulid)
 	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, ErrEngramNotFound
+		}
 		return nil, fmt.Errorf("restore: %w", err)
 	}
 	if eng.State != storage.StateSoftDeleted {

--- a/internal/transport/rest/coverage_boost_test.go
+++ b/internal/transport/rest/coverage_boost_test.go
@@ -250,7 +250,7 @@ func TestGetEngram_EngineError_Boost(t *testing.T) {
 type readErrorEngine struct{ MockEngine }
 
 func (e *readErrorEngine) Read(_ context.Context, _ *ReadRequest) (*ReadResponse, error) {
-	return nil, errors.New("not found")
+	return nil, engine.ErrEngramNotFound
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -651,7 +651,11 @@ func (s *Server) handleGetEngram(w http.ResponseWriter, r *http.Request) {
 	}
 	resp, err := s.engine.Read(r.Context(), &ReadRequest{ID: id, Vault: ctxVault(r)})
 	if err != nil {
-		s.sendError(r, w, http.StatusNotFound, ErrEngramNotFound, err.Error())
+		if errors.Is(err, engine.ErrEngramNotFound) {
+			s.sendError(r, w, http.StatusNotFound, ErrEngramNotFound, err.Error())
+		} else {
+			s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
+		}
 		return
 	}
 	s.sendJSON(w, http.StatusOK, resp)
@@ -665,7 +669,11 @@ func (s *Server) handleDeleteEngram(w http.ResponseWriter, r *http.Request) {
 	}
 	resp, err := s.engine.Forget(r.Context(), &ForgetRequest{ID: id, Vault: ctxVault(r)})
 	if err != nil {
-		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
+		if errors.Is(err, engine.ErrEngramNotFound) {
+			s.sendError(r, w, http.StatusNotFound, ErrEngramNotFound, err.Error())
+		} else {
+			s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
+		}
 		return
 	}
 	s.sendJSON(w, http.StatusOK, resp)
@@ -1343,7 +1351,11 @@ func (s *Server) handleRestore(w http.ResponseWriter, r *http.Request) {
 	}
 	resp, err := s.engine.Restore(r.Context(), ctxVault(r), id)
 	if err != nil {
-		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
+		if errors.Is(err, engine.ErrEngramNotFound) {
+			s.sendError(r, w, http.StatusNotFound, ErrEngramNotFound, err.Error())
+		} else {
+			s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
+		}
 		return
 	}
 	s.sendJSON(w, http.StatusOK, resp)


### PR DESCRIPTION
## Problem

Three HTTP handlers return wrong status codes when an engram is not found:

- `handleGetEngram` — maps **all** errors to 404, including real 500s (storage failure returns 404)
- `handleDeleteEngram` — maps **all** errors to 500, including not-found (should be 404)
- `handleRestore` — same as handleDeleteEngram

Root cause: `engine.Read`, `engine.Forget` (hard+soft), and `engine.Restore` all returned plain-string errors from the storage layer. The transport layer had no reliable way to distinguish "not found" from "storage error", so each handler made a different wrong choice.

## Fix

**engine.go** — `Read`, `Forget` (hard delete), `Forget` (soft delete/deactivate), and `Restore` now return the `ErrEngramNotFound` sentinel when the storage layer returns a "not found" error. The `strings.Contains` check is defensive and matches the storage layer's current error text.

**server.go** — All three handlers now use `errors.Is(err, engine.ErrEngramNotFound)` to dispatch:
- Not found → 404 `ErrEngramNotFound`
- Anything else → 500 `ErrStorageError`

## Test cases
- `GET /api/engrams/{missing-id}` → 404 (was 404 but would also return 404 for real storage errors)
- `DELETE /api/engrams/{missing-id}` → 404 (was 500)
- `POST /api/engrams/{missing-id}/restore` → 404 (was 500)
- All three → 500 on genuine storage failure (was inconsistent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)