### PR TITLE
fix(rest): align handleResolveContradiction vault resolution with all other handlers (#208)

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -93,7 +93,12 @@ func (s *Store) AdminAPIMiddleware(secret []byte, next http.HandlerFunc) http.Ha
 			w.Write([]byte(`{"error":{"code":"AUTH_FAILED","message":"admin session required"}}`))
 			return
 		}
-		next(w, r)
+		vault := r.URL.Query().Get("vault")
+		if vault == "" {
+			vault = "default"
+		}
+		ctx := context.WithValue(r.Context(), ContextVault, vault)
+		next(w, r.WithContext(ctx))
 	}
 }
 

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -1522,10 +1522,7 @@ func (s *Server) handleResolveContradiction(w http.ResponseWriter, r *http.Reque
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "id_a and id_b are required")
 		return
 	}
-	vault := req.Vault
-	if vault == "" {
-		vault = ctxVault(r)
-	}
+	vault := ctxVault(r)
 	if err := s.engine.ResolveContradiction(r.Context(), vault, req.IDA, req.IDB); err != nil {
 		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
 		return

--- a/internal/transport/rest/vault_routing_test.go
+++ b/internal/transport/rest/vault_routing_test.go
@@ -911,16 +911,33 @@ func TestVaultRouting_GetGuide_ExplicitVault(t *testing.T) {
 }
 
 // TestVaultRouting_ResolveContradiction_ExplicitVault verifies that
-// POST /api/admin/contradictions/resolve passes the vault from the request body to the engine.
-// Note: this is an admin endpoint; vault is not set via ?vault= query param but via the body's
-// "vault" field, since withAdminMiddleware does not run VaultAuthMiddleware.
+// POST /api/admin/contradictions/resolve passes the vault from the query parameter to the engine.
+// AdminAPIMiddleware now resolves vault via ?vault= query param, consistent with other handlers.
 func TestVaultRouting_ResolveContradiction_ExplicitVault(t *testing.T) {
-	srv, eng, _ := newVaultTrackingServer(t)
+	eng := &vaultTrackingEngine{}
+	store := newTestAuthStore(t)
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "default", Public: true}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "myvault", Public: true}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+	secret := []byte("test-secret-32-bytes-long-xxxx")
+	srv := NewServer("localhost:0", eng, store, secret, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
-	// sessionSecret is "" in the test server, so admin auth is skipped.
-	body := strings.NewReader(`{"vault":"myvault","id_a":"a1","id_b":"b1"}`)
-	req := httptest.NewRequest("POST", "/api/admin/contradictions/resolve", body)
+	// Create a valid session token to authenticate with AdminAPIMiddleware.
+	token, err := auth.NewSessionToken("admin", secret)
+	if err != nil {
+		t.Fatalf("NewSessionToken: %v", err)
+	}
+
+	body := strings.NewReader(`{"id_a":"a1","id_b":"b1"}`)
+	req := httptest.NewRequest("POST", "/api/admin/contradictions/resolve?vault=myvault", body)
 	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{
+		Name:  "muninn_session",
+		Value: token,
+	})
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
 


### PR DESCRIPTION
## Summary

Closes #208.

- **Root cause**: `AdminAPIMiddleware` did not inject `ContextVault` into request context (unlike `VaultAuthWithAdminBypass`), so `handleResolveContradiction` reading `ctxVault(r)` would always get `"default"` — causing it to use the request body's `vault` field as a workaround instead
- **Fix 1**: `AdminAPIMiddleware` now reads `?vault=` from the query string and injects `ContextVault` into context (identical pattern to `VaultAuthWithAdminBypass`)
- **Fix 2**: `handleResolveContradiction` now uses `ctxVault(r)` exclusively — consistent with every other handler
- **Side effect**: All other admin routes behind `withAdminMiddleware` now also have vault context available (non-breaking; handlers that don't read it are unaffected)

## Test Plan

- [ ] `go test ./internal/auth/...` passes
- [ ] `go test ./internal/transport/rest/...` passes — `TestVaultRouting_ResolveContradiction_ExplicitVault` updated to use `?vault=` query param
- [ ] CI pipelines green