### PR TITLE
fix: local embedder configurable via UI; MUNINN_MCP_URL respected by Connect page

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -339,8 +339,16 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 	}
 
 	// 2. Saved config fallback
-	if cfg.EmbedProvider != "" && cfg.EmbedProvider != "none" && cfg.EmbedProvider != "local" {
+	if cfg.EmbedProvider != "" && cfg.EmbedProvider != "none" {
 		switch cfg.EmbedProvider {
+		case "local":
+			if os.Getenv(localEmbed) != "0" && embedpkg.LocalAvailable() {
+				slog.Info("initializing bundled local ONNX embedder from saved config", "data_dir", dataDir)
+				if svc := tryEmbedService("local://all-MiniLM-L6-v2", plugin.PluginConfig{DataDir: dataDir}); svc != nil {
+					return embedpkg.NewEmbedServiceAdapter(svc), svc, nil
+				}
+				slog.Warn("bundled local embedder init failed (saved config), falling back")
+			}
 		case "ollama":
 			if cfg.EmbedURL != "" {
 				slog.Info("initializing Ollama embedder from saved config", "url", cfg.EmbedURL)

--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"time"
 	"unicode"
@@ -428,6 +430,20 @@ type MCPInfoResponse struct {
 
 // handleMCPInfo returns the MCP endpoint URL and token status for the Connect UI.
 func (s *Server) handleMCPInfo(w http.ResponseWriter, r *http.Request) {
+	// MUNINN_MCP_URL lets operators advertise the externally-reachable MCP URL
+	// (e.g. in Docker or remote deployments where the listen address is not the
+	// same as the address clients should connect to).
+	if override := os.Getenv("MUNINN_MCP_URL"); override != "" {
+		if u, err := url.ParseRequestURI(override); err == nil && u.Host != "" {
+			s.sendJSON(w, http.StatusOK, MCPInfoResponse{
+				URL:             override,
+				TokenConfigured: s.mcpHasToken,
+			})
+			return
+		}
+		slog.Warn("MUNINN_MCP_URL is set but not a valid URL, falling back to derived address", "value", override)
+	}
+
 	addr := s.mcpAddr
 	if addr == "" {
 		addr = ":8750"

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1593,9 +1593,9 @@ document.addEventListener('alpine:init', () => {
       try {
         const data = await this.apiCall('/api/admin/embed/status');
         this.embedStatus = data;
-        // Reflect the active provider in the plugin config UI (local is default, not a plugin choice)
+        // Reflect the active provider in the plugin config UI
         const p = data?.provider;
-        if (p && p !== 'none' && p !== 'local') {
+        if (p && p !== 'none') {
           this.pluginCfg.embedProvider = p;
         }
         this.pluginCfg.embedRatePerSec = data.rate_per_sec ?? 0;


### PR DESCRIPTION
## Summary

Fixes two reported issues in a single PR since they are both small and touch related config/settings paths.

### Closes #257 — Local embedder not configurable via web UI

`buildEmbedder()` in `server.go` previously excluded `"local"` from the saved-config switch with an explicit guard (`cfg.EmbedProvider != "local"`), so selecting local in the UI had no persistent effect after restart — it would silently fall through to the auto-fallback anyway. Added `case "local":` to the switch that explicitly activates the bundled ONNX embedder, respecting `MUNINN_LOCAL_EMBED=0` if set.

Also updated `loadEmbedStatus()` in `app.js` to reflect `"local"` back into the provider selector on page load — it was previously suppressed, so the UI would not show your saved choice.

### Closes #259 — MUNINN_MCP_URL ignored by web UI Connect page

`handleMCPInfo` previously only derived the MCP URL from the server's listen address, hardcoding `127.0.0.1` for wildcard binds. In Docker or remote deployments, this address is unreachable from the browser. `MUNINN_MCP_URL` was only consumed by the CLI stdio proxy.

`handleMCPInfo` now checks `MUNINN_MCP_URL` first. If set and valid, it returns that URL directly. If set but malformed, it logs a warning and falls through to the existing derivation — no silent failure.

## Test plan

- [ ] Set embedder to "local" in web UI settings, restart, reload — selector should reflect "local"
- [ ] Set `MUNINN_MCP_URL=http://10.0.1.25:8750/mcp` in docker-compose.yml, open Connect page — should show that URL
- [ ] Set `MUNINN_MCP_URL` to an invalid value — server should log a warning and Connect page should show the derived address
- [ ] `go test ./internal/transport/rest/... ./cmd/muninn/...` passes