### PR TITLE
fix(storage): adaptive WAL sync — skip fsync when WAL is idle

### DIFF
--- a/internal/storage/wal_syncer.go
+++ b/internal/storage/wal_syncer.go
@@ -54,10 +54,12 @@ const walSyncInterval = 10 * time.Millisecond
 //	  walSyncInterval (10ms) via LogData(nil, pebble.Sync), providing a bounded
 //	  durability window equivalent to MySQL innodb_flush_log_at_trx_commit=2.
 type walSyncer struct {
-	db      *pebble.DB
-	stop    chan struct{}
-	done    chan struct{}
-	stopped atomic.Bool // set true before signalling the goroutine to stop
+	db           *pebble.DB
+	stop         chan struct{}
+	done         chan struct{}
+	stopped      atomic.Bool  // set true before signalling the goroutine to stop
+	lastWALBytes atomic.Uint64 // WAL bytes written at the last sync; used to detect idle
+	syncCount    atomic.Int64  // total doSync() calls; exposed for tests
 }
 
 func newWALSyncer(db *pebble.DB) *walSyncer {
@@ -78,9 +80,22 @@ func (s *walSyncer) run() {
 	for {
 		select {
 		case <-ticker.C:
-			s.doSync()
+			// Only fsync when the WAL has grown since the last sync. Pebble's
+			// Metrics() reads atomic counters — negligible cost at 100 Hz. This
+			// eliminates ~1 MB/s of idle disk writes while preserving the same
+			// ≤10ms durability window for active write paths.
+			//
+			// lastWALBytes is updated AFTER doSync() because LogData(nil, Sync)
+			// itself appends a small record to the WAL, advancing BytesWritten.
+			// Capturing the counter before the sync would cause the following
+			// tick to see a "new" byte count and trigger a spurious re-sync.
+			if s.db.Metrics().WAL.BytesWritten != s.lastWALBytes.Load() {
+				s.doSync()
+				s.lastWALBytes.Store(s.db.Metrics().WAL.BytesWritten)
+			}
 		case <-s.stop:
-			// Final sync before shutdown.
+			// Final sync on shutdown regardless of dirty state — ensures any
+			// in-flight NoSync writes are flushed before db.Close().
 			s.doSync()
 			return
 		}
@@ -114,6 +129,7 @@ func (s *walSyncer) doSync() {
 		}
 	}()
 
+	s.syncCount.Add(1)
 	if err := s.db.LogData(nil, pebble.Sync); err != nil {
 		if s.stopped.Load() || errors.Is(err, pebble.ErrClosed) {
 			return // expected during shutdown

--- a/internal/storage/wal_syncer_adaptive_test.go
+++ b/internal/storage/wal_syncer_adaptive_test.go
@@ -1,0 +1,196 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+)
+
+// TestWALSyncer_IdleNoSync verifies that the syncer does NOT call doSync when
+// no writes have occurred. Before the adaptive fix, the syncer called doSync
+// unconditionally every 10ms, producing ~1MB/s of idle disk writes.
+func TestWALSyncer_IdleNoSync(t *testing.T) {
+	db := openTestPebble(t)
+	s := newWALSyncer(db)
+	defer s.Close()
+
+	// Wait long enough for several ticks to fire with no writes.
+	time.Sleep(5 * walSyncInterval)
+
+	got := s.syncCount.Load()
+	if got != 0 {
+		t.Errorf("expected 0 syncs at idle, got %d", got)
+	}
+}
+
+// TestWALSyncer_SyncsAfterWrite verifies that the syncer DOES call doSync after
+// a NoSync write advances the WAL byte counter.
+func TestWALSyncer_SyncsAfterWrite(t *testing.T) {
+	db := openTestPebble(t)
+	s := newWALSyncer(db)
+	defer s.Close()
+
+	// Confirm no syncs have occurred yet.
+	if got := s.syncCount.Load(); got != 0 {
+		t.Fatalf("pre-write: expected 0 syncs, got %d", got)
+	}
+
+	// Perform a NoSync write to advance WAL.BytesWritten.
+	if err := db.Set([]byte("test-key"), []byte("test-val"), pebble.NoSync); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Wait for at least one tick to pick up the WAL change.
+	deadline := time.Now().Add(10 * walSyncInterval)
+	for time.Now().Before(deadline) {
+		if s.syncCount.Load() > 0 {
+			break
+		}
+		time.Sleep(walSyncInterval / 2)
+	}
+
+	if got := s.syncCount.Load(); got == 0 {
+		t.Errorf("expected at least 1 sync after write, got 0")
+	}
+}
+
+// TestWALSyncer_IdleThenWrite verifies the full lifecycle: idle → write → sync
+// → idle again. After a sync, subsequent ticks with no new writes must not
+// trigger additional syncs.
+func TestWALSyncer_IdleThenWrite(t *testing.T) {
+	db := openTestPebble(t)
+	s := newWALSyncer(db)
+	defer s.Close()
+
+	// Phase 1: idle — no syncs expected.
+	time.Sleep(5 * walSyncInterval)
+	if got := s.syncCount.Load(); got != 0 {
+		t.Fatalf("idle phase: expected 0 syncs, got %d", got)
+	}
+
+	// Phase 2: write — at least one sync expected.
+	if err := db.Set([]byte("k1"), []byte("v1"), pebble.NoSync); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	deadline := time.Now().Add(10 * walSyncInterval)
+	for time.Now().Before(deadline) {
+		if s.syncCount.Load() > 0 {
+			break
+		}
+		time.Sleep(walSyncInterval / 2)
+	}
+	afterWrite := s.syncCount.Load()
+	if afterWrite == 0 {
+		t.Fatalf("write phase: expected at least 1 sync, got 0")
+	}
+
+	// Phase 3: idle again — no additional syncs expected after the WAL is stable.
+	time.Sleep(5 * walSyncInterval)
+	afterIdle := s.syncCount.Load()
+	if afterIdle != afterWrite {
+		t.Errorf("second idle phase: sync count grew from %d to %d with no new writes", afterWrite, afterIdle)
+	}
+}
+
+// TestWALSyncer_MultipleWritesBatchedIntoOneSync verifies that multiple NoSync
+// writes occurring within a single tick window are covered by a single sync
+// (group-commit semantics). The sync count should not exceed the number of
+// tick intervals elapsed, regardless of write volume.
+func TestWALSyncer_MultipleWritesBatchedIntoOneSync(t *testing.T) {
+	db := openTestPebble(t)
+	s := newWALSyncer(db)
+	defer s.Close()
+
+	// Write 20 keys without any delay (all within one tick window).
+	for i := range 20 {
+		key := []byte{byte(i)}
+		if err := db.Set(key, key, pebble.NoSync); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	// Wait for two tick intervals — enough for exactly one or two syncs.
+	time.Sleep(3 * walSyncInterval)
+
+	got := s.syncCount.Load()
+	// 20 writes should not produce 20 syncs; group-commit must batch them.
+	// Allow up to 3 syncs (generous for timing jitter) but never 20.
+	if got > 3 {
+		t.Errorf("expected ≤3 syncs for 20 batched writes, got %d (group-commit not working)", got)
+	}
+	if got == 0 {
+		t.Errorf("expected at least 1 sync for 20 writes, got 0")
+	}
+}
+
+// TestWALSyncer_FinalSyncOnClose verifies that Close() always calls doSync
+// once to flush any in-flight NoSync writes, even if the WAL counter has not
+// changed since the last tick sync.
+func TestWALSyncer_FinalSyncOnClose(t *testing.T) {
+	db := openTestPebble(t)
+
+	// Write before creating the syncer so lastWALBytes starts non-zero.
+	if err := db.Set([]byte("pre"), []byte("write"), pebble.NoSync); err != nil {
+		t.Fatalf("pre-write: %v", err)
+	}
+
+	s := newWALSyncer(db)
+
+	// Wait for the syncer to observe the write and sync.
+	deadline := time.Now().Add(10 * walSyncInterval)
+	for time.Now().Before(deadline) {
+		if s.syncCount.Load() > 0 {
+			break
+		}
+		time.Sleep(walSyncInterval / 2)
+	}
+	beforeClose := s.syncCount.Load()
+
+	// Write again just before close — this should be covered by the final sync.
+	if err := db.Set([]byte("post"), []byte("write"), pebble.NoSync); err != nil {
+		t.Fatalf("post-write: %v", err)
+	}
+
+	// Close must perform the final sync without panicking.
+	s.Close()
+
+	afterClose := s.syncCount.Load()
+	if afterClose <= beforeClose {
+		t.Errorf("Close() did not perform final sync: count before=%d after=%d", beforeClose, afterClose)
+	}
+}
+
+// TestWALSyncer_SyncCountAccurate verifies that syncCount accurately reflects
+// the number of times doSync was called across a sequence of write/idle cycles.
+func TestWALSyncer_SyncCountAccurate(t *testing.T) {
+	db := openTestPebble(t)
+	s := newWALSyncer(db)
+	defer s.Close()
+
+	for cycle := range 3 {
+		// Write a key to trigger a sync.
+		key := []byte{byte(cycle), 0xFF}
+		if err := db.Set(key, key, pebble.NoSync); err != nil {
+			t.Fatalf("cycle %d write: %v", cycle, err)
+		}
+		// Wait for the sync to fire.
+		deadline := time.Now().Add(10 * walSyncInterval)
+		want := int64(cycle + 1)
+		for time.Now().Before(deadline) {
+			if s.syncCount.Load() >= want {
+				break
+			}
+			time.Sleep(walSyncInterval / 2)
+		}
+		if got := s.syncCount.Load(); got < want {
+			t.Errorf("cycle %d: expected syncCount ≥ %d, got %d", cycle, want, got)
+		}
+		// Idle between cycles — count must not grow.
+		snapshot := s.syncCount.Load()
+		time.Sleep(4 * walSyncInterval)
+		if after := s.syncCount.Load(); after != snapshot {
+			t.Errorf("cycle %d idle: sync count grew from %d to %d with no writes", cycle, snapshot, after)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #258.

The WAL syncer fired `LogData(nil, pebble.Sync)` unconditionally every 10ms, producing ~1 MB/s of idle disk writes with zero durability benefit when no writes had occurred.

## Fix

Check `db.Metrics().WAL.BytesWritten` on each tick. If the WAL has not grown since the last sync, the tick is a no-op. `Metrics()` reads Pebble's internal atomic counters — negligible cost at 100 Hz.

One subtle detail: `lastWALBytes` is captured **after** `doSync()`, not before. `LogData(nil, Sync)` itself appends a small record to the WAL (advancing `BytesWritten`). Capturing before the sync would cause the next tick to see a "new" byte count and immediately re-sync, defeating the optimization.

The shutdown path retains its unconditional final sync to flush any in-flight NoSync writes before `db.Close()`.

## Why this approach over a dirty flag

This change covers 100% of write paths — internal, external (`hnsw`, `fts`, `episodic`, `scoring`, `provenance`, `replication`), batch, direct — without touching any call sites. A dirty-flag approach would require instrumentation across 60+ NoSync write sites in 15+ files, with no compile-time enforcement that new write paths remember to set the flag.

## Tests added (6 new cases in `wal_syncer_adaptive_test.go`)

| Test | What it verifies |
|---|---|
| `TestWALSyncer_IdleNoSync` | Zero syncs at idle — the regression this PR fixes |
| `TestWALSyncer_SyncsAfterWrite` | At least one sync fires after a NoSync write |
| `TestWALSyncer_IdleThenWrite` | Idle → write → sync → idle: count stable between write windows |
| `TestWALSyncer_MultipleWritesBatchedIntoOneSync` | 20 writes within one tick window produce ≤3 syncs (group-commit) |
| `TestWALSyncer_FinalSyncOnClose` | `Close()` always performs a final sync |
| `TestWALSyncer_SyncCountAccurate` | syncCount accurately tracks doSync() across 3 write/idle cycles |

## Test plan
- [ ] `go test ./internal/storage/... -run TestWALSyncer` — 8 cases, all pass
- [ ] `go test ./internal/storage/...` — full suite clean