### PR TITLE
fix: address all 4 Opus entity graph architectural findings

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -794,6 +794,11 @@ func runServer() {
 		Description: "backfill embed_dim in ERF records for existing embeddings",
 		Up:          migrate.BackfillEmbedDim,
 	})
+	migRunner.Register(migrate.Migration{
+		Version:     2,
+		Description: "backfill relationship entity index (0x26) for GetEntityAggregate optimisation",
+		Up:          migrate.BackfillRelEntityIndex,
+	})
 	if applied, err := migRunner.Run(); err != nil {
 		slog.Error("migration failed", "err", err)
 		db.Close()

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -153,6 +153,12 @@ type Engine struct {
 	// Set via SetEnrichPlugin after construction.
 	enrichPlugin plugin.EnrichPlugin
 
+	// mergeMu serialises concurrent MergeEntity calls that touch the same entities.
+	// Uses a dedicated stripe array separate from the storage-layer entity locks to
+	// avoid reentrancy deadlock (UpsertEntityRecord acquires storage stripes internally).
+	// See merge_guard.go for the full concurrency contract.
+	mergeMu mergeGuard
+
 	// noveltyJobsDropped counts novelty jobs silently dropped because the channel was full.
 	noveltyJobsDropped atomic.Int64
 

--- a/internal/engine/engine_similarity.go
+++ b/internal/engine/engine_similarity.go
@@ -115,6 +115,12 @@ func (e *Engine) MergeEntity(ctx context.Context, vault, entityA, entityB string
 		return nil, fmt.Errorf("merge_entity: entity_a and entity_b must be different")
 	}
 
+	// Serialise concurrent merges that touch either entity.
+	// Acquired before any reads so the read→check→write sequence is atomic
+	// with respect to other MergeEntity calls on the same entities.
+	e.mergeMu.Lock(entityA, entityB)
+	defer e.mergeMu.Unlock(entityA, entityB)
+
 	ws := e.store.ResolveVaultPrefix(vault)
 
 	recA, err := e.store.GetEntityRecord(ctx, entityA)
@@ -123,6 +129,9 @@ func (e *Engine) MergeEntity(ctx context.Context, vault, entityA, entityB string
 	}
 	if recA == nil {
 		return nil, fmt.Errorf("merge_entity: entity_a %q not found", entityA)
+	}
+	if recA.State == "merged" {
+		return nil, fmt.Errorf("merge_entity: entity_a %q is already merged into %q", entityA, recA.MergedInto)
 	}
 
 	recB, err := e.store.GetEntityRecord(ctx, entityB)

--- a/internal/engine/engine_similarity.go
+++ b/internal/engine/engine_similarity.go
@@ -176,6 +176,14 @@ func (e *Engine) MergeEntity(ctx context.Context, vault, entityA, entityB string
 		}
 	}
 
+	// Step 1b: update any 0x21 relationship records that reference entity A by name,
+	// replacing A with B in both the record value and the 0x21 key (which encodes the
+	// entity hash). The 0x26 index is updated in the same batches. This keeps
+	// ScanEntityRelationships("B") returning the complete set after a merge.
+	if err := e.store.RelinkRelationshipEntity(ctx, ws, entityA, entityB); err != nil {
+		return nil, fmt.Errorf("merge_entity: relink relationship records from entity_a to entity_b: %w", err)
+	}
+
 	// Step 2: mark A as merged.
 	if err := e.store.UpsertEntityRecord(ctx, storage.EntityRecord{
 		Name:       recA.Name,

--- a/internal/engine/engine_similarity.go
+++ b/internal/engine/engine_similarity.go
@@ -46,13 +46,37 @@ func (e *Engine) FindSimilarEntities(ctx context.Context, vault string, threshol
 		return nil, fmt.Errorf("find_similar_entities: scan names: %w", err)
 	}
 
+	// Phase 1: build an inverted trigram index: trigram → []int (indices into names).
+	// This reduces FindSimilarEntities from O(n²) to O(n × T × C) where T is the average
+	// number of trigrams per name (~10) and C is the average candidate count per name
+	// (small at high thresholds). For n=1000 this is ~10K–50K comparisons vs 500K.
+	invertedIdx := make(map[string][]int, len(names)*8)
+	for i, name := range names {
+		for t := range trigrams(name) {
+			invertedIdx[t] = append(invertedIdx[t], i)
+		}
+	}
+
+	// Phase 2: for each name, find candidate indices sharing ≥1 trigram, then compare.
+	// Using j > i avoids duplicate pairs and mirrors the previous double-loop semantics.
+	// Note: trigramSim > 0 iff the trigram sets share at least one entry, so no pair with
+	// sim ≥ threshold > 0 can be missed by the candidate set. At threshold=0 pairs of
+	// entirely different strings are excluded, but that edge case is not meaningful in practice.
 	var pairs []SimilarEntityPair
-	for i := 0; i < len(names); i++ {
-		for j := i + 1; j < len(names); j++ {
-			sim := trigramSim(names[i], names[j])
+	for i, name := range names {
+		candidates := make(map[int]struct{})
+		for t := range trigrams(name) {
+			for _, j := range invertedIdx[t] {
+				if j > i {
+					candidates[j] = struct{}{}
+				}
+			}
+		}
+		for j := range candidates {
+			sim := trigramSim(name, names[j])
 			if sim >= threshold {
 				pairs = append(pairs, SimilarEntityPair{
-					EntityA:    names[i],
+					EntityA:    name,
 					EntityB:    names[j],
 					Similarity: sim,
 				})
@@ -133,10 +157,15 @@ func (e *Engine) MergeEntity(ctx context.Context, vault, entityA, entityB string
 		return result, nil
 	}
 
-	// Step 1: relink each engram from A to B.
+	// Step 1: relink each engram from A to B and delete the stale A links.
+	// Both operations are needed: writing the B link establishes the new association;
+	// deleting the A link removes the ghost that would otherwise persist in the 0x23 index.
 	for _, id := range engramIDs {
 		if err := e.store.WriteEntityEngramLink(ctx, ws, id, entityB); err != nil {
 			return nil, fmt.Errorf("merge_entity: relink engram %s to entity_b: %w", id.String(), err)
+		}
+		if err := e.store.DeleteEntityEngramLink(ctx, ws, id, entityA); err != nil {
+			return nil, fmt.Errorf("merge_entity: remove stale link for engram %s entity_a: %w", id.String(), err)
 		}
 	}
 

--- a/internal/engine/engine_similarity.go
+++ b/internal/engine/engine_similarity.go
@@ -157,15 +157,13 @@ func (e *Engine) MergeEntity(ctx context.Context, vault, entityA, entityB string
 		return result, nil
 	}
 
-	// Step 1: relink each engram from A to B and delete the stale A links.
-	// Both operations are needed: writing the B link establishes the new association;
-	// deleting the A link removes the ghost that would otherwise persist in the 0x23 index.
+	// Step 1: atomically relink each engram from A to B.
+	// RelinkEntityEngramLink writes the new 0x20/0x23 links for B and deletes the
+	// stale 0x20/0x23 links for A in a single Pebble batch, eliminating any crash
+	// window where the engram would appear linked to both or neither entity.
 	for _, id := range engramIDs {
-		if err := e.store.WriteEntityEngramLink(ctx, ws, id, entityB); err != nil {
-			return nil, fmt.Errorf("merge_entity: relink engram %s to entity_b: %w", id.String(), err)
-		}
-		if err := e.store.DeleteEntityEngramLink(ctx, ws, id, entityA); err != nil {
-			return nil, fmt.Errorf("merge_entity: remove stale link for engram %s entity_a: %w", id.String(), err)
+		if err := e.store.RelinkEntityEngramLink(ctx, ws, id, entityA, entityB); err != nil {
+			return nil, fmt.Errorf("merge_entity: relink engram %s from entity_a to entity_b: %w", id.String(), err)
 		}
 	}
 

--- a/internal/engine/engine_similarity_test.go
+++ b/internal/engine/engine_similarity_test.go
@@ -254,6 +254,28 @@ func TestMergeEntity_SameEntityRejected(t *testing.T) {
 	require.Contains(t, err.Error(), "must be different")
 }
 
+func TestMergeEntity_AlreadyMergedEntityARejected(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	writeEntityEngram(t, eng, "default", "Postgre SQL legacy",
+		mbp.InlineEntity{Name: "Postgre SQL", Type: "database"})
+	writeEntityEngram(t, eng, "default", "PostgreSQL canonical",
+		mbp.InlineEntity{Name: "PostgreSQL", Type: "database"})
+	writeEntityEngram(t, eng, "default", "PG shorthand",
+		mbp.InlineEntity{Name: "PG", Type: "database"})
+
+	// First merge: A → B succeeds.
+	_, err := eng.MergeEntity(ctx, "default", "Postgre SQL", "PostgreSQL", false)
+	require.NoError(t, err)
+
+	// Second merge of the same A (now state=merged) must be rejected.
+	_, err = eng.MergeEntity(ctx, "default", "Postgre SQL", "PG", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already merged", "re-merging a merged entity must return an explicit error")
+}
+
 func TestMergeEntity_DeletesStaleLinksForMergedEntity(t *testing.T) {
 	eng, cleanup := testEnv(t)
 	defer cleanup()

--- a/internal/engine/engine_similarity_test.go
+++ b/internal/engine/engine_similarity_test.go
@@ -382,3 +382,82 @@ func TestFindSimilarEntities_InvertedIndexMatchesNaive(t *testing.T) {
 	require.Equal(t, len(naivePairs), len(optimisedPairs),
 		"optimised and naive must return the same number of pairs")
 }
+
+// TestFindSimilarEntities_ThresholdZero_ExcludesZeroSimPairs documents and pins the
+// known behaviour of the inverted-trigram-index at threshold=0.0: only pairs that
+// share at least one trigram (sim > 0) are returned.  Pairs with no shared trigrams
+// (sim == 0) are never candidates in the index and are therefore not returned.
+// This is intentional — a sim=0 pair means "nothing in common" and is not actionable.
+func TestFindSimilarEntities_ThresholdZero_ExcludesZeroSimPairs(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// These two names share no trigrams: "aaa" vs "bbb".
+	// trigramSim("aaa", "bbb") == 0.0 because their trigram sets are disjoint.
+	writeEntityEngram(t, eng, "default", "mention aaa",
+		mbp.InlineEntity{Name: "aaa", Type: "token"})
+	writeEntityEngram(t, eng, "default", "mention bbb",
+		mbp.InlineEntity{Name: "bbb", Type: "token"})
+
+	pairs, err := eng.FindSimilarEntities(ctx, "default", 0.0, 100)
+	require.NoError(t, err)
+
+	for _, p := range pairs {
+		if (p.EntityA == "aaa" && p.EntityB == "bbb") ||
+			(p.EntityA == "bbb" && p.EntityB == "aaa") {
+			t.Errorf("pair (aaa, bbb) with sim=0 must not appear at threshold=0.0: got similarity=%f", p.Similarity)
+		}
+		// Any pair that IS returned must have sim > 0 (shares at least one trigram).
+		if p.Similarity <= 0 {
+			t.Errorf("returned pair (%s, %s) has sim=%f; all returned pairs must have sim > 0",
+				p.EntityA, p.EntityB, p.Similarity)
+		}
+	}
+}
+
+// ── Benchmarks ───────────────────────────────────────────────────────────────
+
+// BenchmarkFindSimilarEntities measures the inverted-trigram-index implementation
+// against a realistic entity set.  Run with -bench=. -benchtime=5s to get stable numbers.
+//
+// Measured baseline on Apple M4 Max (50 entities, threshold=0.5):
+//   BenchmarkFindSimilarEntities-16  5382  606529 ns/op  (~0.6ms)
+//
+// If this regresses above ~5ms for 50 entities the O(n²) path has been reintroduced.
+func BenchmarkFindSimilarEntities(b *testing.B) {
+	eng, cleanup := testEnvTB(b)
+	defer cleanup()
+	ctx := context.Background()
+
+	names := []string{
+		"PostgreSQL", "PostgreSQL DB", "Postgre SQL", "PostGres", "PG",
+		"Redis", "Rediss", "RediSearch", "RedisDB", "Redis Cache",
+		"Kubernetes", "K8s", "KubeCtl", "KubernetesAPI", "KubeAPI",
+		"payment-service", "payment_service", "PaymentService", "PaymentSvc", "pay-svc",
+		"auth-service", "AuthService", "auth_svc", "AuthSvc", "authentication-service",
+		"order-service", "OrderService", "order_svc", "OrderAPI", "orders-api",
+		"user-service", "UserService", "user_svc", "UserAPI", "users-api",
+		"notification-service", "NotificationService", "notif-svc", "NotifAPI", "push-service",
+		"billing-service", "BillingService", "billing_svc", "BillingAPI", "invoice-service",
+		"search-service", "SearchService", "search_svc", "SearchAPI", "ElasticSearch",
+	}
+	for _, name := range names {
+		_, err := eng.Write(context.Background(), &mbp.WriteRequest{
+			Vault:    "bench",
+			Content:  "benchmark entity " + name,
+			Entities: []mbp.InlineEntity{{Name: name, Type: "service"}},
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		_, err := eng.FindSimilarEntities(ctx, "bench", 0.5, 1000)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/engine/engine_similarity_test.go
+++ b/internal/engine/engine_similarity_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/scrypster/muninndb/internal/storage"
 	"github.com/scrypster/muninndb/internal/transport/mbp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -252,6 +253,68 @@ func TestMergeEntity_SameEntityRejected(t *testing.T) {
 	_, err := eng.MergeEntity(ctx, "default", "PostgreSQL", "PostgreSQL", false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "must be different")
+}
+
+// TestMergeEntity_RelinkRelationships verifies that after MergeEntity(A→B), relationship
+// records that referenced A are updated to reference B. ScanEntityRelationships("A")
+// returns nothing; ScanEntityRelationships("B") returns all previously-A relationships.
+func TestMergeEntity_RelinkRelationships(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Write entities in separate engrams to avoid triggering the engine's
+	// automatic co-occurrence relationship (which fires when two entities share an engram).
+	writeEntityEngram(t, eng, "default", "Postgre SQL is a database",
+		mbp.InlineEntity{Name: "Postgre SQL", Type: "database"})
+	writeEntityEngram(t, eng, "default", "auth-service is a service",
+		mbp.InlineEntity{Name: "auth-service", Type: "service"})
+	writeEntityEngram(t, eng, "default", "PostgreSQL canonical",
+		mbp.InlineEntity{Name: "PostgreSQL", Type: "database"})
+
+	// Write a relationship: auth-service uses "Postgre SQL".
+	ws := eng.store.ResolveVaultPrefix("default")
+	require.NoError(t, eng.store.UpsertRelationshipRecord(ctx, ws, storage.NewULID(), storage.RelationshipRecord{
+		FromEntity: "auth-service",
+		ToEntity:   "Postgre SQL",
+		RelType:    "uses",
+		Weight:     0.9,
+		Source:     "test",
+	}))
+
+	// Before merge: ScanEntityRelationships("Postgre SQL") finds 1 record.
+	var before []storage.RelationshipRecord
+	require.NoError(t, eng.store.ScanEntityRelationships(ctx, ws, "Postgre SQL",
+		func(r storage.RelationshipRecord) error {
+			before = append(before, r)
+			return nil
+		}))
+	require.Len(t, before, 1, "must find relationship before merge")
+
+	// Merge A → B.
+	result, err := eng.MergeEntity(ctx, "default", "Postgre SQL", "PostgreSQL", false)
+	require.NoError(t, err)
+	require.False(t, result.DryRun)
+
+	// After merge: "Postgre SQL" must have no relationships.
+	var afterA []storage.RelationshipRecord
+	require.NoError(t, eng.store.ScanEntityRelationships(ctx, ws, "Postgre SQL",
+		func(r storage.RelationshipRecord) error {
+			afterA = append(afterA, r)
+			return nil
+		}))
+	assert.Empty(t, afterA, "ScanEntityRelationships(A) must be empty after merge")
+
+	// After merge: "PostgreSQL" must now own the relationship.
+	var afterB []storage.RelationshipRecord
+	require.NoError(t, eng.store.ScanEntityRelationships(ctx, ws, "PostgreSQL",
+		func(r storage.RelationshipRecord) error {
+			afterB = append(afterB, r)
+			return nil
+		}))
+	require.Len(t, afterB, 1, "ScanEntityRelationships(B) must find the relinked relationship")
+	assert.Equal(t, "auth-service", afterB[0].FromEntity)
+	assert.Equal(t, "PostgreSQL", afterB[0].ToEntity, "ToEntity must be updated to canonical name")
 }
 
 func TestMergeEntity_AlreadyMergedEntityARejected(t *testing.T) {

--- a/internal/engine/engine_similarity_test.go
+++ b/internal/engine/engine_similarity_test.go
@@ -253,3 +253,132 @@ func TestMergeEntity_SameEntityRejected(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "must be different")
 }
+
+func TestMergeEntity_DeletesStaleLinksForMergedEntity(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Write two engrams linking to entity A.
+	writeEntityEngram(t, eng, "default", "Postgre SQL first mention",
+		mbp.InlineEntity{Name: "Postgre SQL", Type: "database"})
+	writeEntityEngram(t, eng, "default", "Postgre SQL second mention",
+		mbp.InlineEntity{Name: "Postgre SQL", Type: "database"})
+	// Write one engram linking to entity B (the canonical).
+	writeEntityEngram(t, eng, "default", "PostgreSQL is canonical",
+		mbp.InlineEntity{Name: "PostgreSQL", Type: "database"})
+
+	_, err := eng.MergeEntity(ctx, "default", "Postgre SQL", "PostgreSQL", false)
+	require.NoError(t, err)
+
+	// After merge: 0x23 reverse index for A must be empty.
+	// A's two engrams were relinked to B; the stale A links must be gone.
+	var staleLinks []storage.ULID
+	err = eng.store.ScanEntityEngrams(ctx, "Postgre SQL", func(_ [8]byte, id storage.ULID) error {
+		staleLinks = append(staleLinks, id)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Empty(t, staleLinks, "merged entity A must have no remaining 0x23 reverse links after merge")
+
+	// Entity B should have all three engrams linked (2 relinked + 1 original).
+	var bLinks []storage.ULID
+	err = eng.store.ScanEntityEngrams(ctx, "PostgreSQL", func(_ [8]byte, id storage.ULID) error {
+		bLinks = append(bLinks, id)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, bLinks, 3, "entity B must have all 3 engrams linked after merge")
+}
+
+func TestMergeEntity_DryRun_PreservesAllLinks(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	writeEntityEngram(t, eng, "default", "Postgre SQL mention",
+		mbp.InlineEntity{Name: "Postgre SQL", Type: "database"})
+	writeEntityEngram(t, eng, "default", "PostgreSQL canonical",
+		mbp.InlineEntity{Name: "PostgreSQL", Type: "database"})
+
+	_, err := eng.MergeEntity(ctx, "default", "Postgre SQL", "PostgreSQL", true)
+	require.NoError(t, err)
+
+	// dryRun must not modify any links — A's link must still exist.
+	var aLinks []storage.ULID
+	err = eng.store.ScanEntityEngrams(ctx, "Postgre SQL", func(_ [8]byte, id storage.ULID) error {
+		aLinks = append(aLinks, id)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, aLinks, 1, "dry run must not delete entity A's reverse links")
+}
+
+// ── FindSimilarEntities — inverted index correctness ─────────────────────────
+
+// TestFindSimilarEntities_InvertedIndexMatchesNaive verifies that the optimised
+// inverted-trigram-index implementation returns the same pairs as a naive O(n²)
+// reference implementation for a representative entity set.
+func TestFindSimilarEntities_InvertedIndexMatchesNaive(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Write a variety of entities with known similarity relationships.
+	entityNames := []string{
+		"PostgreSQL", "PostgreSQL DB", "Postgre SQL",
+		"Redis", "Rediss", "RediSearch",
+		"Kubernetes", "K8s", "KubeCtl",
+		"payment-service", "payment_service", "PaymentService",
+		"auth-service", "AuthService", "auth_svc",
+	}
+	for _, name := range entityNames {
+		writeEntityEngram(t, eng, "default", "mention of "+name,
+			mbp.InlineEntity{Name: name, Type: "technology"})
+	}
+
+	threshold := 0.5
+	optimised, err := eng.FindSimilarEntities(ctx, "default", threshold, 1000)
+	require.NoError(t, err)
+
+	// Build reference result using naive O(n²) approach.
+	ws := eng.store.ResolveVaultPrefix("default")
+	var names []string
+	err = eng.store.ScanVaultEntityNames(ctx, ws, func(name string) error {
+		names = append(names, name)
+		return nil
+	})
+	require.NoError(t, err)
+
+	naivePairs := make(map[[2]string]float64)
+	for i := 0; i < len(names); i++ {
+		for j := i + 1; j < len(names); j++ {
+			sim := trigramSim(names[i], names[j])
+			if sim >= threshold {
+				key := [2]string{names[i], names[j]}
+				if names[i] > names[j] {
+					key = [2]string{names[j], names[i]}
+				}
+				naivePairs[key] = sim
+			}
+		}
+	}
+
+	// Every naive pair must appear in the optimised result.
+	optimisedPairs := make(map[[2]string]float64)
+	for _, p := range optimised {
+		key := [2]string{p.EntityA, p.EntityB}
+		if p.EntityA > p.EntityB {
+			key = [2]string{p.EntityB, p.EntityA}
+		}
+		optimisedPairs[key] = p.Similarity
+	}
+
+	for key := range naivePairs {
+		_, found := optimisedPairs[key]
+		require.True(t, found, "pair (%s, %s) found by naive but missing from optimised result",
+			key[0], key[1])
+	}
+	require.Equal(t, len(naivePairs), len(optimisedPairs),
+		"optimised and naive must return the same number of pairs")
+}

--- a/internal/engine/entity_ops.go
+++ b/internal/engine/entity_ops.go
@@ -70,12 +70,12 @@ func (e *Engine) GetEntityAggregate(ctx context.Context, vault, entityName strin
 		return nil, scanErr
 	}
 
-	// 3. Relationships involving this entity (vault-scoped)
+	// 3. Relationships involving this entity (vault-scoped).
+	// ScanEntityRelationships uses the 0x26 index for O(engrams-referencing-entity) lookup
+	// instead of the O(all vault relationships) full scan that ScanRelationships would do.
 	var rels []storage.RelationshipRecord
-	err = e.store.ScanRelationships(ctx, ws, func(r storage.RelationshipRecord) error {
-		if r.FromEntity == entityName || r.ToEntity == entityName {
-			rels = append(rels, r)
-		}
+	err = e.store.ScanEntityRelationships(ctx, ws, entityName, func(r storage.RelationshipRecord) error {
+		rels = append(rels, r)
 		return nil
 	})
 	if err != nil {

--- a/internal/engine/merge_guard.go
+++ b/internal/engine/merge_guard.go
@@ -1,0 +1,74 @@
+package engine
+
+import (
+	"hash/fnv"
+	"strings"
+	"sync"
+)
+
+// mergeGuardStripes is the number of merge-guard stripes. 256 gives a ~0.4%
+// false-sharing probability for any two random entity names, which is negligible
+// for an infrequent administrative operation like MergeEntity.
+const mergeGuardStripes = 256
+
+// mergeGuard serialises concurrent MergeEntity calls that touch the same entities.
+//
+// Why a separate guard from the storage-layer entityLocks?
+// The storage layer acquires an entity stripe lock inside UpsertEntityRecord to
+// prevent TOCTOU on individual reads. If MergeEntity held the same stripe lock
+// for its entire duration and then called UpsertEntityRecord internally, it would
+// deadlock — sync.Mutex is not reentrant. mergeGuard uses its own independent
+// stripe array that never interacts with storage-layer locks.
+//
+// Concurrency guarantees:
+//   - MergeEntity(A→B) and MergeEntity(A→C) are serialised because both acquire
+//     stripe(A). One blocks until the other completes, preventing A's engrams from
+//     being split across two targets.
+//   - MergeEntity(A→B) and MergeEntity(B→C) are serialised because they share stripe(B).
+//   - MergeEntity(A→B) and MergeEntity(A→B) (duplicate call) are serialised identically.
+//   - MergeEntity(A→B) and MergeEntity(B→A) acquire the same two stripes in the same
+//     canonical (ascending) order, so there is no deadlock.
+//   - Unrelated merges proceed concurrently unless they happen to share a stripe
+//     (acceptable false sharing at 1/256 probability per entity).
+type mergeGuard struct {
+	mu [mergeGuardStripes]sync.Mutex
+}
+
+// stripeIndex returns the stripe index for an entity name, using the same
+// FNV-32a hash and NFKC-inspired lowercasing as the storage entity locks so
+// that similar entity names map predictably.
+func (g *mergeGuard) stripeIndex(name string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(strings.ToLower(strings.TrimSpace(name))))
+	return h.Sum32() % mergeGuardStripes
+}
+
+// Lock acquires the stripe locks for both entityA and entityB in ascending stripe
+// index order to prevent deadlock. If both names hash to the same stripe it is
+// locked exactly once.
+func (g *mergeGuard) Lock(entityA, entityB string) {
+	idxA := g.stripeIndex(entityA)
+	idxB := g.stripeIndex(entityB)
+
+	switch {
+	case idxA == idxB:
+		g.mu[idxA].Lock()
+	case idxA < idxB:
+		g.mu[idxA].Lock()
+		g.mu[idxB].Lock()
+	default:
+		g.mu[idxB].Lock()
+		g.mu[idxA].Lock()
+	}
+}
+
+// Unlock releases the stripe locks acquired by Lock for the same (entityA, entityB) pair.
+// Must be called with the same arguments as the preceding Lock call.
+func (g *mergeGuard) Unlock(entityA, entityB string) {
+	idxA := g.stripeIndex(entityA)
+	idxB := g.stripeIndex(entityB)
+	g.mu[idxA].Unlock()
+	if idxA != idxB {
+		g.mu[idxB].Unlock()
+	}
+}

--- a/internal/engine/merge_guard.go
+++ b/internal/engine/merge_guard.go
@@ -4,6 +4,8 @@ import (
 	"hash/fnv"
 	"strings"
 	"sync"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 // mergeGuardStripes is the number of merge-guard stripes. 256 gives a ~0.4%
@@ -34,12 +36,14 @@ type mergeGuard struct {
 	mu [mergeGuardStripes]sync.Mutex
 }
 
-// stripeIndex returns the stripe index for an entity name, using the same
-// FNV-32a hash and NFKC-inspired lowercasing as the storage entity locks so
-// that similar entity names map predictably.
+// stripeIndex returns the stripe index for an entity name using the same
+// NFKC normalisation + lowercase + trim pipeline as getEntityLock in the storage
+// layer. Consistent normalisation ensures that entity names which differ only in
+// Unicode representation (e.g. "café" vs "cafe\u0301") map to the same stripe.
 func (g *mergeGuard) stripeIndex(name string) uint32 {
+	normalized := strings.ToLower(strings.TrimSpace(norm.NFKC.String(name)))
 	h := fnv.New32a()
-	h.Write([]byte(strings.ToLower(strings.TrimSpace(name))))
+	h.Write([]byte(normalized))
 	return h.Sum32() % mergeGuardStripes
 }
 

--- a/internal/engine/merge_guard_test.go
+++ b/internal/engine/merge_guard_test.go
@@ -1,0 +1,220 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMergeGuard_SameStripeLockedOnce verifies that two entity names mapping to the
+// same stripe result in a single lock acquisition (no self-deadlock).
+func TestMergeGuard_SameStripeLockedOnce(t *testing.T) {
+	var g mergeGuard
+
+	// Build a map of stripe → first name seen, then look for a collision.
+	// With 256 stripes and up to 10 000 distinct names, birthday probability
+	// guarantees a collision well before exhausting the search.
+	stripeToName := make(map[uint32]string, mergeGuardStripes)
+	var nameA, nameB string
+	for i := 0; i < 10_000; i++ {
+		name := fmt.Sprintf("collision-search-%d", i)
+		idx := g.stripeIndex(name)
+		if existing, ok := stripeToName[idx]; ok {
+			nameA, nameB = existing, name
+			break
+		}
+		stripeToName[idx] = name
+	}
+	require.NotEmpty(t, nameA, "birthday paradox guarantees a stripe collision well before 10 000 names")
+
+	// Must not deadlock — same stripe acquired exactly once.
+	g.Lock(nameA, nameB)
+	g.Unlock(nameA, nameB)
+}
+
+// TestMergeGuard_CanonicalOrderNeverDeadlocks verifies that Lock(A,B) and Lock(B,A)
+// both acquire the same two stripes in the same canonical order — neither can deadlock.
+func TestMergeGuard_CanonicalOrderNeverDeadlocks(t *testing.T) {
+	var g mergeGuard
+
+	// Find two names on different stripes.
+	var nameA, nameB string
+	for i := 0; i < 256; i++ {
+		a := fmt.Sprintf("forward-%d", i)
+		b := fmt.Sprintf("reverse-%d", i)
+		if g.stripeIndex(a) != g.stripeIndex(b) {
+			nameA, nameB = a, b
+			break
+		}
+	}
+	require.NotEmpty(t, nameA, "could not find two names on different stripes")
+
+	// Acquire in both orders — neither should block because they use canonical ordering.
+	done := make(chan struct{}, 2)
+
+	go func() {
+		g.Lock(nameA, nameB)
+		g.Unlock(nameA, nameB)
+		done <- struct{}{}
+	}()
+	go func() {
+		g.Lock(nameB, nameA)
+		g.Unlock(nameB, nameA)
+		done <- struct{}{}
+	}()
+
+	<-done
+	<-done
+}
+
+// TestMergeGuard_SerialisesConflictingMerges verifies that two concurrent merge-like
+// operations on the same entity (A→B and A→C) are serialised: the second operation
+// cannot begin its critical section until the first has completed.
+//
+// Run with -race to catch data races.
+func TestMergeGuard_SerialisesConflictingMerges(t *testing.T) {
+	var g mergeGuard
+
+	const entityA = "shared-entity"
+	const entityB = "target-b"
+	const entityC = "target-c"
+
+	// counter is incremented inside the critical section. If two goroutines overlap,
+	// the race detector will flag it; if serialised correctly, the count will be 2.
+	counter := 0
+	var wg sync.WaitGroup
+
+	for _, target := range []string{entityB, entityC} {
+		target := target
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			g.Lock(entityA, target)
+			defer g.Unlock(entityA, target)
+			counter++ // must be safe because A's stripe is held exclusively
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 2, counter, "both merge operations must complete exactly once")
+}
+
+// TestMergeGuard_ConcurrentUnrelatedMergesDoNotBlock verifies that merges between
+// entirely unrelated entity pairs proceed concurrently (no unnecessary serialisation).
+func TestMergeGuard_ConcurrentUnrelatedMergesDoNotBlock(t *testing.T) {
+	var g mergeGuard
+
+	// Find two pairs that share no stripe.
+	type pair struct{ a, b string }
+	var p1, p2 pair
+	found := false
+	for i := 0; i < 256 && !found; i++ {
+		for j := i + 1; j < 256 && !found; j++ {
+			a1 := fmt.Sprintf("p1-alpha-%d", i)
+			b1 := fmt.Sprintf("p1-beta-%d", i)
+			a2 := fmt.Sprintf("p2-alpha-%d", j)
+			b2 := fmt.Sprintf("p2-beta-%d", j)
+			s1a, s1b := g.stripeIndex(a1), g.stripeIndex(b1)
+			s2a, s2b := g.stripeIndex(a2), g.stripeIndex(b2)
+			if s1a != s2a && s1a != s2b && s1b != s2a && s1b != s2b {
+				p1, p2 = pair{a1, b1}, pair{a2, b2}
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Skip("could not find two fully independent entity pairs")
+	}
+
+	// Both critical sections must execute concurrently — signal via channel.
+	bothInCritical := make(chan struct{})
+	var once sync.Once
+	var mu sync.Mutex
+	inCritical := 0
+
+	var wg sync.WaitGroup
+	for _, p := range []pair{p1, p2} {
+		p := p
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			g.Lock(p.a, p.b)
+			defer g.Unlock(p.a, p.b)
+
+			mu.Lock()
+			inCritical++
+			if inCritical == 2 {
+				once.Do(func() { close(bothInCritical) })
+			}
+			mu.Unlock()
+
+			<-bothInCritical // hold the lock until both are inside
+		}()
+	}
+	wg.Wait()
+	// If we reach here without deadlock both goroutines entered concurrently.
+}
+
+// TestMergeGuard_IntegrationConcurrentMerge verifies that concurrent MergeEntity
+// calls at the engine level targeting the same entity A produce a consistent final
+// state — A is merged exactly once, and all its engrams are linked to one target.
+//
+// Run with -race.
+func TestMergeGuard_IntegrationConcurrentMerge(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Write entity A with two engrams, and separate target entities B and C.
+	writeEntityEngram(t, eng, "default", "entity A first mention",
+		mbp.InlineEntity{Name: "EntityA", Type: "service"})
+	writeEntityEngram(t, eng, "default", "entity A second mention",
+		mbp.InlineEntity{Name: "EntityA", Type: "service"})
+	writeEntityEngram(t, eng, "default", "entity B mention",
+		mbp.InlineEntity{Name: "EntityB", Type: "service"})
+	writeEntityEngram(t, eng, "default", "entity C mention",
+		mbp.InlineEntity{Name: "EntityC", Type: "service"})
+
+	// Fire two conflicting merge operations concurrently.
+	// One merges A→B, the other merges A→C.  The guard ensures they are
+	// serialised on A's stripe: whichever runs second will find A already
+	// state=merged and should return an error (entity not found / already merged).
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, target := range []string{"EntityB", "EntityC"} {
+		target := target
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := eng.MergeEntity(ctx, "default", "EntityA", target, false)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	// Exactly one merge must succeed; the other must fail (A already merged).
+	var successes, failures int
+	for err := range errs {
+		if err == nil {
+			successes++
+		} else {
+			failures++
+		}
+	}
+	assert.Equal(t, 1, successes, "exactly one concurrent merge must succeed")
+	assert.Equal(t, 1, failures, "the second concurrent merge must fail (A already merged)")
+
+	// Entity A must be state=merged with a single canonical target.
+	recA, err := eng.store.GetEntityRecord(ctx, "EntityA")
+	require.NoError(t, err)
+	require.NotNil(t, recA)
+	assert.Equal(t, "merged", recA.State)
+	assert.NotEmpty(t, recA.MergedInto, "MergedInto must be set to either B or C")
+}

--- a/internal/storage/entity.go
+++ b/internal/storage/entity.go
@@ -187,21 +187,20 @@ func (ps *PebbleStore) GetEntityRecord(ctx context.Context, name string) (*Entit
 	return &record, nil
 }
 
-// getEntityLock returns a per-entity mutex for the given entity name.
+// getEntityLock returns the stripe mutex for the given entity name.
 // Uses the same NFKC normalization as EntityNameHash for consistent keying.
 func (ps *PebbleStore) getEntityLock(name string) *sync.Mutex {
 	normalized := strings.ToLower(strings.TrimSpace(norm.NFKC.String(name)))
-	m, _ := ps.entityLocks.LoadOrStore(normalized, &sync.Mutex{})
-	return m.(*sync.Mutex)
+	return ps.entityLocks.For([]byte(normalized))
 }
 
-// getCoOccurrenceLock returns a per-pair mutex for the given canonical hash pair.
+// getCoOccurrenceLock returns the stripe mutex for the given canonical hash pair.
 // hashA and hashB must already be canonicalized (hashA <= hashB).
 func (ps *PebbleStore) getCoOccurrenceLock(hashA, hashB [8]byte) *sync.Mutex {
-	// Create a string key from the two 8-byte hashes (16 bytes total)
-	key := string(hashA[:]) + string(hashB[:])
-	m, _ := ps.coOccurrenceLocks.LoadOrStore(key, &sync.Mutex{})
-	return m.(*sync.Mutex)
+	var key [16]byte
+	copy(key[:8], hashA[:])
+	copy(key[8:], hashB[:])
+	return ps.coOccurrenceLocks.For(key[:])
 }
 
 // WriteEntityEngramLink writes a vault-scoped engram→entity link at 0x20
@@ -221,6 +220,26 @@ func (ps *PebbleStore) WriteEntityEngramLink(ctx context.Context, ws [8]byte, en
 	}
 	if err := batch.Set(revKey, nil, nil); err != nil {
 		return fmt.Errorf("write entity link rev: %w", err)
+	}
+	return batch.Commit(pebble.NoSync)
+}
+
+// DeleteEntityEngramLink deletes the 0x20 forward key and 0x23 reverse key for a
+// specific (engram, entity) pair atomically in a single Pebble batch.
+// Used by MergeEntity to remove stale links for the merged-away entity A after
+// relinking each engram to entity B.
+func (ps *PebbleStore) DeleteEntityEngramLink(ctx context.Context, ws [8]byte, engramID ULID, entityName string) error {
+	nameHash := keys.EntityNameHash(entityName)
+	fwdKey := keys.EntityEngramLinkKey(ws, [16]byte(engramID), nameHash)
+	revKey := keys.EntityReverseIndexKey(nameHash, ws, [16]byte(engramID))
+
+	batch := ps.db.NewBatch()
+	defer batch.Close()
+	if err := batch.Delete(fwdKey, nil); err != nil {
+		return fmt.Errorf("delete entity link fwd: %w", err)
+	}
+	if err := batch.Delete(revKey, nil); err != nil {
+		return fmt.Errorf("delete entity link rev: %w", err)
 	}
 	return batch.Commit(pebble.NoSync)
 }
@@ -426,7 +445,71 @@ func (ps *PebbleStore) ScanRelationships(ctx context.Context, ws [8]byte, fn fun
 	return nil
 }
 
-// UpsertRelationshipRecord writes a vault-scoped relationship record at 0x21.
+// ScanEntityRelationships returns all relationship records where entityName appears
+// as fromEntity or toEntity, using the 0x26 relationship entity index for efficient
+// per-entity lookup. This avoids the O(all vault relationships) full scan of
+// ScanRelationships for the common case of querying a single entity's relationships.
+//
+// For each engramID found in the 0x26 index, it scans the per-engram 0x21 prefix and
+// calls fn for every record where fromEntity or toEntity matches entityName.
+func (ps *PebbleStore) ScanEntityRelationships(ctx context.Context, ws [8]byte, entityName string, fn func(record RelationshipRecord) error) error {
+	entityHash := keys.EntityNameHash(entityName)
+	idxPrefix := keys.RelEntityIndexPrefix(ws, entityHash)
+
+	// Collect unique engramIDs from the 0x26 index.
+	idxIter, err := PrefixIterator(ps.db, idxPrefix)
+	if err != nil {
+		return fmt.Errorf("scan entity relationships: idx iter: %w", err)
+	}
+	var engramIDs [][16]byte
+	seen := make(map[[16]byte]struct{})
+	for valid := idxIter.First(); valid; valid = idxIter.Next() {
+		k := idxIter.Key()
+		// Key layout: 0x26(1) | ws(8) | entityHash(8) | engramID(16) = 33 bytes
+		if len(k) != 33 {
+			continue
+		}
+		var id [16]byte
+		copy(id[:], k[17:33])
+		if _, already := seen[id]; !already {
+			seen[id] = struct{}{}
+			engramIDs = append(engramIDs, id)
+		}
+	}
+	if err := idxIter.Close(); err != nil {
+		return fmt.Errorf("scan entity relationships: idx iter close: %w", err)
+	}
+
+	// For each engram, scan its 0x21 keys and filter for records involving entityName.
+	for _, id := range engramIDs {
+		relIter, err := PrefixIterator(ps.db, keys.RelationshipEngramPrefix(ws, id))
+		if err != nil {
+			return fmt.Errorf("scan entity relationships: rel iter for engram: %w", err)
+		}
+		for valid := relIter.First(); valid; valid = relIter.Next() {
+			val := relIter.Value()
+			var rec RelationshipRecord
+			if err := msgpack.Unmarshal(val, &rec); err != nil {
+				continue
+			}
+			if rec.FromEntity != entityName && rec.ToEntity != entityName {
+				continue
+			}
+			if err := fn(rec); err != nil {
+				relIter.Close()
+				return err
+			}
+		}
+		if err := relIter.Close(); err != nil {
+			return fmt.Errorf("scan entity relationships: rel iter close: %w", err)
+		}
+	}
+	return nil
+}
+
+// UpsertRelationshipRecord writes a vault-scoped relationship record at 0x21 and
+// the corresponding 0x26 relationship entity index entries for both fromEntity and
+// toEntity. All three writes are committed atomically in a single Pebble batch.
 func (ps *PebbleStore) UpsertRelationshipRecord(ctx context.Context, ws [8]byte, engramID ULID, record RelationshipRecord) error {
 	record.UpdatedAt = time.Now().UnixNano()
 	val, err := msgpack.Marshal(record)
@@ -436,8 +519,22 @@ func (ps *PebbleStore) UpsertRelationshipRecord(ctx context.Context, ws [8]byte,
 	fromHash := keys.EntityNameHash(record.FromEntity)
 	toHash := keys.EntityNameHash(record.ToEntity)
 	relTypeByte := relTypeByteFromString(record.RelType)
-	key := keys.RelationshipKey(ws, [16]byte(engramID), fromHash, relTypeByte, toHash)
-	return ps.db.Set(key, val, pebble.NoSync)
+	relKey := keys.RelationshipKey(ws, [16]byte(engramID), fromHash, relTypeByte, toHash)
+	idxFromKey := keys.RelEntityIndexKey(ws, fromHash, [16]byte(engramID))
+	idxToKey := keys.RelEntityIndexKey(ws, toHash, [16]byte(engramID))
+
+	batch := ps.db.NewBatch()
+	defer batch.Close()
+	if err := batch.Set(relKey, val, nil); err != nil {
+		return fmt.Errorf("upsert relationship record: set 0x21: %w", err)
+	}
+	if err := batch.Set(idxFromKey, nil, nil); err != nil {
+		return fmt.Errorf("upsert relationship record: set 0x26 from: %w", err)
+	}
+	if err := batch.Set(idxToKey, nil, nil); err != nil {
+		return fmt.Errorf("upsert relationship record: set 0x26 to: %w", err)
+	}
+	return batch.Commit(pebble.NoSync)
 }
 
 const (
@@ -671,11 +768,25 @@ func (ps *PebbleStore) deleteEntityLinks(ws [8]byte, engramID [16]byte, batch *p
 		}
 		return entityNames, fmt.Errorf("delete entity links: rel iter: %w", err)
 	}
+	// 0x21 key layout: 0x21(1) | ws(8) | engramID(16) | fromHash(8) | relTypeByte(1) | toHash(8) = 42 bytes
+	// fromHash starts at byte 25; toHash starts at byte 34.
+	const relFromHashOffset = 25
+	const relToHashOffset = 34
+	const relKeyLen = 42
 	for valid := relIter.First(); valid; valid = relIter.Next() {
 		k := relIter.Key()
 		keyCopy := make([]byte, len(k))
 		copy(keyCopy, k)
 		batch.Delete(keyCopy, nil)
+		// Also delete the two 0x26 relationship entity index entries.
+		// Extract fromHash and toHash directly from the key bytes — no msgpack decode needed.
+		if len(k) == relKeyLen {
+			var fromHash, toHash [8]byte
+			copy(fromHash[:], k[relFromHashOffset:relFromHashOffset+8])
+			copy(toHash[:], k[relToHashOffset:relToHashOffset+8])
+			batch.Delete(keys.RelEntityIndexKey(ws, fromHash, engramID), nil)
+			batch.Delete(keys.RelEntityIndexKey(ws, toHash, engramID), nil)
+		}
 	}
 	if err := relIter.Close(); err != nil {
 		return nil, fmt.Errorf("delete entity links: rel iter close: %w", err)

--- a/internal/storage/entity.go
+++ b/internal/storage/entity.go
@@ -224,6 +224,39 @@ func (ps *PebbleStore) WriteEntityEngramLink(ctx context.Context, ws [8]byte, en
 	return batch.Commit(pebble.NoSync)
 }
 
+// RelinkEntityEngramLink atomically moves a vault-scoped engram link from fromEntity
+// to toEntity in a single Pebble batch. It writes the 0x20 forward and 0x23 reverse
+// keys for toEntity and deletes the corresponding keys for fromEntity — four key
+// operations committed together, eliminating any crash window where the engram would
+// appear linked to both entities or to neither.
+//
+// This is the correct primitive for MergeEntity: calling WriteEntityEngramLink(B)
+// followed by a separate DeleteEntityEngramLink(A) leaves a window between two commits
+// where a crash yields inconsistent state. RelinkEntityEngramLink removes that window.
+func (ps *PebbleStore) RelinkEntityEngramLink(ctx context.Context, ws [8]byte, engramID ULID, fromEntity, toEntity string) error {
+	fromHash := keys.EntityNameHash(fromEntity)
+	toHash := keys.EntityNameHash(toEntity)
+	id := [16]byte(engramID)
+
+	batch := ps.db.NewBatch()
+	defer batch.Close()
+	// Write new links for toEntity.
+	if err := batch.Set(keys.EntityEngramLinkKey(ws, id, toHash), []byte(toEntity), nil); err != nil {
+		return fmt.Errorf("relink entity engram link: set fwd: %w", err)
+	}
+	if err := batch.Set(keys.EntityReverseIndexKey(toHash, ws, id), nil, nil); err != nil {
+		return fmt.Errorf("relink entity engram link: set rev: %w", err)
+	}
+	// Delete stale links for fromEntity.
+	if err := batch.Delete(keys.EntityEngramLinkKey(ws, id, fromHash), nil); err != nil {
+		return fmt.Errorf("relink entity engram link: del fwd: %w", err)
+	}
+	if err := batch.Delete(keys.EntityReverseIndexKey(fromHash, ws, id), nil); err != nil {
+		return fmt.Errorf("relink entity engram link: del rev: %w", err)
+	}
+	return batch.Commit(pebble.NoSync)
+}
+
 // DeleteEntityEngramLink deletes the 0x20 forward key and 0x23 reverse key for a
 // specific (engram, entity) pair atomically in a single Pebble batch.
 // Used by MergeEntity to remove stale links for the merged-away entity A after

--- a/internal/storage/entity.go
+++ b/internal/storage/entity.go
@@ -540,6 +540,151 @@ func (ps *PebbleStore) ScanEntityRelationships(ctx context.Context, ws [8]byte, 
 	return nil
 }
 
+// RelinkRelationshipEntity updates all 0x21 relationship records in vault ws where
+// oldName appears as fromEntity or toEntity, replacing it with newName. The 0x26
+// relationship entity index is updated in the same batch as each 0x21 rewrite: the
+// old-hash entry is deleted and a new-hash entry is written.
+//
+// Called by MergeEntity after relinking engram-entity links so that relationship
+// records stay consistent with the canonical entity name. Each engram's updates are
+// committed in a single batch — delete old 0x21 key, set new 0x21 key (updated name
+// + updated hash in key), delete old 0x26 entry, set new 0x26 entry.
+//
+// If oldName and newName hash identically (same canonical form after normalisation)
+// this is a no-op.
+func (ps *PebbleStore) RelinkRelationshipEntity(ctx context.Context, ws [8]byte, oldName, newName string) error {
+	oldHash := keys.EntityNameHash(oldName)
+	newHash := keys.EntityNameHash(newName)
+	if oldHash == newHash {
+		return nil // same canonical hash — nothing to do
+	}
+
+	// Collect engramIDs referencing oldName via the 0x26 index.
+	idxIter, err := PrefixIterator(ps.db, keys.RelEntityIndexPrefix(ws, oldHash))
+	if err != nil {
+		return fmt.Errorf("relink relationship entity: idx iter: %w", err)
+	}
+	var engramIDs [][16]byte
+	seen := make(map[[16]byte]struct{})
+	for valid := idxIter.First(); valid; valid = idxIter.Next() {
+		k := idxIter.Key()
+		if len(k) != 33 {
+			continue
+		}
+		var id [16]byte
+		copy(id[:], k[17:33])
+		if _, already := seen[id]; !already {
+			seen[id] = struct{}{}
+			engramIDs = append(engramIDs, id)
+		}
+	}
+	if err := idxIter.Close(); err != nil {
+		return fmt.Errorf("relink relationship entity: idx iter close: %w", err)
+	}
+
+	const (
+		relKeyLen        = 42
+		relFromHashStart = 25
+		relToHashStart   = 34
+		relTypeBytePosn  = 33
+	)
+
+	for _, id := range engramIDs {
+		relIter, err := PrefixIterator(ps.db, keys.RelationshipEngramPrefix(ws, id))
+		if err != nil {
+			return fmt.Errorf("relink relationship entity: rel iter: %w", err)
+		}
+
+		type relUpdate struct {
+			oldKey []byte
+			newKey []byte
+			newVal []byte
+		}
+		var updates []relUpdate
+
+		for valid := relIter.First(); valid; valid = relIter.Next() {
+			k := relIter.Key()
+			if len(k) != relKeyLen {
+				continue
+			}
+			var rec RelationshipRecord
+			if err := msgpack.Unmarshal(relIter.Value(), &rec); err != nil {
+				continue
+			}
+			fromMatches := rec.FromEntity == oldName
+			toMatches := rec.ToEntity == oldName
+			if !fromMatches && !toMatches {
+				continue
+			}
+
+			oldKey := make([]byte, relKeyLen)
+			copy(oldKey, k)
+
+			if fromMatches {
+				rec.FromEntity = newName
+			}
+			if toMatches {
+				rec.ToEntity = newName
+			}
+			rec.UpdatedAt = time.Now().UnixNano()
+
+			newVal, err := msgpack.Marshal(rec)
+			if err != nil {
+				relIter.Close()
+				return fmt.Errorf("relink relationship entity: marshal: %w", err)
+			}
+
+			// Build the new 0x21 key — only the changed hash slot(s) differ.
+			var fromHash, toHash [8]byte
+			copy(fromHash[:], k[relFromHashStart:relFromHashStart+8])
+			copy(toHash[:], k[relToHashStart:relToHashStart+8])
+			relTypeByte := k[relTypeBytePosn]
+			if fromMatches {
+				fromHash = newHash
+			}
+			if toMatches {
+				toHash = newHash
+			}
+			newRelKey := keys.RelationshipKey(ws, id, fromHash, relTypeByte, toHash)
+			updates = append(updates, relUpdate{oldKey: oldKey, newKey: newRelKey, newVal: newVal})
+		}
+		if err := relIter.Close(); err != nil {
+			return fmt.Errorf("relink relationship entity: rel iter close: %w", err)
+		}
+		if len(updates) == 0 {
+			continue
+		}
+
+		// Apply all updates for this engram atomically.
+		batch := ps.db.NewBatch()
+		for _, u := range updates {
+			if err := batch.Delete(u.oldKey, nil); err != nil {
+				batch.Close()
+				return fmt.Errorf("relink relationship entity: delete old rel: %w", err)
+			}
+			if err := batch.Set(u.newKey, u.newVal, nil); err != nil {
+				batch.Close()
+				return fmt.Errorf("relink relationship entity: set new rel: %w", err)
+			}
+			// Swap 0x26 index entry: remove old-hash pointer, add new-hash pointer.
+			if err := batch.Delete(keys.RelEntityIndexKey(ws, oldHash, id), nil); err != nil {
+				batch.Close()
+				return fmt.Errorf("relink relationship entity: delete old idx: %w", err)
+			}
+			if err := batch.Set(keys.RelEntityIndexKey(ws, newHash, id), nil, nil); err != nil {
+				batch.Close()
+				return fmt.Errorf("relink relationship entity: set new idx: %w", err)
+			}
+		}
+		if err := batch.Commit(pebble.NoSync); err != nil {
+			batch.Close()
+			return fmt.Errorf("relink relationship entity: commit: %w", err)
+		}
+		batch.Close()
+	}
+	return nil
+}
+
 // UpsertRelationshipRecord writes a vault-scoped relationship record at 0x21 and
 // the corresponding 0x26 relationship entity index entries for both fromEntity and
 // toEntity. All three writes are committed atomically in a single Pebble batch.

--- a/internal/storage/impl.go
+++ b/internal/storage/impl.go
@@ -69,8 +69,11 @@ type PebbleStore struct {
 	// cold-start loads and periodic flushes.
 	transCache *TransitionCache
 	closeOnce   sync.Once
-	entityLocks       sync.Map // key: normalized entity name → *sync.Mutex
-	coOccurrenceLocks sync.Map // key: "hashA:hashB" → *sync.Mutex
+	// entityLocks and coOccurrenceLocks use fixed-size striped mutex arrays instead of
+	// sync.Map to bound memory growth. sync.Map grows unbounded (one entry per unique key
+	// ever seen); stripedMutex uses a constant 256 × sizeof(sync.Mutex) ≈ 6 KB.
+	entityLocks       stripedMutex // prevents TOCTOU in UpsertEntityRecord
+	coOccurrenceLocks stripedMutex // prevents TOCTOU in IncrementEntityCoOccurrence
 	// archiveBloom is an in-memory Bloom filter over src engram IDs that have
 	// archived associations in the 0x25 namespace. Gates the 0x25 prefix scan
 	// during BFS traversal: if the filter says "no," skip the scan entirely.

--- a/internal/storage/keys/keys.go
+++ b/internal/storage/keys/keys.go
@@ -678,6 +678,30 @@ func IdempotencyKey(opID string) []byte {
 	return key
 }
 
+// RelEntityIndexKey constructs the relationship entity index key (0x26 prefix).
+// Written for BOTH fromEntity and toEntity on every UpsertRelationshipRecord call.
+// Enables O(engrams-referencing-entity) relationship lookup instead of a full vault scan.
+// Key: 0x26 | ws(8) | entityHash(8) | engramID(16) = 33 bytes
+// Value: empty (all data is encoded in the key).
+func RelEntityIndexKey(ws [8]byte, entityHash [8]byte, engramID [16]byte) []byte {
+	key := make([]byte, 1+8+8+16)
+	key[0] = 0x26
+	copy(key[1:9], ws[:])
+	copy(key[9:17], entityHash[:])
+	copy(key[17:33], engramID[:])
+	return key
+}
+
+// RelEntityIndexPrefix returns the 17-byte prefix for scanning all relationship
+// engrams for a given entity in a vault (0x26 | ws(8) | entityHash(8)).
+func RelEntityIndexPrefix(ws [8]byte, entityHash [8]byte) []byte {
+	key := make([]byte, 1+8+8)
+	key[0] = 0x26
+	copy(key[1:9], ws[:])
+	copy(key[9:17], entityHash[:])
+	return key
+}
+
 // ArchiveAssocKey constructs the archived association key (0x25 prefix).
 // No weight complement — archive keys are not sorted by weight.
 // No reverse key — restore is one-directional (BFS always traverses outbound edges).

--- a/internal/storage/migrate/v2_rel_entity_index.go
+++ b/internal/storage/migrate/v2_rel_entity_index.go
@@ -1,0 +1,101 @@
+package migrate
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/storage/keys"
+)
+
+// BackfillRelEntityIndex scans all existing 0x21 relationship keys and writes the
+// corresponding 0x26 relationship entity index entries (one for fromEntity, one for
+// toEntity) for any that are missing.
+//
+// This migration is required for the 0x26 secondary index introduced alongside the
+// ScanEntityRelationships optimisation. New writes populate the index automatically
+// via UpsertRelationshipRecord; this function backfills pre-existing data.
+//
+// The fromHash and toHash are extracted directly from the 0x21 key bytes — no msgpack
+// decode is needed. The migration is idempotent: Set on an already-present key is a no-op.
+//
+// 0x21 key layout (42 bytes):
+//
+//	0x21(1) | ws(8) | engramID(16) | fromHash(8) | relTypeByte(1) | toHash(8)
+//
+// Extracted offsets: ws=[1:9], engramID=[9:25], fromHash=[25:33], toHash=[34:42]
+func BackfillRelEntityIndex(db *pebble.DB) error {
+	iter, err := db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte{0x21},
+		UpperBound: []byte{0x22},
+	})
+	if err != nil {
+		return fmt.Errorf("backfill rel entity index: new iter: %w", err)
+	}
+	defer iter.Close()
+
+	const batchSize = 500
+	const relKeyLen = 42
+
+	batch := db.NewBatch()
+	batchCount := 0
+	written, skipped := 0, 0
+
+	for valid := iter.First(); valid; valid = iter.Next() {
+		k := iter.Key()
+		if len(k) != relKeyLen {
+			skipped++
+			continue
+		}
+
+		var ws [8]byte
+		var engramID [16]byte
+		var fromHash [8]byte
+		var toHash [8]byte
+
+		copy(ws[:], k[1:9])
+		copy(engramID[:], k[9:25])
+		copy(fromHash[:], k[25:33])
+		copy(toHash[:], k[34:42])
+
+		fromIdxKey := keys.RelEntityIndexKey(ws, fromHash, engramID)
+		toIdxKey := keys.RelEntityIndexKey(ws, toHash, engramID)
+
+		if err := batch.Set(fromIdxKey, nil, nil); err != nil {
+			batch.Close()
+			return fmt.Errorf("backfill rel entity index: set from key: %w", err)
+		}
+		if err := batch.Set(toIdxKey, nil, nil); err != nil {
+			batch.Close()
+			return fmt.Errorf("backfill rel entity index: set to key: %w", err)
+		}
+		batchCount++
+		written++
+
+		if batchCount >= batchSize {
+			if err := batch.Commit(pebble.Sync); err != nil {
+				batch.Close()
+				return fmt.Errorf("backfill rel entity index: commit batch: %w", err)
+			}
+			batch.Close()
+			batch = db.NewBatch()
+			batchCount = 0
+		}
+	}
+
+	if err := iter.Error(); err != nil {
+		batch.Close()
+		return fmt.Errorf("backfill rel entity index: iter: %w", err)
+	}
+
+	if batchCount > 0 {
+		if err := batch.Commit(pebble.Sync); err != nil {
+			batch.Close()
+			return fmt.Errorf("backfill rel entity index: commit final batch: %w", err)
+		}
+	}
+	batch.Close()
+
+	slog.Info("backfill rel entity index complete", "written", written, "skipped", skipped)
+	return nil
+}

--- a/internal/storage/migrate/v2_rel_entity_index.go
+++ b/internal/storage/migrate/v2_rel_entity_index.go
@@ -39,7 +39,9 @@ func BackfillRelEntityIndex(db *pebble.DB) error {
 
 	batch := db.NewBatch()
 	batchCount := 0
-	written, skipped := 0, 0
+	// relationships counts 0x21 keys processed; indexKeys counts 0x26 entries written
+	// (2 per relationship: one for fromHash, one for toHash).
+	relationships, indexKeys, skipped := 0, 0, 0
 
 	for valid := iter.First(); valid; valid = iter.Next() {
 		k := iter.Key()
@@ -70,7 +72,8 @@ func BackfillRelEntityIndex(db *pebble.DB) error {
 			return fmt.Errorf("backfill rel entity index: set to key: %w", err)
 		}
 		batchCount++
-		written++
+		relationships++
+		indexKeys += 2 // one for fromHash, one for toHash
 
 		if batchCount >= batchSize {
 			if err := batch.Commit(pebble.Sync); err != nil {
@@ -96,6 +99,10 @@ func BackfillRelEntityIndex(db *pebble.DB) error {
 	}
 	batch.Close()
 
-	slog.Info("backfill rel entity index complete", "written", written, "skipped", skipped)
+	slog.Info("backfill rel entity index complete",
+		"relationships", relationships,
+		"index_keys", indexKeys,
+		"skipped", skipped,
+	)
 	return nil
 }

--- a/internal/storage/migrate/v2_rel_entity_index_test.go
+++ b/internal/storage/migrate/v2_rel_entity_index_test.go
@@ -1,0 +1,255 @@
+package migrate
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/scrypster/muninndb/internal/storage/keys"
+)
+
+// makeRelKey builds a raw 0x21 relationship key without going through the storage
+// layer, matching the exact byte layout the migration reads from.
+func makeRelKey(ws [8]byte, engramID [16]byte, fromHash [8]byte, toHash [8]byte) []byte {
+	return keys.RelationshipKey(ws, engramID, fromHash, 0x01, toHash)
+}
+
+// hasRelEntityIndexKey returns true iff the 0x26 key for (ws, entityHash, engramID) exists in db.
+func hasRelEntityIndexKey(t *testing.T, db *pebble.DB, ws [8]byte, entityHash [8]byte, engramID [16]byte) bool {
+	t.Helper()
+	k := keys.RelEntityIndexKey(ws, entityHash, engramID)
+	_, closer, err := db.Get(k)
+	if err == pebble.ErrNotFound {
+		return false
+	}
+	if err != nil {
+		t.Fatalf("db.Get 0x26 key: %v", err)
+	}
+	closer.Close()
+	return true
+}
+
+// TestBackfillRelEntityIndex_WritesFromAndToEntries verifies that a single 0x21 key
+// produces one 0x26 entry for fromHash and one for toHash.
+func TestBackfillRelEntityIndex_WritesFromAndToEntries(t *testing.T) {
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	defer db.Close()
+
+	ws := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	engramID := [16]byte{1}
+	fromHash := [8]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}
+	toHash := [8]byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}
+
+	relKey := makeRelKey(ws, engramID, fromHash, toHash)
+	if err := db.Set(relKey, nil, pebble.Sync); err != nil {
+		t.Fatalf("set 0x21 key: %v", err)
+	}
+
+	if err := BackfillRelEntityIndex(db); err != nil {
+		t.Fatalf("BackfillRelEntityIndex: %v", err)
+	}
+
+	if !hasRelEntityIndexKey(t, db, ws, fromHash, engramID) {
+		t.Error("missing 0x26 entry for fromHash after backfill")
+	}
+	if !hasRelEntityIndexKey(t, db, ws, toHash, engramID) {
+		t.Error("missing 0x26 entry for toHash after backfill")
+	}
+}
+
+// TestBackfillRelEntityIndex_Idempotent verifies that running the migration twice
+// does not error and does not alter the existing 0x26 entries.
+func TestBackfillRelEntityIndex_Idempotent(t *testing.T) {
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	defer db.Close()
+
+	ws := [8]byte{0x10}
+	engramID := [16]byte{2}
+	fromHash := [8]byte{0x11}
+	toHash := [8]byte{0x22}
+
+	relKey := makeRelKey(ws, engramID, fromHash, toHash)
+	if err := db.Set(relKey, nil, pebble.Sync); err != nil {
+		t.Fatalf("set 0x21 key: %v", err)
+	}
+
+	// First run.
+	if err := BackfillRelEntityIndex(db); err != nil {
+		t.Fatalf("BackfillRelEntityIndex (first): %v", err)
+	}
+	// Second run — must be a no-op, no error.
+	if err := BackfillRelEntityIndex(db); err != nil {
+		t.Fatalf("BackfillRelEntityIndex (second): %v", err)
+	}
+
+	// Both 0x26 entries must still exist.
+	if !hasRelEntityIndexKey(t, db, ws, fromHash, engramID) {
+		t.Error("0x26 fromHash entry missing after second run")
+	}
+	if !hasRelEntityIndexKey(t, db, ws, toHash, engramID) {
+		t.Error("0x26 toHash entry missing after second run")
+	}
+}
+
+// TestBackfillRelEntityIndex_SkipsMalformedKey verifies that 0x21-prefixed keys with
+// the wrong length are silently skipped and do not cause an error.
+func TestBackfillRelEntityIndex_SkipsMalformedKey(t *testing.T) {
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	defer db.Close()
+
+	// Write a truncated 0x21 key (wrong length).
+	malformed := []byte{0x21, 0x00, 0x01, 0x02} // only 4 bytes, not 42
+	if err := db.Set(malformed, nil, pebble.Sync); err != nil {
+		t.Fatalf("set malformed key: %v", err)
+	}
+
+	// Must not return an error.
+	if err := BackfillRelEntityIndex(db); err != nil {
+		t.Fatalf("BackfillRelEntityIndex with malformed key: %v", err)
+	}
+
+	// No 0x26 entries should have been written (malformed key skipped).
+	iter, iterErr := db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte{0x26},
+		UpperBound: []byte{0x27},
+	})
+	if iterErr != nil {
+		t.Fatalf("new iter for 0x26 scan: %v", iterErr)
+	}
+	defer iter.Close()
+	if iter.First() {
+		t.Errorf("unexpected 0x26 entry written for malformed 0x21 key: %x", iter.Key())
+	}
+}
+
+// TestBackfillRelEntityIndex_MultiRecord verifies that multiple 0x21 keys across
+// different vaults are all backfilled correctly.
+func TestBackfillRelEntityIndex_MultiRecord(t *testing.T) {
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	defer db.Close()
+
+	type relEntry struct {
+		ws       [8]byte
+		engramID [16]byte
+		fromHash [8]byte
+		toHash   [8]byte
+	}
+	entries := []relEntry{
+		{
+			ws:       [8]byte{0x01},
+			engramID: [16]byte{0x01},
+			fromHash: [8]byte{0xAA},
+			toHash:   [8]byte{0xBB},
+		},
+		{
+			ws:       [8]byte{0x02},
+			engramID: [16]byte{0x02},
+			fromHash: [8]byte{0xCC},
+			toHash:   [8]byte{0xDD},
+		},
+		{
+			ws:       [8]byte{0x01}, // same vault, different engram
+			engramID: [16]byte{0x03},
+			fromHash: [8]byte{0xEE},
+			toHash:   [8]byte{0xFF},
+		},
+	}
+
+	for _, e := range entries {
+		k := makeRelKey(e.ws, e.engramID, e.fromHash, e.toHash)
+		if err := db.Set(k, nil, pebble.Sync); err != nil {
+			t.Fatalf("set 0x21 key: %v", err)
+		}
+	}
+
+	if err := BackfillRelEntityIndex(db); err != nil {
+		t.Fatalf("BackfillRelEntityIndex: %v", err)
+	}
+
+	for _, e := range entries {
+		if !hasRelEntityIndexKey(t, db, e.ws, e.fromHash, e.engramID) {
+			t.Errorf("missing 0x26 fromHash for ws=%x engramID=%x", e.ws, e.engramID)
+		}
+		if !hasRelEntityIndexKey(t, db, e.ws, e.toHash, e.engramID) {
+			t.Errorf("missing 0x26 toHash for ws=%x engramID=%x", e.ws, e.engramID)
+		}
+	}
+}
+
+// TestBackfillRelEntityIndex_EmptyDB verifies that an empty database is a no-op.
+func TestBackfillRelEntityIndex_EmptyDB(t *testing.T) {
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	defer db.Close()
+
+	if err := BackfillRelEntityIndex(db); err != nil {
+		t.Fatalf("BackfillRelEntityIndex on empty DB: %v", err)
+	}
+}
+
+// TestBackfillRelEntityIndex_KeyLayout verifies that the 0x26 key byte layout
+// matches the expected structure: 0x26 | ws(8) | entityHash(8) | engramID(16).
+func TestBackfillRelEntityIndex_KeyLayout(t *testing.T) {
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	defer db.Close()
+
+	ws := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	engramID := [16]byte{
+		0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+		0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+	}
+	fromHash := [8]byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22}
+	toHash := [8]byte{0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00}
+
+	relKey := makeRelKey(ws, engramID, fromHash, toHash)
+	if err := db.Set(relKey, nil, pebble.Sync); err != nil {
+		t.Fatalf("set 0x21 key: %v", err)
+	}
+
+	if err := BackfillRelEntityIndex(db); err != nil {
+		t.Fatalf("BackfillRelEntityIndex: %v", err)
+	}
+
+	// Verify raw byte layout of the fromHash 0x26 key.
+	expectedFromKey := keys.RelEntityIndexKey(ws, fromHash, engramID)
+	if len(expectedFromKey) != 33 {
+		t.Fatalf("expected 0x26 key to be 33 bytes, got %d", len(expectedFromKey))
+	}
+	if expectedFromKey[0] != 0x26 {
+		t.Errorf("key[0] = 0x%02X, want 0x26", expectedFromKey[0])
+	}
+	if !bytes.Equal(expectedFromKey[1:9], ws[:]) {
+		t.Errorf("key[1:9] = %x, want ws %x", expectedFromKey[1:9], ws)
+	}
+	if !bytes.Equal(expectedFromKey[9:17], fromHash[:]) {
+		t.Errorf("key[9:17] = %x, want fromHash %x", expectedFromKey[9:17], fromHash)
+	}
+	if !bytes.Equal(expectedFromKey[17:33], engramID[:]) {
+		t.Errorf("key[17:33] = %x, want engramID %x", expectedFromKey[17:33], engramID)
+	}
+
+	// Confirm the key actually exists in the db.
+	_, closer, err := db.Get(expectedFromKey)
+	if err != nil {
+		t.Fatalf("0x26 key not found after backfill: %v", err)
+	}
+	closer.Close()
+}

--- a/internal/storage/rel_entity_index_test.go
+++ b/internal/storage/rel_entity_index_test.go
@@ -254,3 +254,108 @@ func TestDeleteEntityEngramLink_NoopOnMissing(t *testing.T) {
 	// Must not error on a link that doesn't exist.
 	require.NoError(t, store.DeleteEntityEngramLink(ctx, ws, id, "NonExistent"))
 }
+
+// ---------------------------------------------------------------------------
+// RelinkEntityEngramLink
+// ---------------------------------------------------------------------------
+
+// TestRelinkEntityEngramLink_AtomicMoveWritesBAndDeletesA verifies that a single
+// RelinkEntityEngramLink call correctly writes the 0x20/0x23 links for toEntity
+// and removes the 0x20/0x23 links for fromEntity — all visible as one atomic change.
+func TestRelinkEntityEngramLink_AtomicMoveWritesBAndDeletesA(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("relink-entity-link")
+
+	require.NoError(t, store.UpsertEntityRecord(ctx, EntityRecord{
+		Name: "Postgre SQL", Type: "database", Confidence: 0.8,
+	}, "test"))
+	require.NoError(t, store.UpsertEntityRecord(ctx, EntityRecord{
+		Name: "PostgreSQL", Type: "database", Confidence: 0.9,
+	}, "test"))
+
+	eng := makeTestEngram("relink test engram")
+	_, err := store.WriteEngram(ctx, ws, eng)
+	require.NoError(t, err)
+	require.NoError(t, store.WriteEntityEngramLink(ctx, ws, eng.ID, "Postgre SQL"))
+
+	// Baseline: A has one reverse link, B has none.
+	var beforeA, beforeB []ULID
+	require.NoError(t, store.ScanEntityEngrams(ctx, "Postgre SQL", func(_ [8]byte, id ULID) error {
+		beforeA = append(beforeA, id)
+		return nil
+	}))
+	require.NoError(t, store.ScanEntityEngrams(ctx, "PostgreSQL", func(_ [8]byte, id ULID) error {
+		beforeB = append(beforeB, id)
+		return nil
+	}))
+	require.Len(t, beforeA, 1, "entity A must have one reverse link before relink")
+	require.Empty(t, beforeB, "entity B must have no reverse links before relink")
+
+	// Relink atomically.
+	require.NoError(t, store.RelinkEntityEngramLink(ctx, ws, eng.ID, "Postgre SQL", "PostgreSQL"))
+
+	// After relink: A's 0x23 reverse link must be gone.
+	var afterA []ULID
+	require.NoError(t, store.ScanEntityEngrams(ctx, "Postgre SQL", func(_ [8]byte, id ULID) error {
+		afterA = append(afterA, id)
+		return nil
+	}))
+	assert.Empty(t, afterA, "entity A 0x23 reverse link must be removed by RelinkEntityEngramLink")
+
+	// After relink: B's 0x23 reverse link must be present.
+	var afterB []ULID
+	require.NoError(t, store.ScanEntityEngrams(ctx, "PostgreSQL", func(_ [8]byte, id ULID) error {
+		afterB = append(afterB, id)
+		return nil
+	}))
+	require.Len(t, afterB, 1, "entity B must have one reverse link after relink")
+
+	// After relink: forward index must show B, not A.
+	var entities []string
+	require.NoError(t, store.ScanEngramEntities(ctx, ws, eng.ID, func(name string) error {
+		entities = append(entities, name)
+		return nil
+	}))
+	assert.Contains(t, entities, "PostgreSQL", "0x20 forward link for B must exist after relink")
+	assert.NotContains(t, entities, "Postgre SQL", "0x20 forward link for A must be gone after relink")
+}
+
+// TestRelinkEntityEngramLink_IdempotentOnRepeat verifies that calling RelinkEntityEngramLink
+// twice (e.g. after a crash-restart) produces the same correct state.
+func TestRelinkEntityEngramLink_IdempotentOnRepeat(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("relink-entity-link-idempotent")
+
+	require.NoError(t, store.UpsertEntityRecord(ctx, EntityRecord{
+		Name: "Postgre SQL", Type: "database", Confidence: 0.8,
+	}, "test"))
+	require.NoError(t, store.UpsertEntityRecord(ctx, EntityRecord{
+		Name: "PostgreSQL", Type: "database", Confidence: 0.9,
+	}, "test"))
+
+	eng := makeTestEngram("idempotent relink engram")
+	_, err := store.WriteEngram(ctx, ws, eng)
+	require.NoError(t, err)
+	require.NoError(t, store.WriteEntityEngramLink(ctx, ws, eng.ID, "Postgre SQL"))
+
+	// First relink.
+	require.NoError(t, store.RelinkEntityEngramLink(ctx, ws, eng.ID, "Postgre SQL", "PostgreSQL"))
+	// Second relink — must not error and must leave state identical.
+	require.NoError(t, store.RelinkEntityEngramLink(ctx, ws, eng.ID, "Postgre SQL", "PostgreSQL"))
+
+	var afterA []ULID
+	require.NoError(t, store.ScanEntityEngrams(ctx, "Postgre SQL", func(_ [8]byte, id ULID) error {
+		afterA = append(afterA, id)
+		return nil
+	}))
+	assert.Empty(t, afterA, "entity A must have no reverse links after repeated relink")
+
+	var afterB []ULID
+	require.NoError(t, store.ScanEntityEngrams(ctx, "PostgreSQL", func(_ [8]byte, id ULID) error {
+		afterB = append(afterB, id)
+		return nil
+	}))
+	require.Len(t, afterB, 1, "entity B must have exactly one reverse link after repeated relink")
+}

--- a/internal/storage/rel_entity_index_test.go
+++ b/internal/storage/rel_entity_index_test.go
@@ -1,0 +1,256 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// UpsertRelationshipRecord — 0x26 index writes
+// ---------------------------------------------------------------------------
+
+func TestUpsertRelationshipRecord_WritesRelEntityIndex(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("rel-index-write")
+
+	eng := makeTestEngram("relationship index write test")
+	_, err := store.WriteEngram(ctx, ws, eng)
+	require.NoError(t, err)
+
+	require.NoError(t, store.UpsertRelationshipRecord(ctx, ws, eng.ID, RelationshipRecord{
+		FromEntity: "payment-service",
+		ToEntity:   "PostgreSQL",
+		RelType:    "uses",
+		Weight:     0.9,
+		Source:     "test",
+	}))
+
+	// ScanEntityRelationships must find the record via the 0x26 index for fromEntity.
+	var fromRels []RelationshipRecord
+	require.NoError(t, store.ScanEntityRelationships(ctx, ws, "payment-service",
+		func(r RelationshipRecord) error {
+			fromRels = append(fromRels, r)
+			return nil
+		}))
+	require.Len(t, fromRels, 1, "0x26 index must route fromEntity query to the record")
+	assert.Equal(t, "payment-service", fromRels[0].FromEntity)
+	assert.Equal(t, "PostgreSQL", fromRels[0].ToEntity)
+
+	// ScanEntityRelationships must also find the record via the 0x26 index for toEntity.
+	var toRels []RelationshipRecord
+	require.NoError(t, store.ScanEntityRelationships(ctx, ws, "PostgreSQL",
+		func(r RelationshipRecord) error {
+			toRels = append(toRels, r)
+			return nil
+		}))
+	require.Len(t, toRels, 1, "0x26 index must route toEntity query to the record")
+	assert.Equal(t, "PostgreSQL", toRels[0].ToEntity)
+}
+
+// ---------------------------------------------------------------------------
+// ScanEntityRelationships — filtering
+// ---------------------------------------------------------------------------
+
+func TestScanEntityRelationships_ReturnsOnlyEntityRelationships(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("rel-index-filter")
+
+	eng1 := makeTestEngram("engram one")
+	eng2 := makeTestEngram("engram two")
+	_, err := store.WriteEngram(ctx, ws, eng1)
+	require.NoError(t, err)
+	_, err = store.WriteEngram(ctx, ws, eng2)
+	require.NoError(t, err)
+
+	// eng1 has payment-service → PostgreSQL
+	require.NoError(t, store.UpsertRelationshipRecord(ctx, ws, eng1.ID, RelationshipRecord{
+		FromEntity: "payment-service",
+		ToEntity:   "PostgreSQL",
+		RelType:    "uses",
+		Weight:     0.9,
+		Source:     "test",
+	}))
+	// eng2 has auth-service → Redis (unrelated to PostgreSQL)
+	require.NoError(t, store.UpsertRelationshipRecord(ctx, ws, eng2.ID, RelationshipRecord{
+		FromEntity: "auth-service",
+		ToEntity:   "Redis",
+		RelType:    "uses",
+		Weight:     0.8,
+		Source:     "test",
+	}))
+
+	var rels []RelationshipRecord
+	require.NoError(t, store.ScanEntityRelationships(ctx, ws, "PostgreSQL",
+		func(r RelationshipRecord) error {
+			rels = append(rels, r)
+			return nil
+		}))
+
+	require.Len(t, rels, 1, "must only return relationships involving PostgreSQL")
+	assert.Equal(t, "PostgreSQL", rels[0].ToEntity)
+	assert.NotEqual(t, "Redis", rels[0].ToEntity, "unrelated Redis relationship must not appear")
+}
+
+func TestScanEntityRelationships_BothDirections(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("rel-index-directions")
+
+	eng1 := makeTestEngram("from direction")
+	eng2 := makeTestEngram("to direction")
+	_, err := store.WriteEngram(ctx, ws, eng1)
+	require.NoError(t, err)
+	_, err = store.WriteEngram(ctx, ws, eng2)
+	require.NoError(t, err)
+
+	// eng1: PostgreSQL is fromEntity
+	require.NoError(t, store.UpsertRelationshipRecord(ctx, ws, eng1.ID, RelationshipRecord{
+		FromEntity: "PostgreSQL",
+		ToEntity:   "payment-service",
+		RelType:    "used_by",
+		Weight:     0.8,
+		Source:     "test",
+	}))
+	// eng2: PostgreSQL is toEntity
+	require.NoError(t, store.UpsertRelationshipRecord(ctx, ws, eng2.ID, RelationshipRecord{
+		FromEntity: "auth-service",
+		ToEntity:   "PostgreSQL",
+		RelType:    "uses",
+		Weight:     0.9,
+		Source:     "test",
+	}))
+
+	var rels []RelationshipRecord
+	require.NoError(t, store.ScanEntityRelationships(ctx, ws, "PostgreSQL",
+		func(r RelationshipRecord) error {
+			rels = append(rels, r)
+			return nil
+		}))
+
+	require.Len(t, rels, 2, "must find records where entity is either from or to")
+}
+
+func TestScanEntityRelationships_NoopOnMissing(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("rel-index-noop")
+
+	var rels []RelationshipRecord
+	require.NoError(t, store.ScanEntityRelationships(ctx, ws, "NonExistent",
+		func(r RelationshipRecord) error {
+			rels = append(rels, r)
+			return nil
+		}))
+	assert.Empty(t, rels, "must return empty for entity with no relationships")
+}
+
+// ---------------------------------------------------------------------------
+// DeleteEngram — 0x26 index cleanup
+// ---------------------------------------------------------------------------
+
+func TestDeleteEngram_CleansRelEntityIndex(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("rel-index-cleanup")
+
+	eng := makeTestEngram("relationship cleanup test")
+	_, err := store.WriteEngram(ctx, ws, eng)
+	require.NoError(t, err)
+
+	require.NoError(t, store.UpsertRelationshipRecord(ctx, ws, eng.ID, RelationshipRecord{
+		FromEntity: "payment-service",
+		ToEntity:   "PostgreSQL",
+		RelType:    "uses",
+		Weight:     0.9,
+		Source:     "test",
+	}))
+
+	// Verify 0x26 index is populated before delete.
+	var before []RelationshipRecord
+	require.NoError(t, store.ScanEntityRelationships(ctx, ws, "PostgreSQL",
+		func(r RelationshipRecord) error {
+			before = append(before, r)
+			return nil
+		}))
+	require.Len(t, before, 1, "0x26 index must be populated before delete")
+
+	require.NoError(t, store.DeleteEngram(ctx, ws, eng.ID))
+
+	// After hard delete: 0x26 entries must be gone.
+	var after []RelationshipRecord
+	require.NoError(t, store.ScanEntityRelationships(ctx, ws, "PostgreSQL",
+		func(r RelationshipRecord) error {
+			after = append(after, r)
+			return nil
+		}))
+	assert.Empty(t, after, "0x26 relationship entity index must be cleaned up after DeleteEngram")
+
+	// Also verify from-entity side.
+	var fromAfter []RelationshipRecord
+	require.NoError(t, store.ScanEntityRelationships(ctx, ws, "payment-service",
+		func(r RelationshipRecord) error {
+			fromAfter = append(fromAfter, r)
+			return nil
+		}))
+	assert.Empty(t, fromAfter, "0x26 from-entity index must also be cleaned up after DeleteEngram")
+}
+
+// ---------------------------------------------------------------------------
+// DeleteEntityEngramLink
+// ---------------------------------------------------------------------------
+
+func TestDeleteEntityEngramLink_RemovesForwardAndReverseKeys(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("delete-entity-link")
+
+	require.NoError(t, store.UpsertEntityRecord(ctx, EntityRecord{
+		Name: "PostgreSQL", Type: "database", Confidence: 0.9,
+	}, "test"))
+
+	eng := makeTestEngram("test engram")
+	_, err := store.WriteEngram(ctx, ws, eng)
+	require.NoError(t, err)
+	require.NoError(t, store.WriteEntityEngramLink(ctx, ws, eng.ID, "PostgreSQL"))
+
+	// Verify reverse link exists before delete.
+	var before []ULID
+	require.NoError(t, store.ScanEntityEngrams(ctx, "PostgreSQL", func(_ [8]byte, id ULID) error {
+		before = append(before, id)
+		return nil
+	}))
+	require.Len(t, before, 1)
+
+	require.NoError(t, store.DeleteEntityEngramLink(ctx, ws, eng.ID, "PostgreSQL"))
+
+	// Reverse link must be gone.
+	var after []ULID
+	require.NoError(t, store.ScanEntityEngrams(ctx, "PostgreSQL", func(_ [8]byte, id ULID) error {
+		after = append(after, id)
+		return nil
+	}))
+	assert.Empty(t, after, "0x23 reverse link must be removed by DeleteEntityEngramLink")
+
+	// Forward link must also be gone.
+	var entities []string
+	require.NoError(t, store.ScanEngramEntities(ctx, ws, eng.ID, func(name string) error {
+		entities = append(entities, name)
+		return nil
+	}))
+	assert.Empty(t, entities, "0x20 forward link must be removed by DeleteEntityEngramLink")
+}
+
+func TestDeleteEntityEngramLink_NoopOnMissing(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("delete-entity-link-noop")
+
+	id := NewULID()
+	// Must not error on a link that doesn't exist.
+	require.NoError(t, store.DeleteEntityEngramLink(ctx, ws, id, "NonExistent"))
+}

--- a/internal/storage/rel_entity_index_test.go
+++ b/internal/storage/rel_entity_index_test.go
@@ -52,6 +52,140 @@ func TestUpsertRelationshipRecord_WritesRelEntityIndex(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// RelinkRelationshipEntity
+// ---------------------------------------------------------------------------
+
+// TestRelinkRelationshipEntity_UpdatesFromAndToEntries verifies that after calling
+// RelinkRelationshipEntity(oldName, newName):
+//   - ScanEntityRelationships(oldName) returns 0 records
+//   - ScanEntityRelationships(newName) returns all records that previously referenced oldName
+//   - The record values themselves contain newName (not oldName)
+func TestRelinkRelationshipEntity_UpdatesFromAndToEntries(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("relink-rel-entity")
+
+	eng := makeTestEngram("relink relationship test")
+	_, err := store.WriteEngram(ctx, ws, eng)
+	require.NoError(t, err)
+
+	// Write a relationship: "Postgre SQL" uses "PostgreSQL".
+	require.NoError(t, store.UpsertRelationshipRecord(ctx, ws, eng.ID, RelationshipRecord{
+		FromEntity: "Postgre SQL",
+		ToEntity:   "PostgreSQL",
+		RelType:    "uses",
+		Weight:     0.9,
+		Source:     "test",
+	}))
+
+	// Before relink: ScanEntityRelationships("Postgre SQL") finds 1 record.
+	var before []RelationshipRecord
+	require.NoError(t, store.ScanEntityRelationships(ctx, ws, "Postgre SQL",
+		func(r RelationshipRecord) error {
+			before = append(before, r)
+			return nil
+		}))
+	require.Len(t, before, 1, "must find record before relink")
+
+	// Relink "Postgre SQL" → "PostgreSQL" in all relationship records.
+	require.NoError(t, store.RelinkRelationshipEntity(ctx, ws, "Postgre SQL", "PostgreSQL"))
+
+	// After relink: ScanEntityRelationships("Postgre SQL") must return nothing.
+	var afterOld []RelationshipRecord
+	require.NoError(t, store.ScanEntityRelationships(ctx, ws, "Postgre SQL",
+		func(r RelationshipRecord) error {
+			afterOld = append(afterOld, r)
+			return nil
+		}))
+	assert.Empty(t, afterOld, "ScanEntityRelationships for old name must return nothing after relink")
+
+	// ScanEntityRelationships("PostgreSQL") must find 1 record where both sides are "PostgreSQL".
+	var afterNew []RelationshipRecord
+	require.NoError(t, store.ScanEntityRelationships(ctx, ws, "PostgreSQL",
+		func(r RelationshipRecord) error {
+			afterNew = append(afterNew, r)
+			return nil
+		}))
+	require.Len(t, afterNew, 1, "ScanEntityRelationships for new name must return 1 record")
+	assert.Equal(t, "PostgreSQL", afterNew[0].FromEntity, "FromEntity must be updated to new name")
+	assert.Equal(t, "PostgreSQL", afterNew[0].ToEntity, "ToEntity must remain PostgreSQL")
+}
+
+// TestRelinkRelationshipEntity_ToEntitySide verifies the case where oldName appears
+// as toEntity (not fromEntity).
+func TestRelinkRelationshipEntity_ToEntitySide(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("relink-rel-to")
+
+	eng := makeTestEngram("relink to-entity test")
+	_, err := store.WriteEngram(ctx, ws, eng)
+	require.NoError(t, err)
+
+	require.NoError(t, store.UpsertRelationshipRecord(ctx, ws, eng.ID, RelationshipRecord{
+		FromEntity: "payment-service",
+		ToEntity:   "Postgre SQL",
+		RelType:    "uses",
+		Weight:     0.8,
+		Source:     "test",
+	}))
+
+	require.NoError(t, store.RelinkRelationshipEntity(ctx, ws, "Postgre SQL", "PostgreSQL"))
+
+	var rels []RelationshipRecord
+	require.NoError(t, store.ScanEntityRelationships(ctx, ws, "PostgreSQL",
+		func(r RelationshipRecord) error {
+			rels = append(rels, r)
+			return nil
+		}))
+	require.Len(t, rels, 1)
+	assert.Equal(t, "payment-service", rels[0].FromEntity)
+	assert.Equal(t, "PostgreSQL", rels[0].ToEntity, "ToEntity must be renamed")
+}
+
+// TestRelinkRelationshipEntity_NoopOnMissing verifies that calling RelinkRelationshipEntity
+// for an entity that has no relationships returns nil without error.
+func TestRelinkRelationshipEntity_NoopOnMissing(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("relink-rel-noop")
+	require.NoError(t, store.RelinkRelationshipEntity(ctx, ws, "NonExistent", "Target"))
+}
+
+// TestRelinkRelationshipEntity_IdempotentOnRepeat verifies that calling RelinkRelationshipEntity
+// twice produces the same correct final state.
+func TestRelinkRelationshipEntity_IdempotentOnRepeat(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("relink-rel-idempotent")
+
+	eng := makeTestEngram("idempotent relink rel")
+	_, err := store.WriteEngram(ctx, ws, eng)
+	require.NoError(t, err)
+
+	require.NoError(t, store.UpsertRelationshipRecord(ctx, ws, eng.ID, RelationshipRecord{
+		FromEntity: "Postgre SQL",
+		ToEntity:   "Redis",
+		RelType:    "uses",
+		Weight:     0.7,
+		Source:     "test",
+	}))
+
+	require.NoError(t, store.RelinkRelationshipEntity(ctx, ws, "Postgre SQL", "PostgreSQL"))
+	// Second call — must not error; old-hash entries are already gone, new-hash entries idempotently set.
+	require.NoError(t, store.RelinkRelationshipEntity(ctx, ws, "Postgre SQL", "PostgreSQL"))
+
+	var rels []RelationshipRecord
+	require.NoError(t, store.ScanEntityRelationships(ctx, ws, "PostgreSQL",
+		func(r RelationshipRecord) error {
+			rels = append(rels, r)
+			return nil
+		}))
+	require.Len(t, rels, 1)
+	assert.Equal(t, "PostgreSQL", rels[0].FromEntity)
+}
+
+// ---------------------------------------------------------------------------
 // ScanEntityRelationships — filtering
 // ---------------------------------------------------------------------------
 

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -200,7 +200,17 @@ type EngineStore interface {
 
 	// ScanRelationships scans all vault-scoped relationship records at the 0x21 prefix.
 	// Calls fn for each RelationshipRecord until fn returns a non-nil error or the scan is exhausted.
+	// Use ScanEntityRelationships for per-entity queries — this method does a full vault scan.
 	ScanRelationships(ctx context.Context, ws [8]byte, fn func(record RelationshipRecord) error) error
+
+	// ScanEntityRelationships returns all relationship records where entityName appears
+	// as fromEntity or toEntity, using the 0x26 relationship entity index.
+	// O(engrams-referencing-entity) instead of O(all vault relationships).
+	ScanEntityRelationships(ctx context.Context, ws [8]byte, entityName string, fn func(record RelationshipRecord) error) error
+
+	// DeleteEntityEngramLink deletes the 0x20 forward key and 0x23 reverse key for a
+	// specific (engram, entity) pair atomically. Used by MergeEntity to clean up stale links.
+	DeleteEntityEngramLink(ctx context.Context, ws [8]byte, engramID ULID, entityName string) error
 
 	// IncrementEntityCoOccurrence increments the co-occurrence count for two entity names
 	// within a vault. Uses the 0x24 index. Pair is stored in canonical (hashA <= hashB) order.

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -218,6 +218,12 @@ type EngineStore interface {
 	// specific (engram, entity) pair atomically. Used by MergeEntity to clean up stale links.
 	DeleteEntityEngramLink(ctx context.Context, ws [8]byte, engramID ULID, entityName string) error
 
+	// RelinkRelationshipEntity updates all 0x21 relationship records in vault ws where
+	// oldName appears as fromEntity or toEntity, replacing it with newName and updating
+	// both the 0x21 key (which encodes the entity hash) and the 0x26 index accordingly.
+	// Called by MergeEntity after relinking engram-entity links.
+	RelinkRelationshipEntity(ctx context.Context, ws [8]byte, oldName, newName string) error
+
 	// IncrementEntityCoOccurrence increments the co-occurrence count for two entity names
 	// within a vault. Uses the 0x24 index. Pair is stored in canonical (hashA <= hashB) order.
 	IncrementEntityCoOccurrence(ctx context.Context, ws [8]byte, nameA, nameB string) error

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -182,6 +182,12 @@ type EngineStore interface {
 	// WriteEntityEngramLink writes a vault-scoped engram→entity link.
 	WriteEntityEngramLink(ctx context.Context, ws [8]byte, engramID ULID, entityName string) error
 
+	// RelinkEntityEngramLink atomically moves a vault-scoped engram link from fromEntity
+	// to toEntity in a single Pebble batch, writing the new 0x20/0x23 keys for toEntity
+	// and deleting the stale 0x20/0x23 keys for fromEntity. Eliminates the crash window
+	// that exists when WriteEntityEngramLink and DeleteEntityEngramLink are called separately.
+	RelinkEntityEngramLink(ctx context.Context, ws [8]byte, engramID ULID, fromEntity, toEntity string) error
+
 	// ScanEntityEngrams scans the 0x23 reverse index for all vault-scoped (ws, engramID)
 	// pairs that mention the given entity name. Calls fn for each pair until fn returns
 	// a non-nil error or the index is exhausted.

--- a/internal/storage/striped_mutex.go
+++ b/internal/storage/striped_mutex.go
@@ -1,0 +1,26 @@
+package storage
+
+import (
+	"hash/fnv"
+	"sync"
+)
+
+const lockStripes = 256
+
+// stripedMutex is a fixed-size array of mutexes for lock striping.
+// Replaces unbounded sync.Map-based lock pools. Memory usage is constant at
+// lockStripes × sizeof(sync.Mutex) ≈ 6 KB regardless of key count.
+//
+// Two different keys may map to the same mutex stripe (false sharing), but at
+// 256 stripes this is negligible in practice and safe — contention causes
+// brief waiting, never data corruption.
+type stripedMutex struct {
+	mu [lockStripes]sync.Mutex
+}
+
+// For returns the mutex for the given byte key using FNV-32a hashing.
+func (s *stripedMutex) For(key []byte) *sync.Mutex {
+	h := fnv.New32a()
+	h.Write(key)
+	return &s.mu[h.Sum32()%lockStripes]
+}

--- a/internal/storage/striped_mutex_test.go
+++ b/internal/storage/striped_mutex_test.go
@@ -1,0 +1,136 @@
+package storage
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripedMutex_SameKeyReturnsSameStripe(t *testing.T) {
+	var s stripedMutex
+	key := []byte("PostgreSQL")
+	m1 := s.For(key)
+	m2 := s.For(key)
+	require.NotNil(t, m1)
+	assert.Same(t, m1, m2, "same key must always map to the same mutex stripe")
+}
+
+func TestStripedMutex_EmptyKey(t *testing.T) {
+	var s stripedMutex
+	mu := s.For([]byte{})
+	require.NotNil(t, mu, "For(empty) must return a non-nil mutex")
+}
+
+func TestStripedMutex_NilKey(t *testing.T) {
+	var s stripedMutex
+	mu := s.For(nil)
+	require.NotNil(t, mu, "For(nil) must return a non-nil mutex")
+}
+
+func TestStripedMutex_DistributesKeys(t *testing.T) {
+	// With 256 stripes and 100 distinct keys, we expect decent distribution.
+	// This is a probabilistic check — FNV-32a distributes well in practice.
+	var s stripedMutex
+	seen := make(map[*sync.Mutex]int)
+	for i := 0; i < 100; i++ {
+		key := []byte(fmt.Sprintf("entity-%d", i))
+		seen[s.For(key)]++
+	}
+	// With 100 keys across 256 stripes, we expect at least 10 distinct stripes used.
+	// Pure hash collision risk is negligible at this scale.
+	assert.GreaterOrEqual(t, len(seen), 10,
+		"poor distribution: only %d distinct stripes used for 100 keys", len(seen))
+}
+
+// TestStripedMutex_ConcurrentAccess verifies that the striped mutex correctly serialises
+// concurrent read-modify-write operations on the same key. Run with -race to detect races.
+func TestStripedMutex_ConcurrentAccess(t *testing.T) {
+	var s stripedMutex
+	key := []byte("shared-entity")
+
+	const goroutines = 64
+	const itersPerGoroutine = 100
+	counter := 0
+
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range itersPerGoroutine {
+				mu := s.For(key)
+				mu.Lock()
+				counter++ // unsynchronised increment — safe only under the stripe lock
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, goroutines*itersPerGoroutine, counter,
+		"concurrent increments must be fully serialised by the stripe lock")
+}
+
+// TestStripedMutex_IndependentKeys verifies that two different keys whose hashes
+// land on different stripes do not block each other.
+func TestStripedMutex_IndependentKeys(t *testing.T) {
+	var s stripedMutex
+
+	// Find two keys that hash to different stripes.
+	// We try pairs until we find one; this avoids depending on specific hash values.
+	var keyA, keyB []byte
+	for i := 0; i < 256; i++ {
+		a := []byte(fmt.Sprintf("alpha-%d", i))
+		b := []byte(fmt.Sprintf("beta-%d", i))
+		if s.For(a) != s.For(b) {
+			keyA, keyB = a, b
+			break
+		}
+	}
+	if keyA == nil {
+		t.Skip("could not find two keys on different stripes")
+	}
+
+	// Lock stripe A and confirm that stripe B is independently acquirable.
+	muA := s.For(keyA)
+	muB := s.For(keyB)
+
+	muA.Lock()
+	locked := make(chan struct{})
+	go func() {
+		muB.Lock()
+		close(locked)
+		muB.Unlock()
+	}()
+	// If muB were the same stripe as muA, this would deadlock.
+	select {
+	case <-locked:
+		// success — muB acquired independently
+	default:
+		// give the goroutine a moment to run
+		muA.Unlock()
+		<-locked
+		return
+	}
+	muA.Unlock()
+}
+
+// TestStripedMutex_BoundedMemory verifies that the type has a fixed number of mutexes
+// regardless of how many distinct keys are used. This is the core correctness property
+// (prevents unbounded sync.Map growth).
+func TestStripedMutex_BoundedMemory(t *testing.T) {
+	var s stripedMutex
+
+	// Call For() with 10,000 distinct keys.
+	seen := make(map[*sync.Mutex]struct{})
+	for i := range 10_000 {
+		seen[s.For([]byte(fmt.Sprintf("entity-%d", i)))] = struct{}{}
+	}
+
+	// Despite 10,000 distinct keys, the number of distinct mutexes must be capped at lockStripes.
+	assert.LessOrEqual(t, len(seen), lockStripes,
+		"stripedMutex must use at most %d distinct mutexes regardless of key count", lockStripes)
+}


### PR DESCRIPTION
## Summary

Addresses the 4 issues identified by Opus in the architectural review of the entity graph subsystem.

### Fix 1 — MergeEntity ghost links (correctness bug)
- **Problem**: `MergeEntity` wrote new 0x20/0x23 links for entity B but never deleted the old links for entity A. After a merge, `ScanEntityEngrams("A")` still returned all engrams — entity A was a permanent ghost in the index.
- **Fix**: New `DeleteEntityEngramLink` storage method deletes the 0x20 forward key and 0x23 reverse key atomically. `MergeEntity` now calls it for each engram after relinking.

### Fix 2 — Relationship entity secondary index (performance)
- **Problem**: `GetEntityAggregate` called `ScanRelationships(ws)` which scanned **all** 0x21 keys in the vault and filtered in Go — O(all vault relationships) for every single entity lookup.
- **Fix**: New 0x26 prefix `RelEntityIndexKey(ws, entityHash, engramID)` written for both fromEntity and toEntity on every `UpsertRelationshipRecord`. New `ScanEntityRelationships` uses this index for O(engrams-referencing-entity) lookup. `GetEntityAggregate` swapped to the new method.
- **Migration**: `BackfillRelEntityIndex` (v2) backfills 0x26 entries for existing 0x21 data on startup — batched in groups of 500, idempotent, no msgpack decode needed (hashes extracted directly from key bytes).

### Fix 3 — Striped mutex array (memory)
- **Problem**: `entityLocks` and `coOccurrenceLocks` were `sync.Map` instances that grew without bound — one entry per unique entity name and co-occurrence pair ever seen, with no eviction.
- **Fix**: New `stripedMutex` type: fixed 256-stripe array using FNV-32a. Memory bounded at ~6 KB constant regardless of entity count. False sharing at 1/256 is safe (causes brief waiting, never corruption).

### Fix 4 — Inverted trigram index in FindSimilarEntities (performance)
- **Problem**: O(n²) pairwise trigram comparison. At 1,000 entities: 500K comparisons.
- **Fix**: Build in-memory inverted index (trigram → `[]int` indices). For each entity, compare only candidates sharing ≥1 trigram. At threshold ≥ 0.5, candidates per entity is a small fraction of n. Results are mathematically identical for any threshold > 0 (Dice coefficient = 0 iff no shared trigrams).

## No breaking changes
- 0x1F entity records, 0x21 relationship records unchanged
- Migration v2 runs synchronously on startup before connections are accepted
- `ScanRelationships` preserved for full-vault graph export (unchanged behavior)
- Striped mutex is purely internal infrastructure

## Test plan
- [x] 9 new tests added covering all 4 fixes
- [x] `TestMergeEntity_DeletesStaleLinksForMergedEntity` — A's reverse index empty after merge
- [x] `TestMergeEntity_DryRun_PreservesAllLinks` — dry run leaves all links intact
- [x] `TestUpsertRelationshipRecord_WritesRelEntityIndex` — 0x26 written for from+to
- [x] `TestScanEntityRelationships_ReturnsOnlyEntityRelationships` — no false positives
- [x] `TestScanEntityRelationships_BothDirections` — finds records where entity is from OR to
- [x] `TestDeleteEngram_CleansRelEntityIndex` — 0x26 deleted on hard delete
- [x] `TestDeleteEntityEngramLink_RemovesForwardAndReverseKeys` — both keys deleted atomically
- [x] `TestFindSimilarEntities_InvertedIndexMatchesNaive` — optimised == naive for same input
- [x] Full suite passes under `-race`