### PR TITLE
fix(upgrade): wait up to 15s for daemon exit before installing new binary

### DIFF
--- a/cmd/muninn/upgrade.go
+++ b/cmd/muninn/upgrade.go
@@ -221,12 +221,18 @@ func runUpgrade(args []string) {
 			if pid, err := readPID(pidPath); err == nil {
 				if proc, err := os.FindProcess(pid); err == nil {
 					_ = stopProcess(proc)
-					for i := 0; i < 30; i++ {
+					deadline := time.Now().Add(15 * time.Second)
+					for time.Now().Before(deadline) {
 						if !isProcessRunning(pid) {
 							break
 						}
 						time.Sleep(100 * time.Millisecond)
 					}
+					if isProcessRunning(pid) {
+						_ = proc.Kill()
+						time.Sleep(500 * time.Millisecond)
+					}
+					time.Sleep(200 * time.Millisecond)
 				}
 			}
 			os.Remove(pidPath)
@@ -479,14 +485,22 @@ func selfUpdate(latest string) error {
 		if err := stopProcess(proc); err != nil {
 			return fmt.Errorf("stop daemon: %w", err)
 		}
-		// Wait up to 3s for process to exit
-		deadline := time.Now().Add(3 * time.Second)
+		// Wait up to 15s for graceful exit (PebbleDB flush + WAL sync can take several seconds).
+		deadline := time.Now().Add(15 * time.Second)
 		for time.Now().Before(deadline) {
 			if !isProcessRunning(pid) {
 				break
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
+		// If still alive after graceful period, force-kill to unblock the upgrade.
+		if isProcessRunning(pid) {
+			_ = proc.Kill()
+			time.Sleep(500 * time.Millisecond)
+		}
+		// Brief grace period for the OS to release file locks (e.g. PebbleDB LOCK file)
+		// before the new binary attempts to open the same data directory.
+		time.Sleep(200 * time.Millisecond)
 		os.Remove(pidPath)
 		return nil
 	}); err != nil {


### PR DESCRIPTION
Fixes #202

## Root Cause

`selfUpdate()` sent SIGTERM to the old daemon, then polled `isProcessRunning` for a **maximum of 3 seconds** before continuing with the binary install and restart. The reporter's log shows exactly what happened:

```
time=2026-03-11T17:08:47.348Z level=INFO msg="shutdown signal received — starting graceful shutdown"
time=2026-03-11T17:08:47.349Z level=INFO msg="shutting down"
2026/03/11 17:08:51.568Z level=ERROR msg="open pebble" err="resource temporarily unavailable"
```

The old daemon received SIGTERM at 17:08:47 and started a graceful shutdown. The new binary was started at ~17:08:51 — only 4 seconds later — while the old process was still flushing PebbleDB and holding its `LOCK` file. The new process hit `EAGAIN` trying to open the same data directory.

The 3-second wait is insufficient: PebbleDB flushes memtables, syncs the WAL, and closes compaction goroutines on shutdown. On any moderately loaded system this reliably exceeds 3 seconds.

## Fix

Two changes in `upgrade.go`, applied to both the `selfUpdate` path and the Homebrew stop path:

1. **Extend graceful wait: 3s → 15s** — gives the daemon time to complete a clean shutdown under normal conditions
2. **Force-kill fallback** — if the process is still alive after 15s (e.g. stuck goroutine), send `SIGKILL` and wait 500ms so the upgrade is never permanently blocked
3. **200ms post-exit grace period** — small buffer for the OS to release file locks after the process exits, before the new binary opens the data directory

## Testing

The existing upgrade tests cover the stop/restart flow. No new test infrastructure is needed for this timing fix, but the commit message references issue #202 for traceability.