### PR TITLE
fix(ui): map created_at to createdAt — fix "Created: unknown" for all memories

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -974,7 +974,7 @@ document.addEventListener('alpine:init', () => {
         if (f.minConf > 0) url += '&min_confidence=' + f.minConf;
         if (f.maxConf > 0) url += '&max_confidence=' + f.maxConf;
         const data = await this.apiCall(url);
-        this.memories = data.engrams || [];
+        this.memories = (data.engrams || []).map(e => ({ ...e, createdAt: e.created_at }));
         this.totalMemories = data.total || 0;
       } catch (err) {
         this.addNotification('error', 'Load failed: ' + err.message);
@@ -1090,7 +1090,7 @@ document.addEventListener('alpine:init', () => {
           const resp = await fetch('/api/engrams/' + encodeURIComponent(m.id) + '?vault=' + encodeURIComponent(this.vault));
           if (resp.ok) {
             const full = await resp.json();
-            m = { ...m, ...full };
+            m = { ...m, ...full, createdAt: full.created_at || m.createdAt };
           }
         } catch (e) { /* fall through with partial data */ }
       }
@@ -1773,7 +1773,8 @@ document.addEventListener('alpine:init', () => {
           '&since=' + encodeURIComponent(since) + '&limit=100'
         );
         // GetSessionResponse has { entries: [] } or raw array
-        this.sessionEntries = data.entries || (Array.isArray(data) ? data : []);
+        const raw = data.entries || (Array.isArray(data) ? data : []);
+        this.sessionEntries = raw.map(e => ({ ...e, createdAt: e.created_at }));
       } catch (err) {
         this.addNotification('error', 'Session: ' + err.message);
       }


### PR DESCRIPTION
## Summary

- **Root cause**: The API returns `created_at` (snake_case) in all responses (`EngramItem`, `SessionItem`, `ReadResponse`) but the Alpine.js template accesses `createdAt` (camelCase). Three data-loading paths assigned the raw API response directly with no field mapping, so `createdAt` was always `undefined` → falsy → template rendered "unknown".
- `loadMemories`: `this.memories = data.engrams || []` → now maps `createdAt: e.created_at`
- `openMemory`: full-fetch spread `{ ...m, ...full }` → now includes `createdAt: full.created_at || m.createdAt`
- `loadSession`: `this.sessionEntries = data.entries` → now maps `createdAt: e.created_at`
- `searchMemories` already mapped correctly and is unchanged.

## Test plan

- [ ] Create a memory via POST or MCP, open Web UI — **Created** field shows a real date instead of "unknown"
- [ ] Memory list in the Memories tab shows dates in the list view
- [ ] Click a memory from search results — detail panel shows correct date
- [ ] Session view shows timestamps for recent entries