### PR TITLE
feat: allow updating entity type via entity_state (#232)

### DIFF
--- a/internal/engine/engine_entity_state.go
+++ b/internal/engine/engine_entity_state.go
@@ -7,9 +7,10 @@ import (
 	"github.com/scrypster/muninndb/internal/storage"
 )
 
-// SetEntityState sets the lifecycle state of a named entity.
-// For state="merged", mergedInto must be the canonical entity name.
-func (e *Engine) SetEntityState(ctx context.Context, entityName, state, mergedInto string) error {
+// SetEntityState sets the lifecycle state of a named entity, and optionally
+// corrects its type. For state="merged", mergedInto must be the canonical name.
+// entityType may be empty — when empty the existing type is preserved.
+func (e *Engine) SetEntityState(ctx context.Context, entityName, state, mergedInto, entityType string) error {
 	if entityName == "" {
 		return fmt.Errorf("set_entity_state: entity_name is required")
 	}
@@ -23,13 +24,18 @@ func (e *Engine) SetEntityState(ctx context.Context, entityName, state, mergedIn
 		return fmt.Errorf("set_entity_state: entity %q not found", entityName)
 	}
 
+	// Use provided type; fall back to existing when caller omits it.
+	resolvedType := existing.Type
+	if entityType != "" {
+		resolvedType = entityType
+	}
+
 	// Build updated record — UpsertEntityRecord will validate state and MergedInto consistency.
 	record := storage.EntityRecord{
 		Name:       entityName,
 		State:      state,
 		MergedInto: mergedInto,
-		// Preserve existing fields.
-		Type:       existing.Type,
+		Type:       resolvedType,
 		Confidence: existing.Confidence,
 	}
 

--- a/internal/engine/engine_entity_state_test.go
+++ b/internal/engine/engine_entity_state_test.go
@@ -1,0 +1,86 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+	"github.com/stretchr/testify/require"
+)
+
+// writeEntityForStateTest writes one engram with an inline entity and returns the entity name.
+func writeEntityForStateTest(t *testing.T, eng *Engine, vault, name, entityType string) {
+	t.Helper()
+	_, err := eng.Write(context.Background(), &mbp.WriteRequest{
+		Vault:   vault,
+		Content: name + " is a thing",
+		Concept: "test entity",
+		Entities: []mbp.InlineEntity{
+			{Name: name, Type: entityType},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestSetEntityState_PreservesTypeWhenNotProvided(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	writeEntityForStateTest(t, eng, "default", "Modbus", "protocol")
+
+	// Change state only — entityType param is empty.
+	err := eng.SetEntityState(ctx, "Modbus", "deprecated", "", "")
+	require.NoError(t, err)
+
+	rec, err := eng.store.GetEntityRecord(ctx, "modbus")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	require.Equal(t, "deprecated", rec.State, "state should be updated")
+	require.Equal(t, "protocol", rec.Type, "type should be preserved when not provided")
+}
+
+func TestSetEntityState_UpdatesTypeWhenProvided(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Entity created with wrong type from early enrichment.
+	writeEntityForStateTest(t, eng, "default", "2014/53/EU", "other")
+
+	// Correct the type while keeping state active.
+	err := eng.SetEntityState(ctx, "2014/53/EU", "active", "", "directive")
+	require.NoError(t, err)
+
+	rec, err := eng.store.GetEntityRecord(ctx, "2014/53/eu")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	require.Equal(t, "active", rec.State)
+	require.Equal(t, "directive", rec.Type, "type should be updated to the provided value")
+}
+
+func TestSetEntityState_UpdatesBothStateAndType(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	writeEntityForStateTest(t, eng, "default", "Bridge Dongle", "other")
+
+	err := eng.SetEntityState(ctx, "Bridge Dongle", "deprecated", "", "module")
+	require.NoError(t, err)
+
+	rec, err := eng.store.GetEntityRecord(ctx, "bridge dongle")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	require.Equal(t, "deprecated", rec.State)
+	require.Equal(t, "module", rec.Type)
+}
+
+func TestSetEntityState_NotFound(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	err := eng.SetEntityState(ctx, "ghost entity", "deprecated", "", "")
+	require.Error(t, err, "should error for entity that does not exist")
+}

--- a/internal/mcp/engine.go
+++ b/internal/mcp/engine.go
@@ -97,9 +97,10 @@ type EngineInterface interface {
 	// WriteIdempotency stores an idempotency receipt (op_id → engramID).
 	WriteIdempotency(ctx context.Context, opID, engramID string) error
 
-	// SetEntityState sets the lifecycle state of a named entity.
+	// SetEntityState sets the lifecycle state of a named entity, and optionally
+	// corrects its type. entityType may be empty (preserves existing type).
 	// For state="merged", mergedInto must be the canonical entity name.
-	SetEntityState(ctx context.Context, entityName, state, mergedInto string) error
+	SetEntityState(ctx context.Context, entityName, state, mergedInto, entityType string) error
 
 	// GetEntityClusters returns entity pairs that frequently co-occur in the same engrams,
 	// sorted by count descending. Only pairs with count >= minCount are returned.

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -329,8 +329,8 @@ func (a *mcpEngineAdapter) WriteIdempotency(ctx context.Context, opID, engramID 
 	return a.eng.Store().WriteIdempotency(ctx, opID, engramID)
 }
 
-func (a *mcpEngineAdapter) SetEntityState(ctx context.Context, entityName, state, mergedInto string) error {
-	return a.eng.SetEntityState(ctx, entityName, state, mergedInto)
+func (a *mcpEngineAdapter) SetEntityState(ctx context.Context, entityName, state, mergedInto, entityType string) error {
+	return a.eng.SetEntityState(ctx, entityName, state, mergedInto, entityType)
 }
 
 func (a *mcpEngineAdapter) ExportGraph(ctx context.Context, vault string, includeEngrams bool) (*engine.ExportGraph, error) {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -889,16 +889,21 @@ func (s *MCPServer) handleEntityState(ctx context.Context, w http.ResponseWriter
 		sendError(w, id, -32602, "invalid params: 'merged_into' is required when state=merged")
 		return
 	}
+	entityType, _ := args["type"].(string)
 
-	if err := s.engine.SetEntityState(ctx, entityName, state, mergedInto); err != nil {
+	if err := s.engine.SetEntityState(ctx, entityName, state, mergedInto, entityType); err != nil {
 		sendError(w, id, -32000, "tool error: "+err.Error())
 		return
 	}
-	out, _ := json.Marshal(map[string]any{
+	resp := map[string]any{
 		"entity": entityName,
 		"state":  state,
 		"ok":     true,
-	})
+	}
+	if entityType != "" {
+		resp["type"] = entityType
+	}
+	out, _ := json.Marshal(resp)
 	sendResult(w, id, textContent(string(out)))
 }
 

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -1582,8 +1582,8 @@ func (e *slowIdempotentEngine) WhereLeftOff(ctx context.Context, vault string, l
 func (e *slowIdempotentEngine) FindByEntity(ctx context.Context, vault, entityName string, limit int) ([]*storage.Engram, error) {
 	return (&fakeEngine{}).FindByEntity(ctx, vault, entityName, limit)
 }
-func (e *slowIdempotentEngine) SetEntityState(ctx context.Context, entityName, state, mergedInto string) error {
-	return (&fakeEngine{}).SetEntityState(ctx, entityName, state, mergedInto)
+func (e *slowIdempotentEngine) SetEntityState(ctx context.Context, entityName, state, mergedInto, entityType string) error {
+	return (&fakeEngine{}).SetEntityState(ctx, entityName, state, mergedInto, entityType)
 }
 func (e *slowIdempotentEngine) GetEntityClusters(ctx context.Context, vault string, minCount, topN int) ([]EntityClusterResult, error) {
 	return (&fakeEngine{}).GetEntityClusters(ctx, vault, minCount, topN)
@@ -1670,7 +1670,7 @@ func TestHandleRemember_ConcurrentSameOpID(t *testing.T) {
 // entityStateEngine is a minimal engine stub for muninn_entity_state tests.
 type entityStateEngine struct{ fakeEngine }
 
-func (e *entityStateEngine) SetEntityState(_ context.Context, name, state, mergedInto string) error {
+func (e *entityStateEngine) SetEntityState(_ context.Context, name, state, mergedInto, entityType string) error {
 	if name == "" {
 		return fmt.Errorf("entity_name is required")
 	}
@@ -1680,7 +1680,7 @@ func (e *entityStateEngine) SetEntityState(_ context.Context, name, state, merge
 // entityStateErrEngine returns an error from SetEntityState.
 type entityStateErrEngine struct{ fakeEngine }
 
-func (e *entityStateErrEngine) SetEntityState(_ context.Context, _, _, _ string) error {
+func (e *entityStateErrEngine) SetEntityState(_ context.Context, _, _, _, _ string) error {
 	return fmt.Errorf("entity %q not found", "PostgreSQL")
 }
 
@@ -1772,6 +1772,39 @@ func TestHandleEntityStateMergedWithoutMergedInto(t *testing.T) {
 	}
 	if resp.Error != nil && !strings.Contains(resp.Error.Message, "merged_into") {
 		t.Errorf("expected error message to mention merged_into requirement, got: %q", resp.Error.Message)
+	}
+}
+
+func TestHandleEntityStateWithType(t *testing.T) {
+	// Verify that providing a "type" field succeeds and is reflected in the response.
+	srv := newTestServerWith(&entityStateEngine{})
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_entity_state","arguments":{"vault":"default","entity_name":"Modbus","state":"active","type":"protocol"}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	content := extractInnerJSON(t, resp)
+	if content["type"] != "protocol" {
+		t.Errorf("type = %v, want protocol", content["type"])
+	}
+	if content["entity"] != "Modbus" {
+		t.Errorf("entity = %v, want Modbus", content["entity"])
+	}
+}
+
+func TestHandleEntityStateWithoutTypeOmitsTypeField(t *testing.T) {
+	// Verify that omitting "type" does not include a "type" key in the response.
+	srv := newTestServerWith(&entityStateEngine{})
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_entity_state","arguments":{"vault":"default","entity_name":"PostgreSQL","state":"active"}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	content := extractInnerJSON(t, resp)
+	if _, hasType := content["type"]; hasType {
+		t.Errorf("response should not include 'type' field when type was not provided")
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -112,7 +112,7 @@ func (f *fakeEngine) CheckIdempotency(_ context.Context, _ string) (*storage.Ide
 func (f *fakeEngine) WriteIdempotency(_ context.Context, _, _ string) error {
 	return nil
 }
-func (f *fakeEngine) SetEntityState(_ context.Context, _, _, _ string) error {
+func (f *fakeEngine) SetEntityState(_ context.Context, _, _, _, _ string) error {
 	return nil
 }
 func (f *fakeEngine) GetEntityClusters(_ context.Context, _ string, _, _ int) ([]EntityClusterResult, error) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -408,13 +408,14 @@ func allToolDefinitions() []ToolDefinition {
 		// Entity lifecycle state tool
 		{
 			Name:        "muninn_entity_state",
-			Description: "Set the lifecycle state of a named entity (active, deprecated, merged, resolved). For state=merged, provide merged_into with the canonical entity name.",
+			Description: "Set the lifecycle state of a named entity (active, deprecated, merged, resolved) and optionally correct its type. For state=merged, provide merged_into with the canonical entity name. The type field is optional — omit it to preserve the existing type.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"entity_name": map[string]any{"type": "string", "description": "The entity name to update"},
 					"state":       map[string]any{"type": "string", "description": "New state: active, deprecated, merged, or resolved"},
 					"merged_into": map[string]any{"type": "string", "description": "Canonical entity name (required when state=merged)"},
+					"type":        map[string]any{"type": "string", "description": "Correct the entity type (e.g. 'directive', 'protocol', 'module'). Omit to preserve the existing type."},
 					"vault":       vaultProp,
 				},
 				"required": []string{"entity_name", "state"},


### PR DESCRIPTION
## Summary

Fixes #232. Entity types set incorrectly by early LLM enrichment (e.g. type=`"other"`) had no correction path — the type was effectively write-once.

Extends `muninn_entity_state` with an optional `type` field:

- **When provided**: entity type is updated to the new value
- **When omitted**: existing type is preserved (fully backwards compatible — zero breaking changes)
- **Combinable**: state change and type correction in one call

Real-world use case from the issue:
```json
{"entity_name": "2014/53/EU", "state": "active", "type": "directive"}
```

No new tool, no storage format change — the `EntityRecord.Type` field already existed and was already preserved on state updates. This is purely a wiring change.

## Test plan

- [ ] `TestSetEntityState_PreservesTypeWhenNotProvided` — omitting type leaves existing type intact
- [ ] `TestSetEntityState_UpdatesTypeWhenProvided` — wrong type corrected to new value
- [ ] `TestSetEntityState_UpdatesBothStateAndType` — state + type updated together
- [ ] `TestSetEntityState_NotFound` — error for unknown entity
- [ ] `TestHandleEntityStateWithType` — handler returns `type` field in response when provided
- [ ] `TestHandleEntityStateWithoutTypeOmitsTypeField` — handler omits `type` field when not provided
- [ ] All 7 existing entity_state handler tests pass unchanged
- [ ] Full engine + mcp `-race` suite clean