### PR TITLE
fix(ui): pass vault as ?vault= query param to contradictions/resolve

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -808,10 +808,10 @@ document.addEventListener('alpine:init', () => {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ state: 'archived' }),
           });
-          await fetch('/api/admin/contradictions/resolve', {
+          await fetch('/api/admin/contradictions/resolve?vault=' + encodeURIComponent(vault), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
+            body: JSON.stringify({ id_a: idA, id_b: idB }),
           });
         } else if (action === 'keep_b') {
           // B supersedes A; archive A
@@ -825,16 +825,16 @@ document.addEventListener('alpine:init', () => {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ state: 'archived' }),
           });
-          await fetch('/api/admin/contradictions/resolve', {
+          await fetch('/api/admin/contradictions/resolve?vault=' + encodeURIComponent(vault), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
+            body: JSON.stringify({ id_a: idA, id_b: idB }),
           });
         } else if (action === 'dismiss') {
-          await fetch('/api/admin/contradictions/resolve', {
+          await fetch('/api/admin/contradictions/resolve?vault=' + encodeURIComponent(vault), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
+            body: JSON.stringify({ id_a: idA, id_b: idB }),
           });
         } else if (action === 'merge') {
           // Open consolidate modal pre-filled with both IDs


### PR DESCRIPTION
## Summary

The three `contradictions/resolve` call sites in the Web UI (`keep_a`, `keep_b`, `dismiss`) were passing vault only in the JSON body. `AdminAPIMiddleware` reads vault from the `?vault=` URL query string — the body vault was silently ignored, breaking contradiction resolution for non-default vaults.

Fixes the JS-layer bug identified by @To3Knee in PR #210 (closed as duplicate of #214 at the handler level, but the UI fix was still needed).

## Test Plan
- [x] `go test ./internal/transport/rest/...` passes
- [x] `TestVaultRouting_ResolveContradiction_ExplicitVault` already validates vault flows through URL query param