### PR TITLE
fix(build): add -tags localassets and fix Docker publish trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: cd web && npm ci --ignore-scripts && npm run build
 
       - name: Build server
-        run: go build -o muninndb-server ./cmd/muninn/...
+        run: go build -tags localassets -o muninndb-server ./cmd/muninn/...
 
       - name: Run Go tests
         run: go test -tags localassets ./... -timeout 300s -race -coverprofile=coverage.out -covermode=atomic
@@ -145,7 +145,7 @@ jobs:
         run: cd web && npm ci --ignore-scripts && npm run build
 
       - name: Build server
-        run: go build -o muninn.exe ./cmd/muninn/...
+        run: go build -tags localassets -o muninn.exe ./cmd/muninn/...
 
       - name: Run unit tests
         run: go test -tags localassets ./cmd/muninn/... -timeout 120s -count=1
@@ -229,7 +229,7 @@ jobs:
         run: cd web && npm ci --ignore-scripts && npm run build
 
       - name: Build server
-        run: go build -o muninndb-server ./cmd/muninn/...
+        run: go build -tags localassets -o muninndb-server ./cmd/muninn/...
 
       - name: Start MuninnDB server
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run shellcheck
-        run: shellcheck install.sh
+        run: shellcheck install.sh scripts/check-build-tags.sh
+
+      - name: Check build tags
+        run: bash scripts/check-build-tags.sh
 
   # ── API spec validation — catches drift before it ships ───────────────
   api-spec-validation:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,14 @@
 name: Docker
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v0.4.6-alpha). Defaults to latest tag.'
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,11 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  # workflow_dispatch allows manually triggering a Docker build for an existing
+  # tag (e.g. to publish v0.4.6-alpha after this workflow was added). When
+  # triggering manually, select the tag ref in the GitHub UI — GITHUB_REF will
+  # be set to refs/tags/<tag> and metadata-action will extract it correctly.
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to build (e.g. v0.4.6-alpha). Defaults to latest tag.'
-        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
           CC: ${{ matrix.cc }}
         run: |
           go build \
+            -tags localassets \
             -ldflags "-X main.version=${GITHUB_REF_NAME}" \
             -o muninn-${{ matrix.goos }}-${{ matrix.goarch }} \
             ./cmd/muninn/...
@@ -147,7 +148,7 @@ jobs:
 
       - name: Build binary
         run: |
-          go build -ldflags "-X main.version=$env:GITHUB_REF_NAME" -o muninn-windows-amd64.exe ./cmd/muninn/...
+          go build -tags localassets -ldflags "-X main.version=$env:GITHUB_REF_NAME" -o muninn-windows-amd64.exe ./cmd/muninn/...
         shell: pwsh
 
       - name: Package archive

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN cd web && npm ci --ignore-scripts && npm run build
 # Build the server binary.
 # CGO_ENABLED=0 would break the local ONNX embedder (dlopen at runtime).
 # The binary links against glibc — debian-slim provides it in the runtime stage.
-RUN go build -ldflags="-s -w" -o /muninndb-server ./cmd/muninn/...
+RUN go build -tags localassets -ldflags="-s -w" -o /muninndb-server ./cmd/muninn/...
 
 # Stage 2: Minimal runtime image
 FROM debian:bookworm-slim

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ css:
 
 ## build: build the server binary (requires fetch-assets and web first).
 build: web
-	@go build -o muninndb-server ./cmd/muninn/...
+	@go build -tags localassets -o muninndb-server ./cmd/muninn/...
 
 ## test: run unit tests across all packages.
 test:

--- a/cmd/muninn/integration_test.go
+++ b/cmd/muninn/integration_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 	tmp.Close()
 	muninnBin = tmp.Name()
 
-	out, err := exec.Command("go", "build", "-o", muninnBin, ".").CombinedOutput()
+	out, err := exec.Command("go", "build", "-tags", "localassets", "-o", muninnBin, ".").CombinedOutput()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "integration: build failed: %v\n%s\n", err, out)
 		os.Remove(muninnBin)

--- a/internal/plugin/embed/local_test.go
+++ b/internal/plugin/embed/local_test.go
@@ -98,6 +98,18 @@ func TestReadAll_Empty(t *testing.T) {
 	}
 }
 
+// TestLocalAvailable asserts that the ONNX model and tokenizer were actually
+// embedded at build time. This test is only compiled with -tags localassets,
+// so a failure here means the assets are missing despite the build tag being
+// set — which would indicate a fetch-assets / go:embed problem.
+//
+// Crucially, if any go build command for the muninn binary is missing
+// -tags localassets, this test will not be compiled at all, meaning the
+// regression silently escapes. The scripts/check-build-tags.sh static check
+// closes that gap.
 func TestLocalAvailable(t *testing.T) {
-	_ = LocalAvailable()
+	if !LocalAvailable() {
+		t.Fatal("LocalAvailable() returned false: ONNX model or tokenizer was not embedded at build time. " +
+			"Run 'make fetch-assets' and rebuild with -tags localassets.")
+	}
 }

--- a/scripts/check-build-tags.sh
+++ b/scripts/check-build-tags.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# check-build-tags.sh — fail if any muninn binary build is missing -tags localassets.
+#
+# The bundled local ONNX embedder requires this build tag to activate. Without
+# it, LocalAvailable() always returns false and the embedder silently falls
+# through to noop, breaking out-of-the-box semantic search.
+#
+# Files scanned: Dockerfile, Makefile, .github/workflows/*.yml,
+#                cmd/muninn/integration_test.go
+
+set -euo pipefail
+
+FAILED=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Patterns that indicate a muninn binary build command.
+# We match on lines that contain a go build invocation targeting the muninn
+# binary (by output name or by package path) but NOT containing localassets.
+check_file() {
+    local file="$1"
+    local relfile="${file#"${ROOT}/"}"
+
+    # Extract lines that look like go build commands for the muninn binary.
+    # A line qualifies if it contains "go build" and one of:
+    #   - targets ./cmd/muninn
+    #   - produces muninndb-server, muninn.exe, or muninn-<os>-<arch>
+    while IFS= read -r line; do
+        # Skip blank lines and comment lines.
+        [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+
+        # Must mention go build.
+        echo "$line" | grep -q 'go build' || continue
+
+        # Must be targeting the muninn binary (by package or output name).
+        echo "$line" | grep -qE 'cmd/muninn|muninndb-server|muninn\.exe|muninn-[a-z]' || continue
+
+        # If it already has localassets, it is fine.
+        echo "$line" | grep -q 'localassets' && continue
+
+        echo "ERROR: go build without -tags localassets in ${relfile}:"
+        echo "  ${line}"
+        FAILED=1
+    done < "$file"
+}
+
+FILES=(
+    "${ROOT}/Dockerfile"
+    "${ROOT}/Makefile"
+    "${ROOT}/cmd/muninn/integration_test.go"
+)
+
+# Add all workflow YAML files.
+while IFS= read -r f; do
+    FILES+=("$f")
+done < <(find "${ROOT}/.github/workflows" -name '*.yml' 2>/dev/null)
+
+for f in "${FILES[@]}"; do
+    [[ -f "$f" ]] && check_file "$f"
+done
+
+if [[ "$FAILED" -ne 0 ]]; then
+    echo ""
+    echo "Fix: add '-tags localassets' to the flagged go build command(s)."
+    echo "See local_assets_noembed.go — without this tag LocalAvailable() always returns false."
+    exit 1
+fi
+
+echo "OK: all muninn binary build commands include -tags localassets."


### PR DESCRIPTION
## Root cause

Issue #291 had two distinct root causes:

### 1. Local embedder never activating (missing build tag)

`LocalAvailable()` is only `true` when the binary is compiled with `-tags localassets` (see `local_assets_noembed.go` — the stub always returns `false`). All three build paths were missing this tag:

- `Dockerfile` — `go build` without `-tags localassets`
- `release.yml` — same, for all 4 native platforms + Windows
- `Makefile` `build` target — same

The model and tokenizer files were being fetched correctly, but never embedded in the binary.

### 2. Docker image never published (workflow trigger)

`docker-publish.yml` triggered on `release: types: [published]`. However, `release.yml` creates the GitHub release using `GITHUB_TOKEN`, and GitHub Actions intentionally blocks downstream workflow triggers from `GITHUB_TOKEN` to prevent infinite loops. So Docker images were silently never built.

## Fix

- Add `-tags localassets` to `go build` in `Dockerfile`, `release.yml` (Linux/macOS and Windows), and `Makefile`
- Change `docker-publish.yml` trigger from `release: published` → `push: tags: ['v*']` (same event that fires `release.yml`)
- Add `workflow_dispatch` so we can manually kick off a Docker build for `v0.4.6-alpha` without re-tagging

## After merge

1. Merge this PR into develop → main
2. Manually trigger the Docker publish workflow via `workflow_dispatch` targeting `v0.4.6-alpha` (or re-tag)
3. Future tag pushes will automatically build both release binaries and Docker images

Fixes #291