### PR TITLE
fix(ui): handle named SSE error events in connectLive

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -515,6 +515,23 @@ document.addEventListener('alpine:init', () => {
         }
       };
 
+      es.addEventListener('error', (e) => {
+        let msg = 'Live feed error';
+        try {
+          const data = JSON.parse(e.data);
+          if (data.error) msg = 'Live feed: ' + data.error;
+        } catch (_) {}
+        console.warn('[muninn] SSE error event:', msg);
+        this.addNotification('error', msg);
+        this.liveConnected = false;
+        es.close();
+        this._es = null;
+        window._muninnSSE = null;
+        const delay = Math.min(500 * Math.pow(1.5, this._esRetries), 30000);
+        this._esRetries++;
+        setTimeout(() => this.connectLive(), delay);
+      });
+
       this._es = es;
     },
 


### PR DESCRIPTION
## Problem

The server sends a **named** SSE event (`event: error\ndata: {...}\n\n`) after 200 OK headers are committed — for example, when the vault's subscription limit is reached or the vault is invalid.

The existing `connectLive()` only used `es.onerror`, which only fires on **connection-level** errors (network drop, CORS rejection, server closing the connection without sending a named event). Named events like `event: error` require `es.addEventListener('error', ...)`.

Result: the server's error message was silently ignored. `liveConnected` stayed `true`, no notification was shown, and no reconnect was triggered.

## Fix

Added `es.addEventListener('error', (e) => { ... })` inside `connectLive()` that:

1. Parses the error message from `e.data` (JSON `{ "error": "..." }`)
2. Shows a user-visible notification via `addNotification('error', msg)`
3. Closes the EventSource and clears `this._es` / `window._muninnSSE`
4. Triggers the existing exponential-backoff reconnect via `_esRetries`

The handler is defensive — if `e.data` is missing or not valid JSON it falls back to `'Live feed error'`.

## Notes

- No change to the existing `es.onerror` handler (still handles connection drops)
- No change to the server — this is purely a client-side fix
- The reconnect logic (`_esRetries`, `Math.min(500 * Math.pow(1.5, n), 30000)`) already existed; this handler just plugs into it

🤖 Generated with [Claude Code](https://claude.com/claude-code)