### PR TITLE
fix(retroactive): remove dead EmbedPlugin branch from processEnrichEngram (#207)

### DIFF
--- a/internal/plugin/retroactive.go
+++ b/internal/plugin/retroactive.go
@@ -387,7 +387,7 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 		}
 
 		// Non-embed (enrich) path: one-at-a-time as before.
-		if err := rp.processEngram(ctx, eng); err != nil {
+		if err := rp.processEnrichEngram(ctx, eng); err != nil {
 			if errors.Is(err, ErrNothingToEnrich) {
 				// Nothing to enrich is not a failure — mark the engram as
 				// enrichment-complete so it is not retried on the next scan.
@@ -485,34 +485,7 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 	return true
 }
 
-func (rp *RetroactiveProcessor) processEngram(ctx context.Context, eng *Engram) error {
-	// Check if this is an embed plugin
-	if embed, ok := rp.plugin.(EmbedPlugin); ok {
-		// Call Embed with the concept and content
-		text := eng.Concept + " " + eng.Content
-		vec, err := embed.Embed(ctx, []string{text})
-		if err != nil {
-			return err
-		}
-
-		// Store the embedding
-		if err := rp.store.UpdateEmbedding(ctx, eng.ID, vec); err != nil {
-			return err
-		}
-
-		// Insert into HNSW index
-		if err := rp.store.HNSWInsert(ctx, eng.ID, vec); err != nil {
-			return err
-		}
-
-		// Auto-link by embedding
-		if err := rp.store.AutoLinkByEmbedding(ctx, eng.ID, vec); err != nil {
-			return err
-		}
-
-		return nil
-	}
-
+func (rp *RetroactiveProcessor) processEnrichEngram(ctx context.Context, eng *Engram) error {
 	// Check if this is an enrich plugin
 	if enrich, ok := rp.plugin.(EnrichPlugin); ok {
 		// Read per-stage digest flags so we don't re-run stages the caller already provided.

--- a/internal/plugin/retroactive_test.go
+++ b/internal/plugin/retroactive_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// Enrichment-capable mock for processEngram tests
+// Enrichment-capable mock for processEnrichEngram tests
 // ---------------------------------------------------------------------------
 
 type enrichMockForRetro struct {
@@ -177,7 +177,7 @@ func TestRetroactiveProcessor_ProcessBatchNilIterator(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// processBatch — enrich path (processEngram)
+// processBatch — enrich path (processEnrichEngram)
 // ---------------------------------------------------------------------------
 
 func TestRetroactiveProcessor_ProcessBatchEnrich(t *testing.T) {
@@ -289,7 +289,7 @@ func TestRetroactiveProcessor_ProcessBatchEmbedUpdateError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// processBatch — enrich processEngram error
+// processBatch — enrich processEnrichEngram error
 // ---------------------------------------------------------------------------
 
 func TestRetroactiveProcessor_ProcessBatchEnrichError(t *testing.T) {
@@ -425,51 +425,26 @@ func TestRetroactiveProcessor_ProcessBatchCancelled(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// processEngram — plain plugin (not embed, not enrich) → no-op
+// processEnrichEngram — plain plugin (not embed, not enrich) → no-op
 // ---------------------------------------------------------------------------
 
-func TestRetroactiveProcessor_ProcessEngramPlainPlugin(t *testing.T) {
+func TestRetroactiveProcessor_ProcessEnrichEngramPlainPlugin(t *testing.T) {
 	store := &mockPluginStore{}
 	p := &mockPlugin{name: "plain", tier: TierEmbed}
 	rp := NewRetroactiveProcessor(store, p, DigestEmbed)
 
 	eng := &Engram{Concept: "x", Content: "y"}
-	err := rp.processEngram(context.Background(), eng)
+	err := rp.processEnrichEngram(context.Background(), eng)
 	if err != nil {
-		t.Errorf("processEngram plain should return nil, got %v", err)
+		t.Errorf("processEnrichEngram plain should return nil, got %v", err)
 	}
 }
 
 // ---------------------------------------------------------------------------
-// processEngram — embed path
+// processEnrichEngram — enrich path
 // ---------------------------------------------------------------------------
 
-func TestRetroactiveProcessor_ProcessEngramEmbed(t *testing.T) {
-	store := &mockPluginStore{}
-	p := &mockEmbedPlugin{mockPlugin: mockPlugin{name: "pe", tier: TierEmbed}}
-	rp := NewRetroactiveProcessor(store, p, DigestEmbed)
-
-	eng := &Engram{Concept: "hello", Content: "world"}
-	err := rp.processEngram(context.Background(), eng)
-	if err != nil {
-		t.Errorf("processEngram embed should succeed, got %v", err)
-	}
-	if store.updateEmbedCalls != 1 {
-		t.Errorf("expected 1 UpdateEmbedding call, got %d", store.updateEmbedCalls)
-	}
-	if store.hnswInsertCalls != 1 {
-		t.Errorf("expected 1 HNSWInsert call, got %d", store.hnswInsertCalls)
-	}
-	if store.autoLinkCalls != 1 {
-		t.Errorf("expected 1 AutoLinkByEmbedding call, got %d", store.autoLinkCalls)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// processEngram — enrich path
-// ---------------------------------------------------------------------------
-
-func TestRetroactiveProcessor_ProcessEngramEnrich(t *testing.T) {
+func TestRetroactiveProcessor_ProcessEnrichEngramEnrich(t *testing.T) {
 	store := &mockPluginStore{}
 	p := &enrichMockForRetro{
 		mockPlugin:   mockPlugin{name: "pe-enrich", tier: TierEnrich},
@@ -478,25 +453,9 @@ func TestRetroactiveProcessor_ProcessEngramEnrich(t *testing.T) {
 	rp := NewRetroactiveProcessor(store, p, DigestEnrich)
 
 	eng := &Engram{Concept: "hello", Content: "world"}
-	err := rp.processEngram(context.Background(), eng)
+	err := rp.processEnrichEngram(context.Background(), eng)
 	if err != nil {
-		t.Errorf("processEngram enrich should succeed, got %v", err)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// processEngram — embed errors propagate
-// ---------------------------------------------------------------------------
-
-func TestRetroactiveProcessor_ProcessEngramEmbedError(t *testing.T) {
-	store := &mockPluginStore{updateEmbedErr: errors.New("store fail")}
-	p := &mockEmbedPlugin{mockPlugin: mockPlugin{name: "ee", tier: TierEmbed}}
-	rp := NewRetroactiveProcessor(store, p, DigestEmbed)
-
-	eng := &Engram{Concept: "a", Content: "b"}
-	err := rp.processEngram(context.Background(), eng)
-	if err == nil {
-		t.Error("expected error from UpdateEmbedding failure")
+		t.Errorf("processEnrichEngram enrich should succeed, got %v", err)
 	}
 }
 
@@ -562,11 +521,11 @@ func TestRetroactiveProcessor_NotifyWakeup(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// processEngram — DigestEntities flag suppresses UpsertEntity calls
+// processEnrichEngram — DigestEntities flag suppresses UpsertEntity calls
 // ---------------------------------------------------------------------------
 
 // TestRetroactiveProcessor_DigestEntitiesFlagSkipsUpsert verifies the core bug fix:
-// when the DigestEntities flag is already set on an engram, processEngram must NOT
+// when the DigestEntities flag is already set on an engram, processEnrichEngram must NOT
 // call UpsertEntity. Previously, hasEntities was derived from len(KeyPoints) > 0,
 // which incorrectly conflated summarization key points with entity extraction.
 // After the fix, GetDigestFlags is the authoritative source.
@@ -598,9 +557,9 @@ func TestRetroactiveProcessor_DigestEntitiesFlagSkipsUpsert(t *testing.T) {
 	}
 	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
 
-	err := rp.processEngram(context.Background(), eng)
+	err := rp.processEnrichEngram(context.Background(), eng)
 	if err != nil {
-		t.Fatalf("processEngram should succeed, got %v", err)
+		t.Fatalf("processEnrichEngram should succeed, got %v", err)
 	}
 
 	// UpsertEntity must NOT have been called because DigestEntities flag was set.
@@ -637,9 +596,9 @@ func TestRetroactiveProcessor_NoDigestEntitiesFlagCallsUpsert(t *testing.T) {
 	}
 	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
 
-	err := rp.processEngram(context.Background(), eng)
+	err := rp.processEnrichEngram(context.Background(), eng)
 	if err != nil {
-		t.Fatalf("processEngram should succeed, got %v", err)
+		t.Fatalf("processEnrichEngram should succeed, got %v", err)
 	}
 
 	// UpsertEntity MUST be called once per entity when flag is not set.
@@ -677,9 +636,9 @@ func TestRetroactiveProcessor_KeyPointsAloneDoNotSkipEntities(t *testing.T) {
 	}
 	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
 
-	err := rp.processEngram(context.Background(), eng)
+	err := rp.processEnrichEngram(context.Background(), eng)
 	if err != nil {
-		t.Fatalf("processEngram should succeed, got %v", err)
+		t.Fatalf("processEnrichEngram should succeed, got %v", err)
 	}
 
 	// Even though KeyPoints is non-empty, entities must be upserted because
@@ -708,8 +667,8 @@ func TestRetroactiveProcessor_MissingDigestFlagsDoNotSkipEngram(t *testing.T) {
 	}
 	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
 
-	if err := rp.processEngram(context.Background(), eng); err != nil {
-		t.Fatalf("processEngram should succeed when digest flags are missing: %v", err)
+	if err := rp.processEnrichEngram(context.Background(), eng); err != nil {
+		t.Fatalf("processEnrichEngram should succeed when digest flags are missing: %v", err)
 	}
 	if enrichPlugin.callCount != 1 {
 		t.Fatalf("expected enrich to run when digest flags are missing, got %d calls", enrichPlugin.callCount)


### PR DESCRIPTION
## Summary

Closes #207.

- **Removes dead code**: The `EmbedPlugin` branch in `processEngram` was unreachable — `processBatch` always handles embed plugins via its micro-batch path with `continue`, so `processEngram` was only ever called for enrich plugins
- **Renames** `processEngram` → `processEnrichEngram` to make the enrich-only invariant explicit
- **Removes 2 embed-path tests** that directly tested the dead branch; embed coverage is preserved by the existing `processBatch` embed tests
- **Updates all comment references** in the test file to use the new name

## Test Plan

- [ ] `go test ./internal/plugin/...` passes
- [ ] No `processEngram` references remain in production code
- [ ] Embed path coverage preserved via `TestRetroactiveProcessor_ProcessBatchEmbed`
- [ ] CI pipelines green