### PR TITLE
refactor(storage): PR 1/3 — add purpose-built methods to PebbleStore; deprecate GetDB()

### DIFF
--- a/internal/storage/impl.go
+++ b/internal/storage/impl.go
@@ -14,6 +14,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/scrypster/muninndb/internal/provenance"
+	"github.com/scrypster/muninndb/internal/scoring"
 	"github.com/scrypster/muninndb/internal/storage/erf"
 	"github.com/scrypster/muninndb/internal/storage/keys"
 	"github.com/scrypster/muninndb/internal/wal"
@@ -41,6 +42,7 @@ type PebbleStore struct {
 	noSyncEngrams bool
 	vaultCounters sync.Map          // [8]byte -> *vaultCounter
 	provenance    *provenance.Store // Provenance chain for tracking engram creation/updates
+	scoringStore  *scoring.Store   // Per-vault learnable scoring weights
 	walSync       *walSyncer        // Periodic WAL fsync — covers all pebble.NoSync writes
 	counterFlush  *counterCoalescer // Coalesces vault count Pebble writes (100ms timer)
 	provWork      *provenanceWorker // NumCPU goroutines for provenance appends
@@ -178,6 +180,7 @@ func NewPebbleStore(db *pebble.DB, cfg PebbleStoreConfig) *PebbleStore {
 		db:               db,
 		cache:            NewL1Cache(cfg.CacheSize),
 		provenance:       prov,
+		scoringStore:     scoring.NewStore(db),
 		noSyncEngrams:    cfg.NoSyncEngrams,
 		metaCache:        metaCache,
 		vaultPrefixCache: vaultPrefixCache,
@@ -547,9 +550,82 @@ func (ps *PebbleStore) ReadCoherence(vaultPrefix [8]byte) ([7]int64, bool, error
 }
 
 // GetDB returns the underlying Pebble database instance.
-// Used for accessing Pebble directly (e.g., by scoring store).
+//
+// Deprecated: use purpose-built methods instead:
+//   - Checkpoint() for backup snapshots
+//   - PebbleMetrics() for observability
+//   - ScoringStore() for the scoring.Store instance
+//   - ProvenanceStore() for the provenance.Store instance
+//   - ClearFTSKeys() / SetFTSVersionMarker() for FTS reindex operations
+//
+// GetDB will be removed once all call sites are migrated.
 func (ps *PebbleStore) GetDB() *pebble.DB {
 	return ps.db
+}
+
+// Checkpoint creates a Pebble checkpoint (consistent on-disk snapshot) at destDir.
+// This is a purpose-built replacement for store.GetDB().Checkpoint(destDir).
+func (ps *PebbleStore) Checkpoint(destDir string) error {
+	return ps.db.Checkpoint(destDir)
+}
+
+// PebbleMetrics returns the raw Pebble metrics for observability and diagnostics.
+// This is a purpose-built replacement for store.GetDB().Metrics().
+func (ps *PebbleStore) PebbleMetrics() *pebble.Metrics {
+	return ps.db.Metrics()
+}
+
+// ScoringStore returns the scoring.Store that manages per-vault learnable weights.
+// The store is constructed once at PebbleStore creation and shared — callers must
+// not close it independently.
+// This is a purpose-built replacement for scoring.NewStore(store.GetDB()).
+func (ps *PebbleStore) ScoringStore() *scoring.Store {
+	return ps.scoringStore
+}
+
+// ProvenanceStore returns the provenance.Store used for audit trail appends.
+// The store is constructed once at PebbleStore creation and shared — callers must
+// not close it independently.
+// This is a purpose-built replacement for provenance.NewStore(store.GetDB()).
+func (ps *PebbleStore) ProvenanceStore() *provenance.Store {
+	return ps.provenance
+}
+
+// ClearFTSKeys deletes all FTS index keys for the given vault workspace prefix via
+// range tombstones. Prefixes cleared: 0x05 (posting lists), 0x06 (trigrams),
+// 0x08 (FTS global stats), 0x09 (per-term stats).
+// This is a purpose-built replacement for raw Pebble batch operations in engine_reindex_fts.go.
+func (ps *PebbleStore) ClearFTSKeys(ws, wsPlus [8]byte) error {
+	ftsPrefixes := []byte{0x05, 0x06, 0x08, 0x09}
+	batch := ps.db.NewBatch()
+	for _, p := range ftsPrefixes {
+		lo := make([]byte, 9)
+		lo[0] = p
+		copy(lo[1:], ws[:])
+		hi := make([]byte, 9)
+		hi[0] = p
+		copy(hi[1:], wsPlus[:])
+		if err := batch.DeleteRange(lo, hi, nil); err != nil {
+			batch.Close()
+			return fmt.Errorf("storage: clear FTS keys 0x%02X: %w", p, err)
+		}
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
+		batch.Close()
+		return fmt.Errorf("storage: commit FTS clear batch: %w", err)
+	}
+	batch.Close()
+	return nil
+}
+
+// SetFTSVersionMarker writes the FTS schema version marker for the given workspace.
+// This is a purpose-built replacement for the raw db.Set in engine_reindex_fts.go.
+func (ps *PebbleStore) SetFTSVersionMarker(ws [8]byte, version byte) error {
+	versionKey := keys.FTSVersionKey(ws)
+	if err := ps.db.Set(versionKey, []byte{version}, pebble.Sync); err != nil {
+		return fmt.Errorf("storage: set FTS version marker: %w", err)
+	}
+	return nil
 }
 
 // TransitionCache returns the tiered PAS transition cache.

--- a/internal/storage/store_methods_test.go
+++ b/internal/storage/store_methods_test.go
@@ -1,0 +1,197 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/storage/keys"
+)
+
+// TestPebbleStore_Checkpoint verifies that Checkpoint creates a readable
+// Pebble database at the destination directory.
+func TestPebbleStore_Checkpoint(t *testing.T) {
+	store := openTestStore(t)
+
+	// Write something so the checkpoint is non-trivial.
+	if err := store.db.Set([]byte("chk-key"), []byte("chk-val"), pebble.Sync); err != nil {
+		t.Fatalf("setup write: %v", err)
+	}
+
+	// Pebble requires the destination directory to not exist.
+	destDir := t.TempDir() + "/checkpoint"
+	t.Cleanup(func() { os.RemoveAll(destDir) })
+
+	if err := store.Checkpoint(destDir); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+
+	// The destination must be a valid Pebble database.
+	chkDB, err := OpenPebble(destDir, DefaultOptions())
+	if err != nil {
+		t.Fatalf("open checkpoint db: %v", err)
+	}
+	defer chkDB.Close()
+
+	val, closer, err := chkDB.Get([]byte("chk-key"))
+	if err != nil {
+		t.Fatalf("get from checkpoint: %v", err)
+	}
+	defer closer.Close()
+	if string(val) != "chk-val" {
+		t.Errorf("checkpoint value: got %q, want %q", val, "chk-val")
+	}
+}
+
+// TestPebbleStore_PebbleMetrics verifies that PebbleMetrics returns a non-nil
+// metrics struct and that DiskSpaceUsage is consistent with DiskSize.
+func TestPebbleStore_PebbleMetrics(t *testing.T) {
+	store := openTestStore(t)
+
+	m := store.PebbleMetrics()
+	if m == nil {
+		t.Fatal("PebbleMetrics returned nil")
+	}
+	// DiskSize() uses Metrics() internally; values should agree.
+	if got, want := store.DiskSize(), int64(m.DiskSpaceUsage()); got != want {
+		t.Errorf("DiskSize()=%d != PebbleMetrics().DiskSpaceUsage()=%d", got, want)
+	}
+}
+
+// TestPebbleStore_ScoringStore verifies that ScoringStore returns the same
+// non-nil instance on repeated calls (shared, not re-created).
+func TestPebbleStore_ScoringStore(t *testing.T) {
+	store := openTestStore(t)
+
+	s1 := store.ScoringStore()
+	if s1 == nil {
+		t.Fatal("ScoringStore returned nil")
+	}
+	s2 := store.ScoringStore()
+	if s1 != s2 {
+		t.Error("ScoringStore returned different instances on repeated calls — must be shared")
+	}
+}
+
+// TestPebbleStore_ProvenanceStore verifies that ProvenanceStore returns the same
+// non-nil instance on repeated calls (shared, not re-created).
+func TestPebbleStore_ProvenanceStore(t *testing.T) {
+	store := openTestStore(t)
+
+	p1 := store.ProvenanceStore()
+	if p1 == nil {
+		t.Fatal("ProvenanceStore returned nil")
+	}
+	p2 := store.ProvenanceStore()
+	if p1 != p2 {
+		t.Error("ProvenanceStore returned different instances on repeated calls — must be shared")
+	}
+}
+
+// TestPebbleStore_ProvenanceStore_SameAsInternal verifies that ProvenanceStore()
+// returns the same instance held internally by PebbleStore (used by provWork),
+// confirming there is no duplicate store.
+func TestPebbleStore_ProvenanceStore_SameAsInternal(t *testing.T) {
+	store := openTestStore(t)
+	if store.ProvenanceStore() != store.provenance {
+		t.Error("ProvenanceStore() is not the same instance as store.provenance — duplicate store detected")
+	}
+}
+
+// TestPebbleStore_ClearFTSKeys verifies that ClearFTSKeys deletes all keys
+// under the four FTS prefixes for the given vault workspace.
+func TestPebbleStore_ClearFTSKeys(t *testing.T) {
+	store := openTestStore(t)
+
+	ws := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	wsPlus := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x09}
+
+	// Write one key under each FTS prefix.
+	ftsPrefixes := []byte{0x05, 0x06, 0x08, 0x09}
+	for _, p := range ftsPrefixes {
+		k := make([]byte, 9)
+		k[0] = p
+		copy(k[1:], ws[:])
+		if err := store.db.Set(k, []byte{p}, pebble.Sync); err != nil {
+			t.Fatalf("setup key 0x%02X: %v", p, err)
+		}
+	}
+
+	// Also write a key with a different prefix that must NOT be deleted.
+	safeKey := []byte{0x01, 0x01, 0x02, 0x03}
+	if err := store.db.Set(safeKey, []byte("keep"), pebble.Sync); err != nil {
+		t.Fatalf("setup safe key: %v", err)
+	}
+
+	if err := store.ClearFTSKeys(ws, wsPlus); err != nil {
+		t.Fatalf("ClearFTSKeys: %v", err)
+	}
+
+	// All FTS keys must be gone.
+	for _, p := range ftsPrefixes {
+		k := make([]byte, 9)
+		k[0] = p
+		copy(k[1:], ws[:])
+		_, closer, err := store.db.Get(k)
+		if err == nil {
+			closer.Close()
+			t.Errorf("FTS key 0x%02X still present after ClearFTSKeys", p)
+		}
+	}
+
+	// Non-FTS key must still exist.
+	val, closer, err := store.db.Get(safeKey)
+	if err != nil {
+		t.Fatalf("safe key missing after ClearFTSKeys: %v", err)
+	}
+	defer closer.Close()
+	if string(val) != "keep" {
+		t.Errorf("safe key value corrupted: got %q", val)
+	}
+}
+
+// TestPebbleStore_SetFTSVersionMarker verifies that SetFTSVersionMarker writes
+// the correct version byte at the FTS version key for the vault.
+func TestPebbleStore_SetFTSVersionMarker(t *testing.T) {
+	store := openTestStore(t)
+
+	ws := [8]byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22}
+
+	if err := store.SetFTSVersionMarker(ws, 0x01); err != nil {
+		t.Fatalf("SetFTSVersionMarker: %v", err)
+	}
+
+	versionKey := keys.FTSVersionKey(ws)
+	val, closer, err := store.db.Get(versionKey)
+	if err != nil {
+		t.Fatalf("get version marker: %v", err)
+	}
+	defer closer.Close()
+
+	if len(val) != 1 || val[0] != 0x01 {
+		t.Errorf("version marker: got %v, want [0x01]", val)
+	}
+}
+
+// TestPebbleStore_SetFTSVersionMarker_Overwrite verifies that the version marker
+// can be updated (e.g. from 0x00 to 0x01).
+func TestPebbleStore_SetFTSVersionMarker_Overwrite(t *testing.T) {
+	store := openTestStore(t)
+	ws := [8]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88}
+
+	for _, ver := range []byte{0x00, 0x01, 0x02} {
+		if err := store.SetFTSVersionMarker(ws, ver); err != nil {
+			t.Fatalf("SetFTSVersionMarker(%d): %v", ver, err)
+		}
+		versionKey := keys.FTSVersionKey(ws)
+		val, closer, err := store.db.Get(versionKey)
+		if err != nil {
+			t.Fatalf("get version marker after write(%d): %v", ver, err)
+		}
+		if len(val) != 1 || val[0] != ver {
+			closer.Close()
+			t.Errorf("version %d: got %v, want [0x%02X]", ver, val, ver)
+		}
+		closer.Close()
+	}
+}


### PR DESCRIPTION
## Summary

First of three PRs to eliminate the `GetDB() *pebble.DB` abstraction leak.

`GetDB()` exposes the raw `*pebble.DB` to engine-layer callers, meaning writes from those packages (scoring, provenance, FTS reindex) bypass any instrumentation inside `PebbleStore`. This PR adds purpose-built methods that absorb every `GetDB()` call site without changing any consumers yet.

**This PR is purely additive — zero behavior changes, zero consumer migrations.**

## New methods

| Method | Replaces |
|---|---|
| `Checkpoint(destDir)` | `store.GetDB().Checkpoint(destDir)` in `engine_checkpoint.go` |
| `PebbleMetrics()` | `store.GetDB().Metrics()` in `observability.go` |
| `ScoringStore()` | `scoring.NewStore(store.GetDB())` in `engine.go` |
| `ProvenanceStore()` | `provenance.NewStore(store.GetDB())` in `engine.go` |
| `ClearFTSKeys(ws, wsPlus)` | Raw `NewBatch()` + `DeleteRange()` block in `engine_reindex_fts.go` |
| `SetFTSVersionMarker(ws, version)` | Raw `db.Set(versionKey, ...)` in `engine_reindex_fts.go` |

## Bug fixed (latent)

`engine.go` was calling `provenance.NewStore(store.GetDB())` to create a second `provenance.Store` — a duplicate of the one `PebbleStore` already constructs internally and uses for its `provenanceWorker`. `ProvenanceStore()` returns the shared instance. PR 2/3 will eliminate the duplicate.

## `GetDB()` deprecation

Marked deprecated in the doc comment with pointers to each replacement. Will be removed in PR 3/3 after all call sites are migrated.

## Tests added (8 cases in `store_methods_test.go`)

- `Checkpoint` creates a valid readable Pebble snapshot
- `PebbleMetrics` returns non-nil metrics consistent with `DiskSize()`
- `ScoringStore` returns the same non-nil instance on repeated calls (shared)
- `ProvenanceStore` returns the same non-nil instance on repeated calls (shared)
- `ProvenanceStore` is identical to `store.provenance` (no duplicate store)
- `ClearFTSKeys` deletes all four FTS prefixes without touching other keys
- `SetFTSVersionMarker` writes the correct version byte
- `SetFTSVersionMarker` correctly overwrites existing values

## Next

- **PR 2/3**: Migrate all `GetDB()` call sites in the engine layer to the new methods
- **PR 3/3**: Remove `GetDB()`, clean up test helpers