### PR TITLE
feat(enrich): add Google Gemini as enrichment provider

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -470,6 +470,7 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 //	ollama://localhost:11434/llama3.2          (local, no key required)
 //	openai://gpt-4o-mini                       (MUNINN_ENRICH_API_KEY required)
 //	anthropic://claude-haiku-4-5-20251001      (MUNINN_ANTHROPIC_KEY or MUNINN_ENRICH_API_KEY)
+//	google://gemini-1.5-flash                  (MUNINN_GOOGLE_KEY or MUNINN_ENRICH_API_KEY)
 //
 // Returns nil without error if MUNINN_ENRICH_URL is not set — LLM enrichment
 // is optional. Logs a warning on init failure so the server starts without
@@ -504,6 +505,9 @@ func buildEnricher(ctx context.Context, cfg plugincfg.PluginConfig) plugin.Enric
 	apiKey := os.Getenv("MUNINN_ENRICH_API_KEY")
 	if apiKey == "" {
 		apiKey = os.Getenv("MUNINN_ANTHROPIC_KEY")
+	}
+	if apiKey == "" {
+		apiKey = os.Getenv("MUNINN_GOOGLE_KEY")
 	}
 	if apiKey == "" {
 		apiKey = cfg.EnrichAPIKey // saved config fallback

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -177,6 +177,11 @@ muninn server
 export MUNINN_ENRICH_URL="anthropic://claude-haiku-4-5-20251001"
 export MUNINN_ANTHROPIC_KEY="sk-ant-..."
 muninn server
+
+# Google
+export MUNINN_ENRICH_URL="google://gemini-1.5-flash"
+export MUNINN_GOOGLE_KEY="AIza..."  # or MUNINN_ENRICH_API_KEY
+muninn server
 ```
 
 Provider comparison:

--- a/internal/plugin/enrich/enrich.go
+++ b/internal/plugin/enrich/enrich.go
@@ -71,6 +71,8 @@ func NewEnrichService(providerURL string) (*EnrichService, error) {
 		prov = NewOpenAILLMProvider()
 	case plugin.SchemeAnthropic:
 		prov = NewAnthropicLLMProvider()
+	case plugin.SchemeGoogle:
+		prov = NewGoogleLLMProvider()
 	default:
 		return nil, fmt.Errorf("unsupported enrich provider scheme: %q", provCfg.Scheme)
 	}
@@ -252,6 +254,9 @@ func (s *EnrichService) createRateLimiter(scheme plugin.ProviderScheme) *TokenBu
 	case plugin.SchemeAnthropic:
 		// 8 requests per second for Anthropic (claude-haiku)
 		return NewTokenBucketLimiter(8.0, 8.0)
+	case plugin.SchemeGoogle:
+		// Gemini Flash paid tier: ~2000 RPM. Use 10 RPS as a conservative default.
+		return NewTokenBucketLimiter(10.0, 10.0)
 	default:
 		// Default: 5 requests per second
 		return NewTokenBucketLimiter(5.0, 5.0)

--- a/internal/plugin/enrich/google.go
+++ b/internal/plugin/enrich/google.go
@@ -1,0 +1,148 @@
+package enrich
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// GoogleLLMProvider is an HTTP client for Google's Gemini generateContent endpoint.
+type GoogleLLMProvider struct {
+	client  *http.Client
+	baseURL string
+	model   string
+	apiKey  string
+}
+
+// googleGenerateRequest is the request structure for Gemini generateContent.
+type googleGenerateRequest struct {
+	Contents          []googleContent       `json:"contents"`
+	SystemInstruction *googleSystemContent  `json:"systemInstruction,omitempty"`
+	GenerationConfig  googleGenerationConfig `json:"generationConfig"`
+}
+
+type googleContent struct {
+	Role  string       `json:"role"`
+	Parts []googlePart `json:"parts"`
+}
+
+type googleSystemContent struct {
+	Parts []googlePart `json:"parts"`
+}
+
+type googlePart struct {
+	Text string `json:"text"`
+}
+
+type googleGenerationConfig struct {
+	Temperature      float32 `json:"temperature"`
+	MaxOutputTokens  int     `json:"maxOutputTokens"`
+	ResponseMimeType string  `json:"responseMimeType"`
+}
+
+// googleGenerateResponse is the response structure from Gemini generateContent.
+type googleGenerateResponse struct {
+	Candidates []struct {
+		Content struct {
+			Parts []googlePart `json:"parts"`
+		} `json:"content"`
+	} `json:"candidates"`
+}
+
+// NewGoogleLLMProvider creates a new Google Gemini provider.
+func NewGoogleLLMProvider() *GoogleLLMProvider {
+	return &GoogleLLMProvider{
+		client: &http.Client{Timeout: 300 * time.Second},
+	}
+}
+
+// Name returns the provider name.
+func (p *GoogleLLMProvider) Name() string {
+	return "google"
+}
+
+// Init initializes the provider and validates connectivity.
+func (p *GoogleLLMProvider) Init(ctx context.Context, cfg LLMProviderConfig) error {
+	p.baseURL = cfg.BaseURL
+	p.model = cfg.Model
+	p.apiKey = cfg.APIKey
+
+	if p.apiKey == "" {
+		return fmt.Errorf("google provider requires API key")
+	}
+
+	// Send a probe completion request to validate connectivity.
+	// The system prompt explicitly mentions "json" to be consistent with the
+	// OpenAI provider pattern — defensively guards against providers that
+	// reject JSON output mode without a json keyword in the prompt.
+	_, err := p.Complete(ctx, "You are a connectivity probe. Respond with valid JSON only.", `{"ok":true}`)
+	if err != nil {
+		return fmt.Errorf("google connectivity check failed: %w", err)
+	}
+
+	return nil
+}
+
+// Complete sends a generateContent request to the Gemini API.
+func (p *GoogleLLMProvider) Complete(ctx context.Context, system, user string) (string, error) {
+	req := googleGenerateRequest{
+		Contents: []googleContent{
+			{Role: "user", Parts: []googlePart{{Text: user}}},
+		},
+		SystemInstruction: &googleSystemContent{
+			Parts: []googlePart{{Text: system}},
+		},
+		GenerationConfig: googleGenerationConfig{
+			Temperature:      0.0,
+			MaxOutputTokens:  1024,
+			ResponseMimeType: "application/json",
+		},
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/v1beta/models/%s:generateContent", p.baseURL, p.model)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	// Google uses x-goog-api-key, not Authorization: Bearer.
+	httpReq.Header.Set("x-goog-api-key", p.apiKey)
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("google returned status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var genResp googleGenerateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&genResp); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if len(genResp.Candidates) == 0 || len(genResp.Candidates[0].Content.Parts) == 0 {
+		return "", fmt.Errorf("google response has no candidates")
+	}
+
+	return genResp.Candidates[0].Content.Parts[0].Text, nil
+}
+
+// Close releases HTTP connections.
+func (p *GoogleLLMProvider) Close() error {
+	p.client.CloseIdleConnections()
+	return nil
+}

--- a/internal/plugin/enrich/providers_test.go
+++ b/internal/plugin/enrich/providers_test.go
@@ -572,3 +572,176 @@ func TestAnthropicProvider_Close(t *testing.T) {
 		t.Fatalf("Close failed: %v", err)
 	}
 }
+
+// --- Google ---
+
+func TestGoogleProvider_Name(t *testing.T) {
+	p := NewGoogleLLMProvider()
+	if p.Name() != "google" {
+		t.Fatalf("expected 'google', got %q", p.Name())
+	}
+}
+
+func TestGoogleProvider_Complete_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify path includes model name and generateContent action.
+		if r.URL.Path != "/v1beta/models/test-model:generateContent" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		// Google uses x-goog-api-key, not Authorization: Bearer.
+		if r.Header.Get("x-goog-api-key") != "test-key" {
+			t.Errorf("bad x-goog-api-key header: %q", r.Header.Get("x-goog-api-key"))
+		}
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("unexpected Authorization header — Google does not use Bearer auth")
+		}
+
+		var req googleGenerateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if len(req.Contents) == 0 || req.Contents[0].Role != "user" {
+			t.Errorf("expected contents[0].role == 'user'")
+		}
+		if req.SystemInstruction == nil || len(req.SystemInstruction.Parts) == 0 {
+			t.Errorf("expected systemInstruction to be set")
+		}
+
+		resp := googleGenerateResponse{}
+		resp.Candidates = []struct {
+			Content struct {
+				Parts []googlePart `json:"parts"`
+			} `json:"content"`
+		}{
+			{Content: struct {
+				Parts []googlePart `json:"parts"`
+			}{Parts: []googlePart{{Text: "google response"}}}},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	p := NewGoogleLLMProvider()
+	p.baseURL = srv.URL
+	p.model = "test-model"
+	p.apiKey = "test-key"
+
+	got, err := p.Complete(context.Background(), "system prompt", "user msg")
+	if err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+	if got != "google response" {
+		t.Fatalf("expected 'google response', got %q", got)
+	}
+}
+
+func TestGoogleProvider_Complete_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte("rate limited"))
+	}))
+	defer srv.Close()
+
+	p := NewGoogleLLMProvider()
+	p.baseURL = srv.URL
+	p.model = "m"
+	p.apiKey = "k"
+
+	_, err := p.Complete(context.Background(), "s", "u")
+	if err == nil {
+		t.Fatal("expected error for 429 status")
+	}
+}
+
+func TestGoogleProvider_Complete_NoCandidates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := googleGenerateResponse{}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	p := NewGoogleLLMProvider()
+	p.baseURL = srv.URL
+	p.model = "m"
+	p.apiKey = "k"
+
+	_, err := p.Complete(context.Background(), "s", "u")
+	if err == nil {
+		t.Fatal("expected error for empty candidates")
+	}
+}
+
+func TestGoogleProvider_Complete_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("{bad json"))
+	}))
+	defer srv.Close()
+
+	p := NewGoogleLLMProvider()
+	p.baseURL = srv.URL
+	p.model = "m"
+	p.apiKey = "k"
+
+	_, err := p.Complete(context.Background(), "s", "u")
+	if err == nil {
+		t.Fatal("expected error for bad JSON")
+	}
+}
+
+func TestGoogleProvider_Init_MissingKey(t *testing.T) {
+	p := NewGoogleLLMProvider()
+	err := p.Init(context.Background(), LLMProviderConfig{
+		BaseURL: "http://localhost",
+		Model:   "m",
+		APIKey:  "",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+}
+
+func TestGoogleProvider_Init_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := googleGenerateResponse{}
+		resp.Candidates = []struct {
+			Content struct {
+				Parts []googlePart `json:"parts"`
+			} `json:"content"`
+		}{
+			{Content: struct {
+				Parts []googlePart `json:"parts"`
+			}{Parts: []googlePart{{Text: `{"ok":true}`}}}},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	p := NewGoogleLLMProvider()
+	err := p.Init(context.Background(), LLMProviderConfig{
+		BaseURL: srv.URL,
+		Model:   "test",
+		APIKey:  "key",
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+}
+
+func TestGoogleProvider_Init_ConnectivityFail(t *testing.T) {
+	p := NewGoogleLLMProvider()
+	err := p.Init(context.Background(), LLMProviderConfig{
+		BaseURL: "http://127.0.0.1:1", // unreachable port
+		Model:   "test",
+		APIKey:  "key",
+	})
+	if err == nil {
+		t.Fatal("expected error for unreachable host")
+	}
+}
+
+func TestGoogleProvider_Close(t *testing.T) {
+	p := NewGoogleLLMProvider()
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+}

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -86,7 +86,7 @@ type Server struct {
 	embedHardwareAccelerated *bool  // nil for cloud/noop providers; true/false for Ollama
 
 	// Enrichment info — set at construction time, static for the lifetime of the server.
-	enrichProvider string // "ollama", "openai", "anthropic", or ""
+	enrichProvider string // "ollama", "openai", "anthropic", "google", or ""
 	enrichModel    string // model name, or ""
 
 	// MCP info — set at construction time for the /api/admin/mcp-info endpoint.
@@ -127,7 +127,7 @@ type EmbedInfo struct {
 
 // EnrichInfo carries static enrichment metadata set at server construction time.
 type EnrichInfo struct {
-	Provider string // "ollama", "openai", "anthropic", or ""
+	Provider string // "ollama", "openai", "anthropic", "google", or ""
 	Model    string // model name, or ""
 }
 

--- a/web/plugin-config-utils.test.js
+++ b/web/plugin-config-utils.test.js
@@ -140,6 +140,27 @@ describe('parsePluginConfigResponse', () => {
 
     // ── Full round-trip scenarios ────────────────────────────────────────────
 
+    it('parses google enrich URL to model name', () => {
+        const r = parsePluginConfigResponse({
+            enrich_provider: 'google',
+            enrich_url: 'google://gemini-1.5-flash',
+            enrich_api_key: 'AIza-test',
+        });
+        expect(r.enrichProvider).toBe('google');
+        expect(r.enrichModel).toBe('gemini-1.5-flash');
+        expect(r.enrichApiKey).toBe('AIza-test');
+        expect(r.enrichOllamaModel).toBeNull();
+    });
+
+    it('does not parse google enrich URL when enrich_provider is not google', () => {
+        const r = parsePluginConfigResponse({
+            enrich_provider: 'openai',
+            enrich_url: 'google://gemini-1.5-flash',
+        });
+        expect(r.enrichProvider).toBe('openai');
+        expect(r.enrichModel).toBeNull();
+    });
+
     it('full anthropic enrich + ollama embed round-trip', () => {
         const r = parsePluginConfigResponse({
             embed_provider: 'ollama',

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -216,7 +216,7 @@ document.addEventListener('alpine:init', () => {
       embedUrl: '',           // custom base URL for openai-compatible endpoints
       embedShowForm: false,
       embedError: '',
-      enrichProvider: 'none', // 'none' | 'ollama' | 'openai' | 'anthropic'
+      enrichProvider: 'none', // 'none' | 'ollama' | 'openai' | 'anthropic' | 'google'
       enrichOllamaModel: 'llama3.2',
       enrichModel: 'claude-haiku-4-5-20251001',
       enrichApiKey: '',
@@ -2569,8 +2569,9 @@ document.addEventListener('alpine:init', () => {
           ? `ollama://localhost:11434/${c.enrichOllamaModel}`
           : c.enrichProvider === 'openai' ? 'openai://gpt-4o-mini'
           : c.enrichProvider === 'anthropic' ? `anthropic://${c.enrichModel}`
+          : c.enrichProvider === 'google' ? `google://${c.enrichModel}`
           : '',
-        enrich_api_key: (c.enrichProvider === 'openai' || c.enrichProvider === 'anthropic') ? c.enrichApiKey : '',
+        enrich_api_key: (c.enrichProvider === 'openai' || c.enrichProvider === 'anthropic' || c.enrichProvider === 'google') ? c.enrichApiKey : '',
       };
 
       try {

--- a/web/static/js/plugin-config-utils.js
+++ b/web/static/js/plugin-config-utils.js
@@ -26,6 +26,7 @@
  *   enrich_url "ollama://localhost:11434/{model}" → enrichOllamaModel
  *   enrich_url "anthropic://{model}"              → enrichModel
  *   enrich_url "openai://{model}"                 → enrichModel
+ *   enrich_url "google://{model}"                 → enrichModel
  *
  * @param {object|null} data - raw API response object
  * @returns {object|null} parsed state, or null when data is falsy
@@ -67,6 +68,10 @@ export function parsePluginConfigResponse(data) {
     } else if (result.enrichProvider === 'openai' && enrichUrl.startsWith('openai://')) {
         // "openai://gpt-4o-mini" → "gpt-4o-mini"
         const model = enrichUrl.replace('openai://', '');
+        if (model) result.enrichModel = model;
+    } else if (result.enrichProvider === 'google' && enrichUrl.startsWith('google://')) {
+        // "google://gemini-1.5-flash" → "gemini-1.5-flash"
+        const model = enrichUrl.replace('google://', '');
         if (model) result.enrichModel = model;
     }
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1791,9 +1791,9 @@
               <div style="margin-bottom:1rem;">
                 <div style="font-size:0.8125rem;font-weight:600;color:var(--text-primary);margin-bottom:0.625rem;">Select provider</div>
                 <div style="display:flex;gap:0.5rem;flex-wrap:wrap;">
-                  <template x-for="opt in [{val:'none',label:'None'},{val:'ollama',label:'Ollama (local)'},{val:'openai',label:'OpenAI'},{val:'anthropic',label:'Anthropic'}]" :key="opt.val">
+                  <template x-for="opt in [{val:'none',label:'None'},{val:'ollama',label:'Ollama (local)'},{val:'openai',label:'OpenAI'},{val:'anthropic',label:'Anthropic'},{val:'google',label:'Google'}]" :key="opt.val">
                     <button
-                      @click="pluginCfg.enrichProvider=opt.val;pluginCfg.enrichCmd=''"
+                      @click="pluginCfg.enrichProvider=opt.val;pluginCfg.enrichCmd='';if(opt.val==='google')pluginCfg.enrichModel='gemini-1.5-flash';if(opt.val==='anthropic')pluginCfg.enrichModel='claude-haiku-4-5-20251001'"
                       :class="pluginCfg.enrichProvider===opt.val ? 'tab-btn active' : 'tab-btn'"
                       x-text="opt.label">
                     </button>
@@ -1876,6 +1876,22 @@
                   <select class="input-field" x-model="pluginCfg.enrichModel">
                     <option value="claude-haiku-4-5-20251001">claude-haiku-4-5-20251001 (fastest)</option>
                     <option value="claude-sonnet-4-6">claude-sonnet-4-6</option>
+                  </select>
+                </div>
+              </div>
+
+              <!-- Google fields -->
+              <div x-show="pluginCfg.enrichProvider==='google'" style="margin-bottom:1rem;">
+                <div class="form-group" style="margin-bottom:0.75rem;">
+                  <label>Google API Key</label>
+                  <input class="input-field" type="password" x-model="pluginCfg.enrichApiKey" placeholder="AIza..." autocomplete="off" />
+                </div>
+                <div class="form-group">
+                  <label>Model</label>
+                  <select class="input-field" x-model="pluginCfg.enrichModel">
+                    <option value="gemini-1.5-flash">gemini-1.5-flash (recommended)</option>
+                    <option value="gemini-1.5-pro">gemini-1.5-pro</option>
+                    <option value="gemini-2.0-flash">gemini-2.0-flash</option>
                   </select>
                 </div>
               </div>


### PR DESCRIPTION
Closes #286.

## Summary

Adds `google://` as a fourth LLM enrichment provider alongside Ollama, OpenAI, and Anthropic. Purely additive — all existing provider branches are character-for-character unchanged.

**Usage:**
```bash
export MUNINN_ENRICH_URL="google://gemini-1.5-flash"
export MUNINN_GOOGLE_KEY="AIza..."  # or MUNINN_ENRICH_API_KEY
muninn server
```

## Changes

**Backend (`internal/plugin/enrich/google.go` — new file)**
- `GoogleLLMProvider` implementing `LLMProvider` interface
- Endpoint: `POST {baseURL}/v1beta/models/{model}:generateContent`
- Auth: `x-goog-api-key` header (not `Authorization: Bearer` — confirmed per Google docs)
- JSON output mode via `responseMimeType: "application/json"`
- Connectivity probe includes "json" in system prompt (defensive, per OpenAI lesson)

**Backend (`enrich.go`, `cmd/muninn/server.go`)**
- `case plugin.SchemeGoogle` added to `NewEnrichService` and `createRateLimiter` (10 RPS)
- `MUNINN_GOOGLE_KEY` env var alias mirrors `MUNINN_ANTHROPIC_KEY` pattern
- Comment updates only in `server.go` (REST)

**UI (`index.html`, `app.js`, `plugin-config-utils.js`)**
- Google tab in provider selector; form with API key + model dropdown (`gemini-1.5-flash`, `gemini-1.5-pro`, `gemini-2.0-flash`)
- Tab `@click` resets `enrichModel` to a provider-appropriate default (fixes stale model name when switching tabs)
- Save logic and URL parse chain extended for `google://`

**Docs:** `docs/plugins.md` updated with Google example

## Test plan

- [x] 9 new Go tests in `providers_test.go`: Name, Complete (success/error/no candidates/bad JSON), Init (missing key/success/connectivity fail), Close — all pass
- [x] 2 new JS tests in `plugin-config-utils.test.js`: positive parse + provider-guard negative — 17/17 pass
- [x] `go build ./...` clean
- [x] `go test ./internal/plugin/...` all pass
- [x] Opus reviewed and approved (2 rounds — auth header fix + Issue C stale model fix applied)