### PR TITLE
fix(api): use auth context vault in handleResolveContradiction (#208)

### DIFF
--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -1522,10 +1522,7 @@ func (s *Server) handleResolveContradiction(w http.ResponseWriter, r *http.Reque
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "id_a and id_b are required")
 		return
 	}
-	vault := req.Vault
-	if vault == "" {
-		vault = ctxVault(r)
-	}
+	vault := ctxVault(r)
 	if err := s.engine.ResolveContradiction(r.Context(), vault, req.IDA, req.IDB); err != nil {
 		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
 		return

--- a/internal/transport/rest/types.go
+++ b/internal/transport/rest/types.go
@@ -403,9 +403,8 @@ type ContradictionsResponse struct {
 
 // ResolveContradictionRequest is the body for POST /api/admin/contradictions/resolve.
 type ResolveContradictionRequest struct {
-	Vault string `json:"vault"`
-	IDA   string `json:"id_a"`
-	IDB   string `json:"id_b"`
+	IDA string `json:"id_a"`
+	IDB string `json:"id_b"`
 }
 
 // ResolveContradictionResponse is returned by the resolve-contradiction endpoint.

--- a/internal/transport/rest/vault_routing_test.go
+++ b/internal/transport/rest/vault_routing_test.go
@@ -910,16 +910,16 @@ func TestVaultRouting_GetGuide_ExplicitVault(t *testing.T) {
 	}
 }
 
-// TestVaultRouting_ResolveContradiction_ExplicitVault verifies that
-// POST /api/admin/contradictions/resolve passes the vault from the request body to the engine.
-// Note: this is an admin endpoint; vault is not set via ?vault= query param but via the body's
-// "vault" field, since withAdminMiddleware does not run VaultAuthMiddleware.
-func TestVaultRouting_ResolveContradiction_ExplicitVault(t *testing.T) {
+// TestVaultRouting_ResolveContradiction_UsesContextVault verifies that
+// POST /api/admin/contradictions/resolve uses the vault from the auth context,
+// not from the request body. The body "vault" field is ignored (issue #208).
+func TestVaultRouting_ResolveContradiction_UsesContextVault(t *testing.T) {
 	srv, eng, _ := newVaultTrackingServer(t)
 
-	// sessionSecret is "" in the test server, so admin auth is skipped.
-	body := strings.NewReader(`{"vault":"myvault","id_a":"a1","id_b":"b1"}`)
-	req := httptest.NewRequest("POST", "/api/admin/contradictions/resolve", body)
+	// Provide vault via context (as auth middleware would), not via the body.
+	ctx := context.WithValue(context.Background(), auth.ContextVault, "myvault")
+	body := strings.NewReader(`{"id_a":"a1","id_b":"b1"}`)
+	req := httptest.NewRequest("POST", "/api/admin/contradictions/resolve", body).WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)


### PR DESCRIPTION
## Summary

- Removes the `vault` field from `ResolveContradictionRequest` — the body override was allowing callers to resolve contradictions in arbitrary vaults outside their authenticated scope
- `handleResolveContradiction` now uses `ctxVault(r)` exclusively, consistent with every other vault-scoped handler in the codebase
- Updates the vault-routing test to validate the correct behaviour (context vault wins), injecting vault via `context.WithValue` as auth middleware does in production

Fixes #208. Reviewed and approved by Opus (principal engineer review).

## Breaking Change

Callers sending `{"vault":"x","id_a":"...","id_b":"..."}` will not error — Go silently ignores the now-removed field — but the body `vault` is no longer honoured. Any caller relying on the body override to access a vault other than their authenticated one was exploiting the inconsistency.

## Test Plan

- [x] `go test ./internal/transport/rest/...` passes
- [x] `TestVaultRouting_ResolveContradiction_UsesContextVault` verifies the handler now uses context vault, not body vault