### PR TITLE
feat(recall): hint on empty results + session-start guidance in muninn_guide

### DIFF
--- a/internal/mcp/guide.go
+++ b/internal/mcp/guide.go
@@ -41,7 +41,11 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 		b.WriteString("Remember: decisions and their rationale, user preferences, errors and their fixes, ")
 		b.WriteString("project context, important facts, and anything the user might need later. ")
 		b.WriteString("Before starting any task, recall relevant memories. ")
-		b.WriteString("After completing work, remember key outcomes.\n")
+		b.WriteString("After completing work, remember key outcomes.\n\n")
+		b.WriteString("**Session start pattern:** At the start of every session, call recall twice:\n")
+		b.WriteString("1. `muninn_recall(context=[\"session start\"], mode=\"recent\")` — restores recent continuity regardless of topic.\n")
+		b.WriteString("2. Once the user provides context, call `muninn_recall(context=[<user topic>])` for semantic relevance.\n")
+		b.WriteString("Alternatively, use `muninn_where_left_off` — it is purpose-built for session resumption.\n")
 	}
 
 	// Enrichment guidance based on behavior mode + inline enrichment setting
@@ -67,7 +71,8 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 	b.WriteString("\n## Available Tools\n\n")
 	b.WriteString("- **muninn_remember** — Store a new memory\n")
 	b.WriteString("- **muninn_remember_batch** — Store multiple memories at once (max 50)\n")
-	b.WriteString("- **muninn_recall** — Search memories by semantic context\n")
+	b.WriteString("- **muninn_recall** — Search memories by semantic context (use mode='recent' at session start)\n")
+	b.WriteString("- **muninn_where_left_off** — Resume a previous session; returns recent activity summary\n")
 	b.WriteString("- **muninn_read** — Fetch a single memory by ID\n")
 	b.WriteString("- **muninn_forget** — Soft-delete a memory\n")
 	b.WriteString("- **muninn_link** — Create associations between memories\n")
@@ -145,6 +150,8 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 
 	// Tips
 	b.WriteString("\n## Tips\n\n")
+	b.WriteString("- Use muninn_where_left_off at session start — purpose-built for resuming where you left off.\n")
+	b.WriteString("- Use muninn_recall with mode='recent' when you need continuity but lack specific context.\n")
 	b.WriteString("- Use muninn_recall with mode='deep' for thorough searches across the memory graph.\n")
 	b.WriteString("- Use muninn_link to connect related memories and strengthen the knowledge graph.\n")
 	b.WriteString("- Use muninn_decide to record decisions — they automatically link to supporting evidence.\n")

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -375,10 +375,14 @@ func (s *MCPServer) handleRecall(ctx context.Context, w http.ResponseWriter, id 
 	for i := range resp.Activations {
 		memories = append(memories, activationToMemory(&resp.Activations[i]))
 	}
-	sendResult(w, id, textContent(mustJSON(map[string]any{
+	result := map[string]any{
 		"memories": memories,
 		"total":    resp.TotalFound,
-	})))
+	}
+	if len(memories) == 0 {
+		result["hint"] = "No results matched. For session continuity try mode='recent', or use muninn_where_left_off. For semantic recall, provide more specific context."
+	}
+	sendResult(w, id, textContent(mustJSON(result)))
 }
 
 func (s *MCPServer) handleRead(ctx context.Context, w http.ResponseWriter, id json.RawMessage, vault string, args map[string]any) {


### PR DESCRIPTION
## Summary

Two targeted improvements from the analysis in #294 and the decision in #299.

### 1. Hint on empty recall response

When `muninn_recall` returns 0 results, the response now includes:
```json
{
  "memories": [],
  "total": 0,
  "hint": "No results matched. For session continuity try mode='recent', or use muninn_where_left_off. For semantic recall, provide more specific context."
}
```

This keeps the semantic contract clean — no silent fallback, no behavior change — while giving agents actionable guidance in the payload rather than silence.

### 2. `muninn_guide` session-start pattern

The autonomous mode guidance now explicitly teaches the two-call session-start pattern:
1. `mode='recent'` first for continuity before user context exists
2. Semantic recall once the user's topic is known

`muninn_where_left_off` is also added to the tools list (it was missing) and surfaces in two new Tips entries.

## What this does NOT do

- No fallback behavior (deliberate — see #299)
- No API contract changes
- No new parameters

## Test plan

- [ ] CI passes
- [ ] `muninn_recall` with context that matches nothing returns `hint` in response
- [ ] `muninn_recall` with results does NOT include `hint`
- [ ] `muninn_guide` output includes session-start pattern and `muninn_where_left_off`