### PR TITLE
fix(enrich): handle duplicate JSON output from local LLMs (llama3.2)

### DIFF
--- a/internal/plugin/enrich/parse.go
+++ b/internal/plugin/enrich/parse.go
@@ -37,10 +37,44 @@ func extractJSON(s string) string {
 		return s
 	}
 
-	// Find matching end from the end of string backwards
-	for i := len(s) - 1; i >= start; i-- {
-		if s[i] == ']' || s[i] == '}' {
-			return strings.TrimSpace(s[start : i+1])
+	// Walk forward with a bracket-depth counter to find the end of the first
+	// complete JSON object or array. A backwards scan would incorrectly grab
+	// both objects when a model (e.g. llama3.2) repeats its output. The depth
+	// walk also correctly skips brackets inside quoted strings.
+	open := s[start]
+	var close byte
+	if open == '{' {
+		close = '}'
+	} else {
+		close = ']'
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if c == '"' {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		if c == open {
+			depth++
+		} else if c == close {
+			depth--
+			if depth == 0 {
+				return strings.TrimSpace(s[start : i+1])
+			}
 		}
 	}
 

--- a/internal/plugin/enrich/parse_test.go
+++ b/internal/plugin/enrich/parse_test.go
@@ -310,6 +310,64 @@ func TestExtractJSON_PlainCodeFences(t *testing.T) {
 	}
 }
 
+// TestExtractJSON_DuplicateOutput covers models (e.g. llama3.2) that repeat
+// their JSON output in a single completion. The parser must return only the
+// first complete object and ignore everything after it.
+func TestExtractJSON_DuplicateOutput(t *testing.T) {
+	raw := `{"entities": [{"name": "foo", "type": "tool"}]} {"entities": [{"name": "bar", "type": "tool"}]}`
+	extracted := extractJSON(raw)
+	// Must stop at the end of the first object — second object must not appear.
+	if contains(extracted, `"bar"`) {
+		t.Fatalf("extractJSON grabbed both duplicate objects: %q", extracted)
+	}
+	if !contains(extracted, `"foo"`) {
+		t.Fatalf("extractJSON dropped the first object: %q", extracted)
+	}
+}
+
+// TestParseEntityResponse_DuplicateOutput is the end-to-end version of the
+// above: ParseEntityResponse must succeed and return only the first object's
+// entities when the LLM repeats itself.
+func TestParseEntityResponse_DuplicateOutput(t *testing.T) {
+	raw := `{"entities": [{"name": "fb-automate", "type": "tool", "confidence": 1.0}]} {"entities": [{"name": "reply-comment", "type": "project", "confidence": 0.7}]}`
+	entities, err := ParseEntityResponse(raw)
+	if err != nil {
+		t.Fatalf("ParseEntityResponse failed on duplicate output: %v", err)
+	}
+	if len(entities) != 1 {
+		t.Fatalf("expected 1 entity from first object, got %d: %+v", len(entities), entities)
+	}
+	if entities[0].Name != "fb-automate" {
+		t.Fatalf("expected 'fb-automate', got %q", entities[0].Name)
+	}
+}
+
+// TestParseSummarizeResponse_DuplicateOutput ensures summarization parsing
+// handles the llama3.2 duplicate-output pattern.
+func TestParseSummarizeResponse_DuplicateOutput(t *testing.T) {
+	raw := `{"summary": "first summary", "key_points": ["point A"]} {"summary": "second summary", "key_points": ["point B"]}`
+	summary, keyPoints, err := ParseSummarizeResponse(raw)
+	if err != nil {
+		t.Fatalf("ParseSummarizeResponse failed on duplicate output: %v", err)
+	}
+	if summary != "first summary" {
+		t.Fatalf("expected 'first summary', got %q", summary)
+	}
+	if len(keyPoints) != 1 || keyPoints[0] != "point A" {
+		t.Fatalf("expected ['point A'], got %v", keyPoints)
+	}
+}
+
+// TestExtractJSON_BracketInsideString ensures brackets inside quoted strings
+// do not confuse the depth counter.
+func TestExtractJSON_BracketInsideString(t *testing.T) {
+	raw := `{"key": "value with } brace and { another"}`
+	extracted := extractJSON(raw)
+	if extracted != raw {
+		t.Fatalf("extractJSON mangled JSON with brackets in string: %q", extracted)
+	}
+}
+
 func TestExtractJSON_NoJSON(t *testing.T) {
 	raw := "no json here"
 	extracted := extractJSON(raw)


### PR DESCRIPTION
## Problem

Users running llama3.2 via Ollama for enrichment were seeing repeated `WARN enrich: entity extraction failed` and `WARN enrich: summarization failed` errors. The error message showed apparently valid JSON — because it *is* valid, just duplicated:

```
invalid entity response JSON: {"entities": [...]} {"entities": [...]}
```

llama3.2 (and likely other smaller local models) sometimes repeats its output in a single completion, producing two JSON objects concatenated back-to-back.

## Root cause

`extractJSON` was scanning **backwards from the end of the string** to find the closing bracket. With duplicate output, the scan spans both objects — the full string is not valid JSON and `json.Unmarshal` fails.

## Fix

Replace the backwards scan with a **forward bracket-depth walk** that stops at the end of the first complete JSON object. The walk is string-aware: brackets inside quoted strings are skipped, and escaped quotes are handled correctly. Everything after the first complete object is ignored.

## Tests added

- `TestExtractJSON_DuplicateOutput` — low-level unit test for `extractJSON`
- `TestParseEntityResponse_DuplicateOutput` — end-to-end with exact strings from the user report
- `TestParseSummarizeResponse_DuplicateOutput` — summarization path
- `TestExtractJSON_BracketInsideString` — ensures brackets inside string values don't confuse the depth counter

All 19 parse tests pass.