### PR TITLE
fix: status and startup health check probe hardcoded ports (#230)

### DIFF
--- a/cmd/muninn/lifecycle.go
+++ b/cmd/muninn/lifecycle.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -137,8 +138,10 @@ func runStart(webEnabled bool) error {
 		fmt.Fprintf(os.Stderr, "warning: could not write PID file: %v\n", err)
 	}
 
-	// Wait for health check (up to 5s)
-	mcpHealthURL := "http://127.0.0.1:" + defaultMCPPort + "/mcp/health"
+	// Wait for health check (up to 5s).
+	// Use the actual MCP port from daemon args — may differ from defaultMCPPort
+	// when the user passed --mcp-addr.
+	mcpHealthURL := "http://127.0.0.1:" + mcpPortFromArgs(args) + "/mcp/health"
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		time.Sleep(200 * time.Millisecond)
@@ -153,7 +156,6 @@ func runStart(webEnabled bool) error {
 			fmt.Printf("muninn started (pid %d)\n", cmd.Process.Pid)
 			fmt.Println()
 			printStatusDisplay(true)
-			fmt.Println("  Web UI → http://127.0.0.1:8476")
 			fmt.Println()
 			return nil
 		}
@@ -169,7 +171,8 @@ func runStart(webEnabled bool) error {
 
 // runStop signals the running daemon to shut down.
 func runStop() {
-	pidPath := filepath.Join(defaultDataDir(), "muninn.pid")
+	dataDir := defaultDataDir()
+	pidPath := filepath.Join(dataDir, "muninn.pid")
 	pid, err := readPID(pidPath)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -193,6 +196,18 @@ func runStop() {
 
 	fmt.Printf("muninn stopped (pid %d)\n", pid)
 	os.Remove(pidPath)
+	os.Remove(filepath.Join(dataDir, addrsFileName))
+}
+
+// mcpPortFromArgs extracts the MCP port from daemon args.
+// Returns defaultMCPPort if --mcp-addr is absent or unparseable.
+func mcpPortFromArgs(args []string) string {
+	if v := parseExplicitFlag("mcp-addr", args); v != "" {
+		if _, p, err := net.SplitHostPort(v); err == nil && p != "" {
+			return p
+		}
+	}
+	return defaultMCPPort
 }
 
 // waitForProcessExit polls isProcessRunning every 100ms until the process

--- a/cmd/muninn/lifecycle_test.go
+++ b/cmd/muninn/lifecycle_test.go
@@ -162,3 +162,28 @@ func TestDefaultDataDirEnvOverride(t *testing.T) {
 		t.Errorf("defaultDataDir = %q, want %q (from MUNINNDB_DATA)", dir, testDir)
 	}
 }
+
+func TestMCPPortFromArgs_Default(t *testing.T) {
+	if got := mcpPortFromArgs(nil); got != defaultMCPPort {
+		t.Errorf("nil args: got %q, want %q", got, defaultMCPPort)
+	}
+}
+
+func TestMCPPortFromArgs_CustomPort(t *testing.T) {
+	cases := []struct {
+		args []string
+		want string
+	}{
+		{[]string{"--mcp-addr", ":8760"}, "8760"},
+		{[]string{"--mcp-addr", "0.0.0.0:8760"}, "8760"},
+		{[]string{"--mcp-addr", "127.0.0.1:8750"}, "8750"},
+		{[]string{"--other-flag", "value"}, defaultMCPPort},
+		{[]string{"--mcp-addr=:9000"}, "9000"},
+	}
+	for _, c := range cases {
+		got := mcpPortFromArgs(c.args)
+		if got != c.want {
+			t.Errorf("mcpPortFromArgs(%v) = %q, want %q", c.args, got, c.want)
+		}
+	}
+}

--- a/cmd/muninn/pid.go
+++ b/cmd/muninn/pid.go
@@ -1,11 +1,45 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
+
+// daemonAddrs records the actual addresses the daemon bound to.
+// Written to muninn.addrs in the data directory so 'muninn status' and
+// the startup health poll can probe the correct ports when non-default
+// --*-addr flags are used.
+type daemonAddrs struct {
+	RestAddr string `json:"rest_addr"`
+	MCPAddr  string `json:"mcp_addr"`
+	UIAddr   string `json:"ui_addr"`
+}
+
+const addrsFileName = "muninn.addrs"
+
+func writeAddrsFile(dataDir string, addrs daemonAddrs) error {
+	b, err := json.Marshal(addrs)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dataDir, addrsFileName), b, 0600)
+}
+
+func readAddrsFile(dataDir string) (daemonAddrs, error) {
+	b, err := os.ReadFile(filepath.Join(dataDir, addrsFileName))
+	if err != nil {
+		return daemonAddrs{}, err
+	}
+	var a daemonAddrs
+	if err := json.Unmarshal(b, &a); err != nil {
+		return daemonAddrs{}, err
+	}
+	return a, nil
+}
 
 func writePID(path string, pid int) error {
 	return os.WriteFile(path, []byte(strconv.Itoa(pid)+"\n"), 0600)

--- a/cmd/muninn/pid_test.go
+++ b/cmd/muninn/pid_test.go
@@ -27,3 +27,48 @@ func TestReadPIDMissingFile(t *testing.T) {
 		t.Error("expected error for missing PID file")
 	}
 }
+
+func TestWriteReadAddrsFile(t *testing.T) {
+	dir := t.TempDir()
+	want := daemonAddrs{
+		RestAddr: "127.0.0.1:8475",
+		MCPAddr:  "0.0.0.0:8760",
+		UIAddr:   "127.0.0.1:8476",
+	}
+	if err := writeAddrsFile(dir, want); err != nil {
+		t.Fatalf("writeAddrsFile: %v", err)
+	}
+	got, err := readAddrsFile(dir)
+	if err != nil {
+		t.Fatalf("readAddrsFile: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestReadAddrsMissingFile(t *testing.T) {
+	_, err := readAddrsFile("/nonexistent/dir")
+	if err == nil {
+		t.Error("expected error for missing addrs file")
+	}
+}
+
+func TestWriteAddrsFileOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	first := daemonAddrs{RestAddr: "127.0.0.1:8475", MCPAddr: "127.0.0.1:8750", UIAddr: "127.0.0.1:8476"}
+	second := daemonAddrs{RestAddr: "127.0.0.1:8475", MCPAddr: "0.0.0.0:8760", UIAddr: "127.0.0.1:9000"}
+	if err := writeAddrsFile(dir, first); err != nil {
+		t.Fatalf("writeAddrsFile: %v", err)
+	}
+	if err := writeAddrsFile(dir, second); err != nil {
+		t.Fatalf("writeAddrsFile overwrite: %v", err)
+	}
+	got, err := readAddrsFile(dir)
+	if err != nil {
+		t.Fatalf("readAddrsFile: %v", err)
+	}
+	if got != second {
+		t.Errorf("got %+v, want %+v", got, second)
+	}
+}

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -654,6 +654,14 @@ func runServer() {
 	}
 	flag.Parse()
 
+	// Persist actual bound addresses so 'muninn status' and the startup health poll
+	// can probe the correct ports when non-default --*-addr flags are used.
+	_ = writeAddrsFile(*dataDir, daemonAddrs{
+		RestAddr: *restAddr,
+		MCPAddr:  *mcpAddr,
+		UIAddr:   *uiAddr,
+	})
+
 	// MCP token: --mcp-token flag is an explicit override (tests, container entrypoints).
 	// Default path reads from ~/.muninn/mcp.token so the token never appears in `ps` output.
 	if *mcpToken == "" {

--- a/cmd/muninn/status.go
+++ b/cmd/muninn/status.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -73,8 +75,17 @@ var probeServicesFn = probeServicesDefault
 // probeServices delegates to probeServicesFn for testability.
 func probeServices() []serviceStatus { return probeServicesFn() }
 
-// probeServicesDefault hits all health endpoints and returns statuses.
+// probeServicesDefault reads the actual bound addresses from the data directory
+// and probes the correct ports. Falls back to hardcoded defaults when the
+// sidecar file is absent (daemon stopped or pre-fix version).
 func probeServicesDefault() []serviceStatus {
+	addrs, _ := readAddrsFile(defaultDataDir())
+	return probeServicesWithAddrs(addrs)
+}
+
+// probeServicesWithAddrs is the testable implementation. addrs contains the
+// actual addresses the daemon bound to; empty strings fall back to defaults.
+func probeServicesWithAddrs(addrs daemonAddrs) []serviceStatus {
 	client := &http.Client{Timeout: 2 * time.Second}
 	probe := func(url string) bool {
 		resp, err := client.Get(url)
@@ -84,11 +95,29 @@ func probeServicesDefault() []serviceStatus {
 		resp.Body.Close()
 		return resp.StatusCode >= 200 && resp.StatusCode < 300
 	}
+	// portFrom extracts the port from an "host:port" address string.
+	// Returns fallback when addr is empty or unparseable.
+	portFrom := func(addr, fallback string) string {
+		if addr != "" {
+			if _, p, err := net.SplitHostPort(addr); err == nil && p != "" {
+				return p
+			}
+		}
+		return fallback
+	}
+
+	restPort := portFrom(addrs.RestAddr, "8475")
+	mcpPort := portFrom(addrs.MCPAddr, "8750")
+	uiPort := portFrom(addrs.UIAddr, "8476")
+
+	restPortInt, _ := strconv.Atoi(restPort)
+	mcpPortInt, _ := strconv.Atoi(mcpPort)
+	uiPortInt, _ := strconv.Atoi(uiPort)
 
 	return []serviceStatus{
-		{name: "database", port: 8475, up: probe("http://127.0.0.1:8475/api/health")},
-		{name: "mcp", port: 8750, up: probe("http://127.0.0.1:8750/mcp/health")},
-		{name: "web ui", port: 8476, up: probe("http://127.0.0.1:8476/")},
+		{name: "database", port: restPortInt, up: probe("http://127.0.0.1:" + restPort + "/api/health")},
+		{name: "mcp", port: mcpPortInt, up: probe("http://127.0.0.1:" + mcpPort + "/mcp/health")},
+		{name: "web ui", port: uiPortInt, up: probe("http://127.0.0.1:" + uiPort + "/")},
 	}
 }
 
@@ -162,7 +191,14 @@ func printStatusDisplay(compact bool) runState {
 		}
 		if state == stateRunning {
 			fmt.Println()
-			fmt.Println("  Web UI → http://127.0.0.1:8476")
+			uiPort := "8476"
+			for _, s := range svcs {
+				if s.name == "web ui" && s.port != 0 {
+					uiPort = strconv.Itoa(s.port)
+					break
+				}
+			}
+			fmt.Printf("  Web UI → http://127.0.0.1:%s\n", uiPort)
 			checkVersionHint()
 		}
 	}

--- a/cmd/muninn/status_test.go
+++ b/cmd/muninn/status_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net"
 	"strings"
 	"testing"
 )
@@ -93,6 +94,58 @@ func TestPrintStatusDisplayOutputContainsName(t *testing.T) {
 	})
 	if !strings.Contains(out, "muninn") {
 		t.Errorf("output should contain 'muninn', got: %s", out)
+	}
+}
+
+func TestProbeServicesWithAddrs_CustomPorts(t *testing.T) {
+	srv := newHealthServer()
+	defer srv.Close()
+	_, port, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+
+	addrs := daemonAddrs{
+		RestAddr: "127.0.0.1:" + port,
+		MCPAddr:  "127.0.0.1:" + port,
+		UIAddr:   "127.0.0.1:" + port,
+	}
+	svcs := probeServicesWithAddrs(addrs)
+	if len(svcs) != 3 {
+		t.Fatalf("expected 3 services, got %d", len(svcs))
+	}
+	for _, s := range svcs {
+		if !s.up {
+			t.Errorf("service %q should be up at custom port %s", s.name, port)
+		}
+	}
+}
+
+func TestProbeServicesWithAddrs_EmptyUsesDefaults(t *testing.T) {
+	// Empty addrs → hardcoded defaults. All down (no server running), but ports must match.
+	svcs := probeServicesWithAddrs(daemonAddrs{})
+	ports := map[string]int{"database": 8475, "mcp": 8750, "web ui": 8476}
+	for _, s := range svcs {
+		want := ports[s.name]
+		if s.port != want {
+			t.Errorf("service %q: got port %d, want %d", s.name, s.port, want)
+		}
+	}
+}
+
+func TestProbeServicesWithAddrs_ColonOnlyPort(t *testing.T) {
+	// ":8760" style (no host) — common when user passes --mcp-addr :8760
+	srv := newHealthServer()
+	defer srv.Close()
+	_, port, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+
+	addrs := daemonAddrs{
+		RestAddr: "127.0.0.1:" + port,
+		MCPAddr:  ":" + port, // colon-only style
+		UIAddr:   "127.0.0.1:" + port,
+	}
+	svcs := probeServicesWithAddrs(addrs)
+	for _, s := range svcs {
+		if !s.up {
+			t.Errorf("service %q should be up (colon-port style)", s.name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

`muninn status` and the startup health poll hardcoded ports 8475/8750/8476, so any non-default `--mcp-addr` / `--rest-addr` / `--ui-addr` caused:
- `muninn status` to report false "down" even when the daemon was healthy
- `muninn start` to time out the health check and print an error, even though the daemon started successfully

## Fix

- Daemon writes `muninn.addrs` (JSON) to the data dir right after `flag.Parse`, recording the actual `rest_addr`, `mcp_addr`, `ui_addr` it will bind to
- `probeServicesDefault` reads `muninn.addrs` and probes the real ports; falls back to hardcoded defaults when the file is absent (stopped daemon or pre-fix version — no regression)
- `mcpPortFromArgs` extracts the MCP port from daemon args so the startup health poll in `runStart` uses the correct URL
- `printStatusDisplay` Web UI URL uses the actual UI port from `svcs` instead of hardcoded 8476
- `runStop` removes `muninn.addrs` alongside `muninn.pid`

## Test plan

- [x] `TestWriteReadAddrsFile` — round-trip write/read
- [x] `TestReadAddrsMissingFile` — error on missing file
- [x] `TestWriteAddrsFileOverwrites` — second write replaces first
- [x] `TestProbeServicesWithAddrs_CustomPorts` — real httptest server on custom port, all svcs up
- [x] `TestProbeServicesWithAddrs_EmptyUsesDefaults` — empty addrs → ports 8475/8750/8476
- [x] `TestProbeServicesWithAddrs_ColonOnlyPort` — `:8760` style address handled
- [x] `TestMCPPortFromArgs_Default` — nil args → defaultMCPPort
- [x] `TestMCPPortFromArgs_CustomPort` — `:8760`, `0.0.0.0:8760`, `--mcp-addr=:9000`
- [x] Full `cmd/muninn` suite passes

Closes #230