### PR TITLE
feat(observability): LLM call observability — aggregate counters + opt-in verbose logs (#126)

### DIFF
--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -27,6 +27,10 @@ type PluginConfig struct {
 	EnrichClassification *bool  `json:"enrich_classification,omitempty"`
 	EnrichSummary        *bool  `json:"enrich_summary,omitempty"`
 	EnrichMode           string `json:"enrich_mode,omitempty"` // "full" (default) or "light"
+
+	// LLMVerboseLogs enables per-call LLM log entries in the Logs page.
+	// nil = false. Overridden by MUNINN_LLM_VERBOSE_LOGS=true env var.
+	LLMVerboseLogs *bool `json:"llm_verbose_logs,omitempty"`
 }
 
 // EnrichStageEnabled returns whether a given enrichment stage is enabled.

--- a/internal/engine/observability.go
+++ b/internal/engine/observability.go
@@ -7,7 +7,19 @@ import (
 
 	"github.com/scrypster/muninndb/internal/cognitive"
 	"github.com/scrypster/muninndb/internal/metrics/latency"
+	"github.com/scrypster/muninndb/internal/plugin"
+	"github.com/scrypster/muninndb/internal/plugin/llmstats"
 )
+
+// LLMStats holds aggregate LLM call metrics for enrich and embed subsystems.
+type LLMStats struct {
+	EnrichCalls  int64   `json:"enrich_calls"`
+	EnrichErrors int64   `json:"enrich_errors"`
+	EnrichAvgMs  float64 `json:"enrich_avg_latency_ms"`
+	EmbedCalls   int64   `json:"embed_calls"`
+	EmbedErrors  int64   `json:"embed_errors"`
+	EmbedAvgMs   float64 `json:"embed_avg_latency_ms"`
+}
 
 // ObservabilitySnapshot is a full system snapshot for the observability endpoint.
 type ObservabilitySnapshot struct {
@@ -16,6 +28,7 @@ type ObservabilitySnapshot struct {
 	Processors []ProcessorStats             `json:"processors"`
 	Workers    WorkerStatsSnapshot           `json:"cognitive_workers"`
 	Vaults     map[string]VaultObservability `json:"vaults"`
+	LLM        *LLMStats                     `json:"llm,omitempty"`
 }
 
 // SystemStats holds Go runtime and process-level metrics.
@@ -210,11 +223,45 @@ func (e *Engine) Observability(ctx context.Context, version string, uptimeSecond
 		}
 	}
 
+	// 6. LLM stats — only populated when at least one LLM plugin is active.
+	var llmStats *LLMStats
+	if e.enrichPlugin != nil {
+		if p, ok := e.enrichPlugin.(llmstats.Provider); ok {
+			snap := p.LLMStats()
+			if llmStats == nil {
+				llmStats = &LLMStats{}
+			}
+			llmStats.EnrichCalls = snap.Calls
+			llmStats.EnrichErrors = snap.Errors
+			llmStats.EnrichAvgMs = snap.AvgLatMs
+		}
+	}
+	for _, rp := range e.retroProcessors {
+		if rp == nil {
+			continue
+		}
+		plug := rp.Plugin()
+		if plug == nil || plug.Tier() != plugin.TierEmbed {
+			continue
+		}
+		if p, ok := plug.(llmstats.Provider); ok {
+			snap := p.LLMStats()
+			if llmStats == nil {
+				llmStats = &LLMStats{}
+			}
+			llmStats.EmbedCalls = snap.Calls
+			llmStats.EmbedErrors = snap.Errors
+			llmStats.EmbedAvgMs = snap.AvgLatMs
+			break
+		}
+	}
+
 	return &ObservabilitySnapshot{
 		System:     sys,
 		Storage:    stor,
 		Processors: processors,
 		Workers:    workers,
 		Vaults:     vaults,
+		LLM:        llmStats,
 	}, nil
 }

--- a/internal/plugin/embed/batch.go
+++ b/internal/plugin/embed/batch.go
@@ -3,22 +3,35 @@ package embed
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin/llmstats"
 )
 
 // BatchEmbedder splits large text arrays into chunks before sending to provider.
 type BatchEmbedder struct {
-	provider  Provider
-	limiter   *TokenBucketLimiter
-	batchSize int // max texts per request
+	provider    Provider
+	limiter     *TokenBucketLimiter
+	batchSize   int // max texts per request
+	stats       *llmstats.LLMCallStats
+	verboseLogs atomic.Bool // safe for concurrent read/write
 }
 
 // NewBatchEmbedder creates a new BatchEmbedder.
-func NewBatchEmbedder(provider Provider, limiter *TokenBucketLimiter) *BatchEmbedder {
+func NewBatchEmbedder(provider Provider, limiter *TokenBucketLimiter, stats *llmstats.LLMCallStats) *BatchEmbedder {
 	return &BatchEmbedder{
 		provider:  provider,
 		limiter:   limiter,
 		batchSize: provider.MaxBatchSize(),
+		stats:     stats,
 	}
+}
+
+// SetVerboseLogs enables or disables per-call log entries. Safe to call concurrently.
+func (b *BatchEmbedder) SetVerboseLogs(flag *bool) {
+	b.verboseLogs.Store(flag != nil && *flag)
 }
 
 // Embed sends texts in batches, returns concatenated embeddings.
@@ -38,7 +51,30 @@ func (b *BatchEmbedder) Embed(ctx context.Context, texts []string) ([]float32, e
 			}
 		}
 
+		start := time.Now()
 		chunk, err := b.provider.EmbedBatch(ctx, texts[i:end])
+		latMs := time.Since(start).Milliseconds()
+		if b.stats != nil {
+			b.stats.TotalCalls.Add(1)
+			b.stats.TotalLatencyMs.Add(latMs)
+			if err != nil {
+				b.stats.TotalErrors.Add(1)
+			}
+		}
+		if llmstats.VerboseEnabledBool(b.verboseLogs.Load()) {
+			attrs := []any{
+				"source", "llm",
+				"subsystem", "embed",
+				"call_type", "embed_batch",
+				"provider", b.provider.Name(),
+				"latency_ms", latMs,
+				"batch_size", end - i,
+			}
+			if err != nil {
+				attrs = append(attrs, "error", err.Error())
+			}
+			slog.InfoContext(ctx, "llm.embed_batch", attrs...)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/internal/plugin/embed/batch_test.go
+++ b/internal/plugin/embed/batch_test.go
@@ -43,7 +43,7 @@ func (m *MockProvider) Close() error {
 
 func TestBatchEmbedder_SingleBatch(t *testing.T) {
 	mock := &MockProvider{maxBatchSize: 32}
-	embedder := NewBatchEmbedder(mock, nil)
+	embedder := NewBatchEmbedder(mock, nil, nil)
 
 	texts := []string{"hello", "world"}
 	result, err := embedder.Embed(context.Background(), texts)
@@ -63,7 +63,7 @@ func TestBatchEmbedder_SingleBatch(t *testing.T) {
 
 func TestBatchEmbedder_MultipleBatches(t *testing.T) {
 	mock := &MockProvider{maxBatchSize: 2}
-	embedder := NewBatchEmbedder(mock, nil)
+	embedder := NewBatchEmbedder(mock, nil, nil)
 
 	texts := []string{"a", "b", "c", "d", "e"}
 	result, err := embedder.Embed(context.Background(), texts)
@@ -85,7 +85,7 @@ func TestBatchEmbedder_MultipleBatches(t *testing.T) {
 
 func TestBatchEmbedder_ExactBatchSize(t *testing.T) {
 	mock := &MockProvider{maxBatchSize: 3}
-	embedder := NewBatchEmbedder(mock, nil)
+	embedder := NewBatchEmbedder(mock, nil, nil)
 
 	texts := []string{"a", "b", "c", "d", "e", "f"}
 	result, err := embedder.Embed(context.Background(), texts)
@@ -107,7 +107,7 @@ func TestBatchEmbedder_ExactBatchSize(t *testing.T) {
 
 func TestBatchEmbedder_SingleText(t *testing.T) {
 	mock := &MockProvider{maxBatchSize: 10}
-	embedder := NewBatchEmbedder(mock, nil)
+	embedder := NewBatchEmbedder(mock, nil, nil)
 
 	texts := []string{"single"}
 	result, err := embedder.Embed(context.Background(), texts)
@@ -127,7 +127,7 @@ func TestBatchEmbedder_SingleText(t *testing.T) {
 
 func TestBatchEmbedder_EmptyInput(t *testing.T) {
 	mock := &MockProvider{maxBatchSize: 32}
-	embedder := NewBatchEmbedder(mock, nil)
+	embedder := NewBatchEmbedder(mock, nil, nil)
 
 	texts := []string{}
 	result, err := embedder.Embed(context.Background(), texts)
@@ -146,7 +146,7 @@ func TestBatchEmbedder_EmptyInput(t *testing.T) {
 
 func TestBatchEmbedder_LargeBatch(t *testing.T) {
 	mock := &MockProvider{maxBatchSize: 10}
-	embedder := NewBatchEmbedder(mock, nil)
+	embedder := NewBatchEmbedder(mock, nil, nil)
 
 	// Create 25 texts
 	texts := make([]string, 25)
@@ -173,7 +173,7 @@ func TestBatchEmbedder_LargeBatch(t *testing.T) {
 
 func TestBatchEmbedder_ContextCancellation(t *testing.T) {
 	mock := &MockProvider{maxBatchSize: 2}
-	embedder := NewBatchEmbedder(mock, nil)
+	embedder := NewBatchEmbedder(mock, nil, nil)
 
 	texts := []string{"a", "b", "c", "d"}
 
@@ -198,7 +198,7 @@ func (e *emptyProvider) EmbedBatch(_ context.Context, _ []string) ([]float32, er
 
 func TestBatchEmbedder_ProviderReturnsEmpty(t *testing.T) {
 	mock := &emptyProvider{MockProvider: MockProvider{maxBatchSize: 32}}
-	embedder := NewBatchEmbedder(mock, nil)
+	embedder := NewBatchEmbedder(mock, nil, nil)
 
 	_, err := embedder.Embed(context.Background(), []string{"hello"})
 	if err == nil {
@@ -216,7 +216,7 @@ func (e *errorProvider) EmbedBatch(_ context.Context, _ []string) ([]float32, er
 
 func TestBatchEmbedder_ProviderError(t *testing.T) {
 	mock := &errorProvider{MockProvider: MockProvider{maxBatchSize: 32}}
-	embedder := NewBatchEmbedder(mock, nil)
+	embedder := NewBatchEmbedder(mock, nil, nil)
 
 	_, err := embedder.Embed(context.Background(), []string{"hello"})
 	if err == nil {
@@ -227,7 +227,7 @@ func TestBatchEmbedder_ProviderError(t *testing.T) {
 func TestBatchEmbedder_WithRateLimiter(t *testing.T) {
 	mock := &MockProvider{maxBatchSize: 2}
 	limiter := NewTokenBucketLimiter(1000.0, 1000.0)
-	embedder := NewBatchEmbedder(mock, limiter)
+	embedder := NewBatchEmbedder(mock, limiter, nil)
 
 	texts := []string{"a", "b", "c", "d"}
 	result, err := embedder.Embed(context.Background(), texts)
@@ -253,7 +253,7 @@ func TestBatchEmbedder_WithRateLimiter_ContextCancelled(t *testing.T) {
 	// Consume the only available token.
 	limiter.Wait(context.Background())
 
-	embedder := NewBatchEmbedder(mock, limiter)
+	embedder := NewBatchEmbedder(mock, limiter, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -266,7 +266,7 @@ func TestBatchEmbedder_WithRateLimiter_ContextCancelled(t *testing.T) {
 
 func TestBatchEmbedder_MockEmbedding(t *testing.T) {
 	mock := &MockProvider{maxBatchSize: 2}
-	embedder := NewBatchEmbedder(mock, nil)
+	embedder := NewBatchEmbedder(mock, nil, nil)
 
 	texts := []string{"hello", "world"}
 	result, err := embedder.Embed(context.Background(), texts)

--- a/internal/plugin/embed/embed.go
+++ b/internal/plugin/embed/embed.go
@@ -7,7 +7,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/scrypster/muninndb/internal/config"
 	"github.com/scrypster/muninndb/internal/plugin"
+	"github.com/scrypster/muninndb/internal/plugin/llmstats"
 )
 
 // Provider is the internal interface for provider HTTP clients.
@@ -40,15 +42,17 @@ type ProviderHTTPConfig struct {
 
 // EmbedService implements plugin.EmbedPlugin.
 type EmbedService struct {
-	provider Provider
-	cfg      plugin.PluginConfig
-	provCfg  *plugin.ProviderConfig
-	dim      int    // detected at Init time
-	name     string // "embed-ollama", "embed-openai", "embed-voyage"
-	batcher  *BatchEmbedder
-	limiter  *TokenBucketLimiter
-	mu       sync.Mutex
-	closed   bool
+	provider        Provider
+	cfg             plugin.PluginConfig
+	provCfg         *plugin.ProviderConfig
+	dim             int    // detected at Init time
+	name            string // "embed-ollama", "embed-openai", "embed-voyage"
+	batcher         *BatchEmbedder
+	limiter         *TokenBucketLimiter
+	stats           llmstats.LLMCallStats
+	verboseLogsFlag *bool
+	mu              sync.Mutex
+	closed          bool
 }
 
 // NewEmbedService creates an EmbedService from a parsed provider URL.
@@ -149,7 +153,8 @@ func (s *EmbedService) Init(ctx context.Context, cfg plugin.PluginConfig) error 
 	s.limiter = s.createRateLimiter(s.provCfg.Scheme, cfg.Options)
 
 	// Set up batch embedder
-	s.batcher = NewBatchEmbedder(s.provider, s.limiter)
+	s.batcher = NewBatchEmbedder(s.provider, s.limiter, &s.stats)
+	s.batcher.SetVerboseLogs(s.verboseLogsFlag)
 
 	return nil
 }
@@ -181,6 +186,33 @@ func (s *EmbedService) Dimension() int {
 // MaxBatchSize delegates to the underlying provider's optimal batch size.
 func (s *EmbedService) MaxBatchSize() int {
 	return s.provider.MaxBatchSize()
+}
+
+// LLMStats returns a point-in-time snapshot of LLM call metrics.
+func (s *EmbedService) LLMStats() llmstats.Snapshot {
+	return s.stats.Snapshot()
+}
+
+// SetVerboseLogs sets the verbose logs flag for per-call log entries.
+func (s *EmbedService) SetVerboseLogs(flag *bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.verboseLogsFlag = flag
+	if s.batcher != nil {
+		s.batcher.SetVerboseLogs(flag)
+	}
+}
+
+// SetServerConfig propagates server-level plugin configuration to the embed service.
+func (s *EmbedService) SetServerConfig(cfg *config.PluginConfig) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if cfg != nil {
+		s.verboseLogsFlag = cfg.LLMVerboseLogs
+	}
+	if s.batcher != nil {
+		s.batcher.SetVerboseLogs(s.verboseLogsFlag)
+	}
 }
 
 // Close releases external connections.

--- a/internal/plugin/enrich/enrich.go
+++ b/internal/plugin/enrich/enrich.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/scrypster/muninndb/internal/config"
 	"github.com/scrypster/muninndb/internal/plugin"
+	"github.com/scrypster/muninndb/internal/plugin/llmstats"
 	"github.com/scrypster/muninndb/internal/storage"
 )
 
@@ -148,6 +149,17 @@ func (s *EnrichService) Enrich(ctx context.Context, eng *storage.Engram) (*plugi
 	}
 
 	return s.pipeline.Run(ctx, eng)
+}
+
+// LLMStats returns a point-in-time snapshot of LLM call metrics.
+func (s *EnrichService) LLMStats() llmstats.Snapshot {
+	s.mu.Lock()
+	pipeline := s.pipeline
+	s.mu.Unlock()
+	if pipeline == nil {
+		return llmstats.Snapshot{}
+	}
+	return pipeline.LLMStats()
 }
 
 // Close releases external connections.

--- a/internal/plugin/enrich/pipeline.go
+++ b/internal/plugin/enrich/pipeline.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/scrypster/muninndb/internal/config"
 	"github.com/scrypster/muninndb/internal/plugin"
+	"github.com/scrypster/muninndb/internal/plugin/llmstats"
 	"github.com/scrypster/muninndb/internal/storage"
 )
 
@@ -27,6 +29,7 @@ type EnrichmentPipeline struct {
 	prompts  *Prompts
 	limiter  *TokenBucketLimiter
 	cfg      *config.PluginConfig
+	stats    llmstats.LLMCallStats
 }
 
 // NewPipeline creates a new enrichment pipeline.
@@ -42,6 +45,41 @@ func NewPipeline(provider LLMProvider, limiter *TokenBucketLimiter) *EnrichmentP
 // SetConfig applies server-level enrichment configuration (per-stage flags, mode).
 func (p *EnrichmentPipeline) SetConfig(cfg *config.PluginConfig) {
 	p.cfg = cfg
+}
+
+// LLMStats returns a point-in-time snapshot of LLM call metrics.
+func (p *EnrichmentPipeline) LLMStats() llmstats.Snapshot {
+	return p.stats.Snapshot()
+}
+
+// verboseLogsFlag returns the LLMVerboseLogs config flag pointer, or nil if cfg is nil.
+func (p *EnrichmentPipeline) verboseLogsFlag() *bool {
+	if p.cfg == nil {
+		return nil
+	}
+	return p.cfg.LLMVerboseLogs
+}
+
+// recordComplete updates aggregate stats and emits a verbose log entry when enabled.
+func (p *EnrichmentPipeline) recordComplete(ctx context.Context, callType string, latMs int64, err error) {
+	p.stats.TotalCalls.Add(1)
+	p.stats.TotalLatencyMs.Add(latMs)
+	if err != nil {
+		p.stats.TotalErrors.Add(1)
+	}
+	if llmstats.VerboseEnabled(p.verboseLogsFlag()) {
+		attrs := []any{
+			"source", "llm",
+			"subsystem", "enrich",
+			"call_type", callType,
+			"provider", p.provider.Name(),
+			"latency_ms", latMs,
+		}
+		if err != nil {
+			attrs = append(attrs, "error", err.Error())
+		}
+		slog.InfoContext(ctx, "llm.complete", attrs...)
+	}
 }
 
 // stageEnabled returns whether a named stage is enabled given config and light-mode rules.
@@ -197,7 +235,9 @@ func (p *EnrichmentPipeline) extractEntities(ctx context.Context, eng *storage.E
 	}
 
 	userMsg := fmt.Sprintf("Concept: %s\n\nContent: %s", eng.Concept, eng.Content)
+	start := time.Now()
 	resp, err := p.provider.Complete(ctx, p.prompts.EntitiesSystem, userMsg)
+	p.recordComplete(ctx, "entities", time.Since(start).Milliseconds(), err)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +263,9 @@ func (p *EnrichmentPipeline) extractRelationships(ctx context.Context, eng *stor
 
 	userMsg := fmt.Sprintf("Entities: %s\n\nConcept: %s\n\nContent: %s",
 		entitiesJSON, eng.Concept, eng.Content)
+	start := time.Now()
 	resp, err := p.provider.Complete(ctx, p.prompts.RelationshipsSystem, userMsg)
+	p.recordComplete(ctx, "relationships", time.Since(start).Milliseconds(), err)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +280,9 @@ func (p *EnrichmentPipeline) classify(ctx context.Context, eng *storage.Engram) 
 	}
 
 	userMsg := fmt.Sprintf("Concept: %s\n\nContent: %s", eng.Concept, eng.Content)
+	start := time.Now()
 	resp, err := p.provider.Complete(ctx, p.prompts.ClassifySystem, userMsg)
+	p.recordComplete(ctx, "classification", time.Since(start).Milliseconds(), err)
 	if err != nil {
 		return "", "", "", "", nil, err
 	}
@@ -253,7 +297,9 @@ func (p *EnrichmentPipeline) summarize(ctx context.Context, eng *storage.Engram)
 	}
 
 	userMsg := fmt.Sprintf("Concept: %s\n\nContent: %s", eng.Concept, eng.Content)
+	start := time.Now()
 	resp, err := p.provider.Complete(ctx, p.prompts.SummarizeSystem, userMsg)
+	p.recordComplete(ctx, "summary", time.Since(start).Milliseconds(), err)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/plugin/llmstats/llmstats.go
+++ b/internal/plugin/llmstats/llmstats.go
@@ -1,0 +1,56 @@
+package llmstats
+
+import (
+	"os"
+	"sync/atomic"
+)
+
+// LLMCallStats tracks aggregate LLM call metrics using lock-free atomics.
+// Safe to embed in structs and access concurrently.
+type LLMCallStats struct {
+	TotalCalls     atomic.Int64
+	TotalErrors    atomic.Int64
+	TotalLatencyMs atomic.Int64
+}
+
+// Snapshot returns a point-in-time copy of the stats.
+func (s *LLMCallStats) Snapshot() Snapshot {
+	calls := s.TotalCalls.Load()
+	errs := s.TotalErrors.Load()
+	latMs := s.TotalLatencyMs.Load()
+	var avgMs float64
+	if calls > 0 {
+		avgMs = float64(latMs) / float64(calls)
+	}
+	return Snapshot{Calls: calls, Errors: errs, AvgLatMs: avgMs}
+}
+
+// Snapshot is a point-in-time copy of LLMCallStats.
+type Snapshot struct {
+	Calls    int64
+	Errors   int64
+	AvgLatMs float64
+}
+
+// Provider is implemented by services that expose LLM call stats.
+type Provider interface {
+	LLMStats() Snapshot
+}
+
+// VerboseEnabled returns true if verbose LLM logging is enabled via
+// the provided config flag or the MUNINN_LLM_VERBOSE_LOGS env var.
+func VerboseEnabled(cfgFlag *bool) bool {
+	if os.Getenv("MUNINN_LLM_VERBOSE_LOGS") == "true" {
+		return true
+	}
+	return cfgFlag != nil && *cfgFlag
+}
+
+// VerboseEnabledBool is like VerboseEnabled but accepts a plain bool
+// (for use with atomic.Bool.Load()).
+func VerboseEnabledBool(enabled bool) bool {
+	if os.Getenv("MUNINN_LLM_VERBOSE_LOGS") == "true" {
+		return true
+	}
+	return enabled
+}

--- a/internal/plugin/llmstats/llmstats_test.go
+++ b/internal/plugin/llmstats/llmstats_test.go
@@ -1,0 +1,86 @@
+package llmstats_test
+
+import (
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/plugin/llmstats"
+)
+
+func TestSnapshot_ZeroCalls(t *testing.T) {
+	var s llmstats.LLMCallStats
+	snap := s.Snapshot()
+	if snap.Calls != 0 || snap.Errors != 0 || snap.AvgLatMs != 0 {
+		t.Errorf("expected zero snapshot, got %+v", snap)
+	}
+}
+
+func TestSnapshot_AvgLatency(t *testing.T) {
+	var s llmstats.LLMCallStats
+	s.TotalCalls.Add(4)
+	s.TotalLatencyMs.Add(400)
+	snap := s.Snapshot()
+	if snap.AvgLatMs != 100.0 {
+		t.Errorf("expected avg 100ms, got %f", snap.AvgLatMs)
+	}
+	if snap.Calls != 4 {
+		t.Errorf("expected 4 calls, got %d", snap.Calls)
+	}
+}
+
+func TestSnapshot_ErrorCount(t *testing.T) {
+	var s llmstats.LLMCallStats
+	s.TotalCalls.Add(10)
+	s.TotalErrors.Add(3)
+	s.TotalLatencyMs.Add(1000)
+	snap := s.Snapshot()
+	if snap.Errors != 3 {
+		t.Errorf("expected 3 errors, got %d", snap.Errors)
+	}
+}
+
+func TestVerboseEnabled_NilFlag(t *testing.T) {
+	t.Setenv("MUNINN_LLM_VERBOSE_LOGS", "")
+	if llmstats.VerboseEnabled(nil) {
+		t.Error("expected false with nil flag and no env var")
+	}
+}
+
+func TestVerboseEnabled_EnvVar(t *testing.T) {
+	t.Setenv("MUNINN_LLM_VERBOSE_LOGS", "true")
+	if !llmstats.VerboseEnabled(nil) {
+		t.Error("expected true when env var set")
+	}
+}
+
+func TestVerboseEnabled_ConfigFlagTrue(t *testing.T) {
+	t.Setenv("MUNINN_LLM_VERBOSE_LOGS", "")
+	enabled := true
+	if !llmstats.VerboseEnabled(&enabled) {
+		t.Error("expected true when config flag is true")
+	}
+}
+
+func TestVerboseEnabled_ConfigFlagFalse(t *testing.T) {
+	t.Setenv("MUNINN_LLM_VERBOSE_LOGS", "")
+	disabled := false
+	if llmstats.VerboseEnabled(&disabled) {
+		t.Error("expected false when config flag is false")
+	}
+}
+
+func TestVerboseEnabledBool_EnvVar(t *testing.T) {
+	t.Setenv("MUNINN_LLM_VERBOSE_LOGS", "true")
+	if !llmstats.VerboseEnabledBool(false) {
+		t.Error("expected true when env var set, even if bool is false")
+	}
+}
+
+func TestVerboseEnabledBool_FlagOnly(t *testing.T) {
+	t.Setenv("MUNINN_LLM_VERBOSE_LOGS", "")
+	if !llmstats.VerboseEnabledBool(true) {
+		t.Error("expected true when bool is true")
+	}
+	if llmstats.VerboseEnabledBool(false) {
+		t.Error("expected false when bool is false and no env var")
+	}
+}

--- a/internal/plugin/retroactive.go
+++ b/internal/plugin/retroactive.go
@@ -93,6 +93,11 @@ func (rp *RetroactiveProcessor) Stats() RetroactiveStats {
 	return rp.stats
 }
 
+// Plugin returns the plugin associated with this processor.
+func (p *RetroactiveProcessor) Plugin() Plugin {
+	return p.plugin
+}
+
 // Mode returns "embed" when this processor handles embedding (DigestEmbed flag)
 // or "enrich" when it handles enrichment (DigestEnrich flag).
 func (rp *RetroactiveProcessor) Mode() string {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -791,6 +791,58 @@
             </template>
           </div>
 
+          <!-- LLM Calls -->
+          <div class="settings-card" style="margin-bottom:1.25rem;">
+            <h3 style="margin:0 0 1rem 0;font-size:0.9375rem;">LLM Calls</h3>
+            <template x-if="obs.llm">
+              <div style="display:flex;flex-direction:column;gap:0.75rem;">
+                <!-- Enrich -->
+                <div style="background:var(--card-bg);border:1px solid var(--border);border-radius:0.5rem;padding:0.75rem 1rem;">
+                  <div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.5rem;">
+                    <span style="font-weight:600;font-size:0.8125rem;">enrich</span>
+                  </div>
+                  <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:0.5rem;font-size:0.75rem;">
+                    <div>
+                      <div style="color:var(--text-muted);">Calls</div>
+                      <div style="font-weight:600;" x-text="obs.llm.enrich_calls"></div>
+                    </div>
+                    <div>
+                      <div style="color:var(--text-muted);">Errors</div>
+                      <div style="font-weight:600;" x-text="obs.llm.enrich_calls > 0 ? obs.llm.enrich_errors + ' (' + (obs.llm.enrich_errors / obs.llm.enrich_calls * 100).toFixed(1) + '%)' : obs.llm.enrich_errors"></div>
+                    </div>
+                    <div>
+                      <div style="color:var(--text-muted);">Avg Latency</div>
+                      <div style="font-weight:600;" x-text="obs.llm.enrich_avg_latency_ms.toFixed(0) + 'ms'"></div>
+                    </div>
+                  </div>
+                </div>
+                <!-- Embed -->
+                <div style="background:var(--card-bg);border:1px solid var(--border);border-radius:0.5rem;padding:0.75rem 1rem;">
+                  <div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.5rem;">
+                    <span style="font-weight:600;font-size:0.8125rem;">embed</span>
+                  </div>
+                  <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:0.5rem;font-size:0.75rem;">
+                    <div>
+                      <div style="color:var(--text-muted);">Calls</div>
+                      <div style="font-weight:600;" x-text="obs.llm.embed_calls"></div>
+                    </div>
+                    <div>
+                      <div style="color:var(--text-muted);">Errors</div>
+                      <div style="font-weight:600;" x-text="obs.llm.embed_calls > 0 ? obs.llm.embed_errors + ' (' + (obs.llm.embed_errors / obs.llm.embed_calls * 100).toFixed(1) + '%)' : obs.llm.embed_errors"></div>
+                    </div>
+                    <div>
+                      <div style="color:var(--text-muted);">Avg Latency</div>
+                      <div style="font-weight:600;" x-text="obs.llm.embed_avg_latency_ms.toFixed(0) + 'ms'"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </template>
+            <template x-if="!obs.llm">
+              <div style="font-size:0.8125rem;color:var(--text-muted);">No LLM plugins configured</div>
+            </template>
+          </div>
+
           <!-- Cognitive Workers -->
           <div class="settings-card" style="margin-bottom:1.25rem;">
             <h3 style="margin:0 0 1rem 0;font-size:0.9375rem;">Cognitive Workers</h3>
@@ -1616,6 +1668,17 @@
                     <option value="claude-haiku-4-5-20251001">claude-haiku-4-5-20251001 (fastest)</option>
                     <option value="claude-sonnet-4-6">claude-sonnet-4-6</option>
                   </select>
+                </div>
+              </div>
+
+              <!-- Verbose LLM logs -->
+              <div style="display:flex;align-items:flex-start;gap:0.75rem;padding:0.75rem 0;border-top:1px solid var(--border);">
+                <input type="checkbox" id="llmVerboseLogs" :checked="pluginCfg.llm_verbose_logs === true"
+                  @change="pluginCfg.llm_verbose_logs = $event.target.checked || undefined"
+                  style="margin-top:0.125rem;cursor:pointer;" />
+                <div>
+                  <label for="llmVerboseLogs" style="font-size:0.8125rem;font-weight:500;cursor:pointer;">Verbose LLM logs</label>
+                  <div style="font-size:0.75rem;color:var(--text-muted);margin-top:0.125rem;">Logs each LLM call to the Logs page (off by default)</div>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary

- **Always-on aggregate counters** (zero ring buffer impact): `GET /api/admin/observability` now returns a `llm` field with calls/errors/avg latency for enrich and embed subsystems, displayed in a new LLM Calls card on the Observability page
- **Opt-in verbose per-call logs** (off by default): enable via `MUNINN_LLM_VERBOSE_LOGS=true` env var or the new "Verbose LLM logs" toggle in Settings — emits `source=llm, subsystem=enrich|embed` entries to the Logs page ring buffer only when enabled
- `BatchEmbedder.verboseLogs` uses `atomic.Bool` (race-safe)
- `recordComplete()` helper extracted — eliminates 4x duplicated instrumentation block in pipeline stages
- `LLM *LLMStats` is a pointer with `omitempty` — `obs.llm` is `null` in JSON when no plugins are configured, so the UI fallback ("No LLM plugins configured") works correctly

## Test plan

- [ ] `go test ./internal/plugin/llmstats/... ./internal/plugin/enrich/... ./internal/plugin/embed/... ./internal/engine/...` passes
- [ ] Hit `GET /api/admin/observability` with enrich configured — confirm `llm` field with non-zero counts after some engrams processed
- [ ] `obs.llm` is `null` (card hidden) when no LLM plugins configured
- [ ] Default: no `source=llm` entries appear in Logs page
- [ ] `MUNINN_LLM_VERBOSE_LOGS=true` → `source=llm` entries appear in Logs page with `subsystem`, `call_type`, `latency_ms`
- [ ] Settings toggle → save → `plugin_config.json` updated with `llm_verbose_logs: true`