### PR TITLE
fix(docker): bind to 0.0.0.0 so container ports are reachable from host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,12 @@ services:
       # MUNINN_ENRICH_URL: "openai://gpt-4o-mini"
       # MUNINN_ENRICH_API_KEY: ""
 
+      # ── Listen address ───────────────────────────────────────────────────────
+      # Inside a container the server must bind to 0.0.0.0 (all interfaces);
+      # the default 127.0.0.1 is the container loopback and unreachable from
+      # the host even when ports are mapped.
+      MUNINN_LISTEN_HOST: "0.0.0.0"
+
       # ── Memory limits ─────────────────────────────────────────────────────
       MUNINN_MEM_LIMIT_GB: "4"
       MUNINN_GC_PERCENT: "200"


### PR DESCRIPTION
## Summary

Closes #254.

When running via `docker compose up`, all services bind to `127.0.0.1` (the default `MUNINN_LISTEN_HOST`) and are unreachable from the host despite the port mappings in `docker-compose.yml`.

### Root cause

Docker port mapping works at the network layer: the host's port N is forwarded to the container's port N. But traffic arriving at the container's port N needs a listener on `0.0.0.0` (all interfaces) or the specific container IP — not on `127.0.0.1`, which is the container's own loopback and invisible to the outside.

The server already supports `MUNINN_LISTEN_HOST` for exactly this scenario (see `parseListenHost` in `cmd/muninn/server.go`). It just wasn't set in the compose file, so every service logged:

```
REST server starting  addr=127.0.0.1:8475
gRPC server starting  addr=127.0.0.1:8477
UI server listening   addr=127.0.0.1:8476
MBP server starting   addr=127.0.0.1:8474
mcp listening         addr=127.0.0.1:8750
```

…and the mapped ports received no traffic.

### Fix

Add `MUNINN_LISTEN_HOST: "0.0.0.0"` to the `environment` block in `docker-compose.yml`.

With this change all five services bind to `0.0.0.0`, making the mapped ports reachable:

```
REST server starting  addr=0.0.0.0:8475
gRPC server starting  addr=0.0.0.0:8477
UI server listening   addr=0.0.0.0:8476
MBP server starting   addr=0.0.0.0:8474
mcp listening         addr=0.0.0.0:8750
```

### Healthcheck compatibility

The healthcheck (`curl -sf http://localhost:8750/mcp/health`) runs inside the container. A listener on `0.0.0.0` accepts connections on `127.0.0.1`/`localhost` as well as external interfaces, so the healthcheck continues to work without modification.

### Changes

`docker-compose.yml` — one environment variable added with an explanatory comment:

```yaml
# ── Listen address ───────────────────────────────────────────────────────
# Inside a container the server must bind to 0.0.0.0 (all interfaces);
# the default 127.0.0.1 is the container loopback and unreachable from
# the host even when ports are mapped.
MUNINN_LISTEN_HOST: "0.0.0.0"
```

No code changes. No behaviour change for non-Docker deployments (the env var is only set inside the compose environment).