### PR TITLE
fix(mcp): muninn_read returns numeric state string instead of human-readable label

### DIFF
--- a/internal/mcp/convert.go
+++ b/internal/mcp/convert.go
@@ -1,9 +1,9 @@
 package mcp
 
 import (
-	"fmt"
 	"time"
 
+	"github.com/scrypster/muninndb/internal/storage"
 	"github.com/scrypster/muninndb/internal/transport/mbp"
 )
 
@@ -49,7 +49,7 @@ func readResponseToMemory(r *mbp.ReadResponse) Memory {
 		Summary:     r.Summary,
 		Confidence:  r.Confidence,
 		Tags:        r.Tags,
-		State:       fmt.Sprintf("%d", r.State),
+		State:       storage.LifecycleState(r.State).String(),
 		CreatedAt:   time.Unix(0, r.CreatedAt).UTC(),
 		LastAccess:  time.Unix(0, r.LastAccess).UTC(),
 		AccessCount: r.AccessCount,

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -125,6 +125,32 @@ const (
 	StateSoftDeleted LifecycleState = 0x7F
 )
 
+// String returns the human-readable name for a LifecycleState value.
+// It is the inverse of ParseLifecycleState and is the single source of
+// truth for state labels used by the REST, MCP, and embedded SDK layers.
+func (s LifecycleState) String() string {
+	switch s {
+	case StatePlanning:
+		return "planning"
+	case StateActive:
+		return "active"
+	case StatePaused:
+		return "paused"
+	case StateBlocked:
+		return "blocked"
+	case StateCompleted:
+		return "completed"
+	case StateCancelled:
+		return "cancelled"
+	case StateArchived:
+		return "archived"
+	case StateSoftDeleted:
+		return "soft_deleted"
+	default:
+		return fmt.Sprintf("unknown(%d)", uint8(s))
+	}
+}
+
 // ParseLifecycleState parses a string lifecycle state name.
 func ParseLifecycleState(s string) (LifecycleState, error) {
 	states := map[string]LifecycleState{

--- a/internal/transport/rest/engine_adapter.go
+++ b/internal/transport/rest/engine_adapter.go
@@ -298,28 +298,10 @@ func (w *RESTEngineWrapper) EmbedStats() plugin.RetroactiveStats {
 	return w.engine.EmbedStats()
 }
 
-// lifecycleStateLabel returns a human-readable label for a storage.LifecycleState.
+// lifecycleStateLabel returns the human-readable label for a storage.LifecycleState.
+// Delegates to storage.LifecycleState.String() — the single source of truth.
 func lifecycleStateLabel(s storage.LifecycleState) string {
-	switch s {
-	case storage.StatePlanning:
-		return "planning"
-	case storage.StateActive:
-		return "active"
-	case storage.StatePaused:
-		return "paused"
-	case storage.StateBlocked:
-		return "blocked"
-	case storage.StateCompleted:
-		return "completed"
-	case storage.StateCancelled:
-		return "cancelled"
-	case storage.StateArchived:
-		return "archived"
-	case storage.StateSoftDeleted:
-		return "soft_deleted"
-	default:
-		return fmt.Sprintf("unknown(%d)", s)
-	}
+	return s.String()
 }
 
 func (w *RESTEngineWrapper) Evolve(ctx context.Context, vault, engramID, newContent, reason string) (*EvolveResponse, error) {

--- a/internal/transport/rest/markdown_export.go
+++ b/internal/transport/rest/markdown_export.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/storage"
 )
 
 // writeVaultMarkdownExport streams a .tgz archive to w containing:
@@ -258,28 +260,10 @@ func noteFileName(n markdownNote) string {
 	return fmt.Sprintf("%s-%s.md", slug, suffix)
 }
 
-// lifecycleStateLabelFromCode returns a human-readable label for a lifecycle state code.
+// lifecycleStateLabelFromCode returns the human-readable label for a lifecycle state code.
+// Delegates to storage.LifecycleState.String() — the single source of truth.
 func lifecycleStateLabelFromCode(code uint8) string {
-	switch code {
-	case 0:
-		return "planning"
-	case 1:
-		return "active"
-	case 2:
-		return "paused"
-	case 3:
-		return "blocked"
-	case 4:
-		return "completed"
-	case 5:
-		return "cancelled"
-	case 6:
-		return "archived"
-	case 127:
-		return "soft_deleted"
-	default:
-		return fmt.Sprintf("unknown(%d)", code)
-	}
+	return storage.LifecycleState(code).String()
 }
 
 // memoryTypeLabelFromCode returns a human-readable label for a memory type code.

--- a/recall.go
+++ b/recall.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/scrypster/muninndb/internal/engine"
+	"github.com/scrypster/muninndb/internal/storage"
 	"github.com/scrypster/muninndb/internal/transport/mbp"
 )
 
@@ -70,27 +71,8 @@ func isNotFound(err error) bool {
 	return errors.Is(err, engine.ErrEngramNotFound)
 }
 
-// lifecycleStateName converts a raw state byte (from ReadResponse.State) to a
-// human-readable name. Values mirror internal/storage.LifecycleState constants.
+// lifecycleStateName converts a raw state byte to a human-readable name.
+// Delegates to storage.LifecycleState.String() — the single source of truth.
 func lifecycleStateName(state uint8) string {
-	switch state {
-	case 0x00:
-		return "planning"
-	case 0x01:
-		return "active"
-	case 0x02:
-		return "paused"
-	case 0x03:
-		return "blocked"
-	case 0x04:
-		return "completed"
-	case 0x05:
-		return "cancelled"
-	case 0x06:
-		return "archived"
-	case 0x7F:
-		return "soft_deleted"
-	default:
-		return "unknown"
-	}
+	return storage.LifecycleState(state).String()
 }


### PR DESCRIPTION
## Bug

`muninn_read` responses return `\"state\":\"1\"` instead of `\"state\":\"active\"`.

Any AI model calling the tool receives a raw integer string in the `state` field — `\"0\"`, `\"1\"`, `\"2\"` etc. — rather than the human-readable lifecycle state name. The field is populated but carries no usable information for downstream decision-making.

### Root cause

`readResponseToMemory` in `internal/mcp/convert.go` used `fmt.Sprintf(\"%d\", r.State)` to populate the state field:

```go
// before
State: fmt.Sprintf(\"%d\", r.State),   // produces \"0\", \"1\", \"2\" ...
```

`r.State` is a `uint8` from `mbp.ReadResponse` — `fmt.Sprintf(\"%d\", ...)` formats it as a decimal integer string, not a name.

The deeper cause: there was no canonical `String()` method on `storage.LifecycleState`. The state→label mapping existed as three independent, duplicated switch statements:

| Location | Function |
|---|---|
| `internal/transport/rest/engine_adapter.go` | `lifecycleStateLabel(s storage.LifecycleState) string` |
| `internal/transport/rest/markdown_export.go` | `lifecycleStateLabelFromCode(code uint8) string` |
| `recall.go` (embedded SDK) | `lifecycleStateName(state uint8) string` |

The MCP layer had no conversion at all — hence the bug.

## Fix

### 1. Add `LifecycleState.String()` to `internal/storage/types.go`

Single source of truth, placed alongside the existing `ParseLifecycleState` reverse mapping in the same file:

```go
func (s LifecycleState) String() string {
    switch s {
    case StatePlanning:    return \"planning\"
    case StateActive:      return \"active\"
    case StatePaused:      return \"paused\"
    case StateBlocked:     return \"blocked\"
    case StateCompleted:   return \"completed\"
    case StateCancelled:   return \"cancelled\"
    case StateArchived:    return \"archived\"
    case StateSoftDeleted: return \"soft_deleted\"
    default:               return fmt.Sprintf(\"unknown(%d)\", uint8(s))
    }
}
```

### 2. Fix `internal/mcp/convert.go`

```go
// after
State: storage.LifecycleState(r.State).String(),   // produces \"active\", \"planning\" ...
```

### 3. Replace the three duplicate switch statements

Each existing function becomes a one-line delegate:

```go
// rest/engine_adapter.go
func lifecycleStateLabel(s storage.LifecycleState) string { return s.String() }

// rest/markdown_export.go
func lifecycleStateLabelFromCode(code uint8) string { return storage.LifecycleState(code).String() }

// recall.go
func lifecycleStateName(state uint8) string { return storage.LifecycleState(state).String() }
```

All existing callers are preserved — no call-site changes needed.

## Changed files

| File | Change |
|---|---|
| `internal/storage/types.go` | Add `LifecycleState.String()` method |
| `internal/mcp/convert.go` | Use `storage.LifecycleState(r.State).String()` — fixes the bug |
| `internal/transport/rest/engine_adapter.go` | Delegate to `s.String()` |
| `internal/transport/rest/markdown_export.go` | Delegate to `storage.LifecycleState(code).String()`; add `storage` import |
| `recall.go` | Delegate to `storage.LifecycleState(state).String()` |

Net: **40 lines added, 66 removed.** No behavior change to any code path except the MCP `muninn_read` state field.

## Verification

Built and tested on Rocky Linux 8 (glibc 2.28) against the current develop tip:

```
ok  github.com/scrypster/muninndb/internal/storage           23.554s
ok  github.com/scrypster/muninndb/internal/storage/cache      0.122s
ok  github.com/scrypster/muninndb/internal/storage/erf        0.003s
ok  github.com/scrypster/muninndb/internal/storage/keys       0.006s
ok  github.com/scrypster/muninndb/internal/storage/migrate    0.065s
ok  github.com/scrypster/muninndb/internal/mcp                2.045s
ok  github.com/scrypster/muninndb/internal/transport/rest     1.491s
```

`go vet ./internal/mcp/... ./internal/storage/... ./internal/transport/rest/... .` — clean.

## Notes

- The `default` case now returns `\"unknown(N)\"` (matching the format used by `rest/engine_adapter.go`) rather than the bare `\"unknown\"` that `recall.go` previously returned. This is an improvement — callers get the raw byte value for debugging.
- No new public API surface. `LifecycleState.String()` satisfies the standard `fmt.Stringer` interface which is idiomatic Go.
- `ParseLifecycleState` intentionally does not handle `soft_deleted` as an input (it is an internal state, not user-settable). `String()` does handle it as output since it can appear in read responses.