### PR TITLE
feat: Stage 3 — muninn.Open() embedded convenience layer

### DIFF
--- a/muninn.go
+++ b/muninn.go
@@ -1,0 +1,201 @@
+// Package muninn provides an embeddable API for MuninnDB.
+//
+// Open a database with [Open], write memories with [DB.Remember], recall them
+// with [DB.Recall], read by ID with [DB.Read], and remove them with [DB.Forget].
+// Call [DB.Close] when done to flush and release the exclusive Pebble lock.
+//
+// Example:
+//
+//	db, err := muninn.Open("./data")
+//	if err != nil { ... }
+//	defer db.Close()
+//
+//	id, err := db.Remember(ctx, "default", "Go tips", "Prefer table-driven tests.")
+package muninn
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/scrypster/muninndb/internal/cognitive"
+	"github.com/scrypster/muninndb/internal/engine"
+	"github.com/scrypster/muninndb/internal/engine/activation"
+	"github.com/scrypster/muninndb/internal/index/fts"
+	hnswpkg "github.com/scrypster/muninndb/internal/index/hnsw"
+	"github.com/scrypster/muninndb/internal/replication"
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/storage/migrate"
+)
+
+// Options configures an embedded DB instance.
+type Options struct {
+	// Embedder enables semantic (vector) recall in addition to full-text search.
+	// When nil, only full-text search is used.
+	Embedder Embedder
+}
+
+// Embedder converts a single piece of text to a dense vector.
+// Implement this interface to plug in any embedding model.
+type Embedder interface {
+	// Embed returns the embedding vector for the given text.
+	Embed(ctx context.Context, text string) ([]float32, error)
+	// Dims returns the dimensionality of the output vectors.
+	Dims() int
+}
+
+// DB is an open MuninnDB instance. Use [Open] to create one.
+// DB is safe for concurrent use from multiple goroutines.
+type DB struct {
+	eng     *engine.Engine
+	store   *storage.PebbleStore
+	hebbW   *cognitive.HebbianWorker
+	transW  *cognitive.TransitionWorker
+	cancel  context.CancelFunc
+	workers sync.WaitGroup // tracks contradW and confidW goroutines
+}
+
+// Open opens (or creates) a MuninnDB database at dataDir.
+// Only one process may hold the lock at a time; a second Open on the same
+// directory returns an error that wraps the underlying Pebble lock error.
+//
+// Optional functional options may be supplied to configure the instance:
+//
+//	db, err := muninn.Open("./data", func(o *muninn.Options) {
+//	    o.Embedder = myEmbedder
+//	})
+func Open(dataDir string, opts ...func(*Options)) (*DB, error) {
+	var o Options
+	for _, fn := range opts {
+		fn(&o)
+	}
+
+	pebblePath := filepath.Join(dataDir, "pebble")
+	if err := os.MkdirAll(pebblePath, 0o755); err != nil {
+		return nil, fmt.Errorf("muninndb: create data dir %q: %w", pebblePath, err)
+	}
+
+	rawDB, err := storage.OpenPebble(pebblePath, storage.DefaultOptions())
+	if err != nil {
+		if isLockError(err) {
+			return nil, fmt.Errorf("muninndb: %q is held by another process (daemon running?): %w", dataDir, err)
+		}
+		return nil, fmt.Errorf("muninndb: open pebble: %w", err)
+	}
+
+	if err := replication.CheckAndSetSchemaVersion(rawDB); err != nil {
+		_ = rawDB.Close()
+		return nil, fmt.Errorf("muninndb: schema version check: %w", err)
+	}
+
+	migRunner := migrate.NewRunner(rawDB)
+	migRunner.Register(migrate.Migration{
+		Version:     1,
+		Description: "backfill embed_dim in ERF records for existing embeddings",
+		Up:          migrate.BackfillEmbedDim,
+	})
+	migRunner.Register(migrate.Migration{
+		Version:     2,
+		Description: "backfill relationship entity index (0x26) for GetEntityAggregate optimisation",
+		Up:          migrate.BackfillRelEntityIndex,
+	})
+	if _, err := migRunner.Run(); err != nil {
+		_ = rawDB.Close()
+		return nil, fmt.Errorf("muninndb: migration: %w", err)
+	}
+
+	store := storage.NewPebbleStore(rawDB, storage.PebbleStoreConfig{CacheSize: 10000})
+	// No store.SetWAL() — embedded mode; Pebble provides durability.
+
+	ftsIndex := fts.New(rawDB)
+	hnswReg := hnswpkg.NewRegistry(rawDB)
+
+	var actEmbedder activation.Embedder
+	if o.Embedder != nil {
+		actEmbedder = &embedderAdapter{pub: o.Embedder}
+	} else {
+		actEmbedder = activation.NewNoopEmbedder()
+	}
+
+	actEngine := activation.New(store, activation.NewFTSAdapter(ftsIndex), activation.NewHNSWAdapter(hnswReg), actEmbedder)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	hebbW := cognitive.NewHebbianWorker(cognitive.NewHebbianStoreAdapter(store))
+	contradW := cognitive.NewContradictWorker(cognitive.NewContradictStoreAdapter(store))
+	confidW := cognitive.NewConfidenceWorker(cognitive.NewConfidenceStoreAdapter(store))
+	transW := cognitive.NewTransitionWorker(ctx, store.TransitionCache())
+	actEngine.SetTransitionStore(store.TransitionCache())
+
+	eng := engine.NewEngine(engine.EngineConfig{
+		Store:            store,
+		FTSIndex:         ftsIndex,
+		ActivationEngine: actEngine,
+		HebbianWorker:    hebbW,
+		ContradictWorker: contradW.Worker,
+		ConfidenceWorker: confidW.Worker,
+		Embedder:         actEmbedder,
+		HNSWRegistry:     hnswReg,
+	})
+	eng.SetTransitionWorker(transW)
+
+	db := &DB{
+		eng:    eng,
+		store:  store,
+		hebbW:  hebbW,
+		transW: transW,
+		cancel: cancel,
+	}
+
+	db.workers.Add(2)
+	go func() { defer db.workers.Done(); contradW.Worker.Run(ctx) }() //nolint:errcheck
+	go func() { defer db.workers.Done(); confidW.Worker.Run(ctx) }()  //nolint:errcheck
+
+	return db, nil
+}
+
+// Close flushes all pending writes and releases the exclusive database lock.
+// After Close returns, the DB must not be used.
+func (db *DB) Close() error {
+	db.cancel()          // signals contradW and confidW goroutines to stop
+	db.workers.Wait()    // wait for contradW and confidW to flush and exit
+	db.eng.Stop()        // coherence flush, novelty/FTS drain, job drain
+	db.hebbW.Stop()      // AFTER eng.Stop — flushes buffered Hebbian writes
+	db.transW.Stop()
+	return db.store.Close()
+}
+
+// isLockError reports whether err indicates that the Pebble database is already
+// held by another process.
+func isLockError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "lock") || strings.Contains(msg, "LOCK") || strings.Contains(msg, "already in use")
+}
+
+// embedderAdapter adapts the public muninn.Embedder to activation.Embedder.
+type embedderAdapter struct {
+	pub Embedder
+}
+
+func (a *embedderAdapter) Embed(ctx context.Context, texts []string) ([]float32, error) {
+	dims := a.pub.Dims()
+	out := make([]float32, 0, len(texts)*dims)
+	for _, t := range texts {
+		vec, err := a.pub.Embed(ctx, t)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vec...)
+	}
+	return out, nil
+}
+
+func (a *embedderAdapter) Tokenize(text string) []string {
+	return strings.Fields(text)
+}

--- a/muninn_test.go
+++ b/muninn_test.go
@@ -1,0 +1,155 @@
+package muninn_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	muninn "github.com/scrypster/muninndb"
+)
+
+func openTestDB(t *testing.T) *muninn.DB {
+	t.Helper()
+	db, err := muninn.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestOpen_Remember_Recall(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+
+	_, err := db.Remember(ctx, "default", "golang", "Go uses goroutines for concurrency.")
+	if err != nil {
+		t.Fatalf("Remember: %v", err)
+	}
+	_, err = db.Remember(ctx, "default", "python", "Python uses the GIL for thread safety.")
+	if err != nil {
+		t.Fatalf("Remember: %v", err)
+	}
+	_, err = db.Remember(ctx, "default", "rust", "Rust enforces memory safety at compile time.")
+	if err != nil {
+		t.Fatalf("Remember: %v", err)
+	}
+
+	// FTS indexing is async; retry until the written engrams are visible.
+	var results []muninn.Engram
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var err error
+		results, err = db.Recall(ctx, "default", "goroutines concurrency", 5)
+		if err != nil {
+			t.Fatalf("Recall: %v", err)
+		}
+		if len(results) > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("expected at least one result, got none after 5s")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	found := false
+	for _, e := range results {
+		if e.Concept == "golang" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'golang' engram in results; got: %+v", results)
+	}
+}
+
+func TestOpen_Read(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+
+	id, err := db.Remember(ctx, "default", "test concept", "test content")
+	if err != nil {
+		t.Fatalf("Remember: %v", err)
+	}
+
+	e, err := db.Read(ctx, "default", id)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if e.ID != id {
+		t.Errorf("got ID %q, want %q", e.ID, id)
+	}
+	if e.Content != "test content" {
+		t.Errorf("got content %q, want %q", e.Content, "test content")
+	}
+	if e.Concept != "test concept" {
+		t.Errorf("got concept %q, want %q", e.Concept, "test concept")
+	}
+}
+
+func TestOpen_Forget(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+
+	id, err := db.Remember(ctx, "default", "ephemeral", "to be deleted")
+	if err != nil {
+		t.Fatalf("Remember: %v", err)
+	}
+
+	if err := db.Forget(ctx, "default", id); err != nil {
+		t.Fatalf("Forget: %v", err)
+	}
+
+	_, err = db.Read(ctx, "default", id)
+	if err != muninn.ErrNotFound {
+		t.Errorf("expected ErrNotFound after Forget, got: %v", err)
+	}
+}
+
+func TestOpen_Close_Reopen(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	db, err := muninn.Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	id, err := db.Remember(ctx, "default", "durable", "should survive close")
+	if err != nil {
+		t.Fatalf("Remember: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	db2, err := muninn.Open(dir)
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer db2.Close()
+
+	e, err := db2.Read(ctx, "default", id)
+	if err != nil {
+		t.Fatalf("Read after reopen: %v", err)
+	}
+	if e.Content != "should survive close" {
+		t.Errorf("durability failure: got %q", e.Content)
+	}
+}
+
+func TestOpen_AlreadyLocked(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := muninn.Open(dir)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	defer db.Close()
+
+	_, err = muninn.Open(dir)
+	if err == nil {
+		t.Fatal("expected error when opening already-locked database, got nil")
+	}
+}

--- a/recall.go
+++ b/recall.go
@@ -1,0 +1,96 @@
+package muninn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/engine"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// Recall returns up to limit engrams from vault that are relevant to query.
+// When limit is 0 the server default (10) is used.
+// Results are ordered by descending relevance score.
+func (db *DB) Recall(ctx context.Context, vault, query string, limit int) ([]Engram, error) {
+	resp, err := db.eng.Activate(ctx, &mbp.ActivateRequest{
+		Vault:      vault,
+		Context:    []string{query},
+		MaxResults: limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("muninndb recall: %w", err)
+	}
+	out := make([]Engram, len(resp.Activations))
+	for i, a := range resp.Activations {
+		out[i] = Engram{
+			ID:         a.ID,
+			Concept:    a.Concept,
+			Content:    a.Content,
+			Summary:    a.Summary,
+			Score:      float64(a.Score),
+			Confidence: a.Confidence,
+			CreatedAt:  time.Unix(0, a.CreatedAt),
+			LastAccess: time.Unix(0, a.LastAccess),
+		}
+	}
+	return out, nil
+}
+
+// Read retrieves the engram with the given ID from vault.
+// Returns [ErrNotFound] if no such engram exists.
+func (db *DB) Read(ctx context.Context, vault, id string) (*Engram, error) {
+	resp, err := db.eng.Read(ctx, &mbp.ReadRequest{
+		Vault: vault,
+		ID:    id,
+	})
+	if err != nil {
+		if isNotFound(err) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("muninndb read: %w", err)
+	}
+	e := &Engram{
+		ID:         resp.ID,
+		Concept:    resp.Concept,
+		Content:    resp.Content,
+		Summary:    resp.Summary,
+		State:      lifecycleStateName(resp.State),
+		Confidence: resp.Confidence,
+		Tags:       resp.Tags,
+		CreatedAt:  time.Unix(0, resp.CreatedAt),
+		LastAccess: time.Unix(0, resp.LastAccess),
+	}
+	return e, nil
+}
+
+// isNotFound reports whether err indicates a missing engram.
+func isNotFound(err error) bool {
+	return errors.Is(err, engine.ErrEngramNotFound)
+}
+
+// lifecycleStateName converts a raw state byte (from ReadResponse.State) to a
+// human-readable name. Values mirror internal/storage.LifecycleState constants.
+func lifecycleStateName(state uint8) string {
+	switch state {
+	case 0x00:
+		return "planning"
+	case 0x01:
+		return "active"
+	case 0x02:
+		return "paused"
+	case 0x03:
+		return "blocked"
+	case 0x04:
+		return "completed"
+	case 0x05:
+		return "cancelled"
+	case 0x06:
+		return "archived"
+	case 0x7F:
+		return "soft_deleted"
+	default:
+		return "unknown"
+	}
+}

--- a/remember.go
+++ b/remember.go
@@ -1,0 +1,39 @@
+package muninn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// Remember stores a new memory in the given vault and returns its ID.
+// concept is a short label (e.g. "Go tips"); content is the full text.
+func (db *DB) Remember(ctx context.Context, vault, concept, content string) (string, error) {
+	resp, err := db.eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   vault,
+		Concept: concept,
+		Content: content,
+	})
+	if err != nil {
+		return "", fmt.Errorf("muninndb remember: %w", err)
+	}
+	return resp.ID, nil
+}
+
+// Forget permanently deletes the engram with the given ID from vault.
+// Returns [ErrNotFound] if no such engram exists.
+func (db *DB) Forget(ctx context.Context, vault, id string) error {
+	_, err := db.eng.Forget(ctx, &mbp.ForgetRequest{
+		Vault: vault,
+		ID:    id,
+		Hard:  true,
+	})
+	if err != nil {
+		if isNotFound(err) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("muninndb forget: %w", err)
+	}
+	return nil
+}

--- a/types.go
+++ b/types.go
@@ -1,0 +1,23 @@
+package muninn
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrNotFound is returned when an engram with the requested ID does not exist.
+var ErrNotFound = errors.New("engram not found")
+
+// Engram is a single memory record returned by the public API.
+type Engram struct {
+	ID         string
+	Concept    string
+	Content    string
+	Summary    string
+	State      string
+	Score      float64
+	Confidence float32
+	Tags       []string
+	CreatedAt  time.Time
+	LastAccess time.Time
+}


### PR DESCRIPTION
## Summary

Stage 3 of the [embedding adoption roadmap](docs/plans/2026-03-14-embedding-adoption-roadmap.md). Any Go program can now embed MuninnDB with a single import — no daemon, no ports, no HTTP.

```go
db, err := muninn.Open("./data")
defer db.Close()

id, _ := db.Remember(ctx, "default", "Go tips", "Prefer table-driven tests.")
results, _ := db.Recall(ctx, "default", "table tests", 5)
```

## What's in this PR

- `muninn.go` — `DB`, `Open()`, `Close()`, `Options`, `Embedder` interface, full wiring, `embedderAdapter`
- `types.go` — `Engram`, `ErrNotFound`
- `remember.go` — `DB.Remember()`, `DB.Forget()`
- `recall.go` — `DB.Recall()`, `DB.Read()`, `lifecycleStateName`
- `muninn_test.go` — 5 integration tests

No existing files modified. Purely additive.

## Design notes

- **No internal leakage** — `mbp`, `storage`, `cognitive`, `engine` types never appear in public signatures
- **Shutdown safety** — `contradW`/`confidW` goroutines tracked in `sync.WaitGroup`; `Close()` blocks on `workers.Wait()` before `store.Close()`
- **Embedder bridge** — public `Embedder` (single-text, `Dims()`) adapted to internal `activation.Embedder` (batch, `Tokenize`) via `embedderAdapter`
- **No WAL** — embedded mode relies on Pebble's native durability; no replication concern
- **Lock error** — second `Open()` on same directory returns a wrapped error with daemon hint

## Test plan

- [x] `go build ./...` — clean
- [x] `CGO_ENABLED=0 go build .` — clean
- [x] `go test . -count=1 -race -v` — 5/5 pass
- [x] Opus architectural gate review — **APPROVED WITH NOTES** (4 non-blocking follow-ups logged)

## Opus review notes (non-blocking, tracked for follow-up)

1. `Recall` returns partially-populated `Engram` (`State`/`Tags` zero-valued) — `ActivationItem` doesn't carry them; document or split type in future
2. `isLockError` uses string matching — switch to `errors.Is` if Pebble ever exports a typed lock error
3. No test with custom `Embedder` — add mock embedder integration test as follow-up
4. `embedderAdapter.Embed` doesn't validate vector dimensions — add defensive check as follow-up