### PR TITLE
engine: seal Store() leaks and fix Filter.Value type mismatches

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -659,9 +659,34 @@ func (e *Engine) generateEmbeddingBrief(ctx context.Context, items []mbp.Activat
 	return nil
 }
 
-// Store returns the underlying PebbleStore, used by the MCP adapter for direct storage access.
+// Store returns the underlying PebbleStore.
+// Prefer the typed engine methods (GetEngram, UpdateTags, CheckIdempotency, WriteIdempotency)
+// over direct Store() access. Store() is retained for HNSW plugin wiring that
+// requires the raw store adapter.
 func (e *Engine) Store() *storage.PebbleStore {
 	return e.store
+}
+
+// GetEngram fetches a single engram by vault and ULID.
+func (e *Engine) GetEngram(ctx context.Context, vault string, id storage.ULID) (*storage.Engram, error) {
+	wsPrefix := e.store.ResolveVaultPrefix(vault)
+	return e.store.GetEngram(ctx, wsPrefix, id)
+}
+
+// UpdateTags replaces the tags on an engram.
+func (e *Engine) UpdateTags(ctx context.Context, vault string, id storage.ULID, tags []string) error {
+	wsPrefix := e.store.ResolveVaultPrefix(vault)
+	return e.store.UpdateTags(ctx, wsPrefix, id, tags)
+}
+
+// CheckIdempotency looks up an op_id receipt. Returns nil, nil if not found.
+func (e *Engine) CheckIdempotency(ctx context.Context, opID string) (*storage.IdempotencyReceipt, error) {
+	return e.store.CheckIdempotency(ctx, opID)
+}
+
+// WriteIdempotency stores an idempotency receipt (op_id → engramID).
+func (e *Engine) WriteIdempotency(ctx context.Context, opID, engramID string) error {
+	return e.store.WriteIdempotency(ctx, opID, engramID)
 }
 
 // CountEmbedded returns the count of engrams that have had embeddings generated

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -203,10 +203,7 @@ func (a *mcpEngineAdapter) RetryEnrich(ctx context.Context, vault, id string) (*
 		return nil, fmt.Errorf("retry enrich: parse id: %w", err)
 	}
 
-	// Get the vault prefix and fetch the engram
-	store := a.eng.Store()
-	wsPrefix := store.ResolveVaultPrefix(vault)
-	eng, err := store.GetEngram(ctx, wsPrefix, ulid)
+	eng, err := a.eng.GetEngram(ctx, vault, ulid)
 	if err != nil {
 		return nil, fmt.Errorf("retry enrich: get engram: %w", err)
 	}
@@ -322,11 +319,11 @@ func (a *mcpEngineAdapter) FindByEntity(ctx context.Context, vault, entityName s
 }
 
 func (a *mcpEngineAdapter) CheckIdempotency(ctx context.Context, opID string) (*storage.IdempotencyReceipt, error) {
-	return a.eng.Store().CheckIdempotency(ctx, opID)
+	return a.eng.CheckIdempotency(ctx, opID)
 }
 
 func (a *mcpEngineAdapter) WriteIdempotency(ctx context.Context, opID, engramID string) error {
-	return a.eng.Store().WriteIdempotency(ctx, opID, engramID)
+	return a.eng.WriteIdempotency(ctx, opID, engramID)
 }
 
 func (a *mcpEngineAdapter) SetEntityState(ctx context.Context, entityName, state, mergedInto, entityType string) error {

--- a/internal/query/mql/executor.go
+++ b/internal/query/mql/executor.go
@@ -199,12 +199,13 @@ func buildFilter(f *query.Filter, pred Predicate) error {
 func convertFilterToMBPFilters(f *query.Filter) []mbp.Filter {
 	var filters []mbp.Filter
 
-	// State filters
+	// State filters — use storage.LifecycleState directly so passesMetaFilter's
+	// type assertion (f.Value.(storage.LifecycleState)) succeeds.
 	for _, state := range f.States {
 		filters = append(filters, mbp.Filter{
 			Field: "state",
 			Op:    "=",
-			Value: uint8(state),
+			Value: state,
 		})
 	}
 
@@ -226,12 +227,13 @@ func convertFilterToMBPFilters(f *query.Filter) []mbp.Filter {
 		})
 	}
 
-	// CreatedAfter filter
+	// CreatedAfter filter — use time.Time so extractTimeBounds' type assertion
+	// (f.Value.(time.Time)) succeeds and enables time-bounded candidate injection.
 	if f.CreatedAfter != nil {
 		filters = append(filters, mbp.Filter{
 			Field: "created_after",
 			Op:    ">=",
-			Value: f.CreatedAfter.Unix(),
+			Value: *f.CreatedAfter,
 		})
 	}
 

--- a/internal/transport/rest/engine_adapter.go
+++ b/internal/transport/rest/engine_adapter.go
@@ -419,8 +419,7 @@ func (w *RESTEngineWrapper) UpdateTags(ctx context.Context, vault, engramID stri
 	if err != nil {
 		return fmt.Errorf("invalid engram id: %w", err)
 	}
-	ws := w.engine.Store().ResolveVaultPrefix(vault)
-	return w.engine.Store().UpdateTags(ctx, ws, ulid, tags)
+	return w.engine.UpdateTags(ctx, vault, ulid, tags)
 }
 
 func (w *RESTEngineWrapper) ListDeleted(ctx context.Context, vault string, limit int) (*ListDeletedResponse, error) {
@@ -453,8 +452,7 @@ func (w *RESTEngineWrapper) RetryEnrich(ctx context.Context, vault, engramID str
 	if err != nil {
 		return nil, fmt.Errorf("invalid engram id: %w", err)
 	}
-	ws := w.engine.Store().ResolveVaultPrefix(vault)
-	eng, err := w.engine.Store().GetEngram(ctx, ws, ulid)
+	eng, err := w.engine.GetEngram(ctx, vault, ulid)
 	if err != nil {
 		return nil, fmt.Errorf("get engram: %w", err)
 	}
@@ -485,11 +483,10 @@ func (w *RESTEngineWrapper) GetContradictions(ctx context.Context, vault string)
 	if err != nil {
 		return nil, err
 	}
-	ws := w.engine.Store().ResolveVaultPrefix(vault)
 	items := make([]ContradictionItem, 0, len(pairs))
 	for _, pair := range pairs {
-		engA, errA := w.engine.Store().GetEngram(ctx, ws, pair[0])
-		engB, errB := w.engine.Store().GetEngram(ctx, ws, pair[1])
+		engA, errA := w.engine.GetEngram(ctx, vault, pair[0])
+		engB, errB := w.engine.GetEngram(ctx, vault, pair[1])
 		item := ContradictionItem{
 			IDa: pair[0].String(),
 			IDb: pair[1].String(),


### PR DESCRIPTION
## Summary

- **Store() delegation** — adapters no longer reach through `engine.Store()` to call storage methods directly. Four new engine methods encapsulate the logic:
  - `GetEngram(ctx, vault, id)` — vault-prefix-aware engram fetch
  - `UpdateTags(ctx, vault, id, tags)` — vault-prefix-aware tag replacement
  - `CheckIdempotency(ctx, opID)` — delegates to store
  - `WriteIdempotency(ctx, opID, engramID)` — delegates to store
- MCP adapter: `RetryEnrich`, `CheckIdempotency`, `WriteIdempotency` updated
- REST adapter: `RetryEnrich`, `UpdateTags`, `GetContradictions` updated
- `Store()` is retained (updated doc comment) for HNSW plugin wiring that still needs the raw store adapter

- **Filter.Value type fixes** — `convertFilterToMBPFilters` in the MQL executor was inserting wrong Go types into `mbp.Filter.Value`:
  - `state` used `uint8(state)` but `passesMetaFilter` asserts `storage.LifecycleState` → assertion always silently failed
  - `created_after` used `.Unix()` (`int64`) but `extractTimeBounds` asserts `time.Time` → time-bounded candidate injection never triggered for MQL queries
  - Both fixed to use the correct types

## Test plan

- [ ] `go build ./...` passes clean
- [ ] `go test ./internal/engine/... ./internal/mcp/... ./internal/query/mql/... ./internal/transport/rest/... -race -count=1` — all pass
- [ ] No protocol/API changes — purely internal engine surface cleanup