### PR TITLE
fix(api): standardise vault resolution on handleResolveContradiction

### DIFF
--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -1522,9 +1522,9 @@ func (s *Server) handleResolveContradiction(w http.ResponseWriter, r *http.Reque
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "id_a and id_b are required")
 		return
 	}
-	vault := req.Vault
+	vault := r.URL.Query().Get("vault")
 	if vault == "" {
-		vault = ctxVault(r)
+		vault = "default"
 	}
 	if err := s.engine.ResolveContradiction(r.Context(), vault, req.IDA, req.IDB); err != nil {
 		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())

--- a/internal/transport/rest/vault_routing_test.go
+++ b/internal/transport/rest/vault_routing_test.go
@@ -911,15 +911,14 @@ func TestVaultRouting_GetGuide_ExplicitVault(t *testing.T) {
 }
 
 // TestVaultRouting_ResolveContradiction_ExplicitVault verifies that
-// POST /api/admin/contradictions/resolve passes the vault from the request body to the engine.
-// Note: this is an admin endpoint; vault is not set via ?vault= query param but via the body's
-// "vault" field, since withAdminMiddleware does not run VaultAuthMiddleware.
+// POST /api/admin/contradictions/resolve passes the vault from the ?vault= query param to the engine.
+// withAdminMiddleware does not run VaultAuthWithAdminBypass, so vault is read directly from the URL.
 func TestVaultRouting_ResolveContradiction_ExplicitVault(t *testing.T) {
 	srv, eng, _ := newVaultTrackingServer(t)
 
 	// sessionSecret is "" in the test server, so admin auth is skipped.
-	body := strings.NewReader(`{"vault":"myvault","id_a":"a1","id_b":"b1"}`)
-	req := httptest.NewRequest("POST", "/api/admin/contradictions/resolve", body)
+	body := strings.NewReader(`{"id_a":"a1","id_b":"b1"}`)
+	req := httptest.NewRequest("POST", "/api/admin/contradictions/resolve?vault=myvault", body)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -807,9 +807,9 @@ document.addEventListener('alpine:init', () => {
             method: 'PUT',
             body: JSON.stringify({ vault, state: 'archived' }),
           });
-          await this.apiCall('/api/admin/contradictions/resolve', {
+          await this.apiCall('/api/admin/contradictions/resolve?vault=' + encodeURIComponent(vault), {
             method: 'POST',
-            body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
+            body: JSON.stringify({ id_a: idA, id_b: idB }),
           });
         } else if (action === 'keep_b') {
           // B supersedes A; archive A
@@ -821,14 +821,14 @@ document.addEventListener('alpine:init', () => {
             method: 'PUT',
             body: JSON.stringify({ vault, state: 'archived' }),
           });
-          await this.apiCall('/api/admin/contradictions/resolve', {
+          await this.apiCall('/api/admin/contradictions/resolve?vault=' + encodeURIComponent(vault), {
             method: 'POST',
-            body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
+            body: JSON.stringify({ id_a: idA, id_b: idB }),
           });
         } else if (action === 'dismiss') {
-          await this.apiCall('/api/admin/contradictions/resolve', {
+          await this.apiCall('/api/admin/contradictions/resolve?vault=' + encodeURIComponent(vault), {
             method: 'POST',
-            body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
+            body: JSON.stringify({ id_a: idA, id_b: idB }),
           });
         } else if (action === 'merge') {
           // Open consolidate modal pre-filled with both IDs


### PR DESCRIPTION
Closes #208.

Thanks @ojamin for the green light and the pointer to PR #146.

## What this fixes

`handleResolveContradiction` was the only vault-aware handler that read vault from the request body. The correct pattern (as established in #146) is `?vault=` in the URL query string.

## Why not `ctxVault(r)`

`handleResolveContradiction` is registered with `withAdminMiddleware`, which runs `AdminAPIMiddleware` — this validates the admin session cookie but **does not** inject vault into the request context. Only `VaultAuthWithAdminBypass` (used by `withMiddleware`) does that. So `ctxVault(r)` would always return `"default"` for this endpoint regardless of the URL.

The handler therefore reads vault directly from `r.URL.Query().Get("vault")` with a `"default"` fallback — the same pattern used inside `VaultAuthWithAdminBypass`.

## Changes

**`internal/transport/rest/server.go`**
Replace body vault override with `r.URL.Query().Get("vault")` (fallback `"default"`).

**`web/static/js/app.js`**
Add `?vault=encodeURIComponent(vault)` to all three `contradictions/resolve` call sites (keep_a / keep_b / dismiss) and drop `vault` from the JSON body.

**`internal/transport/rest/vault_routing_test.go`**
Update `TestVaultRouting_ResolveContradiction_ExplicitVault`: pass vault as `?vault=myvault` in the URL (not in the body), update comment to reflect the new pattern.

**`internal/transport/rest/types.go`** — no change
`Vault` field kept in `ResolveContradictionRequest` for backwards compatibility with existing API clients; it is now silently ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)