### PR TITLE
feat(sdks): Stage 5 — Swift and Kotlin native HTTP client SDKs

### DIFF
--- a/sdk/kotlin/build.gradle.kts
+++ b/sdk/kotlin/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    kotlin("jvm") version "1.9.22"
+    `java-library`
+    `maven-publish`
+}
+
+group = "com.muninndb"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api("com.squareup.okhttp3:okhttp:4.12.0")
+    api("com.google.code.gson:gson:2.10.1")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation("junit:junit:4.13.2")
+}
+
+kotlin {
+    jvmToolchain(11)
+}
+
+tasks.test {
+    useJUnit()
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+            pom {
+                name.set("MuninnDB Kotlin SDK")
+                description.set("Kotlin client for MuninnDB cognitive memory engine")
+                url.set("https://github.com/scrypster/muninndb")
+            }
+        }
+    }
+}

--- a/sdk/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/sdk/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/sdk/kotlin/gradlew
+++ b/sdk/kotlin/gradlew
@@ -1,0 +1,135 @@
+#!/bin/sh
+#
+# Gradle start up script for UN*X
+#
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+app_path=$0
+
+while
+    APP_HOME=${app_path%"${app_path##*/}"}  # leaves a trailing /; empty if no leading path
+    [ -h "$app_path" ]
+do
+    ls=$( ls -ld "$app_path" )
+    link=${ls#*' -> '}
+    case $link in             #(
+      /*)   app_path=$link ;; #( absolute
+      *)    app_path=$APP_HOME$link ;; #( relative
+    esac
+done
+
+APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
+
+APP_NAME="Gradle"
+APP_BASE_NAME=${0##*/}
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD=maximum
+
+warn () {
+    echo "$*"
+} >&2
+
+die () {
+    echo
+    echo "$*"
+    echo
+    exit 1
+} >&2
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "$( uname )" in                #(
+  CYGWIN* )         cygwin=true  ;; #(
+  Darwin* )         darwin=true  ;; #(
+  MSYS* | MINGW* )  msys=true   ;; #(
+  NONSTOP* )        nonstop=true ;;
+esac
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        JAVACMD=$JAVA_HOME/jre/sh/java
+    else
+        JAVACMD=$JAVA_HOME/bin/java
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD=java
+    if ! command -v java >/dev/null 2>&1
+    then
+        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+fi
+
+# Increase the maximum file descriptors if we can.
+if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
+    case $MAX_FD in #(
+      max*)
+        MAX_FD=$( ulimit -H -n ) ||
+            warn "Could not query maximum file descriptor limit"
+        ;;
+    esac
+    case $MAX_FD in  #(
+      '' | soft) :;; #(
+      *)
+        ulimit -n "$MAX_FD" ||
+            warn "Could not set maximum file descriptor limit to $MAX_FD"
+    esac
+fi
+
+# Collect all arguments for the java command;
+#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
+#     shell script including quotes and variable substitutions, so put them in
+#     double quotes to make sure that they get re-expanded; and
+#   * put everything else in single quotes, so that it's not re-expanded.
+
+set -- \
+        "-Dorg.gradle.appname=$APP_BASE_NAME" \
+        -classpath "$CLASSPATH" \
+        org.gradle.wrapper.GradleWrapperMain \
+        "$@"
+
+# Stop when "xargs" is not available.
+if ! command -v xargs >/dev/null 2>&1
+then
+    die "xargs is not available"
+fi
+
+# Use "xargs" to parse quoted args.
+#
+# With -n1 it outputs one arg per line, with the quotes and backslashes removed.
+#
+# In Bash we could simply go:
+#
+#   readarray ARGS < <( xargs -n1 <<<"$DEFAULT_JVM_OPTS" )
+#
+# but POSIX shell has neither arrays nor command substitution, so instead we
+# post-process each arg (as a line of input to sed) to backslash-escape any
+# temporary variable naming convention.
+
+eval "set -- $(
+        printf '%s\n' "$DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS" |
+        xargs -n1 |
+        sed ' s~[^a-zA-Z0-9/=]~\\&~g; ' |
+        tr '\n' ' '
+    )" '"$@"'
+
+exec "$JAVACMD" "$@"

--- a/sdk/kotlin/settings.gradle.kts
+++ b/sdk/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "muninndb-sdk"

--- a/sdk/kotlin/src/main/kotlin/com/muninndb/client/Errors.kt
+++ b/sdk/kotlin/src/main/kotlin/com/muninndb/client/Errors.kt
@@ -1,0 +1,12 @@
+package com.muninndb.client
+
+sealed class MuninnException(message: String, cause: Throwable? = null) : Exception(message, cause) {
+    class NotFound(message: String) : MuninnException(message)
+    class Unauthorized(message: String) : MuninnException(message)
+    class Conflict(message: String) : MuninnException(message)
+    class Validation(message: String) : MuninnException(message)
+    class ServerError(val status: Int, message: String) : MuninnException(message)
+    class ConnectionFailed(cause: Throwable) : MuninnException(cause.message ?: "Connection failed", cause)
+    class Timeout : MuninnException("Request timed out")
+    class DecodingFailed(message: String, cause: Throwable? = null) : MuninnException(message, cause)
+}

--- a/sdk/kotlin/src/main/kotlin/com/muninndb/client/MuninnClient.kt
+++ b/sdk/kotlin/src/main/kotlin/com/muninndb/client/MuninnClient.kt
@@ -1,0 +1,329 @@
+package com.muninndb.client
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonSyntaxException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.util.concurrent.TimeUnit
+import kotlin.math.pow
+
+class MuninnClient(
+    val baseUrl: String = "http://localhost:8476",
+    val token: String = "",
+    val timeoutMs: Long = 30_000L,
+    val maxRetries: Int = 3,
+    val defaultVault: String = "default",
+    httpClient: OkHttpClient? = null
+) {
+    internal val gson: Gson = GsonBuilder().create()
+    private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
+
+    internal val http: OkHttpClient = httpClient ?: OkHttpClient.Builder()
+        .connectTimeout(timeoutMs, TimeUnit.MILLISECONDS)
+        .readTimeout(timeoutMs, TimeUnit.MILLISECONDS)
+        .writeTimeout(timeoutMs, TimeUnit.MILLISECONDS)
+        .build()
+
+    // ── Write ────────────────────────────────────────────────────────
+
+    suspend fun write(options: WriteOptions): WriteResponse {
+        return request("POST", "/api/engrams", body = options, responseType = WriteResponse::class.java)
+    }
+
+    suspend fun writeBatch(vault: String = defaultVault, engrams: List<WriteOptions>): BatchWriteResponse {
+        val body = BatchWriteBody(engrams.map { it.copy(vault = it.vault ?: vault) })
+        return request("POST", "/api/engrams/batch", body = body, responseType = BatchWriteResponse::class.java)
+    }
+
+    // ── Read ─────────────────────────────────────────────────────────
+
+    suspend fun read(id: String, vault: String? = null): Engram {
+        return request(
+            "GET", "/api/engrams/$id",
+            params = mapOf("vault" to (vault ?: defaultVault)),
+            responseType = Engram::class.java
+        )
+    }
+
+    // ── Forget ───────────────────────────────────────────────────────
+
+    suspend fun forget(id: String, vault: String? = null, hard: Boolean = false) {
+        val v = vault ?: defaultVault
+        val params = mutableMapOf<String, String?>("vault" to v)
+        if (hard) params["hard"] = "true"
+        request("DELETE", "/api/engrams/$id", params = params, responseType = Unit::class.java)
+    }
+
+    // ── Activate ─────────────────────────────────────────────────────
+
+    suspend fun activate(options: ActivateOptions): ActivateResponse {
+        val opts = if (options.vault == null) options.copy(vault = defaultVault) else options
+        return request("POST", "/api/activate", body = opts, responseType = ActivateResponse::class.java)
+    }
+
+    // ── Link ─────────────────────────────────────────────────────────
+
+    suspend fun link(options: LinkOptions) {
+        val opts = if (options.vault == null) options.copy(vault = defaultVault) else options
+        request("POST", "/api/link", body = opts, responseType = Unit::class.java)
+    }
+
+    // ── Traverse ─────────────────────────────────────────────────────
+
+    suspend fun traverse(options: TraverseOptions): TraverseResponse {
+        val opts = if (options.vault == null) options.copy(vault = defaultVault) else options
+        return request("POST", "/api/traverse", body = opts, responseType = TraverseResponse::class.java)
+    }
+
+    // ── Evolve ───────────────────────────────────────────────────────
+
+    suspend fun evolve(id: String, newContent: String, reason: String, vault: String? = null): EvolveResponse {
+        val body = EvolveBody(vault = vault ?: defaultVault, newContent = newContent, reason = reason)
+        return request("POST", "/api/engrams/$id/evolve", body = body, responseType = EvolveResponse::class.java)
+    }
+
+    // ── Consolidate ──────────────────────────────────────────────────
+
+    suspend fun consolidate(ids: List<String>, mergedContent: String, vault: String? = null): ConsolidateResponse {
+        val body = ConsolidateOptions(vault = vault ?: defaultVault, ids = ids, mergedContent = mergedContent)
+        return request("POST", "/api/consolidate", body = body, responseType = ConsolidateResponse::class.java)
+    }
+
+    // ── Decide ───────────────────────────────────────────────────────
+
+    suspend fun decide(options: DecideOptions): DecideResponse {
+        val opts = if (options.vault == null) options.copy(vault = defaultVault) else options
+        return request("POST", "/api/decide", body = opts, responseType = DecideResponse::class.java)
+    }
+
+    // ── Restore ──────────────────────────────────────────────────────
+
+    suspend fun restore(id: String, vault: String? = null): RestoreResponse {
+        return request(
+            "POST", "/api/engrams/$id/restore",
+            params = mapOf("vault" to (vault ?: defaultVault)),
+            responseType = RestoreResponse::class.java
+        )
+    }
+
+    // ── Explain ──────────────────────────────────────────────────────
+
+    suspend fun explain(options: ExplainOptions): ExplainResponse {
+        val opts = if (options.vault == null) options.copy(vault = defaultVault) else options
+        return request("POST", "/api/explain", body = opts, responseType = ExplainResponse::class.java)
+    }
+
+    // ── Set State ────────────────────────────────────────────────────
+
+    suspend fun setState(id: String, state: String, reason: String? = null, vault: String? = null): SetStateResponse {
+        val body = SetStateBody(vault = vault ?: defaultVault, state = state, reason = reason)
+        return request("PUT", "/api/engrams/$id/state", body = body, responseType = SetStateResponse::class.java)
+    }
+
+    // ── List Deleted ─────────────────────────────────────────────────
+
+    suspend fun listDeleted(vault: String? = null, limit: Int? = null): ListDeletedResponse {
+        val params = mutableMapOf<String, String?>("vault" to (vault ?: defaultVault))
+        if (limit != null) params["limit"] = limit.toString()
+        return request("GET", "/api/deleted", params = params, responseType = ListDeletedResponse::class.java)
+    }
+
+    // ── Retry Enrich ─────────────────────────────────────────────────
+
+    suspend fun retryEnrich(id: String, vault: String? = null): RetryEnrichResponse {
+        return request(
+            "POST", "/api/engrams/$id/retry-enrich",
+            params = mapOf("vault" to (vault ?: defaultVault)),
+            responseType = RetryEnrichResponse::class.java
+        )
+    }
+
+    // ── Contradictions ───────────────────────────────────────────────
+
+    suspend fun contradictions(vault: String? = null): ContradictionsResponse {
+        return request(
+            "GET", "/api/contradictions",
+            params = mapOf("vault" to (vault ?: defaultVault)),
+            responseType = ContradictionsResponse::class.java
+        )
+    }
+
+    // ── Guide ────────────────────────────────────────────────────────
+
+    suspend fun guide(vault: String? = null): String {
+        val resp = request(
+            "GET", "/api/guide",
+            params = mapOf("vault" to (vault ?: defaultVault)),
+            responseType = GuideResponseBody::class.java
+        )
+        return resp.guide
+    }
+
+    // ── Stats ────────────────────────────────────────────────────────
+
+    suspend fun stats(vault: String? = null): StatsResponse {
+        val params = mutableMapOf<String, String?>()
+        if (vault != null) params["vault"] = vault
+        return request("GET", "/api/stats", params = params, responseType = StatsResponse::class.java)
+    }
+
+    // ── List Engrams ─────────────────────────────────────────────────
+
+    suspend fun listEngrams(vault: String? = null, limit: Int? = null, offset: Int? = null): ListEngramsResponse {
+        val params = mutableMapOf<String, String?>("vault" to (vault ?: defaultVault))
+        if (limit != null) params["limit"] = limit.toString()
+        if (offset != null) params["offset"] = offset.toString()
+        return request("GET", "/api/engrams", params = params, responseType = ListEngramsResponse::class.java)
+    }
+
+    // ── Get Links ────────────────────────────────────────────────────
+
+    suspend fun getLinks(id: String, vault: String? = null): List<AssociationItem> {
+        val resp = request(
+            "GET", "/api/engrams/$id/links",
+            params = mapOf("vault" to (vault ?: defaultVault)),
+            responseType = GetLinksResponse::class.java
+        )
+        return resp.links
+    }
+
+    // ── List Vaults ──────────────────────────────────────────────────
+
+    suspend fun listVaults(): List<String> {
+        val resp = request("GET", "/api/vaults", responseType = VaultsResponse::class.java)
+        return resp.vaults
+    }
+
+    // ── Session ──────────────────────────────────────────────────────
+
+    suspend fun session(vault: String? = null, since: String? = null, limit: Int? = null, offset: Int? = null): SessionResponse {
+        val params = mutableMapOf<String, String?>("vault" to (vault ?: defaultVault))
+        if (since != null) params["since"] = since
+        if (limit != null) params["limit"] = limit.toString()
+        if (offset != null) params["offset"] = offset.toString()
+        return request("GET", "/api/session", params = params, responseType = SessionResponse::class.java)
+    }
+
+    // ── Subscribe (SSE) ──────────────────────────────────────────────
+
+    fun subscribe(vault: String? = null, pushOnWrite: Boolean = true, threshold: Double? = null): Flow<SseEvent> {
+        val urlBuilder = (baseUrl + "/api/subscribe").toHttpUrl().newBuilder()
+            .addQueryParameter("vault", vault ?: defaultVault)
+            .addQueryParameter("push_on_write", pushOnWrite.toString())
+        if (threshold != null) {
+            urlBuilder.addQueryParameter("threshold", threshold.toString())
+        }
+        val request = Request.Builder()
+            .url(urlBuilder.build())
+            .apply { if (token.isNotEmpty()) addHeader("Authorization", "Bearer $token") }
+            .addHeader("Accept", "text/event-stream")
+            .build()
+        return sseFlow(http, request)
+    }
+
+    // ── Health ───────────────────────────────────────────────────────
+
+    suspend fun health(): HealthResponse {
+        return request("GET", "/api/health", responseType = HealthResponse::class.java)
+    }
+
+    // ── Internal ─────────────────────────────────────────────────────
+
+    private suspend fun <T> request(
+        method: String,
+        path: String,
+        params: Map<String, String?> = emptyMap(),
+        body: Any? = null,
+        responseType: Class<T>
+    ): T = withRetry {
+        withContext(Dispatchers.IO) {
+            val urlBuilder = (baseUrl + path).toHttpUrl().newBuilder()
+            params.forEach { (k, v) -> if (v != null) urlBuilder.addQueryParameter(k, v) }
+            val url = urlBuilder.build()
+
+            val requestBody = if (body != null) {
+                gson.toJson(body).toRequestBody(jsonMediaType)
+            } else null
+
+            val request = Request.Builder()
+                .url(url)
+                .method(method, requestBody ?: if (method == "POST" || method == "PUT") "".toRequestBody(null) else null)
+                .apply { if (token.isNotEmpty()) addHeader("Authorization", "Bearer $token") }
+                .addHeader("Accept", "application/json")
+                .build()
+
+            val response = http.newCall(request).execute()
+            response.use { resp ->
+                val responseBody = resp.body?.string() ?: ""
+                if (!resp.isSuccessful) {
+                    throw mapError(resp.code, responseBody)
+                }
+                if (responseType == Unit::class.java) {
+                    @Suppress("UNCHECKED_CAST")
+                    Unit as T
+                } else {
+                    try {
+                        gson.fromJson(responseBody, responseType)
+                            ?: throw MuninnException.DecodingFailed("Null response body")
+                    } catch (e: JsonSyntaxException) {
+                        throw MuninnException.DecodingFailed("Failed to decode response: ${e.message}", e)
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun <T> withRetry(block: suspend () -> T): T {
+        var attempt = 0
+        while (true) {
+            try {
+                return block()
+            } catch (e: MuninnException.ServerError) {
+                if (attempt >= maxRetries) throw e
+                delay((500L * 2.0.pow(attempt)).toLong())
+                attempt++
+            } catch (e: SocketTimeoutException) {
+                if (attempt >= maxRetries) throw MuninnException.Timeout()
+                delay((500L * 2.0.pow(attempt)).toLong())
+                attempt++
+            } catch (e: IOException) {
+                if (attempt >= maxRetries) throw MuninnException.ConnectionFailed(e)
+                delay((500L * 2.0.pow(attempt)).toLong())
+                attempt++
+            }
+        }
+    }
+
+    private fun mapError(code: Int, body: String): MuninnException {
+        val message = extractErrorMessage(body)
+        return when (code) {
+            400 -> MuninnException.Validation(message)
+            401, 403 -> MuninnException.Unauthorized(message)
+            404 -> MuninnException.NotFound(message)
+            409 -> MuninnException.Conflict(message)
+            429 -> MuninnException.ServerError(code, message)
+            in 500..599 -> MuninnException.ServerError(code, message)
+            else -> MuninnException.ServerError(code, message)
+        }
+    }
+
+    private fun extractErrorMessage(body: String): String {
+        return try {
+            val env = gson.fromJson(body, ErrorEnvelope::class.java)
+            env?.error?.message ?: body
+        } catch (_: Exception) {
+            body
+        }
+    }
+}

--- a/sdk/kotlin/src/main/kotlin/com/muninndb/client/SseStream.kt
+++ b/sdk/kotlin/src/main/kotlin/com/muninndb/client/SseStream.kt
@@ -1,0 +1,38 @@
+package com.muninndb.client
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+
+internal fun sseFlow(client: OkHttpClient, request: Request): Flow<SseEvent> = flow {
+    val response: Response = client.newCall(request).execute()
+    if (!response.isSuccessful) {
+        response.close()
+        throw MuninnException.ServerError(response.code, "SSE subscribe failed: ${response.code}")
+    }
+    val source = response.body?.source() ?: run {
+        response.close()
+        return@flow
+    }
+    try {
+        var eventType = "message"
+        var dataBuffer = StringBuilder()
+        while (!source.exhausted()) {
+            val line = source.readUtf8Line() ?: break
+            when {
+                line.startsWith("event: ") -> eventType = line.removePrefix("event: ")
+                line.startsWith("data: ") -> dataBuffer.append(line.removePrefix("data: "))
+                line.isEmpty() && dataBuffer.isNotEmpty() -> {
+                    emit(SseEvent(type = eventType, rawData = dataBuffer.toString()))
+                    dataBuffer = StringBuilder()
+                    eventType = "message"
+                }
+            }
+        }
+    } finally {
+        source.close()
+        response.close()
+    }
+}

--- a/sdk/kotlin/src/main/kotlin/com/muninndb/client/Types.kt
+++ b/sdk/kotlin/src/main/kotlin/com/muninndb/client/Types.kt
@@ -1,0 +1,360 @@
+package com.muninndb.client
+
+import com.google.gson.annotations.SerializedName
+
+data class WriteOptions(
+    val concept: String,
+    val content: String,
+    val vault: String? = null,
+    val tags: List<String>? = null,
+    val confidence: Double? = null,
+    val stability: Double? = null,
+    @SerializedName("memory_type") val memoryType: Int? = null,
+    @SerializedName("type_label") val typeLabel: String? = null,
+    val summary: String? = null,
+    val entities: List<InlineEntity>? = null,
+    val relationships: List<InlineRelationship>? = null
+)
+
+data class InlineEntity(val name: String, val type: String)
+
+data class InlineRelationship(
+    @SerializedName("target_id") val targetId: String,
+    val relation: String,
+    val weight: Double
+)
+
+data class WriteResponse(
+    val id: String,
+    @SerializedName("created_at") val createdAt: Long
+)
+
+data class BatchWriteResult(
+    val index: Int,
+    val id: String?,
+    val status: String,
+    val error: String?
+)
+
+data class BatchWriteBody(val engrams: List<WriteOptions>)
+
+data class BatchWriteResponse(val results: List<BatchWriteResult>)
+
+data class Engram(
+    val id: String,
+    val concept: String,
+    val content: String,
+    val confidence: Double,
+    val relevance: Double,
+    val stability: Double,
+    @SerializedName("access_count") val accessCount: Int,
+    val tags: List<String>?,
+    val state: Int,
+    @SerializedName("created_at") val createdAt: Long,
+    @SerializedName("updated_at") val updatedAt: Long,
+    @SerializedName("last_access") val lastAccess: Long,
+    val summary: String?,
+    @SerializedName("key_points") val keyPoints: List<String>?,
+    @SerializedName("memory_type") val memoryType: Int,
+    @SerializedName("type_label") val typeLabel: String?,
+    @SerializedName("embed_dim") val embedDim: Int?
+)
+
+data class Weights(
+    @SerializedName("semantic_similarity") val semanticSimilarity: Double? = null,
+    @SerializedName("full_text_relevance") val fullTextRelevance: Double? = null,
+    @SerializedName("decay_factor") val decayFactor: Double? = null,
+    @SerializedName("hebbian_boost") val hebbianBoost: Double? = null,
+    @SerializedName("access_frequency") val accessFrequency: Double? = null,
+    val recency: Double? = null
+)
+
+// Filter value can be String, Int, Double, Boolean, or List<String>.
+// These are send-only (never deserialized), so Any serializes correctly via Gson reflection.
+data class Filter(
+    val field: String,
+    val op: String,
+    val value: Any
+)
+
+data class ActivateOptions(
+    val context: List<String>,
+    val vault: String? = null,
+    @SerializedName("max_results") val maxResults: Int? = null,
+    val threshold: Double? = null,
+    @SerializedName("max_hops") val maxHops: Int? = null,
+    @SerializedName("include_why") val includeWhy: Boolean? = null,
+    @SerializedName("brief_mode") val briefMode: String? = null,
+    @SerializedName("disable_hops") val disableHops: Boolean? = null,
+    val weights: Weights? = null,
+    val filters: List<Filter>? = null
+)
+
+data class ScoreComponents(
+    @SerializedName("semantic_similarity") val semanticSimilarity: Double,
+    @SerializedName("full_text_relevance") val fullTextRelevance: Double,
+    @SerializedName("decay_factor") val decayFactor: Double,
+    @SerializedName("hebbian_boost") val hebbianBoost: Double,
+    @SerializedName("access_frequency") val accessFrequency: Double,
+    val recency: Double,
+    val raw: Double,
+    @SerializedName("final") val finalScore: Double
+)
+
+data class ActivationItem(
+    val id: String,
+    val concept: String,
+    val content: String,
+    val summary: String?,
+    val score: Double,
+    val confidence: Double,
+    val why: String?,
+    @SerializedName("hop_path") val hopPath: List<String>?,
+    val dormant: Boolean?,
+    @SerializedName("created_at") val createdAt: Long?,
+    @SerializedName("last_access") val lastAccess: Long?,
+    @SerializedName("access_count") val accessCount: Int?,
+    val relevance: Double?
+)
+
+data class BriefSentence(
+    @SerializedName("engram_id") val engramId: String,
+    val text: String,
+    val score: Double
+)
+
+data class ActivateResponse(
+    @SerializedName("query_id") val queryId: String,
+    @SerializedName("total_found") val totalFound: Int,
+    val activations: List<ActivationItem>,
+    @SerializedName("latency_ms") val latencyMs: Double?,
+    val brief: List<BriefSentence>?
+)
+
+data class LinkOptions(
+    @SerializedName("source_id") val sourceId: String,
+    @SerializedName("target_id") val targetId: String,
+    @SerializedName("rel_type") val relType: Int,
+    val weight: Double? = null,
+    val vault: String? = null
+)
+
+data class TraverseOptions(
+    val vault: String? = null,
+    @SerializedName("start_id") val startId: String,
+    @SerializedName("max_hops") val maxHops: Int? = null,
+    @SerializedName("max_nodes") val maxNodes: Int? = null,
+    @SerializedName("rel_types") val relTypes: List<String>? = null,
+    @SerializedName("follow_entities") val followEntities: Boolean? = null
+)
+
+data class TraversalNode(
+    val id: String,
+    val concept: String,
+    @SerializedName("hop_dist") val hopDist: Int,
+    val summary: String?
+)
+
+data class TraversalEdge(
+    @SerializedName("from_id") val fromId: String,
+    @SerializedName("to_id") val toId: String,
+    @SerializedName("rel_type") val relType: String,
+    val weight: Double
+)
+
+data class TraverseResponse(
+    val nodes: List<TraversalNode>,
+    val edges: List<TraversalEdge>,
+    @SerializedName("total_reachable") val totalReachable: Int,
+    @SerializedName("query_ms") val queryMs: Double
+)
+
+data class EvolveBody(
+    val vault: String?,
+    @SerializedName("new_content") val newContent: String,
+    val reason: String
+)
+
+data class EvolveResponse(val id: String)
+
+data class ConsolidateOptions(
+    val vault: String?,
+    val ids: List<String>,
+    @SerializedName("merged_content") val mergedContent: String
+)
+
+data class ConsolidateResponse(
+    val id: String,
+    val archived: List<String>,
+    val warnings: List<String>?
+)
+
+data class DecideOptions(
+    val vault: String? = null,
+    val decision: String,
+    val rationale: String,
+    val alternatives: List<String>? = null,
+    @SerializedName("evidence_ids") val evidenceIds: List<String>? = null
+)
+
+data class DecideResponse(
+    val id: String,
+    val warnings: List<String>?
+)
+
+data class RestoreResponse(
+    val id: String,
+    val concept: String,
+    val restored: Boolean,
+    val state: String
+)
+
+data class ExplainOptions(
+    val vault: String? = null,
+    @SerializedName("engram_id") val engramId: String,
+    val query: List<String>
+)
+
+data class ExplainComponents(
+    @SerializedName("full_text_relevance") val fullTextRelevance: Double,
+    @SerializedName("semantic_similarity") val semanticSimilarity: Double,
+    @SerializedName("decay_factor") val decayFactor: Double,
+    @SerializedName("hebbian_boost") val hebbianBoost: Double,
+    @SerializedName("access_frequency") val accessFrequency: Double,
+    val confidence: Double
+)
+
+data class ExplainResponse(
+    @SerializedName("engram_id") val engramId: String,
+    val concept: String,
+    @SerializedName("final_score") val finalScore: Double,
+    val components: ExplainComponents,
+    @SerializedName("fts_matches") val ftsMatches: List<String>,
+    @SerializedName("assoc_path") val assocPath: List<String>,
+    @SerializedName("would_return") val wouldReturn: Boolean,
+    val threshold: Double
+)
+
+data class SetStateBody(
+    val vault: String?,
+    val state: String,
+    val reason: String?
+)
+
+data class SetStateResponse(
+    val id: String,
+    val state: String,
+    val updated: Boolean
+)
+
+data class DeletedEngramItem(
+    val id: String,
+    val concept: String,
+    @SerializedName("deleted_at") val deletedAt: Long,
+    @SerializedName("recoverable_until") val recoverableUntil: Long,
+    val tags: List<String>?
+)
+
+data class ListDeletedResponse(
+    val deleted: List<DeletedEngramItem>,
+    val count: Int
+)
+
+data class RetryEnrichResponse(
+    @SerializedName("engram_id") val engramId: String,
+    @SerializedName("plugins_queued") val pluginsQueued: List<String>,
+    @SerializedName("already_complete") val alreadyComplete: List<String>,
+    val note: String?
+)
+
+data class ContradictionItem(
+    @SerializedName("id_a") val idA: String,
+    @SerializedName("concept_a") val conceptA: String,
+    @SerializedName("id_b") val idB: String,
+    @SerializedName("concept_b") val conceptB: String,
+    @SerializedName("detected_at") val detectedAt: Long
+)
+
+data class ContradictionsResponse(
+    val contradictions: List<ContradictionItem>
+)
+
+data class CoherenceResult(
+    val score: Double,
+    @SerializedName("orphan_ratio") val orphanRatio: Double,
+    @SerializedName("contradiction_density") val contradictionDensity: Double,
+    @SerializedName("duplication_pressure") val duplicationPressure: Double,
+    @SerializedName("temporal_variance") val temporalVariance: Double,
+    @SerializedName("total_engrams") val totalEngrams: Long
+)
+
+data class StatsResponse(
+    @SerializedName("engram_count") val engramCount: Long,
+    @SerializedName("vault_count") val vaultCount: Int,
+    @SerializedName("index_size") val indexSize: Long,
+    @SerializedName("storage_bytes") val storageBytes: Long,
+    val coherence: Map<String, CoherenceResult>?
+)
+
+data class EngramItem(
+    val id: String,
+    val concept: String,
+    val content: String,
+    val confidence: Double,
+    val tags: List<String>?,
+    val vault: String,
+    @SerializedName("created_at") val createdAt: Long,
+    @SerializedName("embed_dim") val embedDim: Int?
+)
+
+data class ListEngramsResponse(
+    val engrams: List<EngramItem>,
+    val total: Int,
+    val limit: Int,
+    val offset: Int
+)
+
+data class AssociationItem(
+    @SerializedName("target_id") val targetId: String,
+    @SerializedName("rel_type") val relType: Int,
+    val weight: Double,
+    @SerializedName("co_activation_count") val coActivationCount: Int,
+    @SerializedName("restored_at") val restoredAt: Long?
+)
+
+data class SessionItem(
+    val id: String,
+    val concept: String,
+    val content: String?,
+    @SerializedName("created_at") val createdAt: Long
+)
+
+data class SessionResponse(
+    val entries: List<SessionItem>,
+    val total: Int,
+    val offset: Int,
+    val limit: Int
+)
+
+data class SseEvent(
+    val type: String,
+    val rawData: String
+)
+
+data class HealthResponse(
+    val status: String,
+    val version: String,
+    @SerializedName("uptime_seconds") val uptimeSeconds: Long,
+    @SerializedName("db_writable") val dbWritable: Boolean
+)
+
+// Internal wrappers for JSON deserialization
+internal data class GuideResponseBody(val guide: String)
+internal data class VaultsResponse(val vaults: List<String>)
+internal data class GetLinksResponse(val links: List<AssociationItem>)
+internal data class ErrorDetail(
+    val code: Int?,
+    val message: String?,
+    @SerializedName("request_id") val requestId: String?
+)
+internal data class ErrorEnvelope(val error: ErrorDetail?)

--- a/sdk/kotlin/src/test/kotlin/com/muninndb/client/ClientTest.kt
+++ b/sdk/kotlin/src/test/kotlin/com/muninndb/client/ClientTest.kt
@@ -1,0 +1,601 @@
+package com.muninndb.client
+
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ClientTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: MuninnClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = MuninnClient(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            token = "test-token"
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    // ── Write ────────────────────────────────────────────────────────
+
+    @Test
+    fun testWrite() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"id":"01ARZ3NDEK","created_at":1700000000}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.write(WriteOptions(concept = "test", content = "content"))
+        assertEquals("01ARZ3NDEK", result.id)
+        assertEquals(1700000000L, result.createdAt)
+
+        val req = server.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/api/engrams", req.path)
+        assertEquals("Bearer test-token", req.getHeader("Authorization"))
+
+        val body = client.gson.fromJson(req.body.readUtf8(), WriteOptions::class.java)
+        assertEquals("test", body.concept)
+        assertEquals("content", body.content)
+    }
+
+    // ── WriteBatch ───────────────────────────────────────────────────
+
+    @Test
+    fun testWriteBatch() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"results":[{"index":0,"id":"id1","status":"ok","error":null},{"index":1,"id":"id2","status":"ok","error":null}]}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.writeBatch("v1", listOf(
+            WriteOptions(concept = "a", content = "aaa"),
+            WriteOptions(concept = "b", content = "bbb")
+        ))
+        assertEquals(2, result.results.size)
+        assertEquals("id1", result.results[0].id)
+        assertEquals("id2", result.results[1].id)
+
+        val req = server.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/api/engrams/batch", req.path)
+    }
+
+    // ── Read ─────────────────────────────────────────────────────────
+
+    @Test
+    fun testRead() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"id":"abc","concept":"c","content":"body","confidence":0.9,"relevance":0.8,"stability":0.7,"access_count":3,"tags":["t"],"state":0,"created_at":100,"updated_at":200,"last_access":300,"summary":null,"key_points":null,"memory_type":1,"type_label":"episodic","embed_dim":null}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val engram = client.read("abc", vault = "v1")
+        assertEquals("abc", engram.id)
+        assertEquals("c", engram.concept)
+        assertEquals(0.9, engram.confidence)
+        assertEquals(1, engram.memoryType)
+
+        val req = server.takeRequest()
+        assertEquals("GET", req.method)
+        assertTrue(req.path!!.startsWith("/api/engrams/abc"))
+        assertTrue(req.path!!.contains("vault=v1"))
+    }
+
+    // ── Forget (soft) ────────────────────────────────────────────────
+
+    @Test
+    fun testForgetSoft() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(204))
+
+        client.forget("abc", vault = "v1")
+
+        val req = server.takeRequest()
+        assertEquals("DELETE", req.method)
+        assertTrue(req.path!!.startsWith("/api/engrams/abc"))
+        assertTrue(req.path!!.contains("vault=v1"))
+    }
+
+    // ── Forget (hard) ────────────────────────────────────────────────
+
+    @Test
+    fun testForgetHard() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(204))
+
+        client.forget("abc", vault = "v1", hard = true)
+
+        val req = server.takeRequest()
+        assertEquals("DELETE", req.method)
+        assertTrue(req.path!!.startsWith("/api/engrams/abc"))
+        assertTrue(req.path!!.contains("hard=true"))
+        assertTrue(req.path!!.contains("vault=v1"))
+    }
+
+    // ── Activate ─────────────────────────────────────────────────────
+
+    @Test
+    fun testActivate() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"query_id":"q1","total_found":1,"activations":[{"id":"e1","concept":"c","content":"body","summary":null,"score":0.95,"confidence":0.9,"why":"match","hop_path":null,"dormant":false,"created_at":100,"last_access":200,"access_count":1,"relevance":0.8}],"latency_ms":12.5,"brief":null}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.activate(ActivateOptions(context = listOf("query"), maxResults = 5))
+        assertEquals("q1", result.queryId)
+        assertEquals(1, result.totalFound)
+        assertEquals(0.95, result.activations[0].score)
+
+        val req = server.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/api/activate", req.path)
+    }
+
+    // ── Link ─────────────────────────────────────────────────────────
+
+    @Test
+    fun testLink() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}").addHeader("Content-Type", "application/json"))
+
+        client.link(LinkOptions(sourceId = "a", targetId = "b", relType = 1, weight = 0.5))
+
+        val req = server.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/api/link", req.path)
+        val body = req.body.readUtf8()
+        assertTrue(body.contains("\"source_id\":\"a\""))
+        assertTrue(body.contains("\"target_id\":\"b\""))
+    }
+
+    // ── Traverse ─────────────────────────────────────────────────────
+
+    @Test
+    fun testTraverse() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"nodes":[{"id":"n1","concept":"c","hop_dist":0,"summary":null}],"edges":[{"from_id":"n1","to_id":"n2","rel_type":"assoc","weight":0.8}],"total_reachable":2,"query_ms":5.0}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.traverse(TraverseOptions(startId = "n1"))
+        assertEquals(1, result.nodes.size)
+        assertEquals(1, result.edges.size)
+        assertEquals(2, result.totalReachable)
+
+        val req = server.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/api/traverse", req.path)
+    }
+
+    // ── Evolve ───────────────────────────────────────────────────────
+
+    @Test
+    fun testEvolve() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"id":"e1"}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.evolve("e1", newContent = "updated", reason = "correction")
+        assertEquals("e1", result.id)
+
+        val req = server.takeRequest()
+        assertEquals("POST", req.method)
+        assertTrue(req.path!!.startsWith("/api/engrams/e1/evolve"))
+    }
+
+    // ── Consolidate ──────────────────────────────────────────────────
+
+    @Test
+    fun testConsolidate() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"id":"merged1","archived":["a","b"],"warnings":null}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.consolidate(listOf("a", "b"), mergedContent = "combined")
+        assertEquals("merged1", result.id)
+        assertEquals(listOf("a", "b"), result.archived)
+
+        val req = server.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/api/consolidate", req.path)
+    }
+
+    // ── Decide ───────────────────────────────────────────────────────
+
+    @Test
+    fun testDecide() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"id":"d1","warnings":null}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.decide(DecideOptions(
+            decision = "chose A",
+            rationale = "because",
+            alternatives = listOf("B", "C")
+        ))
+        assertEquals("d1", result.id)
+
+        val req = server.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/api/decide", req.path)
+    }
+
+    // ── Restore ──────────────────────────────────────────────────────
+
+    @Test
+    fun testRestore() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"id":"r1","concept":"restored","restored":true,"state":"active"}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.restore("r1")
+        assertEquals("r1", result.id)
+        assertTrue(result.restored)
+
+        val req = server.takeRequest()
+        assertEquals("POST", req.method)
+        assertTrue(req.path!!.contains("/api/engrams/r1/restore"))
+    }
+
+    // ── Explain ──────────────────────────────────────────────────────
+
+    @Test
+    fun testExplain() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"engram_id":"e1","concept":"c","final_score":0.85,"components":{"full_text_relevance":0.7,"semantic_similarity":0.8,"decay_factor":0.95,"hebbian_boost":1.1,"access_frequency":0.5,"confidence":0.9},"fts_matches":["word"],"assoc_path":[],"would_return":true,"threshold":0.3}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.explain(ExplainOptions(engramId = "e1", query = listOf("word")))
+        assertEquals("e1", result.engramId)
+        assertEquals(0.85, result.finalScore)
+        assertTrue(result.wouldReturn)
+
+        val req = server.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/api/explain", req.path)
+    }
+
+    // ── Set State ────────────────────────────────────────────────────
+
+    @Test
+    fun testSetState() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"id":"s1","state":"dormant","updated":true}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.setState("s1", state = "dormant", reason = "inactive")
+        assertEquals("s1", result.id)
+        assertEquals("dormant", result.state)
+        assertTrue(result.updated)
+
+        val req = server.takeRequest()
+        assertEquals("PUT", req.method)
+        assertTrue(req.path!!.contains("/api/engrams/s1/state"))
+    }
+
+    // ── List Deleted ─────────────────────────────────────────────────
+
+    @Test
+    fun testListDeleted() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"deleted":[{"id":"d1","concept":"gone","deleted_at":100,"recoverable_until":200,"tags":null}],"count":1}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.listDeleted(limit = 10)
+        assertEquals(1, result.count)
+        assertEquals("d1", result.deleted[0].id)
+
+        val req = server.takeRequest()
+        assertEquals("GET", req.method)
+        assertTrue(req.path!!.startsWith("/api/deleted"))
+    }
+
+    // ── Retry Enrich ─────────────────────────────────────────────────
+
+    @Test
+    fun testRetryEnrich() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"engram_id":"e1","plugins_queued":["summary"],"already_complete":["entities"],"note":null}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.retryEnrich("e1")
+        assertEquals("e1", result.engramId)
+        assertEquals(listOf("summary"), result.pluginsQueued)
+
+        val req = server.takeRequest()
+        assertEquals("POST", req.method)
+        assertTrue(req.path!!.contains("/api/engrams/e1/retry-enrich"))
+    }
+
+    // ── Contradictions ───────────────────────────────────────────────
+
+    @Test
+    fun testContradictions() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"contradictions":[{"id_a":"a1","concept_a":"ca","id_b":"b1","concept_b":"cb","detected_at":500}]}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.contradictions()
+        assertEquals(1, result.contradictions.size)
+        assertEquals("a1", result.contradictions[0].idA)
+
+        val req = server.takeRequest()
+        assertEquals("GET", req.method)
+        assertTrue(req.path!!.startsWith("/api/contradictions"))
+    }
+
+    // ── Guide ────────────────────────────────────────────────────────
+
+    @Test
+    fun testGuide() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"guide":"Use activate to search."}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.guide()
+        assertEquals("Use activate to search.", result)
+
+        val req = server.takeRequest()
+        assertEquals("GET", req.method)
+        assertTrue(req.path!!.startsWith("/api/guide"))
+    }
+
+    // ── Stats ────────────────────────────────────────────────────────
+
+    @Test
+    fun testStats() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"engram_count":42,"vault_count":2,"index_size":1024,"storage_bytes":4096,"coherence":null}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.stats()
+        assertEquals(42L, result.engramCount)
+        assertEquals(2, result.vaultCount)
+
+        val req = server.takeRequest()
+        assertEquals("GET", req.method)
+        assertTrue(req.path!!.startsWith("/api/stats"))
+    }
+
+    // ── List Engrams ─────────────────────────────────────────────────
+
+    @Test
+    fun testListEngrams() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"engrams":[{"id":"e1","concept":"c","content":"body","confidence":0.9,"tags":null,"vault":"default","created_at":100,"embed_dim":null}],"total":1,"limit":20,"offset":0}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.listEngrams(limit = 20)
+        assertEquals(1, result.engrams.size)
+        assertEquals("e1", result.engrams[0].id)
+
+        val req = server.takeRequest()
+        assertEquals("GET", req.method)
+        assertTrue(req.path!!.startsWith("/api/engrams"))
+    }
+
+    // ── Get Links ────────────────────────────────────────────────────
+
+    @Test
+    fun testGetLinks() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"links":[{"target_id":"t1","rel_type":1,"weight":0.8,"co_activation_count":3,"restored_at":null}]}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.getLinks("e1")
+        assertEquals(1, result.size)
+        assertEquals("t1", result[0].targetId)
+        assertEquals(1, result[0].relType)
+
+        val req = server.takeRequest()
+        assertEquals("GET", req.method)
+        assertTrue(req.path!!.contains("/api/engrams/e1/links"))
+    }
+
+    // ── List Vaults ──────────────────────────────────────────────────
+
+    @Test
+    fun testListVaults() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"vaults":["default","work","personal"]}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.listVaults()
+        assertEquals(listOf("default", "work", "personal"), result)
+
+        val req = server.takeRequest()
+        assertEquals("GET", req.method)
+        assertEquals("/api/vaults", req.path)
+    }
+
+    // ── Session ──────────────────────────────────────────────────────
+
+    @Test
+    fun testSession() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"entries":[{"id":"s1","concept":"c","content":"body","created_at":100}],"total":1,"offset":0,"limit":50}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.session(limit = 50)
+        assertEquals(1, result.entries.size)
+        assertEquals("s1", result.entries[0].id)
+
+        val req = server.takeRequest()
+        assertEquals("GET", req.method)
+        assertTrue(req.path!!.startsWith("/api/session"))
+    }
+
+    // ── Health ───────────────────────────────────────────────────────
+
+    @Test
+    fun testHealth() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"status":"ok","version":"0.9.0","uptime_seconds":3600,"db_writable":true}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val result = client.health()
+        assertEquals("ok", result.status)
+        assertEquals("0.9.0", result.version)
+        assertTrue(result.dbWritable)
+
+        val req = server.takeRequest()
+        assertEquals("GET", req.method)
+        assertEquals("/api/health", req.path)
+    }
+
+    // ── Error mapping ────────────────────────────────────────────────
+
+    @Test
+    fun testError401() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(401).setBody("unauthorized"))
+
+        assertFailsWith<MuninnException.Unauthorized> {
+            client.health()
+        }
+    }
+
+    @Test
+    fun testError404() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(404).setBody("not found"))
+
+        assertFailsWith<MuninnException.NotFound> {
+            client.read("missing")
+        }
+    }
+
+    @Test
+    fun testError409() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(409).setBody("conflict"))
+
+        assertFailsWith<MuninnException.Conflict> {
+            client.write(WriteOptions(concept = "dup", content = "dup"))
+        }
+    }
+
+    @Test
+    fun testError400() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(400).setBody("bad request"))
+
+        assertFailsWith<MuninnException.Validation> {
+            client.write(WriteOptions(concept = "", content = ""))
+        }
+    }
+
+    @Test
+    fun testError500() = runBlocking {
+        // Enqueue maxRetries + 1 responses for retry exhaustion
+        repeat(client.maxRetries + 1) {
+            server.enqueue(MockResponse().setResponseCode(500).setBody("server error"))
+        }
+
+        assertFailsWith<MuninnException.ServerError> {
+            client.health()
+        }
+    }
+
+    @Test
+    fun testErrorMessageExtractedFromNestedJson() = runBlocking {
+        server.enqueue(MockResponse()
+            .setResponseCode(404)
+            .setBody("""{"error":{"code":1004,"message":"engram not found"}}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val ex = assertFailsWith<MuninnException.NotFound> {
+            client.read("missing")
+        }
+        assertEquals("engram not found", ex.message)
+    }
+
+    // ── Subscribe (SSE) ──────────────────────────────────────────────
+
+    @Test
+    fun testSubscribe() = runBlocking {
+        // MockWebServer delivers the full body; OkHttp reads it line-by-line via source
+        val sseBody = "data: {\"type\":\"write\",\"id\":\"e1\"}\n\n" +
+                      "data: {\"type\":\"write\",\"id\":\"e2\"}\n\n"
+        server.enqueue(MockResponse()
+            .setBody(sseBody)
+            .addHeader("Content-Type", "text/event-stream"))
+
+        val events = client.subscribe(vault = "myVault").take(2).toList()
+
+        assertEquals(2, events.size)
+        assertEquals("message", events[0].type)
+        assertTrue(events[0].rawData.contains("e1"))
+        assertTrue(events[1].rawData.contains("e2"))
+
+        val req = server.takeRequest()
+        assertEquals("GET", req.method)
+        assertTrue(req.path!!.startsWith("/api/subscribe"))
+        assertTrue(req.path!!.contains("vault=myVault"))
+        assertTrue(req.path!!.contains("push_on_write=true"))
+        assertEquals("Bearer test-token", req.getHeader("Authorization"))
+        assertEquals("text/event-stream", req.getHeader("Accept"))
+    }
+
+    @Test
+    fun testSubscribeEventTypeField() = runBlocking {
+        val sseBody = "event: engram_written\ndata: {\"id\":\"e1\"}\n\n" +
+                      "data: {\"id\":\"e2\"}\n\n"
+        server.enqueue(MockResponse()
+            .setBody(sseBody)
+            .addHeader("Content-Type", "text/event-stream"))
+
+        val events = client.subscribe().take(2).toList()
+
+        assertEquals("engram_written", events[0].type)
+        assertEquals("message", events[1].type)  // default when no event: line
+    }
+
+    @Test
+    fun testSubscribeWithThreshold() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("data: {\"type\":\"write\"}\n\n")
+            .addHeader("Content-Type", "text/event-stream"))
+
+        client.subscribe(vault = "default", threshold = 0.5).take(1).toList()
+
+        val req = server.takeRequest()
+        assertTrue(req.path!!.contains("threshold=0.5"))
+    }
+
+    // ── Auth header ──────────────────────────────────────────────────
+
+    @Test
+    fun testNoAuthHeaderWhenTokenEmpty() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"status":"ok","version":"0.9.0","uptime_seconds":0,"db_writable":true}""")
+            .addHeader("Content-Type", "application/json"))
+
+        val noAuthClient = MuninnClient(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            token = ""
+        )
+        noAuthClient.health()
+
+        val req = server.takeRequest()
+        assertEquals(null, req.getHeader("Authorization"))
+    }
+
+    // ── Default vault ────────────────────────────────────────────────
+
+    @Test
+    fun testDefaultVaultUsed() = runBlocking {
+        server.enqueue(MockResponse()
+            .setBody("""{"id":"abc","concept":"c","content":"body","confidence":0.9,"relevance":0.8,"stability":0.7,"access_count":0,"tags":null,"state":0,"created_at":0,"updated_at":0,"last_access":0,"summary":null,"key_points":null,"memory_type":0,"type_label":null,"embed_dim":null}""")
+            .addHeader("Content-Type", "application/json"))
+
+        client.read("abc")
+
+        val req = server.takeRequest()
+        assertTrue(req.path!!.contains("vault=default"))
+    }
+}

--- a/sdk/swift/.gitignore
+++ b/sdk/swift/.gitignore
@@ -1,0 +1,4 @@
+.build/
+.swiftpm/
+*.xcodeproj
+DerivedData/

--- a/sdk/swift/Package.swift
+++ b/sdk/swift/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "MuninnDB",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v12),
+        .tvOS(.v15),
+        .watchOS(.v8),
+    ],
+    products: [
+        .library(name: "MuninnDB", targets: ["MuninnDB"]),
+    ],
+    targets: [
+        .target(
+            name: "MuninnDB",
+            path: "Sources/MuninnDB"
+        ),
+        .testTarget(
+            name: "MuninnDBTests",
+            dependencies: ["MuninnDB"],
+            path: "Tests/MuninnDBTests"
+        ),
+    ]
+)

--- a/sdk/swift/Sources/MuninnDB/Errors.swift
+++ b/sdk/swift/Sources/MuninnDB/Errors.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public enum MuninnError: Error, LocalizedError {
+    case notFound(String)
+    case unauthorized(String)
+    case conflict(String)
+    case validation(String)
+    case serverError(Int, String)
+    case connectionFailed(Error)
+    case timeout
+    case decodingFailed(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notFound(let msg): return "Not found: \(msg)"
+        case .unauthorized(let msg): return "Unauthorized: \(msg)"
+        case .conflict(let msg): return "Conflict: \(msg)"
+        case .validation(let msg): return "Validation error: \(msg)"
+        case .serverError(let code, let msg): return "Server error \(code): \(msg)"
+        case .connectionFailed(let err): return "Connection failed: \(err.localizedDescription)"
+        case .timeout: return "Request timed out"
+        case .decodingFailed(let err): return "Decoding failed: \(err.localizedDescription)"
+        }
+    }
+}

--- a/sdk/swift/Sources/MuninnDB/MuninnClient.swift
+++ b/sdk/swift/Sources/MuninnDB/MuninnClient.swift
@@ -1,0 +1,323 @@
+import Foundation
+
+public final class MuninnClient: @unchecked Sendable {
+    private let baseURL: URL
+    private let token: String
+    private let timeout: TimeInterval
+    private let maxRetries: Int
+    private let defaultVault: String
+    private let session: URLSession
+
+    public init(
+        baseURL: URL = URL(string: "http://localhost:8476")!,
+        token: String,
+        timeout: TimeInterval = 30,
+        maxRetries: Int = 3,
+        defaultVault: String = "default",
+        session: URLSession = .shared
+    ) {
+        self.baseURL = baseURL
+        self.token = token
+        self.timeout = timeout
+        self.maxRetries = maxRetries
+        self.defaultVault = defaultVault
+        self.session = session
+    }
+
+    // MARK: - Public API
+
+    public func write(_ options: WriteOptions) async throws -> WriteResponse {
+        return try await _request("POST", path: "/api/engrams", body: options)
+    }
+
+    public func writeBatch(vault: String? = nil, engrams: [WriteOptions]) async throws -> BatchWriteResponse {
+        let v = vault ?? defaultVault
+        let body = BatchWriteRequest(engrams: engrams)
+        return try await _request("POST", path: "/api/engrams/batch", queryItems: [URLQueryItem(name: "vault", value: v)], body: body)
+    }
+
+    public func read(_ id: String, vault: String? = nil) async throws -> Engram {
+        let v = vault ?? defaultVault
+        return try await _request("GET", path: "/api/engrams/\(id)", queryItems: [URLQueryItem(name: "vault", value: v)])
+    }
+
+    public func forget(_ id: String, vault: String? = nil, hard: Bool = false) async throws {
+        let v = vault ?? defaultVault
+        // Server exposes DELETE /api/engrams/{id} for both soft and hard delete.
+        // Pass hard=true as a query param; the server currently performs soft delete
+        // regardless — hard delete support is tracked server-side.
+        var queryItems = [URLQueryItem(name: "vault", value: v)]
+        if hard {
+            queryItems.append(URLQueryItem(name: "hard", value: "true"))
+        }
+        try await _requestVoid("DELETE", path: "/api/engrams/\(id)", queryItems: queryItems)
+    }
+
+    public func activate(_ options: ActivateOptions) async throws -> ActivateResponse {
+        return try await _request("POST", path: "/api/activate", body: options)
+    }
+
+    public func link(_ options: LinkOptions) async throws {
+        try await _requestVoid("POST", path: "/api/link", body: options)
+    }
+
+    public func traverse(_ options: TraverseOptions) async throws -> TraverseResponse {
+        return try await _request("POST", path: "/api/traverse", body: options)
+    }
+
+    public func evolve(id: String, newContent: String, reason: String, vault: String? = nil) async throws -> EvolveResponse {
+        let v = vault ?? defaultVault
+        let body = EvolveRequest(newContent: newContent, reason: reason, vault: v)
+        return try await _request("POST", path: "/api/engrams/\(id)/evolve", body: body)
+    }
+
+    public func consolidate(ids: [String], mergedContent: String, vault: String? = nil) async throws -> ConsolidateResponse {
+        let opts = ConsolidateOptions(ids: ids, mergedContent: mergedContent, vault: vault ?? defaultVault)
+        return try await _request("POST", path: "/api/consolidate", body: opts)
+    }
+
+    public func decide(_ options: DecideOptions) async throws -> DecideResponse {
+        return try await _request("POST", path: "/api/decide", body: options)
+    }
+
+    public func restore(_ id: String, vault: String? = nil) async throws -> RestoreResponse {
+        let v = vault ?? defaultVault
+        return try await _request(
+            "POST",
+            path: "/api/engrams/\(id)/restore",
+            queryItems: [URLQueryItem(name: "vault", value: v)]
+        )
+    }
+
+    public func explain(_ options: ExplainOptions) async throws -> ExplainResponse {
+        return try await _request("POST", path: "/api/explain", body: options)
+    }
+
+    public func setState(id: String, state: String, reason: String? = nil, vault: String? = nil) async throws -> SetStateResponse {
+        let body = SetStateRequest(vault: vault ?? defaultVault, state: state, reason: reason)
+        return try await _request("PUT", path: "/api/engrams/\(id)/state", body: body)
+    }
+
+    public func listDeleted(vault: String? = nil, limit: Int? = nil) async throws -> ListDeletedResponse {
+        let v = vault ?? defaultVault
+        var items = [URLQueryItem(name: "vault", value: v)]
+        if let limit = limit {
+            items.append(URLQueryItem(name: "limit", value: String(limit)))
+        }
+        return try await _request("GET", path: "/api/deleted", queryItems: items)
+    }
+
+    public func retryEnrich(_ id: String, vault: String? = nil) async throws -> RetryEnrichResponse {
+        let v = vault ?? defaultVault
+        return try await _request(
+            "POST",
+            path: "/api/engrams/\(id)/retry-enrich",
+            queryItems: [URLQueryItem(name: "vault", value: v)]
+        )
+    }
+
+    public func contradictions(vault: String? = nil) async throws -> ContradictionsResponse {
+        let v = vault ?? defaultVault
+        return try await _request("GET", path: "/api/contradictions", queryItems: [URLQueryItem(name: "vault", value: v)])
+    }
+
+    public func guide(vault: String? = nil) async throws -> String {
+        let v = vault ?? defaultVault
+        let resp: GuideResponse = try await _request("GET", path: "/api/guide", queryItems: [URLQueryItem(name: "vault", value: v)])
+        return resp.guide
+    }
+
+    public func stats(vault: String? = nil) async throws -> StatsResponse {
+        var items: [URLQueryItem]?
+        if let v = vault {
+            items = [URLQueryItem(name: "vault", value: v)]
+        }
+        return try await _request("GET", path: "/api/stats", queryItems: items)
+    }
+
+    public func listEngrams(vault: String? = nil, limit: Int? = nil, offset: Int? = nil) async throws -> ListEngramsResponse {
+        let v = vault ?? defaultVault
+        var items = [URLQueryItem(name: "vault", value: v)]
+        if let limit = limit {
+            items.append(URLQueryItem(name: "limit", value: String(limit)))
+        }
+        if let offset = offset {
+            items.append(URLQueryItem(name: "offset", value: String(offset)))
+        }
+        return try await _request("GET", path: "/api/engrams", queryItems: items)
+    }
+
+    public func getLinks(_ id: String, vault: String? = nil) async throws -> [AssociationItem] {
+        let v = vault ?? defaultVault
+        let resp: LinksResponse = try await _request(
+            "GET",
+            path: "/api/engrams/\(id)/links",
+            queryItems: [URLQueryItem(name: "vault", value: v)]
+        )
+        return resp.links
+    }
+
+    public func listVaults() async throws -> [String] {
+        let resp: VaultsResponse = try await _request("GET", path: "/api/vaults")
+        return resp.vaults
+    }
+
+    public func session(vault: String? = nil, since: String? = nil, limit: Int? = nil, offset: Int? = nil) async throws -> SessionResponse {
+        let v = vault ?? defaultVault
+        var items = [URLQueryItem(name: "vault", value: v)]
+        if let since = since {
+            items.append(URLQueryItem(name: "since", value: since))
+        }
+        if let limit = limit {
+            items.append(URLQueryItem(name: "limit", value: String(limit)))
+        }
+        if let offset = offset {
+            items.append(URLQueryItem(name: "offset", value: String(offset)))
+        }
+        return try await _request("GET", path: "/api/session", queryItems: items)
+    }
+
+    public func subscribe(vault: String? = nil, pushOnWrite: Bool = true, threshold: Double? = nil) -> AsyncThrowingStream<SseEvent, Error> {
+        let v = vault ?? defaultVault
+        var items = [
+            URLQueryItem(name: "vault", value: v),
+            URLQueryItem(name: "push_on_write", value: pushOnWrite ? "true" : "false"),
+        ]
+        if let threshold = threshold {
+            items.append(URLQueryItem(name: "threshold", value: String(threshold)))
+        }
+
+        var components = URLComponents(url: baseURL.appendingPathComponent("/api/subscribe"), resolvingAgainstBaseURL: false)!
+        components.queryItems = items
+
+        var request = URLRequest(url: components.url!)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 0 // SSE streams should not time out
+
+        return makeSubscribeStream(session: session, request: request)
+    }
+
+    public func health() async throws -> HealthResponse {
+        return try await _request("GET", path: "/api/health")
+    }
+
+    // MARK: - Private Helpers
+
+    private func _request<T: Decodable>(
+        _ method: String,
+        path: String,
+        queryItems: [URLQueryItem]? = nil,
+        body: (any Encodable)? = nil
+    ) async throws -> T {
+        let data = try await _executeRequest(method, path: path, queryItems: queryItems, body: body)
+        do {
+            let decoder = JSONDecoder()
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw MuninnError.decodingFailed(error)
+        }
+    }
+
+    private func _requestVoid(
+        _ method: String,
+        path: String,
+        queryItems: [URLQueryItem]? = nil,
+        body: (any Encodable)? = nil
+    ) async throws {
+        _ = try await _executeRequest(method, path: path, queryItems: queryItems, body: body)
+    }
+
+    private func _executeRequest(
+        _ method: String,
+        path: String,
+        queryItems: [URLQueryItem]?,
+        body: (any Encodable)?
+    ) async throws -> Data {
+        var components = URLComponents(url: baseURL.appendingPathComponent(path), resolvingAgainstBaseURL: false)!
+        components.queryItems = queryItems
+
+        guard let url = components.url else {
+            throw MuninnError.validation("Invalid URL: \(path)")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = timeout
+
+        if let body = body {
+            let encoder = JSONEncoder()
+            request.httpBody = try encoder.encode(body)
+        }
+
+        var lastError: Error?
+
+        for attempt in 0..<maxRetries {
+            do {
+                let (data, response) = try await session.data(for: request)
+
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    throw MuninnError.connectionFailed(
+                        NSError(domain: "MuninnDB", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid response"])
+                    )
+                }
+
+                let statusCode = httpResponse.statusCode
+
+                if (200..<300).contains(statusCode) {
+                    return data
+                }
+
+                let errorMsg = _extractError(from: data)
+
+                // Retry on 429 or 5xx
+                if statusCode == 429 || statusCode >= 500 {
+                    lastError = MuninnError.serverError(statusCode, errorMsg)
+                    if attempt < maxRetries - 1 {
+                        let delay = Double(1 << attempt) * 0.5 // 0.5s, 1s, 2s
+                        try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                        continue
+                    }
+                }
+
+                // Non-retryable errors
+                switch statusCode {
+                case 401: throw MuninnError.unauthorized(errorMsg)
+                case 404: throw MuninnError.notFound(errorMsg)
+                case 409: throw MuninnError.conflict(errorMsg)
+                case 429: throw MuninnError.serverError(statusCode, errorMsg) // rate limited — retries exhausted
+                case 400..<500: throw MuninnError.validation(errorMsg)
+                default: throw MuninnError.serverError(statusCode, errorMsg)
+                }
+
+            } catch let error as MuninnError {
+                throw error
+            } catch let error as URLError where error.code == .timedOut {
+                throw MuninnError.timeout
+            } catch {
+                if attempt < maxRetries - 1 {
+                    lastError = error
+                    let delay = Double(1 << attempt) * 0.5
+                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    continue
+                }
+                throw MuninnError.connectionFailed(error)
+            }
+        }
+
+        throw lastError ?? MuninnError.connectionFailed(
+            NSError(domain: "MuninnDB", code: -1, userInfo: [NSLocalizedDescriptionKey: "Max retries exceeded"])
+        )
+    }
+
+    private func _extractError(from data: Data) -> String {
+        if let errorBody = try? JSONDecoder().decode(ErrorBody.self, from: data),
+           let msg = errorBody.error?.message {
+            return msg
+        }
+        return String(data: data, encoding: .utf8) ?? "Unknown error"
+    }
+}

--- a/sdk/swift/Sources/MuninnDB/SSEStream.swift
+++ b/sdk/swift/Sources/MuninnDB/SSEStream.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+public struct SseEvent: Sendable {
+    public let type: String
+    public let rawData: String
+
+    public init(type: String, rawData: String) {
+        self.type = type
+        self.rawData = rawData
+    }
+}
+
+public func makeSubscribeStream(
+    session: URLSession,
+    request: URLRequest
+) -> AsyncThrowingStream<SseEvent, Error> {
+    AsyncThrowingStream { continuation in
+        let task = Task {
+            do {
+                let (bytes, response) = try await session.bytes(for: request)
+
+                if let httpResponse = response as? HTTPURLResponse,
+                   httpResponse.statusCode != 200 {
+                    continuation.finish(
+                        throwing: MuninnError.serverError(
+                            httpResponse.statusCode, "SSE connection failed"
+                        )
+                    )
+                    return
+                }
+
+                var eventType = "message"
+                var dataLines: [String] = []
+
+                for try await line in bytes.lines {
+                    if line.isEmpty {
+                        // Empty line = end of event
+                        if !dataLines.isEmpty {
+                            let rawData = dataLines.joined(separator: "\n")
+                            let event = SseEvent(type: eventType, rawData: rawData)
+                            continuation.yield(event)
+                            dataLines.removeAll()
+                            eventType = "message"
+                        }
+                        continue
+                    }
+
+                    if line.hasPrefix("event:") {
+                        eventType = String(line.dropFirst(6)).trimmingCharacters(in: .whitespaces)
+                    } else if line.hasPrefix("data:") {
+                        let data = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+                        dataLines.append(data)
+                    }
+                    // Ignore comments (lines starting with ':') and other fields
+                }
+
+                // Yield any remaining event
+                if !dataLines.isEmpty {
+                    let rawData = dataLines.joined(separator: "\n")
+                    continuation.yield(SseEvent(type: eventType, rawData: rawData))
+                }
+
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+
+        continuation.onTermination = { _ in
+            task.cancel()
+        }
+    }
+}

--- a/sdk/swift/Sources/MuninnDB/Types.swift
+++ b/sdk/swift/Sources/MuninnDB/Types.swift
@@ -1,0 +1,813 @@
+import Foundation
+
+// MARK: - Write
+
+public struct InlineEntity: Codable, Sendable {
+    public var name: String
+    public var type: String
+
+    public init(name: String, type: String) {
+        self.name = name
+        self.type = type
+    }
+}
+
+public struct InlineRelationship: Codable, Sendable {
+    public var targetId: String
+    public var relation: String
+    public var weight: Double
+
+    public init(targetId: String, relation: String, weight: Double) {
+        self.targetId = targetId
+        self.relation = relation
+        self.weight = weight
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case targetId = "target_id"
+        case relation, weight
+    }
+}
+
+public struct WriteOptions: Codable, Sendable {
+    public var concept: String
+    public var content: String
+    public var vault: String?
+    public var tags: [String]?
+    public var confidence: Double?
+    public var stability: Double?
+    public var memoryType: Int?
+    public var typeLabel: String?
+    public var summary: String?
+    public var entities: [InlineEntity]?
+    public var relationships: [InlineRelationship]?
+
+    public init(
+        concept: String,
+        content: String,
+        vault: String? = nil,
+        tags: [String]? = nil,
+        confidence: Double? = nil,
+        stability: Double? = nil,
+        memoryType: Int? = nil,
+        typeLabel: String? = nil,
+        summary: String? = nil,
+        entities: [InlineEntity]? = nil,
+        relationships: [InlineRelationship]? = nil
+    ) {
+        self.concept = concept
+        self.content = content
+        self.vault = vault
+        self.tags = tags
+        self.confidence = confidence
+        self.stability = stability
+        self.memoryType = memoryType
+        self.typeLabel = typeLabel
+        self.summary = summary
+        self.entities = entities
+        self.relationships = relationships
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case concept, content, vault, tags, confidence, stability
+        case memoryType = "memory_type"
+        case typeLabel = "type_label"
+        case summary, entities, relationships
+    }
+}
+
+public struct WriteResponse: Codable, Sendable {
+    public let id: String
+    public let createdAt: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case createdAt = "created_at"
+    }
+}
+
+// MARK: - Batch Write
+
+public struct BatchWriteResult: Codable, Sendable {
+    public let id: String
+    public let createdAt: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case createdAt = "created_at"
+    }
+}
+
+public struct BatchWriteResponse: Codable, Sendable {
+    public let results: [BatchWriteResult]
+}
+
+// MARK: - Read (Engram)
+
+public struct Engram: Codable, Sendable {
+    public let id: String
+    public let concept: String
+    public let content: String
+    public let confidence: Double
+    public let relevance: Double
+    public let stability: Double
+    public let accessCount: Int
+    public let tags: [String]?
+    public let state: Int
+    public let createdAt: Int64
+    public let updatedAt: Int64
+    public let lastAccess: Int64
+    public let summary: String?
+    public let keyPoints: [String]?
+    public let memoryType: Int
+    public let typeLabel: String?
+    public let embedDim: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case id, concept, content, confidence, relevance, stability
+        case accessCount = "access_count"
+        case tags, state
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case lastAccess = "last_access"
+        case summary
+        case keyPoints = "key_points"
+        case memoryType = "memory_type"
+        case typeLabel = "type_label"
+        case embedDim = "embed_dim"
+    }
+}
+
+// MARK: - Activate
+
+public struct Weights: Codable, Sendable {
+    public var semanticSimilarity: Double?
+    public var fullTextRelevance: Double?
+    public var decayFactor: Double?
+    public var hebbianBoost: Double?
+    public var accessFrequency: Double?
+    public var recency: Double?
+
+    public init(
+        semanticSimilarity: Double? = nil,
+        fullTextRelevance: Double? = nil,
+        decayFactor: Double? = nil,
+        hebbianBoost: Double? = nil,
+        accessFrequency: Double? = nil,
+        recency: Double? = nil
+    ) {
+        self.semanticSimilarity = semanticSimilarity
+        self.fullTextRelevance = fullTextRelevance
+        self.decayFactor = decayFactor
+        self.hebbianBoost = hebbianBoost
+        self.accessFrequency = accessFrequency
+        self.recency = recency
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case semanticSimilarity = "semantic_similarity"
+        case fullTextRelevance = "full_text_relevance"
+        case decayFactor = "decay_factor"
+        case hebbianBoost = "hebbian_boost"
+        case accessFrequency = "access_frequency"
+        case recency
+    }
+}
+
+/// Filter restricts activation results. Matches the server's Filter{field, op, value} wire format.
+/// Common fields: "memory_type", "state", "confidence", "tags".
+/// Common ops: "eq", "gt", "lt", "gte", "lte", "in".
+public struct Filter: Codable, Sendable {
+    public var field: String
+    public var op: String
+    public var value: AnyCodable
+
+    public init(field: String, op: String, value: AnyCodable) {
+        self.field = field
+        self.op = op
+        self.value = value
+    }
+}
+
+/// Type-erased Codable wrapper for Filter.value which can be String, Int, Double, Bool, or [String].
+public struct AnyCodable: Codable, Sendable {
+    public let rawValue: Any
+
+    public init(_ value: Any) { self.rawValue = value }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if let v = try? c.decode(Bool.self)   { rawValue = v; return }
+        if let v = try? c.decode(Int.self)    { rawValue = v; return }
+        if let v = try? c.decode(Double.self) { rawValue = v; return }
+        if let v = try? c.decode(String.self) { rawValue = v; return }
+        if let v = try? c.decode([String].self) { rawValue = v; return }
+        rawValue = ""
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch rawValue {
+        case let v as Bool:     try c.encode(v)
+        case let v as Int:      try c.encode(v)
+        case let v as Double:   try c.encode(v)
+        case let v as String:   try c.encode(v)
+        case let v as [String]: try c.encode(v)
+        default: try c.encodeNil()
+        }
+    }
+}
+
+public struct ActivateOptions: Codable, Sendable {
+    public var context: [String]
+    public var vault: String?
+    public var maxResults: Int?
+    public var threshold: Double?
+    public var maxHops: Int?
+    public var includeWhy: Bool?
+    public var briefMode: String?
+    public var disableHops: Bool?
+    public var weights: Weights?
+    public var filters: [Filter]?
+
+    public init(
+        context: [String],
+        vault: String? = nil,
+        maxResults: Int? = nil,
+        threshold: Double? = nil,
+        maxHops: Int? = nil,
+        includeWhy: Bool? = nil,
+        briefMode: String? = nil,
+        disableHops: Bool? = nil,
+        weights: Weights? = nil,
+        filters: [Filter]? = nil
+    ) {
+        self.context = context
+        self.vault = vault
+        self.maxResults = maxResults
+        self.threshold = threshold
+        self.maxHops = maxHops
+        self.includeWhy = includeWhy
+        self.briefMode = briefMode
+        self.disableHops = disableHops
+        self.weights = weights
+        self.filters = filters
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case context, vault
+        case maxResults = "max_results"
+        case threshold
+        case maxHops = "max_hops"
+        case includeWhy = "include_why"
+        case briefMode = "brief_mode"
+        case disableHops = "disable_hops"
+        case weights, filters
+    }
+}
+
+public struct ScoreComponents: Codable, Sendable {
+    public let fullTextRelevance: Double?
+    public let semanticSimilarity: Double?
+    public let decayFactor: Double?
+    public let hebbianBoost: Double?
+    public let accessFrequency: Double?
+    public let confidence: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case fullTextRelevance = "full_text_relevance"
+        case semanticSimilarity = "semantic_similarity"
+        case decayFactor = "decay_factor"
+        case hebbianBoost = "hebbian_boost"
+        case accessFrequency = "access_frequency"
+        case confidence
+    }
+}
+
+public struct ActivationItem: Codable, Sendable {
+    public let id: String
+    public let concept: String
+    public let content: String
+    public let summary: String?
+    public let score: Double
+    public let confidence: Double
+    public let why: String?
+    public let hopPath: [String]?
+    public let dormant: Bool?
+    public let createdAt: Int64?
+    public let lastAccess: Int64?
+    public let accessCount: Int?
+    public let relevance: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case id, concept, content, summary, score, confidence, why
+        case hopPath = "hop_path"
+        case dormant
+        case createdAt = "created_at"
+        case lastAccess = "last_access"
+        case accessCount = "access_count"
+        case relevance
+    }
+}
+
+public struct BriefSentence: Codable, Sendable {
+    public let engramId: String
+    public let text: String
+    public let score: Double
+
+    enum CodingKeys: String, CodingKey {
+        case engramId = "engram_id"
+        case text, score
+    }
+}
+
+public struct ActivateResponse: Codable, Sendable {
+    public let queryId: String
+    public let totalFound: Int
+    public let activations: [ActivationItem]
+    public let latencyMs: Double?
+    public let brief: [BriefSentence]?
+
+    enum CodingKeys: String, CodingKey {
+        case queryId = "query_id"
+        case totalFound = "total_found"
+        case activations
+        case latencyMs = "latency_ms"
+        case brief
+    }
+}
+
+// MARK: - Link
+
+public struct LinkOptions: Codable, Sendable {
+    public var sourceId: String
+    public var targetId: String
+    public var relType: Int
+    public var weight: Double?
+    public var vault: String?
+
+    public init(
+        sourceId: String,
+        targetId: String,
+        relType: Int,
+        weight: Double? = nil,
+        vault: String? = nil
+    ) {
+        self.sourceId = sourceId
+        self.targetId = targetId
+        self.relType = relType
+        self.weight = weight
+        self.vault = vault
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case sourceId = "source_id"
+        case targetId = "target_id"
+        case relType = "rel_type"
+        case weight, vault
+    }
+}
+
+// MARK: - Traverse
+
+public struct TraverseOptions: Codable, Sendable {
+    public var vault: String?
+    public var startId: String
+    public var maxHops: Int?
+    public var maxNodes: Int?
+    public var relTypes: [String]?
+    public var followEntities: Bool?
+
+    public init(
+        startId: String,
+        vault: String? = nil,
+        maxHops: Int? = nil,
+        maxNodes: Int? = nil,
+        relTypes: [String]? = nil,
+        followEntities: Bool? = nil
+    ) {
+        self.startId = startId
+        self.vault = vault
+        self.maxHops = maxHops
+        self.maxNodes = maxNodes
+        self.relTypes = relTypes
+        self.followEntities = followEntities
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case vault
+        case startId = "start_id"
+        case maxHops = "max_hops"
+        case maxNodes = "max_nodes"
+        case relTypes = "rel_types"
+        case followEntities = "follow_entities"
+    }
+}
+
+public struct TraversalNode: Codable, Sendable {
+    public let id: String
+    public let concept: String
+    public let hopDist: Int
+    public let summary: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, concept
+        case hopDist = "hop_dist"
+        case summary
+    }
+}
+
+public struct TraversalEdge: Codable, Sendable {
+    public let fromId: String
+    public let toId: String
+    public let relType: String
+    public let weight: Double
+
+    enum CodingKeys: String, CodingKey {
+        case fromId = "from_id"
+        case toId = "to_id"
+        case relType = "rel_type"
+        case weight
+    }
+}
+
+public struct TraverseResponse: Codable, Sendable {
+    public let nodes: [TraversalNode]
+    public let edges: [TraversalEdge]
+    public let totalReachable: Int
+    public let queryMs: Double
+
+    enum CodingKeys: String, CodingKey {
+        case nodes, edges
+        case totalReachable = "total_reachable"
+        case queryMs = "query_ms"
+    }
+}
+
+// MARK: - Evolve
+
+public struct EvolveResponse: Codable, Sendable {
+    public let id: String
+}
+
+// MARK: - Consolidate
+
+public struct ConsolidateOptions: Codable, Sendable {
+    public var vault: String?
+    public var ids: [String]
+    public var mergedContent: String
+
+    public init(ids: [String], mergedContent: String, vault: String? = nil) {
+        self.ids = ids
+        self.mergedContent = mergedContent
+        self.vault = vault
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case vault, ids
+        case mergedContent = "merged_content"
+    }
+}
+
+public struct ConsolidateResponse: Codable, Sendable {
+    public let id: String
+    public let archived: [String]
+    public let warnings: [String]?
+}
+
+// MARK: - Decide
+
+public struct DecideOptions: Codable, Sendable {
+    public var vault: String?
+    public var decision: String
+    public var rationale: String
+    public var alternatives: [String]?
+    public var evidenceIds: [String]?
+
+    public init(
+        decision: String,
+        rationale: String,
+        vault: String? = nil,
+        alternatives: [String]? = nil,
+        evidenceIds: [String]? = nil
+    ) {
+        self.decision = decision
+        self.rationale = rationale
+        self.vault = vault
+        self.alternatives = alternatives
+        self.evidenceIds = evidenceIds
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case vault, decision, rationale, alternatives
+        case evidenceIds = "evidence_ids"
+    }
+}
+
+public struct DecideResponse: Codable, Sendable {
+    public let id: String
+    public let warnings: [String]?
+}
+
+// MARK: - Restore
+
+public struct RestoreResponse: Codable, Sendable {
+    public let id: String
+    public let concept: String
+    public let restored: Bool
+    public let state: String
+}
+
+// MARK: - Explain
+
+public struct ExplainOptions: Codable, Sendable {
+    public var vault: String?
+    public var engramId: String
+    public var query: [String]
+
+    public init(engramId: String, query: [String], vault: String? = nil) {
+        self.engramId = engramId
+        self.query = query
+        self.vault = vault
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case vault
+        case engramId = "engram_id"
+        case query
+    }
+}
+
+public struct ExplainComponents: Codable, Sendable {
+    public let fullTextRelevance: Double
+    public let semanticSimilarity: Double
+    public let decayFactor: Double
+    public let hebbianBoost: Double
+    public let accessFrequency: Double
+    public let confidence: Double
+
+    enum CodingKeys: String, CodingKey {
+        case fullTextRelevance = "full_text_relevance"
+        case semanticSimilarity = "semantic_similarity"
+        case decayFactor = "decay_factor"
+        case hebbianBoost = "hebbian_boost"
+        case accessFrequency = "access_frequency"
+        case confidence
+    }
+}
+
+public struct ExplainResponse: Codable, Sendable {
+    public let engramId: String
+    public let concept: String
+    public let finalScore: Double
+    public let components: ExplainComponents
+    public let ftsMatches: [String]
+    public let assocPath: [String]
+    public let wouldReturn: Bool
+    public let threshold: Double
+
+    enum CodingKeys: String, CodingKey {
+        case engramId = "engram_id"
+        case concept
+        case finalScore = "final_score"
+        case components
+        case ftsMatches = "fts_matches"
+        case assocPath = "assoc_path"
+        case wouldReturn = "would_return"
+        case threshold
+    }
+}
+
+// MARK: - Set State
+
+public struct SetStateResponse: Codable, Sendable {
+    public let id: String
+    public let state: String
+    public let updated: Bool
+}
+
+// MARK: - List Deleted
+
+public struct DeletedEngramItem: Codable, Sendable {
+    public let id: String
+    public let concept: String
+    public let deletedAt: Int64
+    public let recoverableUntil: Int64
+    public let tags: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case id, concept
+        case deletedAt = "deleted_at"
+        case recoverableUntil = "recoverable_until"
+        case tags
+    }
+}
+
+public struct ListDeletedResponse: Codable, Sendable {
+    public let deleted: [DeletedEngramItem]
+    public let count: Int
+}
+
+// MARK: - Retry Enrich
+
+public struct RetryEnrichResponse: Codable, Sendable {
+    public let engramId: String
+    public let pluginsQueued: [String]
+    public let alreadyComplete: [String]
+    public let note: String?
+
+    enum CodingKeys: String, CodingKey {
+        case engramId = "engram_id"
+        case pluginsQueued = "plugins_queued"
+        case alreadyComplete = "already_complete"
+        case note
+    }
+}
+
+// MARK: - Contradictions
+
+public struct ContradictionItem: Codable, Sendable {
+    public let idA: String
+    public let conceptA: String
+    public let idB: String
+    public let conceptB: String
+    public let detectedAt: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case idA = "id_a"
+        case conceptA = "concept_a"
+        case idB = "id_b"
+        case conceptB = "concept_b"
+        case detectedAt = "detected_at"
+    }
+}
+
+public struct ContradictionsResponse: Codable, Sendable {
+    public let contradictions: [ContradictionItem]
+}
+
+// MARK: - Stats
+
+public struct CoherenceResult: Codable, Sendable {
+    public let score: Double
+    public let orphanRatio: Double
+    public let contradictionDensity: Double
+    public let duplicationPressure: Double
+    public let temporalVariance: Double
+    public let totalEngrams: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case score
+        case orphanRatio = "orphan_ratio"
+        case contradictionDensity = "contradiction_density"
+        case duplicationPressure = "duplication_pressure"
+        case temporalVariance = "temporal_variance"
+        case totalEngrams = "total_engrams"
+    }
+}
+
+public struct StatsResponse: Codable, Sendable {
+    public let engramCount: Int64
+    public let vaultCount: Int
+    public let indexSize: Int64
+    public let storageBytes: Int64
+    public let coherence: [String: CoherenceResult]?
+
+    enum CodingKeys: String, CodingKey {
+        case engramCount = "engram_count"
+        case vaultCount = "vault_count"
+        case indexSize = "index_size"
+        case storageBytes = "storage_bytes"
+        case coherence
+    }
+}
+
+// MARK: - List Engrams
+
+public struct EngramItem: Codable, Sendable {
+    public let id: String
+    public let concept: String
+    public let content: String
+    public let confidence: Double
+    public let tags: [String]?
+    public let vault: String
+    public let createdAt: Int64
+    public let embedDim: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case id, concept, content, confidence, tags, vault
+        case createdAt = "created_at"
+        case embedDim = "embed_dim"
+    }
+}
+
+public struct ListEngramsResponse: Codable, Sendable {
+    public let engrams: [EngramItem]
+    public let total: Int
+    public let limit: Int
+    public let offset: Int
+}
+
+// MARK: - Associations / Links
+
+public struct AssociationItem: Codable, Sendable {
+    public let targetId: String
+    public let relType: Int
+    public let weight: Double
+    public let coActivationCount: Int
+    public let restoredAt: Int64?
+
+    enum CodingKeys: String, CodingKey {
+        case targetId = "target_id"
+        case relType = "rel_type"
+        case weight
+        case coActivationCount = "co_activation_count"
+        case restoredAt = "restored_at"
+    }
+}
+
+// MARK: - Session
+
+public struct SessionItem: Codable, Sendable {
+    public let id: String
+    public let concept: String
+    public let content: String?
+    public let createdAt: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case id, concept, content
+        case createdAt = "created_at"
+    }
+}
+
+public struct SessionResponse: Codable, Sendable {
+    public let entries: [SessionItem]
+    public let total: Int
+    public let offset: Int
+    public let limit: Int
+}
+
+// MARK: - Health
+
+public struct HealthResponse: Codable, Sendable {
+    public let status: String
+    public let version: String
+    public let uptimeSeconds: Int64
+    public let dbWritable: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case status, version
+        case uptimeSeconds = "uptime_seconds"
+        case dbWritable = "db_writable"
+    }
+}
+
+// MARK: - Internal request/response helpers
+
+struct ErrorDetail: Codable {
+    let code: Int?
+    let message: String?
+    let requestId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case code, message
+        case requestId = "request_id"
+    }
+}
+
+struct ErrorBody: Codable {
+    let error: ErrorDetail?
+}
+
+struct GuideResponse: Codable {
+    let guide: String
+}
+
+struct LinksResponse: Codable {
+    let links: [AssociationItem]
+}
+
+struct VaultsResponse: Codable {
+    let vaults: [String]
+}
+
+struct BatchWriteRequest: Codable {
+    let engrams: [WriteOptions]
+}
+
+struct EvolveRequest: Codable {
+    let newContent: String
+    let reason: String
+    let vault: String?
+
+    enum CodingKeys: String, CodingKey {
+        case newContent = "new_content"
+        case reason, vault
+    }
+}
+
+struct SetStateRequest: Codable {
+    let vault: String?
+    let state: String
+    let reason: String?
+}

--- a/sdk/swift/Tests/MuninnDBTests/ClientTests.swift
+++ b/sdk/swift/Tests/MuninnDBTests/ClientTests.swift
@@ -1,0 +1,795 @@
+import XCTest
+@testable import MuninnDB
+
+final class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: NSError(domain: "MockURLProtocol", code: -1))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+extension URLRequest {
+    /// Read body bytes from either httpBody or httpBodyStream (URLProtocol may convert httpBody to a stream).
+    var bodyData: Data? {
+        if let body = httpBody { return body }
+        guard let stream = httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+        defer { buf.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buf, maxLength: 4096)
+            if read <= 0 { break }
+            data.append(buf, count: read)
+        }
+        return data
+    }
+
+    func bodyJSON() -> [String: Any]? {
+        guard let data = bodyData else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+}
+
+final class ClientTests: XCTestCase {
+    var client: MuninnClient!
+
+    override func setUp() {
+        super.setUp()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        client = MuninnClient(
+            baseURL: URL(string: "http://localhost:8476")!,
+            token: "test-token",
+            timeout: 5,
+            maxRetries: 1,
+            session: session
+        )
+    }
+
+    override func tearDown() {
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func mockResponse(
+        statusCode: Int = 200,
+        json: [String: Any]
+    ) -> (HTTPURLResponse, Data) {
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        let response = HTTPURLResponse(
+            url: URL(string: "http://localhost:8476")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (response, data)
+    }
+
+    private func mockResponse(
+        statusCode: Int = 200,
+        data: Data
+    ) -> (HTTPURLResponse, Data) {
+        let response = HTTPURLResponse(
+            url: URL(string: "http://localhost:8476")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (response, data)
+    }
+
+    // MARK: - Write
+
+    func testWrite() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/engrams"))
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-token")
+
+            let body = request.bodyJSON()!
+            XCTAssertEqual(body["concept"] as? String, "test concept")
+            XCTAssertEqual(body["content"] as? String, "test content")
+
+            return self.mockResponse(json: ["id": "eng-123", "created_at": 1700000000])
+        }
+
+        let result = try await client.write(WriteOptions(concept: "test concept", content: "test content", vault: "default"))
+        XCTAssertEqual(result.id, "eng-123")
+        XCTAssertEqual(result.createdAt, 1700000000)
+    }
+
+    // MARK: - Write Batch
+
+    func testWriteBatch() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/engrams/batch"))
+
+            return self.mockResponse(json: [
+                "results": [
+                    ["id": "eng-1", "created_at": 1700000000],
+                    ["id": "eng-2", "created_at": 1700000001],
+                ],
+            ])
+        }
+
+        let engrams = [
+            WriteOptions(concept: "c1", content: "content1"),
+            WriteOptions(concept: "c2", content: "content2"),
+        ]
+        let result = try await client.writeBatch(vault: "default", engrams: engrams)
+        XCTAssertEqual(result.results.count, 2)
+        XCTAssertEqual(result.results[0].id, "eng-1")
+        XCTAssertEqual(result.results[1].id, "eng-2")
+    }
+
+    // MARK: - Read
+
+    func testRead() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/engrams/eng-123"))
+            XCTAssertTrue(request.url!.query!.contains("vault=default"))
+
+            return self.mockResponse(json: [
+                "id": "eng-123",
+                "concept": "test",
+                "content": "content",
+                "confidence": 0.9,
+                "relevance": 0.8,
+                "stability": 0.7,
+                "access_count": 5,
+                "state": 0,
+                "created_at": 1700000000,
+                "updated_at": 1700000001,
+                "last_access": 1700000002,
+                "memory_type": 1,
+            ])
+        }
+
+        let engram = try await client.read("eng-123")
+        XCTAssertEqual(engram.id, "eng-123")
+        XCTAssertEqual(engram.concept, "test")
+        XCTAssertEqual(engram.confidence, 0.9)
+        XCTAssertEqual(engram.accessCount, 5)
+        XCTAssertEqual(engram.memoryType, 1)
+    }
+
+    // MARK: - Forget (soft)
+
+    func testForgetSoft() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "DELETE")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/engrams/eng-123"))
+
+            return self.mockResponse(json: ["ok": true])
+        }
+
+        try await client.forget("eng-123")
+    }
+
+    // MARK: - Forget (hard)
+
+    func testForgetHard() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "DELETE")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/engrams/eng-123"))
+            XCTAssertTrue(request.url!.query!.contains("hard=true"))
+
+            return self.mockResponse(json: ["ok": true])
+        }
+
+        try await client.forget("eng-123", hard: true)
+    }
+
+    // MARK: - Activate
+
+    func testActivate() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/activate"))
+
+            let body = request.bodyJSON()!
+            XCTAssertEqual(body["context"] as? [String], ["hello world"])
+            XCTAssertEqual(body["max_results"] as? Int, 5)
+
+            return self.mockResponse(json: [
+                "query_id": "q-1",
+                "total_found": 1,
+                "activations": [
+                    [
+                        "id": "eng-1",
+                        "concept": "greeting",
+                        "content": "hello",
+                        "score": 0.95,
+                        "confidence": 0.9,
+                    ],
+                ],
+            ])
+        }
+
+        let result = try await client.activate(ActivateOptions(context: ["hello world"], maxResults: 5))
+        XCTAssertEqual(result.queryId, "q-1")
+        XCTAssertEqual(result.totalFound, 1)
+        XCTAssertEqual(result.activations.count, 1)
+        XCTAssertEqual(result.activations[0].score, 0.95)
+    }
+
+    // MARK: - Link
+
+    func testLink() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/link"))
+
+            let body = request.bodyJSON()!
+            XCTAssertEqual(body["source_id"] as? String, "eng-1")
+            XCTAssertEqual(body["target_id"] as? String, "eng-2")
+            XCTAssertEqual(body["rel_type"] as? Int, 1)
+
+            return self.mockResponse(json: ["ok": true])
+        }
+
+        try await client.link(LinkOptions(sourceId: "eng-1", targetId: "eng-2", relType: 1))
+    }
+
+    // MARK: - Traverse
+
+    func testTraverse() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/traverse"))
+
+            return self.mockResponse(json: [
+                "nodes": [
+                    ["id": "eng-1", "concept": "root", "hop_dist": 0],
+                    ["id": "eng-2", "concept": "child", "hop_dist": 1],
+                ],
+                "edges": [
+                    ["from_id": "eng-1", "to_id": "eng-2", "rel_type": "related", "weight": 0.8],
+                ],
+                "total_reachable": 2,
+                "query_ms": 1.5,
+            ])
+        }
+
+        let result = try await client.traverse(TraverseOptions(startId: "eng-1", maxHops: 2))
+        XCTAssertEqual(result.nodes.count, 2)
+        XCTAssertEqual(result.edges.count, 1)
+        XCTAssertEqual(result.totalReachable, 2)
+        XCTAssertEqual(result.edges[0].weight, 0.8)
+    }
+
+    // MARK: - Evolve
+
+    func testEvolve() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertTrue(request.url!.path.contains("/evolve"))
+
+            return self.mockResponse(json: ["id": "eng-123"])
+        }
+
+        let result = try await client.evolve(id: "eng-123", newContent: "updated", reason: "correction")
+        XCTAssertEqual(result.id, "eng-123")
+    }
+
+    // MARK: - Consolidate
+
+    func testConsolidate() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/consolidate"))
+
+            return self.mockResponse(json: [
+                "id": "eng-new",
+                "archived": ["eng-1", "eng-2"],
+            ])
+        }
+
+        let result = try await client.consolidate(ids: ["eng-1", "eng-2"], mergedContent: "merged")
+        XCTAssertEqual(result.id, "eng-new")
+        XCTAssertEqual(result.archived, ["eng-1", "eng-2"])
+    }
+
+    // MARK: - Decide
+
+    func testDecide() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/decide"))
+
+            return self.mockResponse(json: ["id": "dec-1"])
+        }
+
+        let result = try await client.decide(DecideOptions(decision: "use Swift", rationale: "type safety"))
+        XCTAssertEqual(result.id, "dec-1")
+    }
+
+    // MARK: - Restore
+
+    func testRestore() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertTrue(request.url!.path.contains("/restore"))
+
+            return self.mockResponse(json: [
+                "id": "eng-1",
+                "concept": "restored concept",
+                "restored": true,
+                "state": "active",
+            ])
+        }
+
+        let result = try await client.restore("eng-1")
+        XCTAssertEqual(result.id, "eng-1")
+        XCTAssertTrue(result.restored)
+        XCTAssertEqual(result.state, "active")
+    }
+
+    // MARK: - Explain
+
+    func testExplain() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/explain"))
+
+            return self.mockResponse(json: [
+                "engram_id": "eng-1",
+                "concept": "test",
+                "final_score": 0.85,
+                "components": [
+                    "full_text_relevance": 0.7,
+                    "semantic_similarity": 0.8,
+                    "decay_factor": 0.9,
+                    "hebbian_boost": 0.1,
+                    "access_frequency": 0.5,
+                    "confidence": 0.9,
+                ],
+                "fts_matches": ["test"],
+                "assoc_path": [],
+                "would_return": true,
+                "threshold": 0.1,
+            ])
+        }
+
+        let result = try await client.explain(ExplainOptions(engramId: "eng-1", query: ["test"]))
+        XCTAssertEqual(result.engramId, "eng-1")
+        XCTAssertEqual(result.finalScore, 0.85)
+        XCTAssertEqual(result.components.fullTextRelevance, 0.7)
+        XCTAssertTrue(result.wouldReturn)
+    }
+
+    // MARK: - Set State
+
+    func testSetState() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "PUT")
+            XCTAssertTrue(request.url!.path.contains("/state"))
+
+            return self.mockResponse(json: [
+                "id": "eng-1",
+                "state": "dormant",
+                "updated": true,
+            ])
+        }
+
+        let result = try await client.setState(id: "eng-1", state: "dormant", reason: "no longer relevant")
+        XCTAssertEqual(result.id, "eng-1")
+        XCTAssertEqual(result.state, "dormant")
+        XCTAssertTrue(result.updated)
+    }
+
+    // MARK: - List Deleted
+
+    func testListDeleted() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/deleted"))
+
+            return self.mockResponse(json: [
+                "deleted": [
+                    [
+                        "id": "eng-del-1",
+                        "concept": "old",
+                        "deleted_at": 1700000000,
+                        "recoverable_until": 1700100000,
+                    ],
+                ],
+                "count": 1,
+            ])
+        }
+
+        let result = try await client.listDeleted()
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.deleted[0].id, "eng-del-1")
+    }
+
+    // MARK: - Retry Enrich
+
+    func testRetryEnrich() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertTrue(request.url!.path.contains("/retry-enrich"))
+
+            return self.mockResponse(json: [
+                "engram_id": "eng-1",
+                "plugins_queued": ["summarize"],
+                "already_complete": ["embed"],
+            ])
+        }
+
+        let result = try await client.retryEnrich("eng-1")
+        XCTAssertEqual(result.engramId, "eng-1")
+        XCTAssertEqual(result.pluginsQueued, ["summarize"])
+        XCTAssertEqual(result.alreadyComplete, ["embed"])
+    }
+
+    // MARK: - Contradictions
+
+    func testContradictions() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/contradictions"))
+
+            return self.mockResponse(json: [
+                "contradictions": [
+                    [
+                        "id_a": "eng-1",
+                        "concept_a": "sky is blue",
+                        "id_b": "eng-2",
+                        "concept_b": "sky is green",
+                        "detected_at": 1700000000,
+                    ],
+                ],
+            ])
+        }
+
+        let result = try await client.contradictions()
+        XCTAssertEqual(result.contradictions.count, 1)
+        XCTAssertEqual(result.contradictions[0].idA, "eng-1")
+    }
+
+    // MARK: - Guide
+
+    func testGuide() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/guide"))
+
+            return self.mockResponse(json: ["guide": "Welcome to MuninnDB"])
+        }
+
+        let result = try await client.guide()
+        XCTAssertEqual(result, "Welcome to MuninnDB")
+    }
+
+    // MARK: - Stats
+
+    func testStats() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/stats"))
+
+            return self.mockResponse(json: [
+                "engram_count": 100,
+                "vault_count": 2,
+                "index_size": 4096,
+                "storage_bytes": 1048576,
+            ])
+        }
+
+        let result = try await client.stats()
+        XCTAssertEqual(result.engramCount, 100)
+        XCTAssertEqual(result.vaultCount, 2)
+        XCTAssertEqual(result.storageBytes, 1048576)
+    }
+
+    // MARK: - List Engrams
+
+    func testListEngrams() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/engrams"))
+            XCTAssertTrue(request.url!.query!.contains("limit=10"))
+
+            return self.mockResponse(json: [
+                "engrams": [
+                    [
+                        "id": "eng-1",
+                        "concept": "test",
+                        "content": "content",
+                        "confidence": 0.9,
+                        "vault": "default",
+                        "created_at": 1700000000,
+                    ],
+                ],
+                "total": 1,
+                "limit": 10,
+                "offset": 0,
+            ])
+        }
+
+        let result = try await client.listEngrams(limit: 10)
+        XCTAssertEqual(result.engrams.count, 1)
+        XCTAssertEqual(result.total, 1)
+        XCTAssertEqual(result.engrams[0].id, "eng-1")
+    }
+
+    // MARK: - Get Links
+
+    func testGetLinks() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertTrue(request.url!.path.contains("/links"))
+
+            return self.mockResponse(json: [
+                "links": [
+                    [
+                        "target_id": "eng-2",
+                        "rel_type": 1,
+                        "weight": 0.8,
+                        "co_activation_count": 3,
+                    ],
+                ],
+            ])
+        }
+
+        let result = try await client.getLinks("eng-1")
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].targetId, "eng-2")
+        XCTAssertEqual(result[0].coActivationCount, 3)
+    }
+
+    // MARK: - List Vaults
+
+    func testListVaults() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/vaults"))
+
+            return self.mockResponse(json: ["vaults": ["default", "archive"]])
+        }
+
+        let result = try await client.listVaults()
+        XCTAssertEqual(result, ["default", "archive"])
+    }
+
+    // MARK: - Session
+
+    func testSession() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/session"))
+
+            return self.mockResponse(json: [
+                "entries": [
+                    [
+                        "id": "eng-1",
+                        "concept": "recent item",
+                        "content": "some content",
+                        "created_at": 1700000000,
+                    ],
+                ],
+                "total": 1,
+                "offset": 0,
+                "limit": 50,
+            ])
+        }
+
+        let result = try await client.session()
+        XCTAssertEqual(result.entries.count, 1)
+        XCTAssertEqual(result.entries[0].concept, "recent item")
+        XCTAssertEqual(result.total, 1)
+    }
+
+    // MARK: - Health
+
+    func testHealth() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/health"))
+
+            return self.mockResponse(json: [
+                "status": "ok",
+                "version": "1.0.0",
+                "uptime_seconds": 3600,
+                "db_writable": true,
+            ])
+        }
+
+        let result = try await client.health()
+        XCTAssertEqual(result.status, "ok")
+        XCTAssertEqual(result.version, "1.0.0")
+        XCTAssertEqual(result.uptimeSeconds, 3600)
+        XCTAssertTrue(result.dbWritable)
+    }
+
+    // MARK: - Error Mapping
+
+    // Builds the nested {"error": {"code": ..., "message": "..."}} format the server actually sends.
+    private func errorJSON(code: Int, message: String) -> [String: Any] {
+        ["error": ["code": code, "message": message]]
+    }
+
+    func testUnauthorizedError() async throws {
+        MockURLProtocol.requestHandler = { _ in
+            return self.mockResponse(statusCode: 401, json: self.errorJSON(code: 1010, message: "invalid token"))
+        }
+
+        do {
+            _ = try await client.health()
+            XCTFail("Expected unauthorized error")
+        } catch let error as MuninnError {
+            if case .unauthorized(let msg) = error {
+                XCTAssertEqual(msg, "invalid token")
+            } else {
+                XCTFail("Expected unauthorized, got \(error)")
+            }
+        }
+    }
+
+    func testNotFoundError() async throws {
+        MockURLProtocol.requestHandler = { _ in
+            return self.mockResponse(statusCode: 404, json: self.errorJSON(code: 1000, message: "engram not found"))
+        }
+
+        do {
+            _ = try await client.read("nonexistent")
+            XCTFail("Expected not found error")
+        } catch let error as MuninnError {
+            if case .notFound(let msg) = error {
+                XCTAssertEqual(msg, "engram not found")
+            } else {
+                XCTFail("Expected notFound, got \(error)")
+            }
+        }
+    }
+
+    func testConflictError() async throws {
+        MockURLProtocol.requestHandler = { _ in
+            return self.mockResponse(statusCode: 409, json: self.errorJSON(code: 1004, message: "already exists"))
+        }
+
+        do {
+            try await client.link(LinkOptions(sourceId: "a", targetId: "b", relType: 1))
+            XCTFail("Expected conflict error")
+        } catch let error as MuninnError {
+            if case .conflict(let msg) = error {
+                XCTAssertEqual(msg, "already exists")
+            } else {
+                XCTFail("Expected conflict, got \(error)")
+            }
+        }
+    }
+
+    func testValidationError() async throws {
+        MockURLProtocol.requestHandler = { _ in
+            return self.mockResponse(statusCode: 422, json: self.errorJSON(code: 1002, message: "missing field"))
+        }
+
+        do {
+            _ = try await client.write(WriteOptions(concept: "", content: ""))
+            XCTFail("Expected validation error")
+        } catch let error as MuninnError {
+            if case .validation(let msg) = error {
+                XCTAssertEqual(msg, "missing field")
+            } else {
+                XCTFail("Expected validation, got \(error)")
+            }
+        }
+    }
+
+    func testServerError() async throws {
+        MockURLProtocol.requestHandler = { _ in
+            return self.mockResponse(statusCode: 500, json: self.errorJSON(code: 1020, message: "internal error"))
+        }
+
+        do {
+            _ = try await client.health()
+            XCTFail("Expected server error")
+        } catch let error as MuninnError {
+            if case .serverError(let code, let msg) = error {
+                XCTAssertEqual(code, 500)
+                XCTAssertEqual(msg, "internal error")
+            } else {
+                XCTFail("Expected serverError, got \(error)")
+            }
+        }
+    }
+
+    func testRateLimitedMapsToServerError() async throws {
+        // 429 should map to .serverError (not .validation) after retries exhausted
+        MockURLProtocol.requestHandler = { _ in
+            return self.mockResponse(statusCode: 429, json: self.errorJSON(code: 1016, message: "rate limited"))
+        }
+
+        do {
+            _ = try await client.health()
+            XCTFail("Expected server error for 429")
+        } catch let error as MuninnError {
+            if case .serverError(let code, _) = error {
+                XCTAssertEqual(code, 429)
+            } else {
+                XCTFail("Expected serverError for 429, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - SSE Subscribe
+
+    func testSubscribeRequestShape() async throws {
+        // Deliver a minimal valid SSE response so the stream completes
+        let sseBody = "data: {\"type\":\"write\",\"id\":\"eng-1\"}\n\n"
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/subscribe"))
+            XCTAssertTrue(request.url!.query!.contains("vault=myVault"))
+            XCTAssertTrue(request.url!.query!.contains("push_on_write=true"))
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-token")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "text/event-stream")
+            let data = sseBody.data(using: .utf8)!
+            return self.mockResponse(statusCode: 200, data: data)
+        }
+
+        let stream = client.subscribe(vault: "myVault", pushOnWrite: true)
+        var events: [SseEvent] = []
+        for try await event in stream {
+            events.append(event)
+        }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0].type, "message")
+        XCTAssertTrue(events[0].rawData.contains("eng-1"))
+    }
+
+    func testSubscribeWithThreshold() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertTrue(request.url!.query!.contains("threshold=0.5"))
+            return self.mockResponse(statusCode: 200, data: Data())
+        }
+
+        let stream = client.subscribe(vault: "default", threshold: 0.5)
+        // Just consuming to trigger the request; empty body → stream ends immediately
+        for try await _ in stream {}
+    }
+
+    // MARK: - Auth Header
+
+    func testAuthorizationHeader() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-token")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+            return self.mockResponse(json: [
+                "status": "ok",
+                "version": "1.0.0",
+                "uptime_seconds": 0,
+                "db_writable": true,
+            ])
+        }
+
+        _ = try await client.health()
+    }
+}


### PR DESCRIPTION
## Summary

- **Swift SDK** (`sdk/swift/`): URLSession async/await, `AsyncThrowingStream` SSE, zero external deps, iOS 15+/macOS 12+, 33 unit tests via `URLProtocol` mock
- **Kotlin SDK** (`sdk/kotlin/`): OkHttp 4.x + Gson, Kotlin Coroutines, `Flow`-based SSE, JVM 8+/Android API 21+, 32 unit tests via `MockWebServer`
- Both SDKs implement all **25 API methods** with full wire-format parity verified against server Go types

**Why not gomobile?** iOS/Android background process restrictions prevent the cognitive engine's continuous workers from running — shipping gomobile would deliver a degraded, worker-less product. Native HTTP clients connecting to a hosted daemon is the correct architecture (same pattern as Python/Node.js SDKs).

## Wire-format correctness

All types verified against `internal/transport/mbp/types.go` and `internal/transport/rest/types.go`:
- `EvolveRequest` sends `new_content` (not `content`)
- `Filter` uses `{field, op, value}` schema (not tags/memoryTypes)
- `Weights` CodingKeys/SerializedName match server exactly (`semantic_similarity`, `full_text_relevance`, `decay_factor`, `hebbian_boost`, `access_frequency`, `recency`)
- Error envelope parsed as nested `{"error": {"code": ..., "message": "..."}}`
- Hard forget uses `DELETE /api/engrams/{id}?hard=true` (no separate `/forget` route exists)
- SSE parses `event:` field; defaults to `"message"` type

## Test plan

- [x] Swift: `cd sdk/swift && swift test` → 33/33 passing
- [ ] Kotlin: `cd sdk/kotlin && ./gradlew test` → 32 tests (requires JDK 8+ on CI)
- [ ] CI pipeline green