### PR TITLE
fix: replay_enrichment per-engram timeout and stuck-engram skip (#226)

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -640,6 +640,7 @@ func runServer() {
 		fmt.Fprintf(os.Stderr, "  MUNINN_LOCAL_EMBED           Set to \"0\" to disable bundled ONNX embedder\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_ENRICH_URL            LLM enrichment endpoint URL (optional)\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_ENRICH_API_KEY        API key for enrichment (or MUNINN_ANTHROPIC_KEY)\n")
+		fmt.Fprintf(os.Stderr, "  MUNINN_ENRICH_TIMEOUT        Per-engram LLM timeout for replay_enrichment (e.g. 60s, 2m; default: no extra timeout)\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_HNSW_WARN_THRESHOLD_MB  Emit a warning when HNSW in-memory vector bytes exceed N MB (optional)\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_HNSW_MAX_MB             Skip HNSW insert (keep Pebble write) when memory exceeds N MB (optional)\n")
 		fmt.Fprintf(os.Stderr, "  MUNINN_LISTEN_HOST           Host to bind all servers to (e.g. 0.0.0.0 for LAN access)\n")
@@ -1043,6 +1044,14 @@ func runServer() {
 			slog.Warn("failed to register enrich plugin in registry", "err", err)
 		}
 		eng.SetEnrichPlugin(enrichPlugin)
+		if timeoutStr := os.Getenv("MUNINN_ENRICH_TIMEOUT"); timeoutStr != "" {
+			if d, err := time.ParseDuration(timeoutStr); err == nil && d > 0 {
+				eng.SetReplayEnrichTimeout(d)
+				slog.Info("replay enrichment per-engram timeout configured", "timeout", d)
+			} else if err != nil {
+				slog.Warn("MUNINN_ENRICH_TIMEOUT invalid, ignoring", "value", timeoutStr, "err", err)
+			}
+		}
 		if rew, ok := restWrapper.(*rest.RESTEngineWrapper); ok {
 			rew.SetEnricher(enrichPlugin)
 		}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -159,12 +159,16 @@ type Engine struct {
 	// Useful for Ollama cold-start scenarios (MUNINN_ENRICH_TIMEOUT env var).
 	replayEnrichTimeout time.Duration
 
+	// replayFailMu guards replayFailCounts for atomic read-modify-write.
+	// A plain mutex + map is used instead of sync.Map to avoid the TOCTOU
+	// race inherent in Load-then-Store on sync.Map.
+	replayFailMu sync.Mutex
 	// replayFailCounts tracks how many times each engram has consecutively
 	// failed enrichment during replay calls in this server session.
 	// After maxReplayFails failures, the engram is skipped by subsequent
 	// ReplayEnrichment calls. Keys are storage.ULID; values are int.
 	// Resets on server restart. Cleared per-engram by ResetReplayFailCount.
-	replayFailCounts sync.Map
+	replayFailCounts map[storage.ULID]int
 
 	// mergeMu serialises concurrent MergeEntity calls that touch the same entities.
 	// Uses a dedicated stripe array separate from the storage-layer entity locks to
@@ -342,7 +346,8 @@ func NewEngine(
 		stopCtx:          stopCtx,
 		stopCancel:       stopCancel,
 		hnswRegistry:     hnswRegistry,
-		jobManager:       vaultjob.NewManager(),
+		jobManager:          vaultjob.NewManager(),
+		replayFailCounts:    make(map[storage.ULID]int),
 	}
 	// Start async novelty worker to decouple O(N) Jaccard scan from write hot path.
 	// engine:spawn-ok — tracked by noveltyDone channel, drained in Stop()

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -153,6 +153,19 @@ type Engine struct {
 	// Set via SetEnrichPlugin after construction.
 	enrichPlugin plugin.EnrichPlugin
 
+	// replayEnrichTimeout, when positive, caps each per-engram LLM enrichment
+	// call during ReplayEnrichment. Decouples the per-request timeout from the
+	// MCP request context deadline. Set via SetReplayEnrichTimeout.
+	// Useful for Ollama cold-start scenarios (MUNINN_ENRICH_TIMEOUT env var).
+	replayEnrichTimeout time.Duration
+
+	// replayFailCounts tracks how many times each engram has consecutively
+	// failed enrichment during replay calls in this server session.
+	// After maxReplayFails failures, the engram is skipped by subsequent
+	// ReplayEnrichment calls. Keys are storage.ULID; values are int.
+	// Resets on server restart. Cleared per-engram by ResetReplayFailCount.
+	replayFailCounts sync.Map
+
 	// mergeMu serialises concurrent MergeEntity calls that touch the same entities.
 	// Uses a dedicated stripe array separate from the storage-layer entity locks to
 	// avoid reentrancy deadlock (UpsertEntityRecord acquires storage stripes internally).

--- a/internal/engine/engine_replay.go
+++ b/internal/engine/engine_replay.go
@@ -166,9 +166,12 @@ func (e *Engine) ReplayEnrichment(ctx context.Context, vault string, stages []st
 		}
 
 		// Skip engrams that have failed too many times this session.
-		if v, ok := e.replayFailCounts.Load(eng.ID); ok && v.(int) >= maxReplayFails {
+		e.replayFailMu.Lock()
+		failCount := e.replayFailCounts[eng.ID]
+		e.replayFailMu.Unlock()
+		if failCount >= maxReplayFails {
 			slog.Debug("replay enrichment: skipping persistently failing engram",
-				"id", eng.ID.String(), "fails", v.(int))
+				"id", eng.ID.String(), "fails", failCount)
 			skipped++
 			continue
 		}
@@ -190,18 +193,19 @@ func (e *Engine) ReplayEnrichment(ctx context.Context, vault string, stages []st
 				continue
 			}
 			// Track consecutive failures; skip if threshold reached next time.
-			prev := 0
-			if v, ok := e.replayFailCounts.Load(eng.ID); ok {
-				prev = v.(int)
-			}
-			e.replayFailCounts.Store(eng.ID, prev+1)
+			e.replayFailMu.Lock()
+			e.replayFailCounts[eng.ID]++
+			newCount := e.replayFailCounts[eng.ID]
+			e.replayFailMu.Unlock()
 			slog.Warn("replay enrichment: enrich failed, skipping",
-				"id", eng.ID.String(), "err", enrichErr, "fail_count", prev+1)
+				"id", eng.ID.String(), "err", enrichErr, "fail_count", newCount)
 			failed++
 			continue
 		}
 		// Success — clear any prior failure count.
-		e.replayFailCounts.Delete(eng.ID)
+		e.replayFailMu.Lock()
+		delete(e.replayFailCounts, eng.ID)
+		e.replayFailMu.Unlock()
 
 		// Persist enrichment results (summary, key_points, memory_type, type_label).
 		if updateErr := e.store.UpdateDigest(ctx, eng.ID, result.Summary, result.KeyPoints, result.MemoryType, result.TypeLabel); updateErr != nil {
@@ -324,5 +328,7 @@ func (e *Engine) SetReplayEnrichTimeout(d time.Duration) {
 // ResetReplayFailCount clears the in-session failure counter for the given engram,
 // allowing ReplayEnrichment to attempt it again after a manual reset.
 func (e *Engine) ResetReplayFailCount(id storage.ULID) {
-	e.replayFailCounts.Delete(id)
+	e.replayFailMu.Lock()
+	delete(e.replayFailCounts, id)
+	e.replayFailMu.Unlock()
 }

--- a/internal/engine/engine_replay.go
+++ b/internal/engine/engine_replay.go
@@ -5,11 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/scrypster/muninndb/internal/plugin"
 	"github.com/scrypster/muninndb/internal/plugin/enrich"
 	"github.com/scrypster/muninndb/internal/storage"
 )
+
+// maxReplayFails is the number of consecutive enrichment failures after which
+// an engram is silently skipped by ReplayEnrichment for the remainder of the
+// server session. Prevents a broken engram from blocking every replay call.
+const maxReplayFails = 3
 
 // ReplayEnrichmentResult holds the outcome of a replay enrichment run.
 type ReplayEnrichmentResult struct {
@@ -159,19 +165,43 @@ func (e *Engine) ReplayEnrichment(ctx context.Context, vault string, stages []st
 			continue
 		}
 
-		// Run enrichment for this engram.
-		result, enrichErr := e.enrichPlugin.Enrich(ctx, eng)
+		// Skip engrams that have failed too many times this session.
+		if v, ok := e.replayFailCounts.Load(eng.ID); ok && v.(int) >= maxReplayFails {
+			slog.Debug("replay enrichment: skipping persistently failing engram",
+				"id", eng.ID.String(), "fails", v.(int))
+			skipped++
+			continue
+		}
+
+		// Run enrichment for this engram, optionally with a per-engram timeout.
+		enrichCtx := ctx
+		var enrichCancel context.CancelFunc
+		if e.replayEnrichTimeout > 0 {
+			enrichCtx, enrichCancel = context.WithTimeout(ctx, e.replayEnrichTimeout)
+		}
+		result, enrichErr := e.enrichPlugin.Enrich(enrichCtx, eng)
+		if enrichCancel != nil {
+			enrichCancel()
+		}
 		if enrichErr != nil {
 			if errors.Is(enrichErr, enrich.ErrNothingToEnrich) {
 				slog.Debug("replay enrichment: nothing to enrich, skipping", "id", eng.ID.String())
 				skipped++
 				continue
 			}
+			// Track consecutive failures; skip if threshold reached next time.
+			prev := 0
+			if v, ok := e.replayFailCounts.Load(eng.ID); ok {
+				prev = v.(int)
+			}
+			e.replayFailCounts.Store(eng.ID, prev+1)
 			slog.Warn("replay enrichment: enrich failed, skipping",
-				"id", eng.ID.String(), "err", enrichErr)
+				"id", eng.ID.String(), "err", enrichErr, "fail_count", prev+1)
 			failed++
 			continue
 		}
+		// Success — clear any prior failure count.
+		e.replayFailCounts.Delete(eng.ID)
 
 		// Persist enrichment results (summary, key_points, memory_type, type_label).
 		if updateErr := e.store.UpdateDigest(ctx, eng.ID, result.Summary, result.KeyPoints, result.MemoryType, result.TypeLabel); updateErr != nil {
@@ -281,4 +311,18 @@ func countNonNilEngrams(engrams []*storage.Engram) int {
 // Must be called before ReplayEnrichment is used (not concurrency-safe after start).
 func (e *Engine) SetEnrichPlugin(p plugin.EnrichPlugin) {
 	e.enrichPlugin = p
+}
+
+// SetReplayEnrichTimeout sets a per-engram timeout applied to each Enrich() call
+// inside ReplayEnrichment. A value of 0 (default) disables the extra timeout and
+// lets the MCP request context govern the full run.
+// Useful when the LLM backend (e.g. Ollama) can hang on cold-start.
+func (e *Engine) SetReplayEnrichTimeout(d time.Duration) {
+	e.replayEnrichTimeout = d
+}
+
+// ResetReplayFailCount clears the in-session failure counter for the given engram,
+// allowing ReplayEnrichment to attempt it again after a manual reset.
+func (e *Engine) ResetReplayFailCount(id storage.ULID) {
+	e.replayFailCounts.Delete(id)
 }

--- a/internal/engine/engine_replay_test.go
+++ b/internal/engine/engine_replay_test.go
@@ -647,3 +647,85 @@ func TestReplayEnrichment_PerEngramTimeout(t *testing.T) {
 		t.Error("expected per-engram context to have a deadline when SetReplayEnrichTimeout > 0")
 	}
 }
+
+// TestReplayEnrichment_TimeoutFires verifies that when the per-engram timeout
+// expires before Enrich returns, the error is counted as a failure (not silently
+// swallowed) and the context deadline exceeded error propagates correctly.
+func TestReplayEnrichment_TimeoutFires(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	writeTestEngrams(t, ctx, eng, "default", 1)
+
+	mock := &mockEnrichPlugin{
+		enrichFn: func(enrichCtx context.Context, _ *storage.Engram) (*plugin.EnrichmentResult, error) {
+			// Block until the per-engram context is cancelled.
+			<-enrichCtx.Done()
+			return nil, enrichCtx.Err()
+		},
+	}
+	eng.SetEnrichPlugin(mock)
+	eng.SetReplayEnrichTimeout(10 * time.Millisecond) // fire immediately
+
+	result, err := eng.ReplayEnrichment(ctx, "default", nil, 50, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Failed != 1 {
+		t.Errorf("want Failed=1 after timeout, got %d", result.Failed)
+	}
+	if result.Processed != 0 {
+		t.Errorf("want Processed=0 after timeout, got %d", result.Processed)
+	}
+}
+
+// TestReplayEnrichment_ResetFailCount verifies that ResetReplayFailCount clears
+// the failure counter, allowing a previously-skipped engram to be retried.
+func TestReplayEnrichment_ResetFailCount(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	writeTestEngrams(t, ctx, eng, "default", 1)
+
+	// Fail enough times to trip the circuit breaker.
+	calls := 0
+	mock := &mockEnrichPlugin{
+		enrichFn: func(_ context.Context, _ *storage.Engram) (*plugin.EnrichmentResult, error) {
+			calls++
+			return nil, errors.New("permanent failure")
+		},
+	}
+	eng.SetEnrichPlugin(mock)
+
+	for i := 0; i < maxReplayFails; i++ {
+		eng.ReplayEnrichment(ctx, "default", nil, 50, false) //nolint:errcheck
+	}
+
+	// Confirm the engram is now skipped.
+	callsBefore := calls
+	result, _ := eng.ReplayEnrichment(ctx, "default", nil, 50, false)
+	if calls != callsBefore {
+		t.Fatalf("engram should be skipped after threshold, got extra call")
+	}
+	if result.Skipped != 1 {
+		t.Errorf("want Skipped=1 before reset, got %d", result.Skipped)
+	}
+
+	// Reset the counter — the engram must be attempted again.
+	ids, err := eng.store.ListByState(ctx, eng.store.ResolveVaultPrefix("default"), storage.StateActive, 10)
+	if err != nil || len(ids) == 0 {
+		t.Fatalf("could not list engrams: %v", err)
+	}
+	eng.ResetReplayFailCount(ids[0])
+
+	callsBefore = calls
+	result, _ = eng.ReplayEnrichment(ctx, "default", nil, 50, false)
+	if calls == callsBefore {
+		t.Error("expected Enrich to be called again after ResetReplayFailCount")
+	}
+	if result.Failed != 1 {
+		t.Errorf("want Failed=1 after reset (still failing), got %d", result.Failed)
+	}
+}

--- a/internal/engine/engine_replay_test.go
+++ b/internal/engine/engine_replay_test.go
@@ -2,8 +2,10 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/scrypster/muninndb/internal/plugin"
 	"github.com/scrypster/muninndb/internal/plugin/enrich"
@@ -519,4 +521,129 @@ func TestReplayEnrichment_ContextAlreadyExpired(t *testing.T) {
 		t.Errorf("Remaining: got %d, want 3", result.Remaining)
 	}
 	assertResultInvariant(t, result, 3)
+}
+
+// TestReplayEnrichment_SkipsAfterMaxFailures verifies that an engram which has
+// failed maxReplayFails consecutive times is silently skipped on the next call.
+func TestReplayEnrichment_SkipsAfterMaxFailures(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	writeTestEngrams(t, ctx, eng, "default", 1)
+
+	errBoom := errors.New("LLM boom")
+	calls := 0
+	mock := &mockEnrichPlugin{
+		enrichFn: func(_ context.Context, _ *storage.Engram) (*plugin.EnrichmentResult, error) {
+			calls++
+			return nil, errBoom
+		},
+	}
+	eng.SetEnrichPlugin(mock)
+
+	// First maxReplayFails calls should each attempt enrichment and record a failure.
+	for i := 0; i < maxReplayFails; i++ {
+		result, err := eng.ReplayEnrichment(ctx, "default", nil, 50, false)
+		if err != nil {
+			t.Fatalf("call %d: unexpected error: %v", i+1, err)
+		}
+		if result.Failed != 1 {
+			t.Errorf("call %d: want Failed=1, got %d", i+1, result.Failed)
+		}
+	}
+	if calls != maxReplayFails {
+		t.Errorf("want %d Enrich calls, got %d", maxReplayFails, calls)
+	}
+
+	// Next call: engram has hit the threshold — must be skipped, not attempted again.
+	callsBefore := calls
+	result, err := eng.ReplayEnrichment(ctx, "default", nil, 50, false)
+	if err != nil {
+		t.Fatalf("post-threshold call: unexpected error: %v", err)
+	}
+	if calls != callsBefore {
+		t.Errorf("Enrich should not be called after threshold; got %d extra calls", calls-callsBefore)
+	}
+	if result.Skipped != 1 {
+		t.Errorf("post-threshold: want Skipped=1, got %d", result.Skipped)
+	}
+	if result.Failed != 0 {
+		t.Errorf("post-threshold: want Failed=0, got %d", result.Failed)
+	}
+}
+
+// TestReplayEnrichment_FailCountResetOnSuccess verifies that a successful enrichment
+// run clears the failure counter so the engram is attempted again next time.
+func TestReplayEnrichment_FailCountResetOnSuccess(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	writeTestEngrams(t, ctx, eng, "default", 1)
+
+	shouldFail := true
+	mock := &mockEnrichPlugin{
+		enrichFn: func(_ context.Context, _ *storage.Engram) (*plugin.EnrichmentResult, error) {
+			if shouldFail {
+				return nil, errors.New("temporary failure")
+			}
+			return &plugin.EnrichmentResult{Summary: "ok", KeyPoints: []string{"k"}}, nil
+		},
+	}
+	eng.SetEnrichPlugin(mock)
+
+	// Fail once to set fail count to 1.
+	result, err := eng.ReplayEnrichment(ctx, "default", nil, 50, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Failed != 1 {
+		t.Errorf("want Failed=1, got %d", result.Failed)
+	}
+
+	// Now succeed — should clear the failure counter.
+	shouldFail = false
+	result, err = eng.ReplayEnrichment(ctx, "default", nil, 50, false)
+	if err != nil {
+		t.Fatalf("unexpected error after success: %v", err)
+	}
+	if result.Processed != 1 {
+		t.Errorf("want Processed=1, got %d", result.Processed)
+	}
+
+	// The engram now has all digest flags set, so further calls skip it as done.
+	_ = result
+}
+
+// TestReplayEnrichment_PerEngramTimeout verifies that SetReplayEnrichTimeout
+// causes Enrich to receive a context that has a deadline.
+func TestReplayEnrichment_PerEngramTimeout(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	writeTestEngrams(t, ctx, eng, "default", 1)
+
+	var deadlineSet bool
+	mock := &mockEnrichPlugin{
+		enrichFn: func(enrichCtx context.Context, _ *storage.Engram) (*plugin.EnrichmentResult, error) {
+			dl, ok := enrichCtx.Deadline()
+			deadlineSet = ok && !dl.IsZero()
+			return &plugin.EnrichmentResult{Summary: "ok", KeyPoints: []string{"k"}}, nil
+		},
+	}
+	eng.SetEnrichPlugin(mock)
+	eng.SetReplayEnrichTimeout(30 * time.Second)
+
+	result, err := eng.ReplayEnrichment(ctx, "default", nil, 50, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Processed != 1 {
+		t.Errorf("want Processed=1, got %d", result.Processed)
+	}
+	if !deadlineSet {
+		t.Error("expected per-engram context to have a deadline when SetReplayEnrichTimeout > 0")
+	}
 }


### PR DESCRIPTION
## Summary

Fixes two bugs reported in #226:

- **Stuck/hung tool**: `replay_enrichment` blocked indefinitely when the LLM backend (e.g. Ollama on cold-start) hung mid-call. The MCP request context governed the entire run with no per-engram budget. Added `SetReplayEnrichTimeout` which wraps each `Enrich()` call with `context.WithTimeout`. Opt-in via `MUNINN_ENRICH_TIMEOUT` env var (e.g. `60s`, `2m`).

- **Stuck engram loop**: A broken engram (bad content, LLM always returns an error) was retried on every `replay_enrichment` invocation because failures weren't tracked across calls. Added in-memory `replayFailCounts sync.Map` on `Engine`; after `maxReplayFails` (3) consecutive failures the engram is silently skipped for the rest of the server session. The counter resets on the first success.

## Test plan

- [ ] `TestReplayEnrichment_SkipsAfterMaxFailures` — engram skipped after 3 failures, Enrich not called on 4th run
- [ ] `TestReplayEnrichment_FailCountResetOnSuccess` — counter clears after a successful run
- [ ] `TestReplayEnrichment_PerEngramTimeout` — Enrich receives a context with a deadline when timeout is set
- [ ] Full engine suite passes with `-race`