### PR TITLE
fix(rest): validate ULID format in handleGetEngram and handleDeleteEngram

### DIFF
--- a/internal/transport/rest/coverage_boost_test.go
+++ b/internal/transport/rest/coverage_boost_test.go
@@ -237,7 +237,7 @@ func TestGetEngram_EngineError_Boost(t *testing.T) {
 	eng := &readErrorEngine{}
 	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
-	req := httptest.NewRequest("GET", "/api/engrams/some-id", nil)
+	req := httptest.NewRequest("GET", "/api/engrams/"+testEngramID, nil)
 	w := httptest.NewRecorder()
 	server.mux.ServeHTTP(w, req)
 
@@ -261,7 +261,7 @@ func TestDeleteEngram_EngineError(t *testing.T) {
 	eng := &forgetErrorEngine{}
 	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
-	req := httptest.NewRequest("DELETE", "/api/engrams/01ARZ3NDEKTSV4RRFFQ69G5FAV", nil)
+	req := httptest.NewRequest("DELETE", "/api/engrams/"+testEngramID, nil)
 	w := httptest.NewRecorder()
 	server.mux.ServeHTTP(w, req)
 

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -673,6 +673,10 @@ func (s *Server) handleGetEngram(w http.ResponseWriter, r *http.Request) {
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "missing engram id")
 		return
 	}
+	if len(id) != 26 {
+		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "invalid engram id: must be a 26-character ULID")
+		return
+	}
 	resp, err := s.engine.Read(r.Context(), &ReadRequest{ID: id, Vault: ctxVault(r)})
 	if err != nil {
 		if errors.Is(err, engine.ErrEngramNotFound) {
@@ -689,6 +693,10 @@ func (s *Server) handleDeleteEngram(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "missing engram id")
+		return
+	}
+	if len(id) != 26 {
+		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "invalid engram id: must be a 26-character ULID")
 		return
 	}
 	resp, err := s.engine.Forget(r.Context(), &ForgetRequest{ID: id, Vault: ctxVault(r)})

--- a/internal/transport/rest/server_test.go
+++ b/internal/transport/rest/server_test.go
@@ -27,6 +27,8 @@ import (
 	mbp "github.com/scrypster/muninndb/internal/transport/mbp"
 )
 
+const testEngramID = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
 // MockEngine is a mock implementation of EngineAPI for testing.
 type MockEngine struct {
 	lastActivityReq  *ActivityCountsRequest
@@ -854,7 +856,7 @@ func TestDeleteEngram(t *testing.T) {
 	engine := &MockEngine{}
 	server := NewServer("localhost:8080", engine, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
-	req := httptest.NewRequest("DELETE", "/api/engrams/01ARZ3NDEKTSV4RRFFQ69G5FAV", nil)
+	req := httptest.NewRequest("DELETE", "/api/engrams/"+testEngramID, nil)
 	w := httptest.NewRecorder()
 	server.mux.ServeHTTP(w, req)
 
@@ -1790,7 +1792,7 @@ func TestGetEngram_HappyPath(t *testing.T) {
 	eng := &MockEngine{}
 	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
-	req := httptest.NewRequest("GET", "/api/engrams/test-id?vault=default", nil)
+	req := httptest.NewRequest("GET", "/api/engrams/"+testEngramID+"?vault=default", nil)
 	w := httptest.NewRecorder()
 	server.mux.ServeHTTP(w, req)
 
@@ -1825,7 +1827,7 @@ func (e *readFactEngine) Read(ctx context.Context, req *ReadRequest) (*ReadRespo
 func TestGetEngram_IncludesZeroMemoryType(t *testing.T) {
 	server := NewServer("localhost:8080", &readFactEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
-	req := httptest.NewRequest("GET", "/api/engrams/fact-id?vault=default", nil)
+	req := httptest.NewRequest("GET", "/api/engrams/"+testEngramID+"?vault=default", nil)
 	w := httptest.NewRecorder()
 	server.mux.ServeHTTP(w, req)
 
@@ -1855,13 +1857,29 @@ func (e *readErrEngine) Read(ctx context.Context, req *ReadRequest) (*ReadRespon
 func TestGetEngram_EngineError(t *testing.T) {
 	server := NewServer("localhost:8080", &readErrEngine{}, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
 
-	req := httptest.NewRequest("GET", "/api/engrams/missing-id?vault=default", nil)
+	req := httptest.NewRequest("GET", "/api/engrams/"+testEngramID+"?vault=default", nil)
 	w := httptest.NewRecorder()
 	server.mux.ServeHTTP(w, req)
 
 	// handleGetEngram sends 404 on engine error.
 	if w.Code != http.StatusNotFound && w.Code != http.StatusInternalServerError {
 		t.Errorf("expected 404 or 500, got %d", w.Code)
+	}
+}
+
+// TestGetEngram_InvalidULID verifies that GET /api/engrams/{id} returns 400
+// when the path segment is not a valid 26-character ULID (e.g. "rebuild").
+func TestGetEngram_InvalidULID(t *testing.T) {
+	eng := &MockEngine{}
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+
+	for _, badID := range []string{"rebuild", "short", "toolong-but-still-not-ulid-format"} {
+		req := httptest.NewRequest("GET", "/api/engrams/"+badID+"?vault=default", nil)
+		w := httptest.NewRecorder()
+		server.mux.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("id=%q: expected 400, got %d: %s", badID, w.Code, w.Body.String())
+		}
 	}
 }
 

--- a/internal/transport/rest/vault_routing_test.go
+++ b/internal/transport/rest/vault_routing_test.go
@@ -443,7 +443,7 @@ func TestVaultRouting_Read_ExplicitVault(t *testing.T) {
 		t.Fatalf("SetVaultConfig: %v", err)
 	}
 
-	req := httptest.NewRequest("GET", "/api/engrams/some-id?vault=myvault", nil)
+	req := httptest.NewRequest("GET", "/api/engrams/"+testEngramID+"?vault=myvault", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
 
@@ -465,7 +465,7 @@ func TestVaultRouting_Forget_ExplicitVault(t *testing.T) {
 		t.Fatalf("SetVaultConfig: %v", err)
 	}
 
-	req := httptest.NewRequest("DELETE", "/api/engrams/some-id?vault=myvault", nil)
+	req := httptest.NewRequest("DELETE", "/api/engrams/"+testEngramID+"?vault=myvault", nil)
 	authorizeFullVaultRequest(t, store, req, "myvault")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)


### PR DESCRIPTION
## Problem

`GET /api/engrams/{id}` uses a wildcard route that matches *any* path segment, including non-ULID strings like `rebuild`. When such a segment reaches the engine, `storage.ParseULID` fails with:

```
parse id: parse ulid: ulid: bad data size when unmarshaling
```

This surfaces as a **500 Internal Server Error** — misleading for callers and the root cause of issue #282, where the web UI "Re-embed vault" button triggers `GET /api/engrams/rebuild`, hits the `{id}` wildcard, and returns a 500.

## Fix

Add a `len(id) != 26` guard at the top of `handleGetEngram` and `handleDeleteEngram`. Any path segment that cannot be a valid ULID (always exactly 26 Crockford base-32 characters) is rejected immediately with **400 Bad Request** and a clear message: `invalid engram id: must be a 26-character ULID`.

## Tests

- Updated existing tests to use valid 26-character ULIDs in URL paths.
- Added `TestGetEngram_InvalidULID` covering `rebuild`, `short`, and other non-ULID identifiers — all now correctly return 400.

Fixes #282