### PR TITLE
feat(sdks): Stage 6 — wire-format audit, bug fixes, and test suites

### DIFF
--- a/sdk/go/muninn/client.go
+++ b/sdk/go/muninn/client.go
@@ -76,14 +76,9 @@ func (c *Client) Write(ctx context.Context, vault, concept, content string, tags
 }
 
 // WriteWithOptions writes an engram with full control over all fields.
+// The caller is responsible for setting Confidence and Stability; no defaults
+// are applied (unlike Write, which hard-codes 0.9 and 0.5).
 func (c *Client) WriteWithOptions(ctx context.Context, req WriteRequest) (*WriteResponse, error) {
-	if req.Confidence == 0 {
-		req.Confidence = 0.9
-	}
-	if req.Stability == 0 {
-		req.Stability = 0.5
-	}
-
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
@@ -205,10 +200,16 @@ func (c *Client) Forget(ctx context.Context, id, vault string) error {
 	return c.request(ctx, "DELETE", path, nil, nil)
 }
 
-// Stats gets database statistics.
-func (c *Client) Stats(ctx context.Context) (*StatsResponse, error) {
+// Stats gets database statistics. Pass an empty vault to get global stats.
+func (c *Client) Stats(ctx context.Context, vault string) (*StatsResponse, error) {
+	path := "/api/stats"
+	if vault != "" {
+		q := url.Values{}
+		q.Set("vault", vault)
+		path += "?" + q.Encode()
+	}
 	resp := &StatsResponse{}
-	if err := c.request(ctx, "GET", "/api/stats", nil, resp); err != nil {
+	if err := c.request(ctx, "GET", path, nil, resp); err != nil {
 		return nil, err
 	}
 	return resp, nil
@@ -384,14 +385,16 @@ func (c *Client) Restore(ctx context.Context, id, vault string) (*RestoreRespons
 }
 
 // Traverse traverses the association graph from a starting engram.
-func (c *Client) Traverse(ctx context.Context, vault, startID string, maxHops, maxNodes int, relTypes []string) (*TraverseResponse, error) {
+// Set followEntities to true to follow entity-level associations in addition to engram-level ones.
+func (c *Client) Traverse(ctx context.Context, vault, startID string, maxHops, maxNodes int, relTypes []string, followEntities bool) (*TraverseResponse, error) {
 	payload := struct {
-		Vault    string   `json:"vault"`
-		StartID  string   `json:"start_id"`
-		MaxHops  int      `json:"max_hops"`
-		MaxNodes int      `json:"max_nodes"`
-		RelTypes []string `json:"rel_types,omitempty"`
-	}{Vault: vault, StartID: startID, MaxHops: maxHops, MaxNodes: maxNodes, RelTypes: relTypes}
+		Vault          string   `json:"vault"`
+		StartID        string   `json:"start_id"`
+		MaxHops        int      `json:"max_hops"`
+		MaxNodes       int      `json:"max_nodes"`
+		RelTypes       []string `json:"rel_types,omitempty"`
+		FollowEntities bool     `json:"follow_entities,omitempty"`
+	}{Vault: vault, StartID: startID, MaxHops: maxHops, MaxNodes: maxNodes, RelTypes: relTypes, FollowEntities: followEntities}
 
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/sdk/go/muninn/client_test.go
+++ b/sdk/go/muninn/client_test.go
@@ -179,7 +179,7 @@ func TestTraverse(t *testing.T) {
 	defer srv.Close()
 
 	client := NewClient(srv.URL, "test-token")
-	resp, err := client.Traverse(context.Background(), "default", "n1", 2, 20, nil)
+	resp, err := client.Traverse(context.Background(), "default", "n1", 2, 20, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -360,6 +360,106 @@ func TestRequest_ServerError(t *testing.T) {
 	}
 	if attempts != 3 {
 		t.Errorf("expected 3 attempts (1 initial + 2 retries), got %d", attempts)
+	}
+}
+
+func TestWriteWithOptions_ZeroConfidence_NotOverwritten(t *testing.T) {
+	var receivedBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(201)
+		json.NewEncoder(w).Encode(WriteResponse{ID: "x", CreatedAt: 1700000000})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-token")
+	_, err := client.WriteWithOptions(context.Background(), WriteRequest{
+		Vault:   "default",
+		Concept: "test",
+		Content: "body",
+		// Confidence and Stability explicitly zero — should NOT be defaulted to 0.9/0.5
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// confidence=0 is omitempty so it won't appear in the JSON — that's fine.
+	// The key assertion is that WriteWithOptions doesn't silently overwrite with 0.9.
+	if v, ok := receivedBody["confidence"]; ok && v == 0.9 {
+		t.Error("WriteWithOptions must not default confidence=0 to 0.9; caller controls the value")
+	}
+}
+
+func TestTraverse_FollowEntities_Sent(t *testing.T) {
+	var receivedBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode(TraverseResponse{})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-token")
+	_, err := client.Traverse(context.Background(), "default", "start-id", 2, 20, nil, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v, ok := receivedBody["follow_entities"]; !ok || v != true {
+		t.Errorf("expected follow_entities=true in request body, got: %v", receivedBody)
+	}
+}
+
+func TestStats_WithVault(t *testing.T) {
+	var receivedQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode(StatsResponse{EngramCount: 42})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-token")
+	resp, err := client.Stats(context.Background(), "myvault")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.EngramCount != 42 {
+		t.Errorf("expected 42 engrams, got %d", resp.EngramCount)
+	}
+	if receivedQuery != "vault=myvault" {
+		t.Errorf("expected vault=myvault in query, got: %s", receivedQuery)
+	}
+}
+
+func TestAssociationItem_JSONTags(t *testing.T) {
+	// Verify that AssociationItem deserializes from server wire format (snake_case).
+	data := `{"target_id":"t1","rel_type":5,"weight":0.8,"co_activation_count":3}`
+	var item AssociationItem
+	if err := json.Unmarshal([]byte(data), &item); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if item.TargetID != "t1" {
+		t.Errorf("TargetID: want t1, got %q", item.TargetID)
+	}
+	if item.RelType != 5 {
+		t.Errorf("RelType: want 5, got %d", item.RelType)
+	}
+	if item.CoActivationCount != 3 {
+		t.Errorf("CoActivationCount: want 3, got %d", item.CoActivationCount)
+	}
+}
+
+func TestEngramItem_JSONTags(t *testing.T) {
+	// Verify that EngramItem deserializes with created_at (snake_case) from server.
+	data := `{"id":"e1","concept":"c","content":"x","confidence":0.7,"vault":"default","created_at":1700000000}`
+	var item EngramItem
+	if err := json.Unmarshal([]byte(data), &item); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if item.CreatedAt != 1700000000 {
+		t.Errorf("CreatedAt: want 1700000000, got %d", item.CreatedAt)
 	}
 }
 

--- a/sdk/go/muninn/examples/cognitive_loop/main.go
+++ b/sdk/go/muninn/examples/cognitive_loop/main.go
@@ -104,7 +104,7 @@ func main() {
 	// --- Traverse the graph ---
 	if len(ids) > 0 {
 		fmt.Printf("\nTraversing graph from %s...\n", ids[0][:8])
-		graph, err := client.Traverse(ctx, vault, ids[0], 2, 20, nil)
+		graph, err := client.Traverse(ctx, vault, ids[0], 2, 20, nil, false)
 		if err != nil {
 			log.Fatalf("traverse failed: %v", err)
 		}

--- a/sdk/go/muninn/examples/quickstart/main.go
+++ b/sdk/go/muninn/examples/quickstart/main.go
@@ -61,7 +61,7 @@ func main() {
 	fmt.Printf("Linked %s → %s\n", authID, deployID)
 
 	// Stats
-	stats, err := client.Stats(ctx)
+	stats, err := client.Stats(ctx, "")
 	if err != nil {
 		log.Fatalf("stats failed: %v", err)
 	}

--- a/sdk/go/muninn/types.go
+++ b/sdk/go/muninn/types.go
@@ -121,10 +121,10 @@ type CoherenceResult struct {
 
 // StatsResponse represents the response from the stats endpoint.
 type StatsResponse struct {
-	EngramCount int                          `json:"engram_count"`
-	VaultCount  int                          `json:"vault_count"`
-	StorageBytes int                         `json:"storage_bytes"`
-	Coherence   map[string]CoherenceResult  `json:"coherence,omitempty"`
+	EngramCount  int64                      `json:"engram_count"`
+	VaultCount   int                        `json:"vault_count"`
+	StorageBytes int64                      `json:"storage_bytes"`
+	Coherence    map[string]CoherenceResult `json:"coherence,omitempty"`
 }
 
 // LinkRequest represents a request to link two engrams.
@@ -289,9 +289,10 @@ type EngramItem struct {
 	Concept    string   `json:"concept"`
 	Content    string   `json:"content"`
 	Confidence float32  `json:"confidence"`
+	EmbedDim   uint8    `json:"embed_dim,omitempty"`
 	Tags       []string `json:"tags,omitempty"`
 	Vault      string   `json:"vault"`
-	CreatedAt  int64    `json:"createdAt"`
+	CreatedAt  int64    `json:"created_at"`
 }
 
 // ListEngramsResponse represents a response from listing engrams.
@@ -304,16 +305,19 @@ type ListEngramsResponse struct {
 
 // AssociationItem represents an association/link from an engram.
 type AssociationItem struct {
-	TargetID string  `json:"targetId"`
-	RelType  uint16  `json:"relType"`
-	Weight   float32 `json:"weight"`
+	TargetID          string  `json:"target_id"`
+	RelType           uint16  `json:"rel_type"`
+	Weight            float32 `json:"weight"`
+	CoActivationCount uint32  `json:"co_activation_count,omitempty"`
+	RestoredAt        int64   `json:"restored_at,omitempty"`
 }
 
 // SessionEntry represents an entry in session activity.
 type SessionEntry struct {
 	ID        string `json:"id"`
 	Concept   string `json:"concept"`
-	CreatedAt int64  `json:"createdAt"`
+	Content   string `json:"content,omitempty"`
+	CreatedAt int64  `json:"created_at"`
 }
 
 // SessionResponse represents a response from session activity query.

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -9,10 +9,1904 @@
       "version": "0.2.3",
       "license": "MIT",
       "devDependencies": {
-        "typescript": "^5.9.3"
+        "msw": "^2.7.0",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmmirror.com/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmmirror.com/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmmirror.com/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmmirror.com/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmmirror.com/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmmirror.com/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmmirror.com/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmmirror.com/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmmirror.com/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmmirror.com/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmmirror.com/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmmirror.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmmirror.com/graphql/-/graphql-16.13.1.tgz",
+      "integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmmirror.com/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmmirror.com/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msw": {
+      "version": "2.12.10",
+      "resolved": "https://registry.npmmirror.com/msw/-/msw-2.12.10.tgz",
+      "integrity": "sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.41.2",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.0.2",
+        "graphql": "^16.12.0",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.10.1",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^5.2.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmmirror.com/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmmirror.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rettime": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmmirror.com/rettime/-/rettime-0.10.1.tgz",
+      "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmmirror.com/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmmirror.com/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmmirror.com/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmmirror.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmmirror.com/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmmirror.com/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmmirror.com/tldts/-/tldts-7.0.25.tgz",
+      "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.25"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmmirror.com/tldts-core/-/tldts-core-7.0.25.tgz",
+      "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-5.4.4.tgz",
+      "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -21,12 +1915,279 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmmirror.com/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmmirror.com/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmmirror.com/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -9,6 +9,8 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepublishOnly": "npm run build"
   },
   "keywords": [
@@ -28,6 +30,8 @@
     "url": "https://github.com/scrypster/muninndb"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^3.0.0",
+    "msw": "^2.7.0"
   }
 }

--- a/sdk/node/src/client.test.ts
+++ b/sdk/node/src/client.test.ts
@@ -1,0 +1,225 @@
+/**
+ * MuninnDB Node.js SDK unit tests.
+ *
+ * Uses msw to intercept HTTP requests — no live server required.
+ *
+ * Run: npm test
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { setupServer } from "msw/node";
+import { http, HttpResponse } from "msw";
+import { MuninnClient } from "./client.js";
+import type {
+  BatchWriteResult,
+  TraverseOptions,
+} from "./types.js";
+
+const BASE_URL = "http://muninn-test";
+
+function makeClient(): MuninnClient {
+  return new MuninnClient({ baseUrl: BASE_URL, token: "test-token", maxRetries: 0 });
+}
+
+// ---------------------------------------------------------------------------
+// MSW server setup
+// ---------------------------------------------------------------------------
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// ---------------------------------------------------------------------------
+// Type safety: BatchWriteResult.id is optional
+// ---------------------------------------------------------------------------
+
+describe("BatchWriteResult type", () => {
+  it("allows id to be absent (undefined)", () => {
+    const result: BatchWriteResult = { index: 0, status: "duplicate" };
+    expect(result.id).toBeUndefined();
+  });
+
+  it("allows id to be present", () => {
+    const result: BatchWriteResult = { index: 0, id: "01ARZ3", status: "created" };
+    expect(result.id).toBe("01ARZ3");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Type safety: TraverseOptions has follow_entities
+// ---------------------------------------------------------------------------
+
+describe("TraverseOptions type", () => {
+  it("accepts follow_entities field", () => {
+    const opts: TraverseOptions = {
+      start_id: "s1",
+      follow_entities: true,
+    };
+    expect(opts.follow_entities).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// write
+// ---------------------------------------------------------------------------
+
+describe("write", () => {
+  it("returns id and created_at", async () => {
+    server.use(
+      http.post(`${BASE_URL}/api/engrams`, () =>
+        HttpResponse.json({ id: "01ARZ3", created_at: "2024-01-01T00:00:00Z" }, { status: 201 })
+      )
+    );
+    const client = makeClient();
+    const resp = await client.write({ concept: "test", content: "body" });
+    expect(resp.id).toBe("01ARZ3");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeBatch — checks that id is optional in results
+// ---------------------------------------------------------------------------
+
+describe("writeBatch", () => {
+  it("handles results with and without id", async () => {
+    server.use(
+      http.post(`${BASE_URL}/api/engrams/batch`, () =>
+        HttpResponse.json({
+          results: [
+            { index: 0, id: "id-1", status: "created" },
+            { index: 1, status: "duplicate" },
+          ],
+        })
+      )
+    );
+    const client = makeClient();
+    const resp = await client.writeBatch("default", [
+      { concept: "a", content: "aa" },
+      { concept: "b", content: "bb" },
+    ]);
+    expect(resp.results[0]?.id).toBe("id-1");
+    expect(resp.results[1]?.id).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// activate
+// ---------------------------------------------------------------------------
+
+describe("activate", () => {
+  it("returns activations", async () => {
+    server.use(
+      http.post(`${BASE_URL}/api/activate`, () =>
+        HttpResponse.json({
+          query_id: "q1",
+          total_found: 1,
+          activations: [{ id: "a1", concept: "hit", content: "body", score: 0.9, tags: [], memory_type: "" }],
+          latency_ms: 5,
+        })
+      )
+    );
+    const client = makeClient();
+    const resp = await client.activate({ context: ["query"] });
+    expect(resp.total_found).toBe(1);
+    expect(resp.activations[0]?.id).toBe("a1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// traverse — follow_entities must be forwarded
+// ---------------------------------------------------------------------------
+
+describe("traverse", () => {
+  it("passes follow_entities in the request body", async () => {
+    let capturedBody: unknown;
+    server.use(
+      http.post(`${BASE_URL}/api/traverse`, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ nodes: [], edges: [], total_reachable: 0, query_ms: 1 });
+      })
+    );
+    const client = makeClient();
+    const opts: TraverseOptions = { start_id: "s1", follow_entities: true };
+    await client.traverse(opts);
+    expect((capturedBody as Record<string, unknown>)["follow_entities"]).toBe(true);
+  });
+
+  it("does not send follow_entities when not set", async () => {
+    let capturedBody: unknown;
+    server.use(
+      http.post(`${BASE_URL}/api/traverse`, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ nodes: [], edges: [], total_reachable: 0, query_ms: 1 });
+      })
+    );
+    const client = makeClient();
+    await client.traverse({ start_id: "s1" });
+    expect((capturedBody as Record<string, unknown>)["follow_entities"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stats — correct field names from server
+// ---------------------------------------------------------------------------
+
+describe("stats", () => {
+  it("returns engram_count, vault_count, storage_bytes", async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/stats`, () =>
+        HttpResponse.json({ engram_count: 100, vault_count: 3, storage_bytes: 204800 })
+      )
+    );
+    const client = makeClient();
+    const resp = await client.stats();
+    expect(resp.engram_count).toBe(100);
+    expect(resp.vault_count).toBe(3);
+    expect(resp.storage_bytes).toBe(204800);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subscribe — threshold parameter forwarded in URL
+// ---------------------------------------------------------------------------
+
+describe("subscribe", () => {
+  it("includes threshold in URL when specified", () => {
+    const client = makeClient();
+    // Inspect the generated URL by calling subscribe and checking the AbortController
+    // is created. Since we don't actually start the SSE connection in this test,
+    // we verify the URL by accessing the internal URL construction indirectly.
+    // (subscribe() is a generator — it only connects when iterated)
+    const iterable = client.subscribe("default", true, 0.05);
+    // The iterable exists but is not yet started; we just check it's returned.
+    expect(iterable).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// error handling
+// ---------------------------------------------------------------------------
+
+describe("error handling", () => {
+  it("throws on 404", async () => {
+    const { MuninnNotFoundError } = await import("./errors.js");
+    server.use(
+      http.get(`${BASE_URL}/api/engrams/missing`, () =>
+        HttpResponse.json({ error: "not found" }, { status: 404 })
+      )
+    );
+    const client = makeClient();
+    await expect(client.read("missing")).rejects.toBeInstanceOf(MuninnNotFoundError);
+  });
+
+  it("throws on 401", async () => {
+    const { MuninnAuthError } = await import("./errors.js");
+    server.use(
+      http.get(`${BASE_URL}/api/engrams/secret`, () =>
+        HttpResponse.json({ error: "unauthorized" }, { status: 401 })
+      )
+    );
+    const client = makeClient();
+    await expect(client.read("secret")).rejects.toBeInstanceOf(MuninnAuthError);
+  });
+});

--- a/sdk/node/src/client.ts
+++ b/sdk/node/src/client.ts
@@ -350,9 +350,12 @@ export class MuninnClient {
    * The connection is kept alive until the iterable is broken out of or
    * {@link close} is called.
    */
-  subscribe(vault?: string, pushOnWrite = true): AsyncIterable<SseEvent> {
+  subscribe(vault?: string, pushOnWrite = true, threshold?: number): AsyncIterable<SseEvent> {
     const v = vault ?? this.defaultVault;
-    const url = `${this.baseUrl}/api/subscribe?vault=${encodeURIComponent(v)}&push_on_write=${pushOnWrite}`;
+    let url = `${this.baseUrl}/api/subscribe?vault=${encodeURIComponent(v)}&push_on_write=${pushOnWrite}`;
+    if (threshold !== undefined) {
+      url += `&threshold=${threshold}`;
+    }
     const ac = new AbortController();
     this.activeAbortControllers.add(ac);
 

--- a/sdk/node/src/types.ts
+++ b/sdk/node/src/types.ts
@@ -26,15 +26,15 @@ export interface Engram {
   tags: string[];
   confidence: number;
   stability: number;
-  memory_type: string;
+  memory_type: number;
   type_label: string;
   summary: string;
-  entities: string[];
-  relationships: string[];
-  state: string;
-  created_at: string;
-  updated_at: string;
-  deleted_at?: string;
+  entities?: unknown[];
+  relationships?: unknown[];
+  state: number;
+  created_at: number;
+  updated_at: number;
+  deleted_at?: number;
   [key: string]: unknown;
 }
 
@@ -58,12 +58,12 @@ export interface WriteOptions {
 
 export interface WriteResponse {
   id: string;
-  created_at: string;
+  created_at: number;
 }
 
 export interface BatchWriteResult {
   index: number;
-  id: string;
+  id?: string;
   status: string;
   error?: string;
 }
@@ -80,14 +80,14 @@ export interface ActivateOptions {
   vault?: string;
   context: string[];
   threshold?: number;
-  limit?: number;
+  max_results?: number;
   max_hops?: number;
   profile?: string;
   mode?: string;
   since?: string;
   before?: string;
   include_why?: boolean;
-  brief_mode?: boolean;
+  brief_mode?: string;
 }
 
 export interface ActivationItem {
@@ -102,8 +102,9 @@ export interface ActivationItem {
 }
 
 export interface BriefSentence {
-  id: string;
+  engram_id?: string;
   text: string;
+  score?: number;
 }
 
 export interface ActivateResponse {
@@ -122,15 +123,16 @@ export interface LinkOptions {
   vault?: string;
   source_id: string;
   target_id: string;
-  rel_type: string;
+  rel_type: number;
   weight?: number;
 }
 
 export interface AssociationItem {
-  source_id: string;
   target_id: string;
-  rel_type: string;
+  rel_type: number;
   weight: number;
+  co_activation_count?: number;
+  restored_at?: number;
   [key: string]: unknown;
 }
 
@@ -195,19 +197,21 @@ export interface TraverseOptions {
   max_hops?: number;
   max_nodes?: number;
   rel_types?: string[];
+  follow_entities?: boolean;
 }
 
 export interface TraversalNode {
   id: string;
   concept: string;
-  depth: number;
+  hop_dist: number;
+  summary?: string;
   [key: string]: unknown;
 }
 
 export interface TraversalEdge {
-  source: string;
-  target: string;
-  rel_type: string;
+  from_id: string;
+  to_id: string;
+  rel_type: number;
   weight: number;
   [key: string]: unknown;
 }
@@ -230,12 +234,12 @@ export interface ExplainOptions {
 }
 
 export interface ExplainComponents {
-  semantic: number;
-  recency: number;
+  full_text_relevance: number;
+  semantic_similarity: number;
+  decay_factor: number;
+  hebbian_boost: number;
+  access_frequency: number;
   confidence: number;
-  stability: number;
-  association: number;
-  [key: string]: unknown;
 }
 
 export interface ExplainResponse {
@@ -256,7 +260,7 @@ export interface ExplainResponse {
 export interface SetStateResponse {
   id: string;
   state: string;
-  previous_state: string;
+  updated: boolean;
   [key: string]: unknown;
 }
 
@@ -267,8 +271,9 @@ export interface SetStateResponse {
 export interface DeletedEngram {
   id: string;
   concept: string;
-  deleted_at: string;
-  [key: string]: unknown;
+  deleted_at: number;
+  recoverable_until: number;
+  tags?: string[];
 }
 
 export interface ListDeletedResponse {
@@ -293,10 +298,10 @@ export interface RetryEnrichResponse {
 
 export interface ContradictionItem {
   id_a: string;
+  concept_a: string;
   id_b: string;
-  concept: string;
-  description: string;
-  [key: string]: unknown;
+  concept_b: string;
+  detected_at: number;
 }
 
 export interface ContradictionsResponse {
@@ -309,15 +314,18 @@ export interface ContradictionsResponse {
 
 export interface CoherenceResult {
   score: number;
-  issues: string[];
-  [key: string]: unknown;
+  orphan_ratio: number;
+  contradiction_density: number;
+  duplication_pressure: number;
+  temporal_variance: number;
+  total_engrams: number;
 }
 
 export interface StatsResponse {
-  vault: string;
-  total_engrams: number;
-  coherence?: CoherenceResult;
-  [key: string]: unknown;
+  engram_count: number;
+  vault_count: number;
+  storage_bytes: number;
+  coherence?: Record<string, CoherenceResult>;
 }
 
 // ---------------------------------------------------------------------------
@@ -337,8 +345,9 @@ export interface ListEngramsResponse {
 
 export interface SessionEntry {
   id: string;
-  action: string;
-  timestamp: string;
+  concept: string;
+  content: string;
+  created_at: number;
   [key: string]: unknown;
 }
 

--- a/sdk/node/vitest.config.ts
+++ b/sdk/node/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: false,
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/sdk/php/composer.json
+++ b/sdk/php/composer.json
@@ -9,10 +9,25 @@
         "ext-curl": "*",
         "ext-json": "*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.0"
+    },
     "autoload": {
         "psr-4": {
             "MuninnDB\\": "src/"
+        },
+        "classmap": [
+            "src/Types/Types.php",
+            "src/Exceptions/Exceptions.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "MuninnDB\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "test": "phpunit --testdox"
     },
     "minimum-stability": "stable"
 }

--- a/sdk/php/composer.lock
+++ b/sdk/php/composer.lock
@@ -1,0 +1,1804 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "d296558d306543297d989266d48d2394",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "11.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.46"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-24T07:01:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T13:52:54+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:07:44+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:08:43+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.55",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-18T12:37:06+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:41:36+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:26:40+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:49:50+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-21T11:55:47+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:12:51+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:57:36+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:58:38+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:00:13+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:01:32+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:42:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:55:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=8.1",
+        "ext-curl": "*",
+        "ext-json": "*"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/sdk/php/src/MuninnClient.php
+++ b/sdk/php/src/MuninnClient.php
@@ -127,33 +127,43 @@ class MuninnClient
         array $context,
         string $vault = 'default',
         float $threshold = 0.0,
-        int $limit = 10,
+        int $maxResults = 10,
         int $maxHops = 0,
         string $profile = '',
         string $mode = '',
         ?string $since = null,
         ?string $before = null,
         bool $includeWhy = false,
-        bool $briefMode = false,
+        string $briefMode = '',
     ): ActivateResponse {
-        $body = array_filter([
+        // Always-present fields (threshold=0.0 is a valid value, must not be dropped).
+        $body = [
             'vault'       => $vault,
             'context'     => $context,
             'threshold'   => $threshold,
-            'limit'       => $limit,
-            'max_hops'    => $maxHops,
-            'profile'     => $profile,
-            'mode'        => $mode,
-            'since'       => $since,
-            'before'      => $before,
-            'include_why' => $includeWhy,
-            'brief_mode'  => $briefMode,
-        ], fn(mixed $v) => $v !== '' && $v !== 0 && $v !== 0.0 && $v !== false && $v !== null);
-
-        // These fields must always be present
-        $body['vault']   = $vault;
-        $body['context'] = $context;
-        $body['limit']   = $limit;
+            'max_results' => $maxResults,
+        ];
+        if ($maxHops > 0) {
+            $body['max_hops'] = $maxHops;
+        }
+        if ($profile !== '') {
+            $body['profile'] = $profile;
+        }
+        if ($mode !== '') {
+            $body['mode'] = $mode;
+        }
+        if ($since !== null) {
+            $body['since'] = $since;
+        }
+        if ($before !== null) {
+            $body['before'] = $before;
+        }
+        if ($includeWhy) {
+            $body['include_why'] = true;
+        }
+        if ($briefMode !== '') {
+            $body['brief_mode'] = $briefMode;
+        }
 
         return ActivateResponse::fromArray(
             $this->request('POST', '/api/activate?vault=' . urlencode($vault), $body),
@@ -164,7 +174,7 @@ class MuninnClient
     public function link(
         string $sourceId,
         string $targetId,
-        string $relType = 'related',
+        int $relType = 1,
         float $weight = 1.0,
         string $vault = 'default',
     ): void {
@@ -249,16 +259,24 @@ class MuninnClient
         int $maxHops = 2,
         int $maxNodes = 20,
         array $relTypes = [],
+        bool $followEntities = false,
         string $vault = 'default',
     ): TraverseResponse {
+        $body = [
+            'vault'     => $vault,
+            'start_id'  => $startId,
+            'max_hops'  => $maxHops,
+            'max_nodes' => $maxNodes,
+        ];
+        if ($relTypes !== []) {
+            $body['rel_types'] = $relTypes;
+        }
+        if ($followEntities) {
+            $body['follow_entities'] = true;
+        }
+
         return TraverseResponse::fromArray(
-            $this->request('POST', '/api/traverse?vault=' . urlencode($vault), array_filter([
-                'vault'     => $vault,
-                'start_id'  => $startId,
-                'max_hops'  => $maxHops,
-                'max_nodes' => $maxNodes,
-                'rel_types' => $relTypes,
-            ], fn(mixed $v) => $v !== [])),
+            $this->request('POST', '/api/traverse?vault=' . urlencode($vault), $body),
         );
     }
 

--- a/sdk/php/src/Types/Types.php
+++ b/sdk/php/src/Types/Types.php
@@ -254,8 +254,8 @@ class TraversalNode
     public function __construct(
         public readonly string $id,
         public readonly string $concept,
-        public readonly ?string $content = null,
-        public readonly ?int $depth = null,
+        public readonly int $hopDist = 0,
+        public readonly ?string $summary = null,
     ) {}
 
     public static function fromArray(array $data): self
@@ -263,8 +263,8 @@ class TraversalNode
         return new self(
             id: $data['id'] ?? '',
             concept: $data['concept'] ?? '',
-            content: $data['content'] ?? null,
-            depth: $data['depth'] ?? null,
+            hopDist: (int) ($data['hop_dist'] ?? 0),
+            summary: $data['summary'] ?? null,
         );
     }
 }
@@ -272,8 +272,8 @@ class TraversalNode
 class TraversalEdge
 {
     public function __construct(
-        public readonly string $source,
-        public readonly string $target,
+        public readonly string $fromId,
+        public readonly string $toId,
         public readonly string $relType,
         public readonly float $weight,
     ) {}
@@ -281,8 +281,8 @@ class TraversalEdge
     public static function fromArray(array $data): self
     {
         return new self(
-            source: $data['source'] ?? '',
-            target: $data['target'] ?? '',
+            fromId: $data['from_id'] ?? '',
+            toId: $data['to_id'] ?? '',
             relType: $data['rel_type'] ?? '',
             weight: (float) ($data['weight'] ?? 1.0),
         );
@@ -322,43 +322,52 @@ class TraverseResponse
 class ExplainComponents
 {
     public function __construct(
-        public readonly ?float $semantic = null,
-        public readonly ?float $recency = null,
-        public readonly ?float $confidence = null,
-        public readonly ?float $stability = null,
-        public readonly ?float $tagBoost = null,
-        public readonly ?float $entityBoost = null,
+        public readonly float $fullTextRelevance = 0.0,
+        public readonly float $semanticSimilarity = 0.0,
+        public readonly float $decayFactor = 0.0,
+        public readonly float $hebbianBoost = 0.0,
+        public readonly float $accessFrequency = 0.0,
+        public readonly float $confidence = 0.0,
     ) {}
 
     public static function fromArray(array $data): self
     {
         return new self(
-            semantic: isset($data['semantic']) ? (float) $data['semantic'] : null,
-            recency: isset($data['recency']) ? (float) $data['recency'] : null,
-            confidence: isset($data['confidence']) ? (float) $data['confidence'] : null,
-            stability: isset($data['stability']) ? (float) $data['stability'] : null,
-            tagBoost: isset($data['tag_boost']) ? (float) $data['tag_boost'] : null,
-            entityBoost: isset($data['entity_boost']) ? (float) $data['entity_boost'] : null,
+            fullTextRelevance: (float) ($data['full_text_relevance'] ?? 0.0),
+            semanticSimilarity: (float) ($data['semantic_similarity'] ?? 0.0),
+            decayFactor: (float) ($data['decay_factor'] ?? 0.0),
+            hebbianBoost: (float) ($data['hebbian_boost'] ?? 0.0),
+            accessFrequency: (float) ($data['access_frequency'] ?? 0.0),
+            confidence: (float) ($data['confidence'] ?? 0.0),
         );
     }
 }
 
 class ExplainResponse
 {
+    /** @param string[] $ftsMatches @param string[] $assocPath */
     public function __construct(
         public readonly string $engramId,
+        public readonly string $concept,
         public readonly float $finalScore,
         public readonly ExplainComponents $components,
-        public readonly ?string $profile = null,
+        public readonly array $ftsMatches = [],
+        public readonly array $assocPath = [],
+        public readonly bool $wouldReturn = false,
+        public readonly float $threshold = 0.0,
     ) {}
 
     public static function fromArray(array $data): self
     {
         return new self(
             engramId: $data['engram_id'] ?? '',
+            concept: $data['concept'] ?? '',
             finalScore: (float) ($data['final_score'] ?? 0.0),
             components: ExplainComponents::fromArray($data['components'] ?? []),
-            profile: $data['profile'] ?? null,
+            ftsMatches: $data['fts_matches'] ?? [],
+            assocPath: $data['assoc_path'] ?? [],
+            wouldReturn: (bool) ($data['would_return'] ?? false),
+            threshold: (float) ($data['threshold'] ?? 0.0),
         );
     }
 }
@@ -368,7 +377,7 @@ class SetStateResponse
     public function __construct(
         public readonly string $id,
         public readonly string $state,
-        public readonly ?string $previousState = null,
+        public readonly bool $updated = false,
     ) {}
 
     public static function fromArray(array $data): self
@@ -376,17 +385,20 @@ class SetStateResponse
         return new self(
             id: $data['id'] ?? '',
             state: $data['state'] ?? '',
-            previousState: $data['previous_state'] ?? null,
+            updated: (bool) ($data['updated'] ?? false),
         );
     }
 }
 
 class DeletedEngram
 {
+    /** @param string[] $tags */
     public function __construct(
         public readonly string $id,
         public readonly string $concept,
-        public readonly ?int $deletedAt = null,
+        public readonly int $deletedAt = 0,
+        public readonly int $recoverableUntil = 0,
+        public readonly array $tags = [],
     ) {}
 
     public static function fromArray(array $data): self
@@ -394,7 +406,9 @@ class DeletedEngram
         return new self(
             id: $data['id'] ?? '',
             concept: $data['concept'] ?? '',
-            deletedAt: $data['deleted_at'] ?? null,
+            deletedAt: (int) ($data['deleted_at'] ?? 0),
+            recoverableUntil: (int) ($data['recoverable_until'] ?? 0),
+            tags: $data['tags'] ?? [],
         );
     }
 }
@@ -419,16 +433,21 @@ class ListDeletedResponse
 
 class RetryEnrichResponse
 {
+    /** @param string[] $pluginsQueued @param string[] $alreadyComplete */
     public function __construct(
-        public readonly string $id,
-        public readonly string $status,
+        public readonly string $engramId,
+        public readonly array $pluginsQueued,
+        public readonly array $alreadyComplete,
+        public readonly ?string $note = null,
     ) {}
 
     public static function fromArray(array $data): self
     {
         return new self(
-            id: $data['id'] ?? '',
-            status: $data['status'] ?? '',
+            engramId: $data['engram_id'] ?? '',
+            pluginsQueued: $data['plugins_queued'] ?? [],
+            alreadyComplete: $data['already_complete'] ?? [],
+            note: $data['note'] ?? null,
         );
     }
 }
@@ -436,19 +455,21 @@ class RetryEnrichResponse
 class ContradictionItem
 {
     public function __construct(
-        public readonly string $engramA,
-        public readonly string $engramB,
-        public readonly string $description,
-        public readonly ?float $severity = null,
+        public readonly string $idA,
+        public readonly string $conceptA,
+        public readonly string $idB,
+        public readonly string $conceptB,
+        public readonly int $detectedAt = 0,
     ) {}
 
     public static function fromArray(array $data): self
     {
         return new self(
-            engramA: $data['engram_a'] ?? '',
-            engramB: $data['engram_b'] ?? '',
-            description: $data['description'] ?? '',
-            severity: isset($data['severity']) ? (float) $data['severity'] : null,
+            idA: $data['id_a'] ?? '',
+            conceptA: $data['concept_a'] ?? '',
+            idB: $data['id_b'] ?? '',
+            conceptB: $data['concept_b'] ?? '',
+            detectedAt: (int) ($data['detected_at'] ?? 0),
         );
     }
 }
@@ -474,43 +495,49 @@ class ContradictionsResponse
 class CoherenceResult
 {
     public function __construct(
-        public readonly ?float $score = null,
-        public readonly ?int $contradictions = null,
+        public readonly float $score = 0.0,
+        public readonly float $orphanRatio = 0.0,
+        public readonly float $contradictionDensity = 0.0,
+        public readonly float $duplicationPressure = 0.0,
+        public readonly float $temporalVariance = 0.0,
+        public readonly int $totalEngrams = 0,
     ) {}
 
     public static function fromArray(array $data): self
     {
         return new self(
-            score: isset($data['score']) ? (float) $data['score'] : null,
-            contradictions: $data['contradictions'] ?? null,
+            score: (float) ($data['score'] ?? 0.0),
+            orphanRatio: (float) ($data['orphan_ratio'] ?? 0.0),
+            contradictionDensity: (float) ($data['contradiction_density'] ?? 0.0),
+            duplicationPressure: (float) ($data['duplication_pressure'] ?? 0.0),
+            temporalVariance: (float) ($data['temporal_variance'] ?? 0.0),
+            totalEngrams: (int) ($data['total_engrams'] ?? 0),
         );
     }
 }
 
 class StatsResponse
 {
+    /** @param array<string, CoherenceResult> $coherence */
     public function __construct(
-        public readonly int $totalEngrams,
-        public readonly int $totalLinks,
-        public readonly ?int $totalVaults = null,
-        public readonly ?int $activeEngrams = null,
-        public readonly ?int $deletedEngrams = null,
-        public readonly ?CoherenceResult $coherence = null,
-        public readonly ?array $raw = null,
+        public readonly int $engramCount,
+        public readonly int $vaultCount,
+        public readonly int $storageBytes,
+        public readonly array $coherence = [],
     ) {}
 
     public static function fromArray(array $data): self
     {
+        $coherence = [];
+        foreach ($data['coherence'] ?? [] as $vault => $c) {
+            $coherence[$vault] = CoherenceResult::fromArray($c);
+        }
+
         return new self(
-            totalEngrams: (int) ($data['total_engrams'] ?? 0),
-            totalLinks: (int) ($data['total_links'] ?? 0),
-            totalVaults: $data['total_vaults'] ?? null,
-            activeEngrams: $data['active_engrams'] ?? null,
-            deletedEngrams: $data['deleted_engrams'] ?? null,
-            coherence: isset($data['coherence'])
-                ? CoherenceResult::fromArray($data['coherence'])
-                : null,
-            raw: $data,
+            engramCount: (int) ($data['engram_count'] ?? 0),
+            vaultCount: (int) ($data['vault_count'] ?? 0),
+            storageBytes: (int) ($data['storage_bytes'] ?? 0),
+            coherence: $coherence,
         );
     }
 }
@@ -568,21 +595,21 @@ class ListEngramsResponse
 class AssociationItem
 {
     public function __construct(
-        public readonly string $id,
-        public readonly string $sourceId,
         public readonly string $targetId,
-        public readonly string $relType,
+        public readonly int $relType,
         public readonly float $weight,
+        public readonly int $coActivationCount = 0,
+        public readonly ?int $restoredAt = null,
     ) {}
 
     public static function fromArray(array $data): self
     {
         return new self(
-            id: $data['id'] ?? '',
-            sourceId: $data['source_id'] ?? '',
             targetId: $data['target_id'] ?? '',
-            relType: $data['rel_type'] ?? '',
+            relType: (int) ($data['rel_type'] ?? 0),
             weight: (float) ($data['weight'] ?? 1.0),
+            coActivationCount: (int) ($data['co_activation_count'] ?? 0),
+            restoredAt: isset($data['restored_at']) ? (int) $data['restored_at'] : null,
         );
     }
 }
@@ -592,8 +619,8 @@ class SessionEntry
     public function __construct(
         public readonly string $id,
         public readonly string $concept,
-        public readonly string $action,
-        public readonly ?int $timestamp = null,
+        public readonly string $content = '',
+        public readonly int $createdAt = 0,
     ) {}
 
     public static function fromArray(array $data): self
@@ -601,8 +628,8 @@ class SessionEntry
         return new self(
             id: $data['id'] ?? '',
             concept: $data['concept'] ?? '',
-            action: $data['action'] ?? '',
-            timestamp: $data['timestamp'] ?? null,
+            content: $data['content'] ?? '',
+            createdAt: (int) ($data['created_at'] ?? 0),
         );
     }
 }
@@ -632,7 +659,8 @@ class HealthResponse
     public function __construct(
         public readonly string $status,
         public readonly ?string $version = null,
-        public readonly ?float $uptime = null,
+        public readonly ?int $uptimeSeconds = null,
+        public readonly bool $dbWritable = true,
     ) {}
 
     public static function fromArray(array $data): self
@@ -640,7 +668,8 @@ class HealthResponse
         return new self(
             status: $data['status'] ?? 'unknown',
             version: $data['version'] ?? null,
-            uptime: isset($data['uptime']) ? (float) $data['uptime'] : null,
+            uptimeSeconds: isset($data['uptime_seconds']) ? (int) $data['uptime_seconds'] : null,
+            dbWritable: (bool) ($data['db_writable'] ?? true),
         );
     }
 }

--- a/sdk/php/tests/TypesTest.php
+++ b/sdk/php/tests/TypesTest.php
@@ -1,0 +1,410 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MuninnDB\Tests;
+
+use MuninnDB\Exceptions\AuthException;
+use MuninnDB\Exceptions\NotFoundException;
+use MuninnDB\Exceptions\ConflictException;
+use MuninnDB\Exceptions\ValidationException;
+use MuninnDB\Exceptions\ServerException;
+use MuninnDB\MuninnClient;
+use MuninnDB\Types\ActivateResponse;
+use MuninnDB\Types\AssociationItem;
+use MuninnDB\Types\BatchWriteResponse;
+use MuninnDB\Types\CoherenceResult;
+use MuninnDB\Types\ContradictionItem;
+use MuninnDB\Types\ContradictionsResponse;
+use MuninnDB\Types\DeletedEngram;
+use MuninnDB\Types\ExplainComponents;
+use MuninnDB\Types\ExplainResponse;
+use MuninnDB\Types\RetryEnrichResponse;
+use MuninnDB\Types\SessionEntry;
+use MuninnDB\Types\StatsResponse;
+use MuninnDB\Types\TraversalEdge;
+use MuninnDB\Types\TraversalNode;
+use MuninnDB\Types\TraverseResponse;
+use MuninnDB\Types\WriteResponse;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for MuninnDB PHP SDK type deserialization and exception mapping.
+ * These tests verify that fromArray() methods read the correct snake_case
+ * field names that the server actually sends on the wire.
+ */
+class TypesTest extends TestCase
+{
+    // ── WriteResponse ───────────────────────────────────────────
+
+    public function testWriteResponseDeserializes(): void
+    {
+        $r = WriteResponse::fromArray(['id' => '01ARZ3', 'created_at' => 1700000000]);
+        self::assertSame('01ARZ3', $r->id);
+        self::assertSame(1700000000, $r->createdAt);
+        self::assertNull($r->hint);
+    }
+
+    // ── BatchWriteResponse ──────────────────────────────────────
+
+    public function testBatchWriteResultIdIsOptional(): void
+    {
+        $resp = BatchWriteResponse::fromArray([
+            'results' => [
+                ['index' => 0, 'id' => 'id-1', 'status' => 'created'],
+                ['index' => 1, 'status' => 'duplicate'],
+            ],
+        ]);
+        self::assertCount(2, $resp->results);
+        self::assertSame('id-1', $resp->results[0]->id);
+        self::assertNull($resp->results[1]->id);
+        self::assertSame('duplicate', $resp->results[1]->status);
+    }
+
+    // ── TraversalNode — hop_dist (not depth) ────────────────────
+
+    public function testTraversalNodeUsesHopDist(): void
+    {
+        $node = TraversalNode::fromArray([
+            'id'       => 'n1',
+            'concept'  => 'test',
+            'hop_dist' => 2,
+            'summary'  => 'brief',
+        ]);
+        self::assertSame('n1', $node->id);
+        self::assertSame(2, $node->hopDist);
+        self::assertSame('brief', $node->summary);
+    }
+
+    public function testTraversalNodeDefaultHopDistIsZero(): void
+    {
+        $node = TraversalNode::fromArray(['id' => 'n1', 'concept' => 'c']);
+        self::assertSame(0, $node->hopDist);
+    }
+
+    // ── TraversalEdge — from_id / to_id (not source/target) ─────
+
+    public function testTraversalEdgeUsesFromIdToId(): void
+    {
+        $edge = TraversalEdge::fromArray([
+            'from_id'  => 'src',
+            'to_id'    => 'dst',
+            'rel_type' => '5',
+            'weight'   => 0.8,
+        ]);
+        self::assertSame('src', $edge->fromId);
+        self::assertSame('dst', $edge->toId);
+        self::assertEqualsWithDelta(0.8, $edge->weight, 0.001);
+    }
+
+    // ── TraverseResponse ─────────────────────────────────────────
+
+    public function testTraverseResponseDeserializes(): void
+    {
+        $resp = TraverseResponse::fromArray([
+            'nodes' => [
+                ['id' => 'n1', 'concept' => 'a', 'hop_dist' => 0],
+                ['id' => 'n2', 'concept' => 'b', 'hop_dist' => 1],
+            ],
+            'edges' => [
+                ['from_id' => 'n1', 'to_id' => 'n2', 'rel_type' => '1', 'weight' => 0.9],
+            ],
+            'total_reachable' => 10,
+            'query_ms'        => 3.5,
+        ]);
+        self::assertCount(2, $resp->nodes);
+        self::assertCount(1, $resp->edges);
+        self::assertSame(10, $resp->totalReachable);
+        self::assertEqualsWithDelta(3.5, $resp->queryMs, 0.001);
+        self::assertSame(1, $resp->nodes[1]->hopDist);
+        self::assertSame('n1', $resp->edges[0]->fromId);
+    }
+
+    // ── ExplainComponents — server field names ───────────────────
+
+    public function testExplainComponentsFieldNames(): void
+    {
+        $c = ExplainComponents::fromArray([
+            'full_text_relevance' => 0.9,
+            'semantic_similarity' => 0.8,
+            'decay_factor'        => 0.7,
+            'hebbian_boost'       => 0.6,
+            'access_frequency'    => 0.5,
+            'confidence'          => 0.4,
+        ]);
+        self::assertEqualsWithDelta(0.9, $c->fullTextRelevance, 0.001);
+        self::assertEqualsWithDelta(0.8, $c->semanticSimilarity, 0.001);
+        self::assertEqualsWithDelta(0.7, $c->decayFactor, 0.001);
+        self::assertEqualsWithDelta(0.6, $c->hebbianBoost, 0.001);
+        self::assertEqualsWithDelta(0.5, $c->accessFrequency, 0.001);
+        self::assertEqualsWithDelta(0.4, $c->confidence, 0.001);
+    }
+
+    public function testExplainResponseDeserializes(): void
+    {
+        $resp = ExplainResponse::fromArray([
+            'engram_id'   => 'e1',
+            'concept'     => 'test',
+            'final_score' => 0.85,
+            'components'  => [
+                'full_text_relevance' => 0.9,
+                'semantic_similarity' => 0.0,
+                'decay_factor'        => 1.0,
+                'hebbian_boost'       => 0.1,
+                'access_frequency'    => 0.2,
+                'confidence'          => 0.8,
+            ],
+            'fts_matches'  => ['token1'],
+            'assoc_path'   => ['e2'],
+            'would_return' => true,
+            'threshold'    => 0.5,
+        ]);
+        self::assertSame('e1', $resp->engramId);
+        self::assertSame('test', $resp->concept);
+        self::assertEqualsWithDelta(0.85, $resp->finalScore, 0.001);
+        self::assertTrue($resp->wouldReturn);
+        self::assertEqualsWithDelta(0.5, $resp->threshold, 0.001);
+        self::assertSame(['token1'], $resp->ftsMatches);
+        self::assertEqualsWithDelta(0.9, $resp->components->fullTextRelevance, 0.001);
+    }
+
+    // ── ContradictionItem — id_a, concept_a, etc. ───────────────
+
+    public function testContradictionItemFieldNames(): void
+    {
+        $item = ContradictionItem::fromArray([
+            'id_a'        => 'aaa',
+            'concept_a'   => 'fire',
+            'id_b'        => 'bbb',
+            'concept_b'   => 'ice',
+            'detected_at' => 1700001000,
+        ]);
+        self::assertSame('aaa', $item->idA);
+        self::assertSame('fire', $item->conceptA);
+        self::assertSame('bbb', $item->idB);
+        self::assertSame('ice', $item->conceptB);
+        self::assertSame(1700001000, $item->detectedAt);
+    }
+
+    public function testContradictionsResponseDeserializes(): void
+    {
+        $resp = ContradictionsResponse::fromArray([
+            'contradictions' => [
+                ['id_a' => 'a1', 'concept_a' => 'hot', 'id_b' => 'b1', 'concept_b' => 'cold', 'detected_at' => 0],
+            ],
+        ]);
+        self::assertCount(1, $resp->contradictions);
+        self::assertSame('a1', $resp->contradictions[0]->idA);
+    }
+
+    // ── CoherenceResult — all server fields ──────────────────────
+
+    public function testCoherenceResultFieldNames(): void
+    {
+        $r = CoherenceResult::fromArray([
+            'score'                  => 0.95,
+            'orphan_ratio'           => 0.01,
+            'contradiction_density'  => 0.02,
+            'duplication_pressure'   => 0.03,
+            'temporal_variance'      => 0.1,
+            'total_engrams'          => 42,
+        ]);
+        self::assertEqualsWithDelta(0.95, $r->score, 0.001);
+        self::assertEqualsWithDelta(0.01, $r->orphanRatio, 0.001);
+        self::assertEqualsWithDelta(0.02, $r->contradictionDensity, 0.001);
+        self::assertEqualsWithDelta(0.03, $r->duplicationPressure, 0.001);
+        self::assertEqualsWithDelta(0.1, $r->temporalVariance, 0.001);
+        self::assertSame(42, $r->totalEngrams);
+    }
+
+    // ── StatsResponse — server field names ──────────────────────
+
+    public function testStatsResponseFieldNames(): void
+    {
+        $resp = StatsResponse::fromArray([
+            'engram_count'  => 100,
+            'vault_count'   => 3,
+            'storage_bytes' => 204800,
+        ]);
+        self::assertSame(100, $resp->engramCount);
+        self::assertSame(3, $resp->vaultCount);
+        self::assertSame(204800, $resp->storageBytes);
+        self::assertEmpty($resp->coherence);
+    }
+
+    public function testStatsResponseWithCoherence(): void
+    {
+        $resp = StatsResponse::fromArray([
+            'engram_count'  => 50,
+            'vault_count'   => 1,
+            'storage_bytes' => 1024,
+            'coherence'     => [
+                'default' => ['score' => 0.9, 'orphan_ratio' => 0.05, 'contradiction_density' => 0.0,
+                              'duplication_pressure' => 0.0, 'temporal_variance' => 0.0, 'total_engrams' => 50],
+            ],
+        ]);
+        self::assertArrayHasKey('default', $resp->coherence);
+        self::assertEqualsWithDelta(0.9, $resp->coherence['default']->score, 0.001);
+    }
+
+    // ── AssociationItem — target_id, rel_type, co_activation_count
+
+    public function testAssociationItemFieldNames(): void
+    {
+        $item = AssociationItem::fromArray([
+            'target_id'           => 'tgt',
+            'rel_type'            => 5,
+            'weight'              => 0.75,
+            'co_activation_count' => 12,
+            'restored_at'         => 1700002000,
+        ]);
+        self::assertSame('tgt', $item->targetId);
+        self::assertSame(5, $item->relType);
+        self::assertEqualsWithDelta(0.75, $item->weight, 0.001);
+        self::assertSame(12, $item->coActivationCount);
+        self::assertSame(1700002000, $item->restoredAt);
+    }
+
+    public function testAssociationItemRestoredAtNullWhenAbsent(): void
+    {
+        $item = AssociationItem::fromArray(['target_id' => 't', 'rel_type' => 1, 'weight' => 1.0]);
+        self::assertNull($item->restoredAt);
+        self::assertSame(0, $item->coActivationCount);
+    }
+
+    // ── SessionEntry — content + created_at ──────────────────────
+
+    public function testSessionEntryFieldNames(): void
+    {
+        $entry = SessionEntry::fromArray([
+            'id'         => 'e1',
+            'concept'    => 'test',
+            'content'    => 'body text',
+            'created_at' => 1700000000,
+        ]);
+        self::assertSame('body text', $entry->content);
+        self::assertSame(1700000000, $entry->createdAt);
+    }
+
+    // ── DeletedEngram — recoverable_until + tags ──────────────────
+
+    public function testDeletedEngramFields(): void
+    {
+        $e = DeletedEngram::fromArray([
+            'id'                => 'del1',
+            'concept'           => 'gone',
+            'deleted_at'        => 1700000000,
+            'recoverable_until' => 1700086400,
+            'tags'              => ['t1', 't2'],
+        ]);
+        self::assertSame('del1', $e->id);
+        self::assertSame(1700000000, $e->deletedAt);
+        self::assertSame(1700086400, $e->recoverableUntil);
+        self::assertSame(['t1', 't2'], $e->tags);
+    }
+
+    public function testDeletedEngramDefaultsForOptionalFields(): void
+    {
+        $e = DeletedEngram::fromArray(['id' => 'x', 'concept' => 'y']);
+        self::assertSame(0, $e->deletedAt);
+        self::assertSame(0, $e->recoverableUntil);
+        self::assertSame([], $e->tags);
+    }
+
+    // ── RetryEnrichResponse ───────────────────────────────────────
+
+    public function testRetryEnrichResponseFieldNames(): void
+    {
+        $resp = RetryEnrichResponse::fromArray([
+            'engram_id'       => 'e1',
+            'plugins_queued'  => ['embed', 'ner'],
+            'already_complete' => ['fts'],
+            'note'            => 'ok',
+        ]);
+        self::assertSame('e1', $resp->engramId);
+        self::assertSame(['embed', 'ner'], $resp->pluginsQueued);
+        self::assertSame(['fts'], $resp->alreadyComplete);
+        self::assertSame('ok', $resp->note);
+    }
+
+    // ── ActivateResponse ──────────────────────────────────────────
+
+    public function testActivateResponseDeserializes(): void
+    {
+        $resp = ActivateResponse::fromArray([
+            'query_id'    => 'q1',
+            'total_found' => 2,
+            'activations' => [
+                ['id' => 'a1', 'concept' => 'hit', 'content' => 'body', 'score' => 0.9],
+                ['id' => 'a2', 'concept' => 'miss', 'content' => 'body', 'score' => 0.3],
+            ],
+            'latency_ms' => 12.5,
+        ]);
+        self::assertSame(2, $resp->totalFound);
+        self::assertSame('a1', $resp->activations[0]->id);
+        self::assertEqualsWithDelta(12.5, $resp->latencyMs, 0.001);
+    }
+
+    // ── Exception mapping (via reflection on handleResponse) ──────
+
+    public function testHandleResponseThrows401AsAuthException(): void
+    {
+        $client = new MuninnClient('http://localhost:8476', 'tok');
+        $method = new \ReflectionMethod($client, 'handleResponse');
+        $method->setAccessible(true);
+
+        $this->expectException(AuthException::class);
+        $method->invoke($client, 401, '{"error":"unauthorized"}');
+    }
+
+    public function testHandleResponseThrows404AsNotFoundException(): void
+    {
+        $client = new MuninnClient('http://localhost:8476', 'tok');
+        $method = new \ReflectionMethod($client, 'handleResponse');
+        $method->setAccessible(true);
+
+        $this->expectException(NotFoundException::class);
+        $method->invoke($client, 404, '{"error":"not found"}');
+    }
+
+    public function testHandleResponseThrows409AsConflictException(): void
+    {
+        $client = new MuninnClient('http://localhost:8476', 'tok');
+        $method = new \ReflectionMethod($client, 'handleResponse');
+        $method->setAccessible(true);
+
+        $this->expectException(ConflictException::class);
+        $method->invoke($client, 409, '{"error":"conflict"}');
+    }
+
+    public function testHandleResponseThrows422AsValidationException(): void
+    {
+        $client = new MuninnClient('http://localhost:8476', 'tok');
+        $method = new \ReflectionMethod($client, 'handleResponse');
+        $method->setAccessible(true);
+
+        $this->expectException(ValidationException::class);
+        $method->invoke($client, 422, '{"error":"bad input"}');
+    }
+
+    public function testHandleResponseThrows500AsServerException(): void
+    {
+        $client = new MuninnClient('http://localhost:8476', 'tok');
+        $method = new \ReflectionMethod($client, 'handleResponse');
+        $method->setAccessible(true);
+
+        $this->expectException(ServerException::class);
+        $method->invoke($client, 500, '{"error":"internal error"}');
+    }
+
+    public function testHandleResponseReturnsDecodedArrayOn200(): void
+    {
+        $client = new MuninnClient('http://localhost:8476', 'tok');
+        $method = new \ReflectionMethod($client, 'handleResponse');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($client, 200, '{"id":"abc","created_at":1700000000}');
+        self::assertSame('abc', $result['id']);
+        self::assertSame(1700000000, $result['created_at']);
+    }
+}

--- a/sdk/python/muninn/client.py
+++ b/sdk/python/muninn/client.py
@@ -219,7 +219,7 @@ class MuninnClient:
         results = [
             BatchWriteResult(
                 index=r.get("index", i),
-                id=r.get("id", ""),
+                id=r.get("id"),
                 status=r.get("status", "error"),
                 error=r.get("error"),
             )
@@ -334,6 +334,7 @@ class MuninnClient:
             created_at=response.get("created_at", 0),
             updated_at=response.get("updated_at", 0),
             last_access=response.get("last_access"),
+            coherence=coherence,
         )
 
     async def forget(self, id: str, vault: str = "default", hard: bool = False) -> bool:
@@ -434,7 +435,7 @@ class MuninnClient:
         self,
         vault: str = "default",
         push_on_write: bool = True,
-        threshold: float = 0.0,
+        threshold: float | None = None,
     ) -> SSEStream:
         """Subscribe to vault events via Server-Sent Events (SSE).
 
@@ -451,7 +452,7 @@ class MuninnClient:
         Args:
             vault: Vault to subscribe to (default: "default")
             push_on_write: Emit push events on new writes (default: True)
-            threshold: Min activation threshold for push events (default: 0.0)
+            threshold: Min activation threshold for push events. None means use server default.
 
         Returns:
             SSEStream async iterable
@@ -463,7 +464,7 @@ class MuninnClient:
             "vault": vault,
             "push_on_write": str(push_on_write).lower(),
         }
-        if threshold:
+        if threshold is not None:
             params["threshold"] = str(threshold)
 
         return SSEStream(self, "/api/subscribe", params)
@@ -568,6 +569,7 @@ class MuninnClient:
         max_hops: int = 2,
         max_nodes: int = 20,
         rel_types: list[str] | None = None,
+        follow_entities: bool = False,
         vault: str = "default",
     ) -> TraverseResponse:
         """Traverse the association graph from a starting engram.
@@ -577,6 +579,7 @@ class MuninnClient:
             max_hops: Maximum hops to traverse (default: 2)
             max_nodes: Maximum nodes to return (default: 20)
             rel_types: Filter by relationship types
+            follow_entities: Follow entity-level associations in addition to engram-level (default: False)
             vault: Vault name (default: "default")
 
         Returns:
@@ -590,6 +593,8 @@ class MuninnClient:
         }
         if rel_types:
             body["rel_types"] = rel_types
+        if follow_entities:
+            body["follow_entities"] = True
         response = await self._request("POST", "/api/traverse", json=body, params={"vault": vault})
         nodes = [
             TraversalNode(

--- a/sdk/python/muninn/langchain.py
+++ b/sdk/python/muninn/langchain.py
@@ -81,7 +81,7 @@ class MuninnDBMemory(_Base):  # type: ignore[misc]
 
     def __init__(
         self,
-        base_url: str = "http://localhost:8475",
+        base_url: str = "http://localhost:8476",
         token: Optional[str] = None,
         vault: str = "default",
         max_results: int = 10,

--- a/sdk/python/muninn/types.py
+++ b/sdk/python/muninn/types.py
@@ -28,8 +28,8 @@ class BatchWriteResult:
     """Result for a single engram in a batch write."""
 
     index: int
-    id: str
     status: str
+    id: str | None = None
     error: str | None = None
 
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -38,6 +38,7 @@ langchain = [
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
+    "respx>=0.22",
     "langchain-core>=0.3",
     "langchain>=0.3",
     "langchain-anthropic>=0.3",

--- a/sdk/python/tests/test_sdk_unit.py
+++ b/sdk/python/tests/test_sdk_unit.py
@@ -1,0 +1,325 @@
+"""SDK unit tests using respx to mock HTTP — no live server required.
+
+Run:
+    pip install -e .[dev]
+    pytest tests/test_sdk_unit.py -v
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from muninn.client import MuninnClient
+
+BASE_URL = "http://muninn-mock"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def mock_client() -> MuninnClient:
+    """Create a MuninnClient whose HTTP will be intercepted by respx."""
+    return MuninnClient(BASE_URL, token="test-token")
+
+
+# ---------------------------------------------------------------------------
+# write / batch
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_write_returns_id():
+    respx.post(f"{BASE_URL}/api/engrams").mock(
+        return_value=httpx.Response(201, json={"id": "01ARZ3", "created_at": 1700000000})
+    )
+    async with mock_client() as c:
+        resp = await c.write(vault="default", concept="test", content="body")
+    assert resp.id == "01ARZ3"
+    assert resp.created_at == 1700000000
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_write_batch_returns_results():
+    respx.post(f"{BASE_URL}/api/engrams/batch").mock(
+        return_value=httpx.Response(200, json={
+            "results": [
+                {"index": 0, "id": "id-1", "status": "created"},
+                {"index": 1, "status": "duplicate"},  # no id — id is optional
+            ]
+        })
+    )
+    async with mock_client() as c:
+        resp = await c.write_batch(
+            vault="default",
+            engrams=[
+                {"concept": "a", "content": "aa"},
+                {"concept": "b", "content": "bb"},
+            ],
+        )
+    assert len(resp.results) == 2
+    assert resp.results[0].id == "id-1"
+    assert resp.results[1].id is None  # optional field absent
+
+
+# ---------------------------------------------------------------------------
+# read — coherence must be included (regression: was silently dropped)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_read_includes_coherence():
+    """read() must pass coherence from the server response through to ReadResponse."""
+    respx.get(f"{BASE_URL}/api/engrams/test-id").mock(
+        return_value=httpx.Response(200, json={
+            "id": "test-id",
+            "concept": "coherent memory",
+            "content": "body",
+            "confidence": 0.8,
+            "relevance": 0.7,
+            "stability": 0.9,
+            "access_count": 2,
+            "tags": [],
+            "state": "active",
+            "created_at": 1700000000,
+            "updated_at": 1700000001,
+            "coherence": {
+                "score": 0.95,
+                "orphan_ratio": 0.01,
+                "contradiction_density": 0.0,
+                "duplication_pressure": 0.02,
+                "temporal_variance": 0.1,
+                "total_engrams": 10,
+            },
+        })
+    )
+    async with mock_client() as c:
+        result = await c.read("test-id", vault="default")
+
+    assert result.coherence is not None, "coherence must not be None"
+    assert result.coherence["score"] == pytest.approx(0.95)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_read_without_coherence():
+    """read() without coherence field should have coherence=None."""
+    respx.get(f"{BASE_URL}/api/engrams/no-coh").mock(
+        return_value=httpx.Response(200, json={
+            "id": "no-coh",
+            "concept": "test",
+            "content": "body",
+            "confidence": 0.8,
+            "relevance": 0.7,
+            "stability": 0.9,
+            "access_count": 0,
+            "tags": [],
+            "state": "active",
+            "created_at": 1700000000,
+            "updated_at": 1700000000,
+        })
+    )
+    async with mock_client() as c:
+        result = await c.read("no-coh", vault="default")
+
+    assert result.coherence is None
+
+
+# ---------------------------------------------------------------------------
+# forget
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_forget_soft_delete():
+    route = respx.delete(f"{BASE_URL}/api/engrams/del-id").mock(
+        return_value=httpx.Response(200, json={"ok": True})
+    )
+    async with mock_client() as c:
+        ok = await c.forget("del-id", vault="default", hard=False)
+    assert ok is True
+    assert route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_forget_hard_delete():
+    route = respx.post(f"{BASE_URL}/api/engrams/hard-id/forget").mock(
+        return_value=httpx.Response(200, json={"ok": True})
+    )
+    async with mock_client() as c:
+        ok = await c.forget("hard-id", vault="default", hard=True)
+    assert ok is True
+    assert route.called
+
+
+# ---------------------------------------------------------------------------
+# subscribe — threshold=0.0 must be sent (regression: was silently dropped)
+# ---------------------------------------------------------------------------
+
+def test_subscribe_threshold_zero_is_sent():
+    """subscribe() with threshold=0.0 must include threshold in the URL params."""
+    client = MuninnClient(BASE_URL, token="tok")
+    # We don't start the SSE stream — just inspect the SSEStream params.
+    stream = client.subscribe(vault="default", push_on_write=True, threshold=0.0)
+    params = stream._params  # type: ignore[attr-defined]
+    assert "threshold" in params, "threshold=0.0 must not be dropped by falsy check"
+    assert params["threshold"] == "0.0"
+
+
+def test_subscribe_threshold_none_not_sent():
+    """subscribe() without threshold should not include the threshold param."""
+    client = MuninnClient(BASE_URL, token="tok")
+    stream = client.subscribe(vault="default")
+    params = stream._params  # type: ignore[attr-defined]
+    assert "threshold" not in params
+
+
+# ---------------------------------------------------------------------------
+# activate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_activate_returns_activations():
+    respx.post(f"{BASE_URL}/api/activate").mock(
+        return_value=httpx.Response(200, json={
+            "query_id": "q1",
+            "total_found": 2,
+            "activations": [
+                {"id": "a1", "concept": "hit", "content": "body", "score": 0.9, "confidence": 0.8},
+                {"id": "a2", "concept": "miss", "content": "body", "score": 0.3, "confidence": 0.5},
+            ],
+            "latency_ms": 12.5,
+        })
+    )
+    async with mock_client() as c:
+        resp = await c.activate(vault="default", context=["query"])
+    assert resp.total_found == 2
+    assert resp.activations[0].id == "a1"
+    assert resp.latency_ms == pytest.approx(12.5)
+
+
+# ---------------------------------------------------------------------------
+# traverse — follow_entities must be forwarded
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_traverse_follow_entities_sent():
+    """When follow_entities=True, the request body must contain follow_entities."""
+    captured_body: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+        captured_body.update(json.loads(request.content))
+        return httpx.Response(200, json={"nodes": [], "edges": [], "total_reachable": 0, "query_ms": 1.0})
+
+    respx.post(f"{BASE_URL}/api/traverse").mock(side_effect=handler)
+
+    async with mock_client() as c:
+        await c.traverse(start_id="s1", follow_entities=True, vault="default")
+
+    assert captured_body.get("follow_entities") is True
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_traverse_follow_entities_not_sent_when_false():
+    """When follow_entities=False (default), it must NOT appear in the request body."""
+    captured_body: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+        captured_body.update(json.loads(request.content))
+        return httpx.Response(200, json={"nodes": [], "edges": [], "total_reachable": 0, "query_ms": 1.0})
+
+    respx.post(f"{BASE_URL}/api/traverse").mock(side_effect=handler)
+
+    async with mock_client() as c:
+        await c.traverse(start_id="s1", vault="default")
+
+    assert "follow_entities" not in captured_body
+
+
+# ---------------------------------------------------------------------------
+# stats
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_stats_returns_engram_count():
+    respx.get(f"{BASE_URL}/api/stats").mock(
+        return_value=httpx.Response(200, json={
+            "engram_count": 42,
+            "vault_count": 3,
+            "storage_bytes": 102400,
+        })
+    )
+    async with mock_client() as c:
+        resp = await c.stats()
+    assert resp.engram_count == 42
+    assert resp.vault_count == 3
+    assert resp.storage_bytes == 102400
+
+
+# ---------------------------------------------------------------------------
+# link
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_link_sends_correct_body():
+    captured_body: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+        captured_body.update(json.loads(request.content))
+        return httpx.Response(200, json={})
+
+    respx.post(f"{BASE_URL}/api/link").mock(side_effect=handler)
+
+    async with mock_client() as c:
+        await c.link(
+            source_id="src",
+            target_id="tgt",
+            vault="default",
+            rel_type=5,
+            weight=0.9,
+        )
+
+    assert captured_body["source_id"] == "src"
+    assert captured_body["target_id"] == "tgt"
+    assert captured_body["rel_type"] == 5
+    assert captured_body["weight"] == pytest.approx(0.9)
+
+
+# ---------------------------------------------------------------------------
+# error handling
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_not_found_raises_muninn_not_found():
+    from muninn.errors import MuninnNotFound
+    respx.get(f"{BASE_URL}/api/engrams/missing").mock(
+        return_value=httpx.Response(404, json={"error": "not found"})
+    )
+    async with mock_client() as c:
+        with pytest.raises(MuninnNotFound):
+            await c.read("missing", vault="default")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_auth_error_raises_muninn_auth_error():
+    from muninn.errors import MuninnAuthError
+    respx.get(f"{BASE_URL}/api/engrams/secret").mock(
+        return_value=httpx.Response(401, json={"error": "unauthorized"})
+    )
+    async with mock_client() as c:
+        with pytest.raises(MuninnAuthError):
+            await c.read("secret", vault="default")


### PR DESCRIPTION
## Summary

Stage 6 of the [Embedding & Adoption Roadmap](docs/plans/2026-03-14-embedding-adoption-roadmap.md): audited all four SDKs (Go, Python, Node.js, PHP) against the server wire format and brought them to production quality.

- **50+ bugs fixed** across all four SDKs — field name mismatches (camelCase vs snake_case), wrong types, falsy-check bugs that silently dropped valid `0.0`/`false` values, missing API parameters
- **Test suites added** to all four SDKs — all passing (Go: existing tests, Python: 15 respx tests, Node.js: 12 vitest+msw tests, PHP: 26 PHPUnit tests)
- Reviewed by Opus before final fixes

## Test plan

- [x] `go test ./...` passes in `sdk/go/muninn`
- [x] `npm test` passes in `sdk/node` (12/12 vitest tests)
- [x] `pytest tests/test_sdk_unit.py` passes in `sdk/python` (15/15 tests)
- [x] `phpunit tests/` passes in `sdk/php` (26/26 tests)
- [ ] CI pipelines pass

## Breaking changes

All SDKs are pre-1.0 so semver doesn't strictly apply, but callers should be aware:
- **Go**: `Stats(ctx)` → `Stats(ctx, vault string)`; `Traverse(...)` gains `followEntities bool` final param
- **Node.js**: Several field renames fixing server wire format mismatches (`depth`→`hop_dist`, `source`/`target`→`from_id`/`to_id`, `limit`→`max_results`, etc.). Old fields were returning `undefined` from server responses anyway.
- **PHP**: `link()` `$relType` changed `string`→`int`; `activate()` `$limit`→`$maxResults`
- **Python**: `BatchWriteResult.id` is now `str|None` (was `str` defaulting to `""`)

## What's next

Stage 5 (Mobile — gomobile iOS/Android bindings) is the only remaining roadmap item before v0.6.0-alpha.