### PR TITLE
release: merge develop into main for v0.4.7-alpha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: cd web && npm ci --ignore-scripts && npm run build
 
       - name: Build server
-        run: go build -o muninndb-server ./cmd/muninn/...
+        run: go build -tags localassets -o muninndb-server ./cmd/muninn/...
 
       - name: Run Go tests
         run: go test -tags localassets ./... -timeout 300s -race -coverprofile=coverage.out -covermode=atomic
@@ -145,7 +145,7 @@ jobs:
         run: cd web && npm ci --ignore-scripts && npm run build
 
       - name: Build server
-        run: go build -o muninn.exe ./cmd/muninn/...
+        run: go build -tags localassets -o muninn.exe ./cmd/muninn/...
 
       - name: Run unit tests
         run: go test -tags localassets ./cmd/muninn/... -timeout 120s -count=1
@@ -229,7 +229,7 @@ jobs:
         run: cd web && npm ci --ignore-scripts && npm run build
 
       - name: Build server
-        run: go build -o muninndb-server ./cmd/muninn/...
+        run: go build -tags localassets -o muninndb-server ./cmd/muninn/...
 
       - name: Start MuninnDB server
         run: |
@@ -342,7 +342,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run shellcheck
-        run: shellcheck install.sh
+        run: shellcheck install.sh scripts/check-build-tags.sh
+
+      - name: Check build tags
+        run: bash scripts/check-build-tags.sh
 
   # ── API spec validation — catches drift before it ships ───────────────
   api-spec-validation:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,14 @@
 name: Docker
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
+  # workflow_dispatch allows manually triggering a Docker build for an existing
+  # tag (e.g. to publish v0.4.6-alpha after this workflow was added). When
+  # triggering manually, select the tag ref in the GitHub UI — GITHUB_REF will
+  # be set to refs/tags/<tag> and metadata-action will extract it correctly.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
           CC: ${{ matrix.cc }}
         run: |
           go build \
+            -tags localassets \
             -ldflags "-X main.version=${GITHUB_REF_NAME}" \
             -o muninn-${{ matrix.goos }}-${{ matrix.goarch }} \
             ./cmd/muninn/...
@@ -147,7 +148,7 @@ jobs:
 
       - name: Build binary
         run: |
-          go build -ldflags "-X main.version=$env:GITHUB_REF_NAME" -o muninn-windows-amd64.exe ./cmd/muninn/...
+          go build -tags localassets -ldflags "-X main.version=$env:GITHUB_REF_NAME" -o muninn-windows-amd64.exe ./cmd/muninn/...
         shell: pwsh
 
       - name: Package archive

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN cd web && npm ci --ignore-scripts && npm run build
 # Build the server binary.
 # CGO_ENABLED=0 would break the local ONNX embedder (dlopen at runtime).
 # The binary links against glibc — debian-slim provides it in the runtime stage.
-RUN go build -ldflags="-s -w" -o /muninndb-server ./cmd/muninn/...
+RUN go build -tags localassets -ldflags="-s -w" -o /muninndb-server ./cmd/muninn/...
 
 # Stage 2: Minimal runtime image
 FROM debian:bookworm-slim

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ css:
 
 ## build: build the server binary (requires fetch-assets and web first).
 build: web
-	@go build -o muninndb-server ./cmd/muninn/...
+	@go build -tags localassets -o muninndb-server ./cmd/muninn/...
 
 ## test: run unit tests across all packages.
 test:

--- a/cmd/muninn/integration_test.go
+++ b/cmd/muninn/integration_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 	tmp.Close()
 	muninnBin = tmp.Name()
 
-	out, err := exec.Command("go", "build", "-o", muninnBin, ".").CombinedOutput()
+	out, err := exec.Command("go", "build", "-tags", "localassets", "-o", muninnBin, ".").CombinedOutput()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "integration: build failed: %v\n%s\n", err, out)
 		os.Remove(muninnBin)

--- a/docs/agent-prompting.md
+++ b/docs/agent-prompting.md
@@ -1,0 +1,100 @@
+# Proactive Agent Prompting
+
+Getting an AI agent to use MuninnDB well is mostly a prompting problem. Agents that are only told "you have memory tools" tend to use them reactively — they'll recall when asked, and store when told to. That's useful, but it's not the same as an agent that saves continuously and arrives at sessions already loaded with context.
+
+This guide covers the system prompt patterns that make the difference.
+
+---
+
+## The core insight
+
+Most agents have an implicit filter: *"Is this important enough to save?"* That filter is the enemy of good memory behavior. It causes agents to hold back on things that seem minor in the moment but matter later. The framing that works is:
+
+> **Saving is a mindset, not a checklist. When in doubt, save it.**
+
+Removing the evaluation gate — replacing it with a bias toward saving — is the single biggest lever for improving proactive behavior.
+
+---
+
+## Recommended CLAUDE.md / system prompt
+
+This pattern works well across Claude Code, Claude Desktop, Cursor, Codebuff, OpenClaw, and other MCP-connected agents. Replace `[vault name]` with your vault (usually `default`):
+
+```markdown
+# Memory: MuninnDB (Canonical)
+
+MuninnDB (muninn MCP) is the canonical memory system. Never use local auto memory.
+
+## Session Start — Always
+Call `muninn_recall` with relevant context before beginning any work.
+This loads prior context. Vault: [vault name].
+
+## During Every Session
+- Save to Muninn continuously — this is a mindset, not a checklist.
+- Anything the user shares or that emerges from the work should be saved immediately.
+- Do not evaluate whether it is "important enough".
+- Do not wait to be asked. When in doubt, save it.
+
+## Tools
+- **Recall**: `muninn_recall` (vault, context)
+- **Store**: `muninn_remember` (vault, concept, content)
+- **Batch**: `muninn_remember_batch` (vault, memories[])
+- **Read**: `muninn_read` (vault, id)
+- **Link**: `muninn_link` (vault, source_id, target_id)
+- **Guide**: `muninn_guide` — call on first connect to learn best practices
+
+Vault: [vault name].
+```
+
+> **Credit:** This pattern was contributed by the community. Thanks to [@cmdillon](https://github.com/cmdillon) for sharing it.
+
+---
+
+## Why `muninn_guide` matters
+
+`muninn_guide` returns vault-specific instructions at runtime — it knows your vault's behavior mode, whether enrichment is active, and any vault-level notes you've set. Including it in the system prompt ensures the agent picks it up on first connect rather than waiting to be told. Think of it as a self-describing configuration layer for memory behavior.
+
+---
+
+## What to save
+
+Agents don't always know what's valuable. Being explicit helps:
+
+- **Decisions** — architecture choices, approach selections, and the reasoning behind them
+- **Preferences** — how the user likes things done, recurring instructions, style choices
+- **Discoveries** — non-obvious patterns, gotchas, workarounds found while working
+- **Project context** — tech stack, constraints, deployment setup, team conventions
+- **Session state** — where you left off, what's in progress, what's blocked
+
+---
+
+## Recall at the start of every session
+
+The recall-first pattern is as important as saving. An agent that saves diligently but doesn't recall at session start loses the benefit of continuity. The system prompt should make recall unconditional — not "if relevant" but "always, before beginning any work."
+
+---
+
+## Batch saves for efficiency
+
+For agents that do a lot of work in one session, `muninn_remember_batch` is more efficient than individual saves — it writes multiple memories in a single round trip. Good agents will naturally group related saves at natural pause points.
+
+---
+
+## Troubleshooting proactive behavior
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Agent only saves when asked | Missing system prompt guidance | Add the CLAUDE.md pattern above |
+| Agent recalls but doesn't save | "important enough" filter active | Add the mindset framing explicitly |
+| Agent saves but context doesn't persist | Wrong vault name | Confirm vault name in system prompt matches MuninnDB |
+| Agent ignores `muninn_guide` | Tool not listed in system prompt | Add `muninn_guide` to the tools section |
+
+---
+
+## Related
+
+- [How Memory Works](how-memory-works.md) — the cognitive engine behind storage and retrieval
+- [Semantic Triggers](semantic-triggers.md) — subscribe to contexts and get push updates when relevance changes
+- [Auth & Vaults](auth.md) — multi-vault setup, API keys, behavior modes
+- [Codebuff Integration](integrations/codebuff.md)
+- [GitHub Copilot Integration](integrations/github-copilot.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ An intent-organized reading guide. Start with what you want to understand.
 
 1. **[Self-Hosting](self-hosting.md)** — Deployment options, environment variables, and data directory setup.
 2. **[Cluster Operations](cluster-operations.md)** — Multi-node clustering, replication, and leader election.
+3. **[Claude.com / ChatGPT via Traefik](integrations/traefik-claude-chatgpt.md)** — Connect a cloud-hosted MuninnDB to Claude.com Connectors or ChatGPT's MCP support.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,8 @@ An intent-organized reading guide. Start with what you want to understand.
 ## If you want to use MuninnDB
 
 1. **[Quickstart](quickstart.md)** — Getting MuninnDB running and making your first memory writes.
-2. **[Feature Reference](feature-reference.md)** — Complete reference for all 35 MCP tools and their parameters.
+2. **[Agent Prompting](agent-prompting.md)** — System prompt patterns that make agents save proactively, not just reactively.
+3. **[Feature Reference](feature-reference.md)** — Complete reference for all 35 MCP tools and their parameters.
 
 ---
 

--- a/docs/integrations/traefik-claude-chatgpt.md
+++ b/docs/integrations/traefik-claude-chatgpt.md
@@ -1,0 +1,216 @@
+# Claude.com / ChatGPT + MuninnDB via Traefik
+
+This guide is for users running MuninnDB on a **publicly accessible cloud server** who want to connect it to Claude.com Connectors or ChatGPT's custom MCP support.
+
+> **This is not a local setup guide.** Claude.com and ChatGPT make MCP calls server-to-server — their backend infrastructure calls your endpoint directly. MuninnDB must be reachable from the internet for this to work. If you're running MuninnDB locally, use [Claude Code](../../quickstart.md) or another local MCP client instead.
+
+---
+
+## How it works
+
+Claude.com and ChatGPT only allow you to configure an MCP URL — they cannot send custom headers like `Authorization: Bearer`. MuninnDB's token auth requires that header. The workaround is to use **Traefik v3 as a reverse proxy** to:
+
+1. Accept requests at a secret URL (`https://muninn.example.com/mcp?vault_key=<secret>`)
+2. Only route requests that include the correct `vault_key` query parameter
+3. Forward matched requests to MuninnDB
+
+The secret lives in Traefik's routing rule, not in MuninnDB itself. MuninnDB runs with no token configured (open access on the internal Docker network only — not exposed directly to the internet).
+
+---
+
+## Security considerations
+
+> **Read this before proceeding.**
+
+**URL query parameters are a security anti-pattern for secrets.** The `vault_key` value will appear in:
+- Traefik access logs (disable per-router — see below)
+- Browser history if you ever open the URL directly
+- Any HTTP proxy or CDN logs between the client and your server
+- Error messages and monitoring tools that log full request URLs
+
+**Mitigations:**
+- Use a long random secret (`openssl rand -hex 24` generates 48 characters)
+- Disable Traefik access logs for the MuninnDB router (see below)
+- Use HTTPS — the query param is encrypted in transit over TLS
+- Rotate the key if you suspect it has been exposed
+- Do not share the full URL in chat, email, or any logged channel
+
+This is a practical workaround, not a hardened auth solution. It is appropriate for personal use on a self-hosted server where you control the infrastructure.
+
+---
+
+## Prerequisites
+
+- A cloud VM with a publicly accessible domain name (e.g. `muninn.example.com`)
+- Docker and Docker Compose installed
+- **Traefik v3** running as your reverse proxy — the `Query()` matcher syntax used here requires v3; see below for the v2 equivalent
+- A Docker network shared between Traefik and MuninnDB (commonly named `traefik` or `proxy`)
+- A DNS A record pointing your domain to the VM's IP
+- Let's Encrypt or another TLS certificate provider configured in Traefik
+
+---
+
+## Setup
+
+### 1. Generate a secret key
+
+```bash
+openssl rand -hex 24
+```
+
+Copy the output — this is your `VAULT_KEY`.
+
+### 2. Create `.env`
+
+```bash
+# .env
+# Keep this file out of version control
+VAULT_KEY=your-generated-secret-here
+```
+
+> **Note:** `${VAULT_KEY}` is resolved by Docker Compose from `.env` at `docker compose up` time. If you change `.env`, recreate the container (`docker compose up -d --force-recreate`) for the new value to take effect.
+
+### 3. Create `docker-compose.yaml`
+
+```yaml
+name: muninn-example-com
+
+networks:
+  traefik:
+    external: true  # must match the network your Traefik instance is on
+
+services:
+  muninn:
+    image: ghcr.io/scrypster/muninndb:latest
+    container_name: muninn.example.com
+    hostname: muninn
+    restart: always
+    networks:
+      - traefik
+
+    volumes:
+      - ./data:/data
+      - ./backup:/backup
+
+    environment:
+      MUNINN_LISTEN_HOST: "0.0.0.0"
+      MUNINN_MEM_LIMIT_GB: "4"
+      MUNINN_GC_PERCENT: "200"
+      MUNINN_CORS_ORIGINS: "https://muninn.example.com"
+      # No MUNINN_MCP_TOKEN set — auth is handled by Traefik routing rule
+
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8750/mcp/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+    labels:
+      - traefik.enable=true
+      # Only route requests that include the correct vault_key query parameter (Traefik v3 syntax)
+      - traefik.http.routers.muninn.rule=Host(`muninn.example.com`) && PathPrefix(`/mcp`) && Query(`vault_key`,`${VAULT_KEY}`)
+      - traefik.http.routers.muninn.tls=true
+      - traefik.http.routers.muninn.tls.certresolver=lets-encrypt
+      - traefik.http.routers.muninn.service=muninn
+      - traefik.http.services.muninn.loadbalancer.server.port=8750
+      # Disable access logs for this router to keep vault_key out of log files
+      - traefik.http.routers.muninn.observability.accesslogs=false
+```
+
+**Traefik v2 users:** Replace the `Query()` matcher with the v2 single-argument syntax:
+```
+traefik.http.routers.muninn.rule=Host(`muninn.example.com`) && PathPrefix(`/mcp`) && Query(`vault_key=${VAULT_KEY}`)
+```
+
+> **Watchtower:** The original community setup includes `com.centurylinklabs.watchtower.enable=true` for automatic image updates. Add it if you run Watchtower.
+
+### 4. Start
+
+```bash
+docker compose up -d
+```
+
+Verify it's running:
+
+```bash
+curl -sf "https://muninn.example.com/mcp/health?vault_key=your-secret" | jq .
+```
+
+A request without the key will return a **404** — Traefik has no matching route for it.
+
+---
+
+## Connect Claude.com
+
+1. Go to **Claude.com → Settings → Connectors → Add custom connector**
+2. Set the MCP URL to:
+   ```
+   https://muninn.example.com/mcp?vault_key=your-secret
+   ```
+3. Save and start a new conversation
+
+Verify by asking Claude to call `muninn_guide`.
+
+---
+
+## Connect ChatGPT
+
+ChatGPT's MCP connector support requires **Developer Mode**, available on Pro, Plus, Business, Enterprise, and Education plans.
+
+1. Go to **ChatGPT → Settings → Apps → Advanced → Enable Developer Mode**
+2. Create a new connector and set the MCP URL to:
+   ```
+   https://muninn.example.com/mcp?vault_key=your-secret
+   ```
+3. Save and start a new conversation
+
+---
+
+## System prompt
+
+For Claude.com or ChatGPT to use memory proactively, add this to your Project instructions:
+
+```markdown
+# Memory: MuninnDB (Canonical)
+
+MuninnDB (muninn MCP) is the canonical memory system. Never use local auto memory.
+
+## Session Start — Always
+Call muninn_recall with relevant context before beginning any work.
+This loads prior context. Vault: default.
+
+## During Every Session
+- Save to Muninn continuously — this is a mindset, not a checklist.
+- Anything the user shares or that emerges from the work should be saved immediately.
+- Do not evaluate whether it is "important enough".
+- Do not wait to be asked. When in doubt, save it.
+
+## Tools
+- Recall: muninn_recall (vault, context)
+- Store: muninn_remember (vault, concept, content)
+- Batch: muninn_remember_batch (vault, memories[])
+- Guide: muninn_guide — call on first connect to learn best practices
+```
+
+See [Agent Prompting](../agent-prompting.md) for more detail on this pattern.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Request returns 404 | Traefik route not matched — verify `vault_key` param matches `.env` exactly, and that the container was recreated after any `.env` change |
+| `connection refused` | MuninnDB container not healthy — check `docker compose logs muninn` |
+| Traefik can't reach MuninnDB | Ensure both services are on the same Docker network (`traefik.enable=true` is not enough) |
+| TLS cert error | Let's Encrypt cert not yet issued — wait a minute and retry |
+| Tools not appearing in Claude/ChatGPT | Restart/reconnect the integration after saving the URL |
+| Agent not storing proactively | Add the system prompt above to your Project instructions |
+| ChatGPT connector option missing | Developer Mode must be enabled first (Settings → Apps → Advanced) |
+
+---
+
+## Credit
+
+This setup was contributed by [@rsubr](https://github.com/rsubr) who solved the Claude.com/ChatGPT connector problem and shared the full working configuration. Thanks for publishing it.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,7 +46,7 @@ This downloads the latest release, extracts to `%LOCALAPPDATA%\muninn`, and adds
 ```bash
 git clone https://github.com/scrypster/muninndb.git
 cd muninndb
-go build -o muninn ./cmd/muninn/...
+go build -tags localassets -o muninn ./cmd/muninn/...
 ```
 
 ---
@@ -229,6 +229,7 @@ muninn shell
 
 | | |
 |---|---|
+| [Agent Prompting](agent-prompting.md) | System prompt patterns that make agents save proactively, not just reactively |
 | [How Memory Works](how-memory-works.md) | Why temporal priority + Hebbian + confidence + PAS produces genuine memory |
 | [Architecture](architecture.md) | The ERF format, 6-phase engine, four wire protocols |
 | [Auth & Vaults](auth.md) | Multiple vaults, API keys, full vs. observe mode |

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -901,9 +901,13 @@ func (e *Engine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteRe
 		ws, _ := e.store.FindVaultPrefix(id)
 		var linkedEntityNames []string
 		for _, ent := range callerEntities {
+			typ := strings.ToLower(strings.TrimSpace(ent.Type))
+			if typ == "" {
+				typ = "other"
+			}
 			record := storage.EntityRecord{
 				Name:       ent.Name,
-				Type:       ent.Type,
+				Type:       typ,
 				Confidence: 1.0,
 			}
 			if err := e.store.UpsertEntityRecord(ctx, record, "inline"); err != nil {
@@ -1297,9 +1301,13 @@ func (e *Engine) WriteBatch(ctx context.Context, reqs []*mbp.WriteRequest) ([]*m
 			ws, _ := e.store.FindVaultPrefix(id)
 			var linkedEntityNames []string
 			for _, ent := range p.callerEntities {
+				typ := strings.ToLower(strings.TrimSpace(ent.Type))
+				if typ == "" {
+					typ = "other"
+				}
 				record := storage.EntityRecord{
 					Name:       ent.Name,
-					Type:       ent.Type,
+					Type:       typ,
 					Confidence: 1.0,
 				}
 				if err := e.store.UpsertEntityRecord(ctx, record, "inline"); err != nil {

--- a/internal/mcp/guide.go
+++ b/internal/mcp/guide.go
@@ -41,7 +41,11 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 		b.WriteString("Remember: decisions and their rationale, user preferences, errors and their fixes, ")
 		b.WriteString("project context, important facts, and anything the user might need later. ")
 		b.WriteString("Before starting any task, recall relevant memories. ")
-		b.WriteString("After completing work, remember key outcomes.\n")
+		b.WriteString("After completing work, remember key outcomes.\n\n")
+		b.WriteString("**Session start pattern:** At the start of every session, call recall twice:\n")
+		b.WriteString("1. `muninn_recall(context=[\"session start\"], mode=\"recent\")` — restores recent continuity regardless of topic.\n")
+		b.WriteString("2. Once the user provides context, call `muninn_recall(context=[<user topic>])` for semantic relevance.\n")
+		b.WriteString("Alternatively, use `muninn_where_left_off` — it is purpose-built for session resumption.\n")
 	}
 
 	// Enrichment guidance based on behavior mode + inline enrichment setting
@@ -67,7 +71,8 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 	b.WriteString("\n## Available Tools\n\n")
 	b.WriteString("- **muninn_remember** — Store a new memory\n")
 	b.WriteString("- **muninn_remember_batch** — Store multiple memories at once (max 50)\n")
-	b.WriteString("- **muninn_recall** — Search memories by semantic context\n")
+	b.WriteString("- **muninn_recall** — Search memories by semantic context (use mode='recent' at session start)\n")
+	b.WriteString("- **muninn_where_left_off** — Resume a previous session; returns recent activity summary\n")
 	b.WriteString("- **muninn_read** — Fetch a single memory by ID\n")
 	b.WriteString("- **muninn_forget** — Soft-delete a memory\n")
 	b.WriteString("- **muninn_link** — Create associations between memories\n")
@@ -145,6 +150,8 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 
 	// Tips
 	b.WriteString("\n## Tips\n\n")
+	b.WriteString("- Use muninn_where_left_off at session start — purpose-built for resuming where you left off.\n")
+	b.WriteString("- Use muninn_recall with mode='recent' when you need continuity but lack specific context.\n")
 	b.WriteString("- Use muninn_recall with mode='deep' for thorough searches across the memory graph.\n")
 	b.WriteString("- Use muninn_link to connect related memories and strengthen the knowledge graph.\n")
 	b.WriteString("- Use muninn_decide to record decisions — they automatically link to supporting evidence.\n")

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -375,10 +375,14 @@ func (s *MCPServer) handleRecall(ctx context.Context, w http.ResponseWriter, id 
 	for i := range resp.Activations {
 		memories = append(memories, activationToMemory(&resp.Activations[i]))
 	}
-	sendResult(w, id, textContent(mustJSON(map[string]any{
+	result := map[string]any{
 		"memories": memories,
 		"total":    resp.TotalFound,
-	})))
+	}
+	if len(memories) == 0 {
+		result["hint"] = "No results matched. For session continuity try mode='recent', or use muninn_where_left_off. For semantic recall, provide more specific context."
+	}
+	sendResult(w, id, textContent(mustJSON(result)))
 }
 
 func (s *MCPServer) handleRead(ctx context.Context, w http.ResponseWriter, id json.RawMessage, vault string, args map[string]any) {

--- a/internal/plugin/embed/local_test.go
+++ b/internal/plugin/embed/local_test.go
@@ -98,6 +98,18 @@ func TestReadAll_Empty(t *testing.T) {
 	}
 }
 
+// TestLocalAvailable asserts that the ONNX model and tokenizer were actually
+// embedded at build time. This test is only compiled with -tags localassets,
+// so a failure here means the assets are missing despite the build tag being
+// set — which would indicate a fetch-assets / go:embed problem.
+//
+// Crucially, if any go build command for the muninn binary is missing
+// -tags localassets, this test will not be compiled at all, meaning the
+// regression silently escapes. The scripts/check-build-tags.sh static check
+// closes that gap.
 func TestLocalAvailable(t *testing.T) {
-	_ = LocalAvailable()
+	if !LocalAvailable() {
+		t.Fatal("LocalAvailable() returned false: ONNX model or tokenizer was not embedded at build time. " +
+			"Run 'make fetch-assets' and rebuild with -tags localassets.")
+	}
 }

--- a/internal/plugin/enrich/parse.go
+++ b/internal/plugin/enrich/parse.go
@@ -37,10 +37,44 @@ func extractJSON(s string) string {
 		return s
 	}
 
-	// Find matching end from the end of string backwards
-	for i := len(s) - 1; i >= start; i-- {
-		if s[i] == ']' || s[i] == '}' {
-			return strings.TrimSpace(s[start : i+1])
+	// Walk forward with a bracket-depth counter to find the end of the first
+	// complete JSON object or array. A backwards scan would incorrectly grab
+	// both objects when a model (e.g. llama3.2) repeats its output. The depth
+	// walk also correctly skips brackets inside quoted strings.
+	open := s[start]
+	var close byte
+	if open == '{' {
+		close = '}'
+	} else {
+		close = ']'
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if c == '"' {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		if c == open {
+			depth++
+		} else if c == close {
+			depth--
+			if depth == 0 {
+				return strings.TrimSpace(s[start : i+1])
+			}
 		}
 	}
 

--- a/internal/plugin/enrich/parse_test.go
+++ b/internal/plugin/enrich/parse_test.go
@@ -310,6 +310,64 @@ func TestExtractJSON_PlainCodeFences(t *testing.T) {
 	}
 }
 
+// TestExtractJSON_DuplicateOutput covers models (e.g. llama3.2) that repeat
+// their JSON output in a single completion. The parser must return only the
+// first complete object and ignore everything after it.
+func TestExtractJSON_DuplicateOutput(t *testing.T) {
+	raw := `{"entities": [{"name": "foo", "type": "tool"}]} {"entities": [{"name": "bar", "type": "tool"}]}`
+	extracted := extractJSON(raw)
+	// Must stop at the end of the first object — second object must not appear.
+	if contains(extracted, `"bar"`) {
+		t.Fatalf("extractJSON grabbed both duplicate objects: %q", extracted)
+	}
+	if !contains(extracted, `"foo"`) {
+		t.Fatalf("extractJSON dropped the first object: %q", extracted)
+	}
+}
+
+// TestParseEntityResponse_DuplicateOutput is the end-to-end version of the
+// above: ParseEntityResponse must succeed and return only the first object's
+// entities when the LLM repeats itself.
+func TestParseEntityResponse_DuplicateOutput(t *testing.T) {
+	raw := `{"entities": [{"name": "fb-automate", "type": "tool", "confidence": 1.0}]} {"entities": [{"name": "reply-comment", "type": "project", "confidence": 0.7}]}`
+	entities, err := ParseEntityResponse(raw)
+	if err != nil {
+		t.Fatalf("ParseEntityResponse failed on duplicate output: %v", err)
+	}
+	if len(entities) != 1 {
+		t.Fatalf("expected 1 entity from first object, got %d: %+v", len(entities), entities)
+	}
+	if entities[0].Name != "fb-automate" {
+		t.Fatalf("expected 'fb-automate', got %q", entities[0].Name)
+	}
+}
+
+// TestParseSummarizeResponse_DuplicateOutput ensures summarization parsing
+// handles the llama3.2 duplicate-output pattern.
+func TestParseSummarizeResponse_DuplicateOutput(t *testing.T) {
+	raw := `{"summary": "first summary", "key_points": ["point A"]} {"summary": "second summary", "key_points": ["point B"]}`
+	summary, keyPoints, err := ParseSummarizeResponse(raw)
+	if err != nil {
+		t.Fatalf("ParseSummarizeResponse failed on duplicate output: %v", err)
+	}
+	if summary != "first summary" {
+		t.Fatalf("expected 'first summary', got %q", summary)
+	}
+	if len(keyPoints) != 1 || keyPoints[0] != "point A" {
+		t.Fatalf("expected ['point A'], got %v", keyPoints)
+	}
+}
+
+// TestExtractJSON_BracketInsideString ensures brackets inside quoted strings
+// do not confuse the depth counter.
+func TestExtractJSON_BracketInsideString(t *testing.T) {
+	raw := `{"key": "value with } brace and { another"}`
+	extracted := extractJSON(raw)
+	if extracted != raw {
+		t.Fatalf("extractJSON mangled JSON with brackets in string: %q", extracted)
+	}
+}
+
 func TestExtractJSON_NoJSON(t *testing.T) {
 	raw := "no json here"
 	extracted := extractJSON(raw)

--- a/scripts/check-build-tags.sh
+++ b/scripts/check-build-tags.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# check-build-tags.sh — fail if any muninn binary build is missing -tags localassets.
+#
+# The bundled local ONNX embedder requires this build tag to activate. Without
+# it, LocalAvailable() always returns false and the embedder silently falls
+# through to noop, breaking out-of-the-box semantic search.
+#
+# Files scanned: Dockerfile, Makefile, .github/workflows/*.yml,
+#                cmd/muninn/integration_test.go
+
+set -euo pipefail
+
+FAILED=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Patterns that indicate a muninn binary build command.
+# We match on lines that contain a go build invocation targeting the muninn
+# binary (by output name or by package path) but NOT containing localassets.
+check_file() {
+    local file="$1"
+    local relfile="${file#"${ROOT}/"}"
+
+    # Extract lines that look like go build commands for the muninn binary.
+    # A line qualifies if it contains "go build" and one of:
+    #   - targets ./cmd/muninn
+    #   - produces muninndb-server, muninn.exe, or muninn-<os>-<arch>
+    while IFS= read -r line; do
+        # Skip blank lines and comment lines.
+        [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+
+        # Must mention go build.
+        echo "$line" | grep -q 'go build' || continue
+
+        # Must be targeting the muninn binary (by package or output name).
+        echo "$line" | grep -qE 'cmd/muninn|muninndb-server|muninn\.exe|muninn-[a-z]' || continue
+
+        # If it already has localassets, it is fine.
+        echo "$line" | grep -q 'localassets' && continue
+
+        echo "ERROR: go build without -tags localassets in ${relfile}:"
+        echo "  ${line}"
+        FAILED=1
+    done < "$file"
+}
+
+FILES=(
+    "${ROOT}/Dockerfile"
+    "${ROOT}/Makefile"
+    "${ROOT}/cmd/muninn/integration_test.go"
+)
+
+# Add all workflow YAML files.
+while IFS= read -r f; do
+    FILES+=("$f")
+done < <(find "${ROOT}/.github/workflows" -name '*.yml' 2>/dev/null)
+
+for f in "${FILES[@]}"; do
+    [[ -f "$f" ]] && check_file "$f"
+done
+
+if [[ "$FAILED" -ne 0 ]]; then
+    echo ""
+    echo "Fix: add '-tags localassets' to the flagged go build command(s)."
+    echo "See local_assets_noembed.go — without this tag LocalAvailable() always returns false."
+    exit 1
+fi
+
+echo "OK: all muninn binary build commands include -tags localassets."

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -974,7 +974,7 @@ document.addEventListener('alpine:init', () => {
         if (f.minConf > 0) url += '&min_confidence=' + f.minConf;
         if (f.maxConf > 0) url += '&max_confidence=' + f.maxConf;
         const data = await this.apiCall(url);
-        this.memories = data.engrams || [];
+        this.memories = (data.engrams || []).map(e => ({ ...e, createdAt: e.created_at }));
         this.totalMemories = data.total || 0;
       } catch (err) {
         this.addNotification('error', 'Load failed: ' + err.message);
@@ -1090,7 +1090,7 @@ document.addEventListener('alpine:init', () => {
           const resp = await fetch('/api/engrams/' + encodeURIComponent(m.id) + '?vault=' + encodeURIComponent(this.vault));
           if (resp.ok) {
             const full = await resp.json();
-            m = { ...m, ...full };
+            m = { ...m, ...full, createdAt: full.created_at || m.createdAt };
           }
         } catch (e) { /* fall through with partial data */ }
       }
@@ -1773,7 +1773,8 @@ document.addEventListener('alpine:init', () => {
           '&since=' + encodeURIComponent(since) + '&limit=100'
         );
         // GetSessionResponse has { entries: [] } or raw array
-        this.sessionEntries = data.entries || (Array.isArray(data) ? data : []);
+        const raw = data.entries || (Array.isArray(data) ? data : []);
+        this.sessionEntries = raw.map(e => ({ ...e, createdAt: e.created_at }));
       } catch (err) {
         this.addNotification('error', 'Session: ' + err.message);
       }

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -3271,11 +3271,12 @@ Authorization = "Bearer &lt;token from %USERPROFILE%\.muninn\mcp.token&gt;"</pre
   <div x-show="cognitiveInfoModal" x-cloak
        class="modal-backdrop" @click.self="cognitiveInfoModal = false"
        @keydown.escape.window="cognitiveInfoModal = false">
-    <div class="modal-box" style="max-width:580px;">
-      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1.125rem;">
+    <div class="modal-box" style="max-width:580px;max-height:90vh;display:flex;flex-direction:column;">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1.125rem;flex-shrink:0;">
         <h2 style="margin:0;font-size:1.125rem;color:var(--text-secondary);">Cognitive Workers</h2>
         <button class="btn-ghost" @click="cognitiveInfoModal = false">✕</button>
       </div>
+      <div style="overflow-y:auto;flex:1;min-height:0;">
       <p style="color:var(--text-muted);font-size:0.875rem;margin:0 0 1.125rem;line-height:1.6;">
         Background workers continuously refine the memory graph — strengthening associations, detecting contradictions, and updating confidence scores — without requiring user interaction.
       </p>
@@ -3292,6 +3293,28 @@ Authorization = "Bearer &lt;token from %USERPROFILE%\.muninn\mcp.token&gt;"</pre
         <code style="font-size:0.75rem;color:#a78bfa;background:var(--bg-card);padding:0.25rem 0.5rem;border-radius:0.375rem;display:inline-block;">
           w&prime; = min(1.0,&nbsp;w &times; (1 + &eta;)<sup>n</sup>)
         </code>
+        <svg viewBox="0 0 460 60" fill="none" style="width:100%;display:block;margin-top:0.75rem;" aria-hidden="true">
+          <defs>
+            <marker id="arr-h" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto">
+              <path d="M0,0.5 L6,3.5 L0,6.5Z" style="fill:var(--border)"/>
+            </marker>
+          </defs>
+          <rect x="4"   y="11" width="104" height="38" rx="5" style="fill:var(--bg-elevated);stroke:var(--accent);stroke-width:1.5;"/>
+          <rect x="120" y="11" width="104" height="38" rx="5" style="fill:var(--bg-elevated);stroke:var(--border);stroke-width:1;"/>
+          <rect x="236" y="11" width="104" height="38" rx="5" style="fill:var(--bg-elevated);stroke:var(--border);stroke-width:1;"/>
+          <rect x="352" y="11" width="104" height="38" rx="5" style="fill:var(--bg-elevated);stroke:var(--accent);stroke-width:1.5;"/>
+          <line x1="109" y1="30" x2="119" y2="30" style="stroke:var(--border);stroke-width:1.5;" marker-end="url(#arr-h)"/>
+          <line x1="225" y1="30" x2="235" y2="30" style="stroke:var(--border);stroke-width:1.5;" marker-end="url(#arr-h)"/>
+          <line x1="341" y1="30" x2="351" y2="30" style="stroke:var(--border);stroke-width:1.5;" marker-end="url(#arr-h)"/>
+          <text x="56"  y="27" text-anchor="middle" font-size="10" font-family="inherit" style="fill:var(--text-secondary);font-weight:600;">Co-recall</text>
+          <text x="56"  y="41" text-anchor="middle" font-size="9"  font-family="inherit" style="fill:var(--text-muted);">memories fire</text>
+          <text x="172" y="27" text-anchor="middle" font-size="10" font-family="inherit" style="fill:var(--text-secondary);font-weight:600;">Hebbian</text>
+          <text x="172" y="41" text-anchor="middle" font-size="9"  font-family="inherit" style="fill:var(--text-muted);">worker runs</text>
+          <text x="288" y="27" text-anchor="middle" font-size="10" font-family="inherit" style="fill:#a78bfa;font-weight:600;">Weight update</text>
+          <text x="288" y="41" text-anchor="middle" font-size="9"  font-family="inherit" style="fill:var(--text-muted);">capped at 1.0</text>
+          <text x="404" y="27" text-anchor="middle" font-size="10" font-family="inherit" style="fill:var(--text-secondary);font-weight:600;">Link stronger</text>
+          <text x="404" y="41" text-anchor="middle" font-size="9"  font-family="inherit" style="fill:var(--text-muted);">next recall ↑</text>
+        </svg>
       </div>
 
       <!-- Contradiction -->
@@ -3300,9 +3323,31 @@ Authorization = "Bearer &lt;token from %USERPROFILE%\.muninn\mcp.token&gt;"</pre
           <span style="font-size:1rem;">⚡</span>
           <span style="font-weight:600;color:var(--text-secondary);font-size:0.9375rem;">Contradict &mdash; Conflict Detection</span>
         </div>
-        <p style="margin:0;font-size:0.8125rem;color:var(--text-muted);line-height:1.6;">
+        <p style="margin:0 0 0.5rem;font-size:0.8125rem;color:var(--text-muted);line-height:1.6;">
           Scans relation-type pairs for logical incompatibilities (e.g., a memory cannot simultaneously <em>support</em> and <em>contradict</em> another). Scores severity against a compatibility matrix and flags conflicts so the recall layer can surface warnings instead of silently returning inconsistent data.
         </p>
+        <svg viewBox="0 0 460 60" fill="none" style="width:100%;display:block;" aria-hidden="true">
+          <defs>
+            <marker id="arr-c" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto">
+              <path d="M0,0.5 L6,3.5 L0,6.5Z" style="fill:var(--border)"/>
+            </marker>
+          </defs>
+          <rect x="4"   y="11" width="104" height="38" rx="5" style="fill:var(--bg-elevated);stroke:var(--warning);stroke-width:1.5;"/>
+          <rect x="120" y="11" width="104" height="38" rx="5" style="fill:var(--bg-elevated);stroke:var(--border);stroke-width:1;"/>
+          <rect x="236" y="11" width="104" height="38" rx="5" style="fill:var(--bg-elevated);stroke:var(--border);stroke-width:1;"/>
+          <rect x="352" y="11" width="104" height="38" rx="5" style="fill:var(--bg-elevated);stroke:var(--warning);stroke-width:1.5;"/>
+          <line x1="109" y1="30" x2="119" y2="30" style="stroke:var(--border);stroke-width:1.5;" marker-end="url(#arr-c)"/>
+          <line x1="225" y1="30" x2="235" y2="30" style="stroke:var(--border);stroke-width:1.5;" marker-end="url(#arr-c)"/>
+          <line x1="341" y1="30" x2="351" y2="30" style="stroke:var(--border);stroke-width:1.5;" marker-end="url(#arr-c)"/>
+          <text x="56"  y="27" text-anchor="middle" font-size="10" font-family="inherit" style="fill:var(--text-secondary);font-weight:600;">Memories</text>
+          <text x="56"  y="41" text-anchor="middle" font-size="9"  font-family="inherit" style="fill:var(--text-muted);">linked</text>
+          <text x="172" y="27" text-anchor="middle" font-size="10" font-family="inherit" style="fill:var(--text-secondary);font-weight:600;">Contradict</text>
+          <text x="172" y="41" text-anchor="middle" font-size="9"  font-family="inherit" style="fill:var(--text-muted);">worker scans</text>
+          <text x="288" y="27" text-anchor="middle" font-size="10" font-family="inherit" style="fill:var(--text-secondary);font-weight:600;">Compat matrix</text>
+          <text x="288" y="41" text-anchor="middle" font-size="9"  font-family="inherit" style="fill:var(--text-muted);">severity scored</text>
+          <text x="404" y="27" text-anchor="middle" font-size="10" font-family="inherit" style="fill:var(--text-secondary);font-weight:600;">Conflict flagged</text>
+          <text x="404" y="41" text-anchor="middle" font-size="9"  font-family="inherit" style="fill:var(--warning);">conflict stored</text>
+        </svg>
       </div>
 
       <!-- Confidence -->
@@ -3312,14 +3357,37 @@ Authorization = "Bearer &lt;token from %USERPROFILE%\.muninn\mcp.token&gt;"</pre
           <span style="font-weight:600;color:var(--text-secondary);font-size:0.9375rem;">Confidence &mdash; Belief Updating</span>
         </div>
         <p style="margin:0 0 0.5rem;font-size:0.8125rem;color:var(--text-muted);line-height:1.6;">
-          Updates per-memory confidence scores using Bayesian inference with Laplace smoothing. Each access event (recall, link, confirm, contradict) is a trial; the posterior is recalculated so frequently validated memories rank higher in search results.
+          Updates per-memory confidence scores using iterative Bayesian belief updating. Each access event (recall, co-activation, user confirm, contradiction) carries an evidence strength; the posterior is recalculated so frequently validated memories rank higher and contradicted memories rank lower.
         </p>
         <code style="font-size:0.75rem;color:#34d399;background:var(--bg-card);padding:0.25rem 0.5rem;border-radius:0.375rem;display:inline-block;">
-          P(belief) = (hits + &alpha;) / (trials + 2&alpha;)
+          P&#x2032; = (P &times; ev) / (P &times; ev + (1&minus;P)(1&minus;ev))
         </code>
+        <svg viewBox="0 0 460 60" fill="none" style="width:100%;display:block;margin-top:0.75rem;" aria-hidden="true">
+          <defs>
+            <marker id="arr-co" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto">
+              <path d="M0,0.5 L6,3.5 L0,6.5Z" style="fill:var(--border)"/>
+            </marker>
+          </defs>
+          <rect x="4"   y="11" width="104" height="38" rx="5" style="fill:var(--bg-elevated);stroke:var(--success);stroke-width:1.5;"/>
+          <rect x="120" y="11" width="104" height="38" rx="5" style="fill:var(--bg-elevated);stroke:var(--border);stroke-width:1;"/>
+          <rect x="236" y="11" width="104" height="38" rx="5" style="fill:var(--bg-elevated);stroke:var(--border);stroke-width:1;"/>
+          <rect x="352" y="11" width="104" height="38" rx="5" style="fill:var(--bg-elevated);stroke:var(--success);stroke-width:1.5;"/>
+          <line x1="109" y1="30" x2="119" y2="30" style="stroke:var(--border);stroke-width:1.5;" marker-end="url(#arr-co)"/>
+          <line x1="225" y1="30" x2="235" y2="30" style="stroke:var(--border);stroke-width:1.5;" marker-end="url(#arr-co)"/>
+          <line x1="341" y1="30" x2="351" y2="30" style="stroke:var(--border);stroke-width:1.5;" marker-end="url(#arr-co)"/>
+          <text x="56"  y="27" text-anchor="middle" font-size="10" font-family="inherit" style="fill:var(--text-secondary);font-weight:600;">Access event</text>
+          <text x="56"  y="41" text-anchor="middle" font-size="9"  font-family="inherit" style="fill:var(--text-muted);">+ evidence score</text>
+          <text x="172" y="27" text-anchor="middle" font-size="10" font-family="inherit" style="fill:var(--text-secondary);font-weight:600;">Confidence</text>
+          <text x="172" y="41" text-anchor="middle" font-size="9"  font-family="inherit" style="fill:var(--text-muted);">worker runs</text>
+          <text x="288" y="27" text-anchor="middle" font-size="9.5" font-family="inherit" style="fill:#34d399;font-weight:600;">Bayes update</text>
+          <text x="288" y="41" text-anchor="middle" font-size="9"  font-family="inherit" style="fill:var(--text-muted);">posterior chained</text>
+          <text x="404" y="27" text-anchor="middle" font-size="10" font-family="inherit" style="fill:var(--text-secondary);font-weight:600;">Score shifts</text>
+          <text x="404" y="41" text-anchor="middle" font-size="9"  font-family="inherit" style="fill:var(--text-muted);">up or down</text>
+        </svg>
       </div>
 
-      <div style="display:flex;justify-content:flex-end;margin-top:1.125rem;">
+      </div><!-- end scroll area -->
+      <div style="display:flex;justify-content:flex-end;margin-top:1.125rem;flex-shrink:0;">
         <button class="btn-secondary" @click="cognitiveInfoModal = false">Close</button>
       </div>
     </div>


### PR DESCRIPTION
## v0.4.7-alpha

### Changes in this release

- **feat(ui):** Add inline SVG flow diagrams to Cognitive Workers modal (#267 / #304)
  - Per-worker flow diagrams (Hebbian, Contradiction, Confidence) color-coded purple/amber/green
  - Modal now scrollable with pinned Close button
  - Confidence formula corrected to reflect actual binary Bayes rule
  - Contradiction node label corrected ("conflict stored" not "recall warns")

- **docs:** Clarify MUNINN_ENRICH_API_KEY vs MUNINN_OPENAI_KEY separation (#285 / #287)

- **docs(plugins):** Traefik + Claude.com / ChatGPT integration guide (#276 / #302)

- **fix(recall):** Add hint to empty recall responses pointing to mode='recent' and muninn_where_left_off (#299 / #301)

- **fix(guide):** Session-start two-call pattern and muninn_where_left_off surfacing (#299 / #301)

- **fix(engine):** Normalize entity types in Write() and WriteBatch() — fixes 39% untyped entities (#298 / #300)

- **fix(ui):** Map created_at → createdAt in loadMemories, openMemory, loadSession (#297)

## Test plan

- [ ] CI green on all checks
- [ ] Tag v0.4.7-alpha after merge