### PR TITLE
fix: correct vault routing for contradiction resolution and lifecycle state calls

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -819,34 +819,34 @@ document.addEventListener('alpine:init', () => {
           // A supersedes B; archive B
           await this.apiCall('/api/link?vault=' + encodeURIComponent(vault), {
             method: 'POST',
-            body: JSON.stringify({ source_id: idA, target_id: idB, rel_type: 4, weight: 1.0, vault }),
+            body: JSON.stringify({ source_id: idA, target_id: idB, rel_type: 4, weight: 1.0 }),
           });
           await this.apiCall('/api/engrams/' + encodeURIComponent(idB) + '/state?vault=' + encodeURIComponent(vault), {
             method: 'PUT',
-            body: JSON.stringify({ vault, state: 'archived' }),
+            body: JSON.stringify({ state: 'archived' }),
           });
-          await this.apiCall('/api/admin/contradictions/resolve', {
+          await this.apiCall('/api/admin/contradictions/resolve?vault=' + encodeURIComponent(vault), {
             method: 'POST',
-            body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
+            body: JSON.stringify({ id_a: idA, id_b: idB }),
           });
         } else if (action === 'keep_b') {
           // B supersedes A; archive A
           await this.apiCall('/api/link?vault=' + encodeURIComponent(vault), {
             method: 'POST',
-            body: JSON.stringify({ source_id: idB, target_id: idA, rel_type: 4, weight: 1.0, vault }),
+            body: JSON.stringify({ source_id: idB, target_id: idA, rel_type: 4, weight: 1.0 }),
           });
           await this.apiCall('/api/engrams/' + encodeURIComponent(idA) + '/state?vault=' + encodeURIComponent(vault), {
             method: 'PUT',
-            body: JSON.stringify({ vault, state: 'archived' }),
+            body: JSON.stringify({ state: 'archived' }),
           });
-          await this.apiCall('/api/admin/contradictions/resolve', {
+          await this.apiCall('/api/admin/contradictions/resolve?vault=' + encodeURIComponent(vault), {
             method: 'POST',
-            body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
+            body: JSON.stringify({ id_a: idA, id_b: idB }),
           });
         } else if (action === 'dismiss') {
-          await this.apiCall('/api/admin/contradictions/resolve', {
+          await this.apiCall('/api/admin/contradictions/resolve?vault=' + encodeURIComponent(vault), {
             method: 'POST',
-            body: JSON.stringify({ vault, id_a: idA, id_b: idB }),
+            body: JSON.stringify({ id_a: idA, id_b: idB }),
           });
         } else if (action === 'merge') {
           // Open consolidate modal pre-filled with both IDs
@@ -2647,7 +2647,7 @@ document.addEventListener('alpine:init', () => {
       try {
         const res = await this.apiCall(
           '/api/engrams/' + encodeURIComponent(id) + '/state?vault=' + encodeURIComponent(this.vault),
-          { method: 'PUT', body: JSON.stringify({ vault: this.vault, state }) }
+          { method: 'PUT', body: JSON.stringify({ state }) }
         );
         if (this.selectedMemory && this.selectedMemory.id === id) {
           this.selectedMemory = { ...this.selectedMemory, state };


### PR DESCRIPTION
## Summary

Two vault routing issues introduced by the main→develop sync (PR #220) conflict resolution in `web/static/js/app.js`:

**1. Redundant vault in body + query string (5 call sites)**

`/api/link` and `PUT /api/engrams/{id}/state` were sending `vault` in both the `?vault=` query param and the JSON body. The auth middleware uses the query param as source of truth (`resolveRequestVault` in `internal/auth/middleware.go`); body vault is validated for consistency then discarded. Removed vault from the body.

**2. Missing vault in query string for `/api/admin/contradictions/resolve` (3 call sites — real bug)**

`AdminAPIMiddleware` reads vault **only** from the query string, defaulting to `"default"`. The JS was sending vault only in the JSON body (which the middleware never reads), causing all contradiction resolution calls to operate against the `"default"` vault regardless of which vault the user was working in. Fixed by moving vault to the query string and removing the ignored body field.

## Affected functions
- `resolveContradiction()` — keep_a, keep_b, dismiss actions
- `updateLifecycleState()`

## Test plan
- [ ] Resolve a contradiction in a non-default vault — verify it resolves against the correct vault (was broken before this fix)
- [ ] Update lifecycle state on an engram in a non-default vault — no regression
- [ ] Create a link between engrams in a non-default vault — no regression