### PR TITLE
embed: isolate ONNX/CGO behind localassets build tag (Stage 1)

### DIFF
--- a/internal/plugin/embed/local.go
+++ b/internal/plugin/embed/local.go
@@ -1,3 +1,5 @@
+//go:build localassets
+
 package embed
 
 import (
@@ -7,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -241,52 +242,6 @@ func (p *LocalProvider) EmbedBatch(ctx context.Context, texts []string) ([]float
 }
 
 // clsPool extracts the [CLS] token embedding at position 0.
-// BGE models (bge-small-en-v1.5) encode sentence meaning into the [CLS] token.
-// hidden: flat [seqLen, dim] slice for a single sequence.
-func clsPool(hidden []float32, dim int) []float32 {
-	result := make([]float32, dim)
-	copy(result, hidden[:dim])
-	return result
-}
-
-// meanPool computes the mean of token embeddings weighted by the attention mask.
-// hidden: flat [1, seqLen, dim] slice; mask: [seqLen] with 0/1 values.
-func meanPool(hidden []float32, mask []int64, seqLen, dim int) []float32 {
-	result := make([]float32, dim)
-	var count float32
-	for t := 0; t < seqLen; t++ {
-		if mask[t] == 0 {
-			continue
-		}
-		count++
-		base := t * dim
-		for d := 0; d < dim; d++ {
-			result[d] += hidden[base+d]
-		}
-	}
-	if count > 0 {
-		for d := range result {
-			result[d] /= count
-		}
-	}
-	return result
-}
-
-// l2Normalize divides v by its L2 norm in place.
-func l2Normalize(v []float32) {
-	var sum float32
-	for _, x := range v {
-		sum += x * x
-	}
-	if sum == 0 {
-		return
-	}
-	inv := float32(1.0 / math.Sqrt(float64(sum)))
-	for i := range v {
-		v[i] *= inv
-	}
-}
-
 // Close releases the ORT session.
 func (p *LocalProvider) Close() error {
 	p.mu.Lock()

--- a/internal/plugin/embed/local_assets_noembed.go
+++ b/internal/plugin/embed/local_assets_noembed.go
@@ -2,6 +2,11 @@
 
 package embed
 
+import (
+	"context"
+	"fmt"
+)
+
 // Stub declarations used when building without embedded assets (no -tags localassets).
 // Run `make fetch-assets` then use `-tags localassets` to build with real assets.
 
@@ -16,3 +21,19 @@ const nativeLibFilename = ""
 func LocalAvailable() bool {
 	return false
 }
+
+// LocalProvider is a stub used when building without -tags localassets.
+// Init always returns an error directing the caller to use a network provider.
+type LocalProvider struct{}
+
+func (p *LocalProvider) Name() string { return "local" }
+func (p *LocalProvider) MaxBatchSize() int { return 0 }
+func (p *LocalProvider) Init(_ context.Context, _ ProviderHTTPConfig) (int, error) {
+	return 0, errLocalUnavailable
+}
+func (p *LocalProvider) EmbedBatch(_ context.Context, _ []string) ([]float32, error) {
+	return nil, errLocalUnavailable
+}
+func (p *LocalProvider) Close() error { return nil }
+
+var errLocalUnavailable = fmt.Errorf("local embedder not available: build with -tags localassets or use a network provider (ollama, openai, etc.)")

--- a/internal/plugin/embed/local_math.go
+++ b/internal/plugin/embed/local_math.go
@@ -1,0 +1,50 @@
+package embed
+
+import "math"
+
+// clsPool extracts the CLS token embedding from a flat hidden-state tensor.
+// BGE models (bge-small-en-v1.5) encode sentence meaning into the [CLS] token.
+// hidden: flat [seqLen, dim] slice for a single sequence.
+func clsPool(hidden []float32, dim int) []float32 {
+	result := make([]float32, dim)
+	copy(result, hidden[:dim])
+	return result
+}
+
+// meanPool computes the mean of token embeddings weighted by the attention mask.
+// hidden: flat [1, seqLen, dim] slice; mask: [seqLen] with 0/1 values.
+func meanPool(hidden []float32, mask []int64, seqLen, dim int) []float32 {
+	result := make([]float32, dim)
+	var count float32
+	for t := 0; t < seqLen; t++ {
+		if mask[t] == 0 {
+			continue
+		}
+		count++
+		base := t * dim
+		for d := 0; d < dim; d++ {
+			result[d] += hidden[base+d]
+		}
+	}
+	if count > 0 {
+		for d := range result {
+			result[d] /= count
+		}
+	}
+	return result
+}
+
+// l2Normalize divides v by its L2 norm in place.
+func l2Normalize(v []float32) {
+	var sum float32
+	for _, x := range v {
+		sum += x * x
+	}
+	if sum == 0 {
+		return
+	}
+	inv := float32(1.0 / math.Sqrt(float64(sum)))
+	for i := range v {
+		v[i] *= inv
+	}
+}

--- a/internal/plugin/embed/local_math_test.go
+++ b/internal/plugin/embed/local_math_test.go
@@ -1,0 +1,138 @@
+package embed
+
+import (
+	"math"
+	"testing"
+)
+
+// TestMeanPool verifies mean pooling logic against a hand-calculated reference.
+func TestMeanPool(t *testing.T) {
+	// 3 tokens, dim=2.  Token 0 and 2 are active (mask=1), token 1 is padding (mask=0).
+	hidden := []float32{
+		1, 2,   // token 0
+		10, 10, // token 1 (padding — excluded)
+		3, 4,   // token 2
+	}
+	mask := []int64{1, 0, 1}
+
+	got := meanPool(hidden, mask, 3, 2)
+
+	// Expected: mean of tokens 0 and 2 = ([1+3]/2, [2+4]/2) = (2, 3)
+	if diff := abs32(got[0] - 2.0); diff > 1e-5 {
+		t.Errorf("dim 0: want 2.0, got %.6f", got[0])
+	}
+	if diff := abs32(got[1] - 3.0); diff > 1e-5 {
+		t.Errorf("dim 1: want 3.0, got %.6f", got[1])
+	}
+}
+
+// TestMeanPoolAllPadding verifies that an all-zero mask returns a zero vector without panic.
+func TestMeanPoolAllPadding(t *testing.T) {
+	hidden := []float32{1, 2, 3, 4}
+	mask := []int64{0, 0}
+	got := meanPool(hidden, mask, 2, 2)
+	if got[0] != 0 || got[1] != 0 {
+		t.Errorf("all-padding: expected [0 0], got %v", got)
+	}
+}
+
+// TestL2Normalize verifies that the output vector has unit norm.
+func TestL2Normalize(t *testing.T) {
+	v := []float32{3, 4} // L2 norm = 5; expected output [0.6, 0.8]
+	l2Normalize(v)
+
+	norm := computeNorm(v)
+	if diff := math.Abs(norm - 1.0); diff > 1e-6 {
+		t.Errorf("expected unit norm, got %.8f", norm)
+	}
+	if diff := abs32(v[0] - 0.6); diff > 1e-5 {
+		t.Errorf("v[0]: want 0.6, got %.6f", v[0])
+	}
+	if diff := abs32(v[1] - 0.8); diff > 1e-5 {
+		t.Errorf("v[1]: want 0.8, got %.6f", v[1])
+	}
+}
+
+// TestL2NormalizeZero verifies that a zero vector doesn't panic or produce NaN/Inf.
+func TestL2NormalizeZero(t *testing.T) {
+	v := []float32{0, 0, 0}
+	l2Normalize(v)
+	for i, x := range v {
+		if math.IsNaN(float64(x)) || math.IsInf(float64(x), 0) {
+			t.Errorf("v[%d] is NaN/Inf after zero-norm l2Normalize", i)
+		}
+	}
+}
+
+// --- clsPool tests (bge-small-en-v1.5 CLS-token extraction) ---
+
+func TestClsPool(t *testing.T) {
+	// 4 tokens, dim=3. CLS token is at position 0.
+	hidden := []float32{
+		1, 2, 3, // token 0: CLS — must be extracted
+		9, 9, 9, // token 1: unused
+		8, 8, 8, // token 2: unused
+		7, 7, 7, // token 3: unused
+	}
+	got := clsPool(hidden, 3)
+
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3", len(got))
+	}
+	if got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("cls token: got %v, want [1 2 3]", got)
+	}
+	// Verify independence: modifying got must not affect hidden.
+	got[0] = 99
+	if hidden[0] == 99 {
+		t.Error("clsPool returned a slice sharing the hidden buffer (must copy)")
+	}
+}
+
+func TestClsPool_MinimalSequence(t *testing.T) {
+	hidden := []float32{0.5, -0.5, 1.0}
+	got := clsPool(hidden, 3)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	for i, want := range []float32{0.5, -0.5, 1.0} {
+		if abs32(got[i]-want) > 1e-6 {
+			t.Errorf("dim %d: got %v, want %v", i, got[i], want)
+		}
+	}
+}
+
+func TestClsPool_AfterL2Normalize(t *testing.T) {
+	hidden := []float32{
+		3, 0, 4, // CLS: norm = 5 → normalized [0.6, 0, 0.8]
+		1, 1, 1, // irrelevant padding token
+	}
+	vec := clsPool(hidden, 3)
+	l2Normalize(vec)
+
+	norm := computeNorm(vec)
+	if math.Abs(norm-1.0) > 1e-5 {
+		t.Errorf("expected unit norm after CLS-pool + L2-normalize, got %.8f", norm)
+	}
+	if abs32(vec[0]-0.6) > 1e-5 {
+		t.Errorf("dim 0: got %v, want 0.6", vec[0])
+	}
+	if abs32(vec[2]-0.8) > 1e-5 {
+		t.Errorf("dim 2: got %v, want 0.8", vec[2])
+	}
+}
+
+func abs32(x float32) float32 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func computeNorm(v []float32) float64 {
+	var sum float64
+	for _, x := range v {
+		sum += float64(x) * float64(x)
+	}
+	return math.Sqrt(sum)
+}

--- a/internal/plugin/embed/local_test.go
+++ b/internal/plugin/embed/local_test.go
@@ -1,129 +1,13 @@
+//go:build localassets
+
 package embed
 
 import (
 	"bytes"
-	"math"
 	"os"
 	"path/filepath"
 	"testing"
 )
-
-// TestMeanPool verifies mean pooling logic against a hand-calculated reference.
-func TestMeanPool(t *testing.T) {
-	// 3 tokens, dim=2.  Token 0 and 2 are active (mask=1), token 1 is padding (mask=0).
-	hidden := []float32{
-		1, 2,   // token 0
-		10, 10, // token 1 (padding — excluded)
-		3, 4,   // token 2
-	}
-	mask := []int64{1, 0, 1}
-
-	got := meanPool(hidden, mask, 3, 2)
-
-	// Expected: mean of tokens 0 and 2 = ([1+3]/2, [2+4]/2) = (2, 3)
-	if diff := abs32(got[0] - 2.0); diff > 1e-5 {
-		t.Errorf("dim 0: want 2.0, got %.6f", got[0])
-	}
-	if diff := abs32(got[1] - 3.0); diff > 1e-5 {
-		t.Errorf("dim 1: want 3.0, got %.6f", got[1])
-	}
-}
-
-// TestMeanPoolAllPadding verifies that an all-zero mask returns a zero vector without panic.
-func TestMeanPoolAllPadding(t *testing.T) {
-	hidden := []float32{1, 2, 3, 4}
-	mask := []int64{0, 0}
-	got := meanPool(hidden, mask, 2, 2)
-	if got[0] != 0 || got[1] != 0 {
-		t.Errorf("all-padding: expected [0 0], got %v", got)
-	}
-}
-
-// TestL2Normalize verifies that the output vector has unit norm.
-func TestL2Normalize(t *testing.T) {
-	v := []float32{3, 4} // L2 norm = 5; expected output [0.6, 0.8]
-	l2Normalize(v)
-
-	norm := computeNorm(v)
-	if diff := math.Abs(norm - 1.0); diff > 1e-6 {
-		t.Errorf("expected unit norm, got %.8f", norm)
-	}
-	if diff := abs32(v[0] - 0.6); diff > 1e-5 {
-		t.Errorf("v[0]: want 0.6, got %.6f", v[0])
-	}
-	if diff := abs32(v[1] - 0.8); diff > 1e-5 {
-		t.Errorf("v[1]: want 0.8, got %.6f", v[1])
-	}
-}
-
-// TestL2NormalizeZero verifies that a zero vector doesn't panic or produce NaN/Inf.
-func TestL2NormalizeZero(t *testing.T) {
-	v := []float32{0, 0, 0}
-	l2Normalize(v)
-	for i, x := range v {
-		if math.IsNaN(float64(x)) || math.IsInf(float64(x), 0) {
-			t.Errorf("v[%d] is NaN/Inf after zero-norm l2Normalize", i)
-		}
-	}
-}
-
-// --- clsPool tests (bge-small-en-v1.5 CLS-token extraction) ---
-
-func TestClsPool(t *testing.T) {
-	// 4 tokens, dim=3. CLS token is at position 0.
-	hidden := []float32{
-		1, 2, 3, // token 0: CLS — must be extracted
-		9, 9, 9, // token 1: unused
-		8, 8, 8, // token 2: unused
-		7, 7, 7, // token 3: unused
-	}
-	got := clsPool(hidden, 3)
-
-	if len(got) != 3 {
-		t.Fatalf("len(got) = %d, want 3", len(got))
-	}
-	if got[0] != 1 || got[1] != 2 || got[2] != 3 {
-		t.Errorf("cls token: got %v, want [1 2 3]", got)
-	}
-	// Verify independence: modifying got must not affect hidden.
-	got[0] = 99
-	if hidden[0] == 99 {
-		t.Error("clsPool returned a slice sharing the hidden buffer (must copy)")
-	}
-}
-
-func TestClsPool_MinimalSequence(t *testing.T) {
-	hidden := []float32{0.5, -0.5, 1.0}
-	got := clsPool(hidden, 3)
-	if len(got) != 3 {
-		t.Fatalf("len = %d, want 3", len(got))
-	}
-	for i, want := range []float32{0.5, -0.5, 1.0} {
-		if abs32(got[i]-want) > 1e-6 {
-			t.Errorf("dim %d: got %v, want %v", i, got[i], want)
-		}
-	}
-}
-
-func TestClsPool_AfterL2Normalize(t *testing.T) {
-	hidden := []float32{
-		3, 0, 4, // CLS: norm = 5 → normalized [0.6, 0, 0.8]
-		1, 1, 1, // irrelevant padding token
-	}
-	vec := clsPool(hidden, 3)
-	l2Normalize(vec)
-
-	norm := computeNorm(vec)
-	if math.Abs(norm-1.0) > 1e-5 {
-		t.Errorf("expected unit norm after CLS-pool + L2-normalize, got %.8f", norm)
-	}
-	if abs32(vec[0]-0.6) > 1e-5 {
-		t.Errorf("dim 0: got %v, want 0.6", vec[0])
-	}
-	if abs32(vec[2]-0.8) > 1e-5 {
-		t.Errorf("dim 2: got %v, want 0.8", vec[2])
-	}
-}
 
 func TestLocalProvider_Name(t *testing.T) {
 	p := &LocalProvider{}
@@ -216,19 +100,4 @@ func TestReadAll_Empty(t *testing.T) {
 
 func TestLocalAvailable(t *testing.T) {
 	_ = LocalAvailable()
-}
-
-func abs32(x float32) float32 {
-	if x < 0 {
-		return -x
-	}
-	return x
-}
-
-func computeNorm(v []float32) float64 {
-	var sum float64
-	for _, x := range v {
-		sum += float64(x) * float64(x)
-	}
-	return math.Sqrt(sum)
 }


### PR DESCRIPTION
## Summary

Stage 1 of the embedding/adoption roadmap. `CGO_ENABLED=0 go build ./...` now compiles cleanly, unblocking gomobile, WASM, and any CGO-free build environment.

- `local.go` gets `//go:build localassets` — the `yalue/onnxruntime_go` CGO dependency is now gated behind the existing `localassets` tag
- `local_math.go` (new) — extracts `clsPool`, `meanPool`, `l2Normalize` as pure-Go helpers with no build tag; always available
- `local_assets_noembed.go` — adds a `LocalProvider` stub that satisfies the `Provider` interface in non-`localassets` builds; `Init` returns a clear error directing callers to a network provider
- `local_math_test.go` (new) — math function tests always run regardless of build tags
- `local_test.go` — `LocalProvider`/utility tests gated on `localassets`

**Daemon builds with `-tags localassets` are byte-for-byte identical to before.**

## Test plan

- [ ] `go build ./...` — passes (CGO enabled, no localassets)
- [ ] `CGO_ENABLED=0 go build ./...` — passes (no CGO, no localassets)
- [ ] `go test ./internal/plugin/embed/... -count=1` — math tests run without localassets
- [ ] CI with `localassets` tag — daemon build + full test suite unchanged