### PR TITLE
feat(dream): dream engine foundation

### DIFF
--- a/cmd/muninn/dream.go
+++ b/cmd/muninn/dream.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	muninn "github.com/scrypster/muninndb"
+)
+
+func runDream(args []string) {
+	fs := flag.NewFlagSet("dream", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	force := fs.Bool("force", false, "bypass trigger gates")
+	dryRun := fs.Bool("dry-run", false, "preview changes without writing")
+	scope := fs.String("scope", "", "limit to a single vault")
+	dataDir := fs.String("data-dir", defaultDataDir(), "data directory")
+
+	if err := fs.Parse(args); err != nil {
+		os.Exit(1)
+	}
+
+	// Check server is not running (Pebble exclusive lock).
+	pidPath := filepath.Join(*dataDir, "muninn.pid")
+	if pid, err := readPID(pidPath); err == nil && isProcessRunning(pid) {
+		fmt.Fprintf(os.Stderr, "error: muninn is running (pid %d) — cannot run offline dream\n", pid)
+		fmt.Fprintln(os.Stderr, "Stop the server first: muninn stop")
+		osExit(1)
+		return
+	}
+
+	// Suppress slog output — dream writes structured output to stdout.
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	db, err := muninn.Open(*dataDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		if isExecLockError(err) {
+			fmt.Fprintf(os.Stderr, "Hint: if the daemon crashed, run 'muninn status' or remove %s/pebble/LOCK\n", *dataDir)
+		}
+		osExit(1)
+		return
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "warn: close: %v\n", err)
+		}
+	}()
+
+	report, err := db.Dream(ctx, muninn.DreamOpts{
+		DryRun: *dryRun,
+		Force:  *force,
+		Scope:  *scope,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		osExit(1)
+		return
+	}
+
+	printDreamReport(report, *dryRun)
+}
+
+func printDreamReport(report *muninn.DreamReport, dryRun bool) {
+	if dryRun {
+		fmt.Println("[DRY RUN] No changes were written.")
+		fmt.Println()
+	}
+
+	fmt.Printf("Dream completed in %s\n", report.TotalDuration.Round(100*time.Millisecond))
+	fmt.Println()
+
+	if len(report.Skipped) > 0 {
+		fmt.Printf("Skipped (legal): %s\n", strings.Join(report.Skipped, ", "))
+	}
+
+	for _, r := range report.Reports {
+		if r.Orient != nil && r.Orient.IsLegal {
+			fmt.Printf("  %-16s  %d engrams (protected, skipped)\n", r.Vault, r.LegalSkipped)
+			continue
+		}
+
+		scanned := 0
+		if r.Orient != nil {
+			scanned = r.Orient.EngramCount
+		}
+
+		fmt.Printf("  %-16s  scanned %d", r.Vault, scanned)
+		var changes []string
+		if r.MergedEngrams > 0 {
+			changes = append(changes, fmt.Sprintf("merged %d", r.MergedEngrams))
+		}
+		if r.InferredEdges > 0 {
+			changes = append(changes, fmt.Sprintf("inferred %d edges", r.InferredEdges))
+		}
+		if len(changes) > 0 {
+			fmt.Printf("  (%s)", strings.Join(changes, ", "))
+		}
+		fmt.Println()
+	}
+}
+

--- a/cmd/muninn/dream.go
+++ b/cmd/muninn/dream.go
@@ -82,10 +82,6 @@ func printDreamReport(report *muninn.DreamReport, dryRun bool) {
 	fmt.Printf("Dream completed in %s\n", report.TotalDuration.Round(100*time.Millisecond))
 	fmt.Println()
 
-	if len(report.Skipped) > 0 {
-		fmt.Printf("Skipped (legal): %s\n", strings.Join(report.Skipped, ", "))
-	}
-
 	for _, r := range report.Reports {
 		if r.Orient != nil && r.Orient.IsLegal {
 			fmt.Printf("  %-16s  %d engrams (protected, skipped)\n", r.Vault, r.LegalSkipped)
@@ -97,7 +93,7 @@ func printDreamReport(report *muninn.DreamReport, dryRun bool) {
 			scanned = r.Orient.EngramCount
 		}
 
-		fmt.Printf("  %-16s  scanned %d", r.Vault, scanned)
+		fmt.Printf("  %-16s  scanned %d engrams", r.Vault, scanned)
 		var changes []string
 		if r.MergedEngrams > 0 {
 			changes = append(changes, fmt.Sprintf("merged %d", r.MergedEngrams))
@@ -109,6 +105,10 @@ func printDreamReport(report *muninn.DreamReport, dryRun bool) {
 			fmt.Printf("  (%s)", strings.Join(changes, ", "))
 		}
 		fmt.Println()
+	}
+
+	if len(report.Skipped) > 0 {
+		fmt.Printf("\nSkipped (legal): %s\n", strings.Join(report.Skipped, ", "))
 	}
 }
 

--- a/cmd/muninn/help.go
+++ b/cmd/muninn/help.go
@@ -123,7 +123,7 @@ var subcommandHelp = map[string]func(){
 	"dream": func() {
 		printSubcommandUsage("dream", "LLM-driven memory consolidation", "muninn dream [flags]",
 			[][2]string{
-				{"--force", "Bypass trigger gates (time + volume)"},
+				{"--force", "Bypass trigger gates (not yet implemented)"},
 				{"--dry-run", "Preview changes without writing"},
 				{"--scope <vault>", "Limit to a single vault"},
 				{"--data-dir <dir>", "Data directory (default: ~/.muninn/data)"},

--- a/cmd/muninn/help.go
+++ b/cmd/muninn/help.go
@@ -120,6 +120,19 @@ var subcommandHelp = map[string]func(){
 	"exec": func() {
 		printExecHelp()
 	},
+	"dream": func() {
+		printSubcommandUsage("dream", "LLM-driven memory consolidation", "muninn dream [flags]",
+			[][2]string{
+				{"--force", "Bypass trigger gates (time + volume)"},
+				{"--dry-run", "Preview changes without writing"},
+				{"--scope <vault>", "Limit to a single vault"},
+				{"--data-dir <dir>", "Data directory (default: ~/.muninn/data)"},
+			},
+			[]string{
+				"muninn dream --dry-run",
+				"muninn dream --force --scope work",
+			})
+	},
 	"backup": func() {
 		printSubcommandUsage("backup", "offline point-in-time backup", "muninn backup --output <dir> [flags]",
 			[][2]string{
@@ -305,6 +318,7 @@ func printHelp() {
 	fmt.Printf("  %-32s %s\n", cyan("muninn api-key <command>"), "API key management (create, list, revoke)")
 	fmt.Printf("  %-32s %s\n", cyan("muninn admin change-password"), "Change the admin password")
 	fmt.Printf("  %-32s %s\n", cyan("muninn exec <op> [flags]"), "One-shot remember/recall/read/forget (no daemon needed)")
+	fmt.Printf("  %-32s %s\n", cyan("muninn dream [--dry-run]"), "LLM-driven memory consolidation (server must be stopped)")
 	fmt.Printf("  %-32s %s\n", cyan("muninn backup --output <dir>"), "Offline point-in-time backup (server must be stopped)")
 	fmt.Printf("  %-32s %s\n", cyan("muninn cluster"), "Cluster management (info, status, failover, add-node, remove-node)")
 	fmt.Printf("  %-32s %s\n", cyan("muninn mcp"), "stdio→HTTP MCP proxy (for OpenClaw)")
@@ -346,7 +360,7 @@ func printHelp() {
 	fmt.Printf("  %-28s %s\n", "MUNINN_OPENAI_URL", "Optional OpenAI base URL or provider URL override")
 	fmt.Printf("  %-28s %s\n", "MUNINN_VOYAGE_KEY", "Voyage AI embeddings API key (voyage-3, 1024d)")
 	fmt.Printf("  %-28s %s\n", "MUNINN_COHERE_KEY", "Cohere embeddings API key (embed-v4, 1024d)")
-	fmt.Printf("  %-28s %s\n", "MUNINN_GOOGLE_KEY", "Google Gemini embeddings API key (text-embedding-004, 768d)")
+	fmt.Printf("  %-28s %s\n", "MUNINN_GOOGLE_KEY", "Google Gemini embeddings API key (gemini-embedding-001, 768d)")
 	fmt.Printf("  %-28s %s\n", "MUNINN_JINA_KEY", "Jina embeddings API key (jina-embeddings-v3, 1024d)")
 	fmt.Printf("  %-28s %s\n", "MUNINN_MISTRAL_KEY", "Mistral embeddings API key (mistral-embed, 1024d)")
 	fmt.Println()

--- a/cmd/muninn/help.go
+++ b/cmd/muninn/help.go
@@ -360,7 +360,7 @@ func printHelp() {
 	fmt.Printf("  %-28s %s\n", "MUNINN_OPENAI_URL", "Optional OpenAI base URL or provider URL override")
 	fmt.Printf("  %-28s %s\n", "MUNINN_VOYAGE_KEY", "Voyage AI embeddings API key (voyage-3, 1024d)")
 	fmt.Printf("  %-28s %s\n", "MUNINN_COHERE_KEY", "Cohere embeddings API key (embed-v4, 1024d)")
-	fmt.Printf("  %-28s %s\n", "MUNINN_GOOGLE_KEY", "Google Gemini embeddings API key (gemini-embedding-001, 768d)")
+	fmt.Printf("  %-28s %s\n", "MUNINN_GOOGLE_KEY", "Google Gemini embeddings API key (text-embedding-004, 768d)")
 	fmt.Printf("  %-28s %s\n", "MUNINN_JINA_KEY", "Jina embeddings API key (jina-embeddings-v3, 1024d)")
 	fmt.Printf("  %-28s %s\n", "MUNINN_MISTRAL_KEY", "Mistral embeddings API key (mistral-embed, 1024d)")
 	fmt.Println()

--- a/cmd/muninn/main.go
+++ b/cmd/muninn/main.go
@@ -59,6 +59,8 @@ func main() {
 		runStatus()
 	case "exec":
 		runExec(rest)
+	case "dream":
+		runDream(rest)
 	case "backup":
 		runBackup(rest)
 	case "upgrade":

--- a/docs/key-space-schema.md
+++ b/docs/key-space-schema.md
@@ -56,6 +56,7 @@ This document is the authoritative reference for every prefix in the system. Upd
 | 0x21 | Entity Relationship | Vault | `ws(8) \| engramID(16) \| fromHash(8) \| relTypeByte(1) \| toHash(8)` | NoSync | Typed relationship between two entities, scoped to an engram. |
 | 0x23 | Entity Reverse Index | Cross-vault | `nameHash(8) \| ws(8) \| engramID(16)` | NoSync | Entity←engram reverse lookup across vaults. Always written atomically with 0x20. |
 | 0x24 | Entity Co-occurrence | Vault | `ws(8) \| hashA(8) \| hashB(8)` | NoSync | Pairwise entity co-occurrence count. Hash pair is canonically ordered (hashA < hashB). |
+| 0x27 | Dream State | Vault | `ws(8)` | NoSync→Sync | Per-vault dream consolidation state (last run time, engram count at run). Also used for global dream-due flag with zero vault prefix. |
 
 \* Engram (0x01) and Metadata (0x02) default to Sync. When `NoSyncEngrams=true`, they move to NoSync tier (WAL syncer provides ≤10ms durability).
 
@@ -85,7 +86,7 @@ Derived indexes that accelerate filtered queries. Each maps a single attribute (
 
 ### Configuration and Metadata (0x0E, 0x0F, 0x11, 0x12, 0x13, 0x15, 0x17, 0x19, 0x1D)
 
-Singleton or low-cardinality keys that store per-vault configuration (vault name, scoring weights, migration versions, embedding model marker, coherence counter) and global operational state (vault name index, digest flags, idempotency receipts). The vault engram count (0x15) is the only key in this group that uses `pebble.Sync` — it enforces storage quotas and must survive crashes to prevent over-allocation.
+Singleton or low-cardinality keys that store per-vault configuration (vault name, scoring weights, migration versions, embedding model marker, coherence counter) and global operational state (vault name index, digest flags, idempotency receipts). The vault engram count (0x15) is the only key in this group that uses `pebble.Sync` — it enforces storage quotas and must survive crashes to prevent over-allocation. Dream state (0x27) tracks the last dream run time and engram count at that time, using Sync durability to prevent over-consolidation.
 
 ### Structural Layer (0x16, 0x1A, 0x1C, 0x1E)
 

--- a/dream.go
+++ b/dream.go
@@ -1,0 +1,34 @@
+package muninn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/scrypster/muninndb/internal/consolidation"
+)
+
+// DreamOpts configures a dream consolidation pass.
+type DreamOpts struct {
+	DryRun bool
+	Force  bool   // bypass trigger gates
+	Scope  string // limit to single vault ("" = all)
+}
+
+// DreamReport is the result of a dream consolidation pass.
+type DreamReport = consolidation.DreamReport
+
+// Dream runs a dream consolidation pass across vaults.
+// It uses a lowered dedup threshold (0.85) to surface near-duplicates.
+func (db *DB) Dream(ctx context.Context, opts DreamOpts) (*DreamReport, error) {
+	w := consolidation.NewWorker(db.eng)
+
+	report, err := w.DreamOnce(ctx, consolidation.DreamOpts{
+		DryRun: opts.DryRun,
+		Force:  opts.Force,
+		Scope:  opts.Scope,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("muninndb dream: %w", err)
+	}
+	return report, nil
+}

--- a/dream.go
+++ b/dream.go
@@ -15,6 +15,8 @@ type DreamOpts struct {
 }
 
 // DreamReport is the result of a dream consolidation pass.
+// NOTE: This is a type alias that exposes internal consolidation types.
+// Consider wrapping before API stabilization.
 type DreamReport = consolidation.DreamReport
 
 // Dream runs a dream consolidation pass across vaults.

--- a/internal/consolidation/dedup.go
+++ b/internal/consolidation/dedup.go
@@ -13,7 +13,10 @@ import (
 // (cosine similarity >= 0.95). The higher-confidence engram is kept as the representative,
 // and the other is archived. In DryRun mode, no mutations occur.
 func (w *Worker) runPhase2Dedup(ctx context.Context, store *storage.PebbleStore, wsPrefix [8]byte, report *ConsolidationReport, vault string) error {
-	const similarityThreshold = 0.95
+	similarityThreshold := float32(0.95)
+	if w.DedupThreshold > 0 {
+		similarityThreshold = w.DedupThreshold
+	}
 
 	// Scan all engrams in the vault
 	allIDs, err := scanAllEngramIDs(ctx, store, wsPrefix)

--- a/internal/consolidation/dream.go
+++ b/internal/consolidation/dream.go
@@ -28,6 +28,9 @@ func (w *Worker) DreamOnce(ctx context.Context, opts DreamOpts) (*DreamReport, e
 	start := time.Now()
 	dreport := &DreamReport{}
 
+	// TODO: enforce trigger gates (time >= 12h + volume >= 3 engrams) when Force is false.
+	// ReadDreamState/WriteDreamState are implemented but gate logic is deferred to PR #2.
+
 	// Resolve which vaults to process.
 	var vaults []string
 	if opts.Scope != "" {
@@ -81,13 +84,9 @@ func (w *Worker) DreamOnce(ctx context.Context, opts DreamOpts) (*DreamReport, e
 
 		// Skip legal vaults entirely.
 		if summary != nil && summary.IsLegal {
-			legalCount := 0
-			if summary != nil {
-				legalCount = summary.EngramCount
-			}
-			report.LegalSkipped = legalCount
+			report.LegalSkipped = summary.EngramCount
 			slog.Info("dream: skipping legal vault (protected)",
-				"vault", vault, "engrams", legalCount)
+				"vault", vault, "engrams", summary.EngramCount)
 			dreport.Skipped = append(dreport.Skipped, vault)
 			report.Duration = time.Since(report.StartedAt)
 			dreport.Reports = append(dreport.Reports, report)

--- a/internal/consolidation/dream.go
+++ b/internal/consolidation/dream.go
@@ -51,15 +51,17 @@ func (w *Worker) DreamOnce(ctx context.Context, opts DreamOpts) (*DreamReport, e
 
 	store := w.Engine.Store()
 
-	// Save original settings and set dream-mode config.
-	origDryRun := w.DryRun
-	origThreshold := w.DedupThreshold
-	w.DryRun = opts.DryRun
-	w.DedupThreshold = 0.85
-	defer func() {
-		w.DryRun = origDryRun
-		w.DedupThreshold = origThreshold
-	}()
+	// Construct a dream-specific worker to avoid mutating the caller's instance.
+	// This prevents data races if DreamOnce is called while the background
+	// consolidation scheduler is running on the same Worker.
+	dw := &Worker{
+		Engine:         w.Engine,
+		Schedule:       w.Schedule,
+		MaxDedup:       w.MaxDedup,
+		MaxTransitive:  w.MaxTransitive,
+		DryRun:         opts.DryRun,
+		DedupThreshold: 0.85,
+	}
 
 	for _, vault := range vaults {
 		if err := ctx.Err(); err != nil {
@@ -75,7 +77,7 @@ func (w *Worker) DreamOnce(ctx context.Context, opts DreamOpts) (*DreamReport, e
 		}
 
 		// Phase 0: Orient
-		summary, err := w.runPhase0Orient(ctx, store, wsPrefix, vault)
+		summary, err := dw.runPhase0Orient(ctx, store, wsPrefix, vault)
 		if err != nil {
 			slog.Warn("dream: phase 0 (orient) failed", "vault", vault, "error", err)
 			report.Errors = append(report.Errors, "phase0_orient: "+err.Error())
@@ -94,13 +96,13 @@ func (w *Worker) DreamOnce(ctx context.Context, opts DreamOpts) (*DreamReport, e
 		}
 
 		// Phase 1: Activation Replay
-		if err := w.runPhase1Replay(ctx, store, wsPrefix, report); err != nil {
+		if err := dw.runPhase1Replay(ctx, store, wsPrefix, report); err != nil {
 			slog.Warn("dream: phase 1 (replay) failed", "vault", vault, "error", err)
 			report.Errors = append(report.Errors, "phase1_replay: "+err.Error())
 		}
 
 		// Phase 2: Semantic Deduplication (threshold 0.85 in dream mode)
-		if err := w.runPhase2Dedup(ctx, store, wsPrefix, report, vault); err != nil {
+		if err := dw.runPhase2Dedup(ctx, store, wsPrefix, report, vault); err != nil {
 			slog.Warn("dream: phase 2 (dedup) failed", "vault", vault, "error", err)
 			report.Errors = append(report.Errors, "phase2_dedup: "+err.Error())
 		}

--- a/internal/consolidation/dream.go
+++ b/internal/consolidation/dream.go
@@ -1,0 +1,123 @@
+package consolidation
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// DreamOpts configures a dream consolidation pass.
+type DreamOpts struct {
+	DryRun bool
+	Force  bool   // bypass trigger gates
+	Scope  string // limit to single vault ("" = all vaults)
+}
+
+// DreamReport collects results across all vaults for a single dream run.
+type DreamReport struct {
+	Reports       []*ConsolidationReport
+	Skipped       []string // vault names skipped (legal, no LLM, etc.)
+	TotalDuration time.Duration
+}
+
+// DreamOnce runs a single dream consolidation pass across vaults.
+// In dream mode, the dedup threshold is lowered to 0.85 to surface
+// near-duplicate candidates for future LLM review (Phase 2b).
+func (w *Worker) DreamOnce(ctx context.Context, opts DreamOpts) (*DreamReport, error) {
+	start := time.Now()
+	dreport := &DreamReport{}
+
+	// Resolve which vaults to process.
+	var vaults []string
+	if opts.Scope != "" {
+		vaults = []string{opts.Scope}
+	} else {
+		var err error
+		vaults, err = w.Engine.ListVaults(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("dream: list vaults: %w", err)
+		}
+	}
+
+	if len(vaults) == 0 {
+		slog.Info("dream: no vaults to process")
+		dreport.TotalDuration = time.Since(start)
+		return dreport, nil
+	}
+
+	store := w.Engine.Store()
+
+	// Save original settings and set dream-mode config.
+	origDryRun := w.DryRun
+	origThreshold := w.DedupThreshold
+	w.DryRun = opts.DryRun
+	w.DedupThreshold = 0.85
+	defer func() {
+		w.DryRun = origDryRun
+		w.DedupThreshold = origThreshold
+	}()
+
+	for _, vault := range vaults {
+		if err := ctx.Err(); err != nil {
+			return dreport, fmt.Errorf("dream: context cancelled: %w", err)
+		}
+
+		wsPrefix := store.ResolveVaultPrefix(vault)
+
+		report := &ConsolidationReport{
+			Vault:     vault,
+			StartedAt: time.Now(),
+			DryRun:    opts.DryRun,
+		}
+
+		// Phase 0: Orient
+		summary, err := w.runPhase0Orient(ctx, store, wsPrefix, vault)
+		if err != nil {
+			slog.Warn("dream: phase 0 (orient) failed", "vault", vault, "error", err)
+			report.Errors = append(report.Errors, "phase0_orient: "+err.Error())
+		}
+		report.Orient = summary
+
+		// Skip legal vaults entirely.
+		if summary != nil && summary.IsLegal {
+			legalCount := 0
+			if summary != nil {
+				legalCount = summary.EngramCount
+			}
+			report.LegalSkipped = legalCount
+			slog.Info("dream: skipping legal vault (protected)",
+				"vault", vault, "engrams", legalCount)
+			dreport.Skipped = append(dreport.Skipped, vault)
+			report.Duration = time.Since(report.StartedAt)
+			dreport.Reports = append(dreport.Reports, report)
+			continue
+		}
+
+		// Phase 1: Activation Replay
+		if err := w.runPhase1Replay(ctx, store, wsPrefix, report); err != nil {
+			slog.Warn("dream: phase 1 (replay) failed", "vault", vault, "error", err)
+			report.Errors = append(report.Errors, "phase1_replay: "+err.Error())
+		}
+
+		// Phase 2: Semantic Deduplication (threshold 0.85 in dream mode)
+		if err := w.runPhase2Dedup(ctx, store, wsPrefix, report, vault); err != nil {
+			slog.Warn("dream: phase 2 (dedup) failed", "vault", vault, "error", err)
+			report.Errors = append(report.Errors, "phase2_dedup: "+err.Error())
+		}
+
+		// Phase 2b: LLM Consolidation (future PR)
+		// Phase 3: Schema Promotion (future PR)
+		// Phase 4: Bidirectional Stability (future PR)
+		// Phase 5: Transitive Inference (future PR)
+
+		report.Duration = time.Since(report.StartedAt)
+		dreport.Reports = append(dreport.Reports, report)
+
+		slog.Info("dream: vault completed", "vault", vault, "duration", report.Duration,
+			"merged", report.MergedEngrams)
+	}
+
+	dreport.TotalDuration = time.Since(start)
+	return dreport, nil
+}

--- a/internal/consolidation/dream_test.go
+++ b/internal/consolidation/dream_test.go
@@ -1,0 +1,134 @@
+package consolidation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+func TestDreamOnce_DryRun_NoMutations(t *testing.T) {
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	vault := "dream_dry"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	embed := []float32{1, 0, 0}
+	id := writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "test", Content: "some content", Confidence: 0.8, Relevance: 0.6,
+		Stability: 20, Embedding: embed,
+	})
+
+	mock := &mockEngineInterface{store: store}
+	w := NewWorker(mock)
+
+	report, err := w.DreamOnce(ctx, DreamOpts{DryRun: true, Force: true, Scope: vault})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(report.Reports) != 1 {
+		t.Fatalf("expected 1 vault report, got %d", len(report.Reports))
+	}
+	if !report.Reports[0].DryRun {
+		t.Error("expected DryRun=true in report")
+	}
+
+	// Verify engram is untouched.
+	eng, err := store.GetEngram(ctx, wsPrefix, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if eng.State == storage.StateArchived {
+		t.Error("engram should not be archived in dry-run mode")
+	}
+}
+
+func TestDreamOnce_LegalVaultSkipped(t *testing.T) {
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	vault := "legal-docs"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	embed := []float32{1, 0, 0}
+	writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "contract", Content: "confidential agreement", Confidence: 0.9, Relevance: 0.9,
+		Stability: 30, Embedding: embed,
+	})
+
+	mock := &mockEngineInterface{store: store}
+	w := NewWorker(mock)
+
+	report, err := w.DreamOnce(ctx, DreamOpts{Force: true, Scope: vault})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(report.Skipped) != 1 || report.Skipped[0] != "legal-docs" {
+		t.Errorf("expected legal-docs in Skipped, got %v", report.Skipped)
+	}
+
+	if len(report.Reports) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(report.Reports))
+	}
+	r := report.Reports[0]
+	if r.LegalSkipped == 0 {
+		t.Error("expected LegalSkipped > 0")
+	}
+	if r.MergedEngrams != 0 {
+		t.Error("legal vault should have 0 merged engrams")
+	}
+}
+
+func TestDreamOnce_ScopeFilter(t *testing.T) {
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	for _, vault := range []string{"work", "personal"} {
+		wsPrefix := store.ResolveVaultPrefix(vault)
+		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+			Concept: "test", Content: "content", Confidence: 0.5, Relevance: 0.5,
+			Stability: 20, Embedding: []float32{1, 0, 0},
+		})
+	}
+
+	mock := &mockEngineInterface{store: store}
+	w := NewWorker(mock)
+
+	report, err := w.DreamOnce(ctx, DreamOpts{Force: true, Scope: "work"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Reports) != 1 {
+		t.Fatalf("expected 1 vault report with scope, got %d", len(report.Reports))
+	}
+	if report.Reports[0].Vault != "work" {
+		t.Errorf("expected vault 'work', got %q", report.Reports[0].Vault)
+	}
+}
+
+func TestDreamOnce_EmptyVault(t *testing.T) {
+	store, _, cleanup := testStoreWithDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	mock := &mockEngineInterface{store: store}
+	w := NewWorker(mock)
+
+	report, err := w.DreamOnce(ctx, DreamOpts{Force: true, Scope: "empty"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Reports) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(report.Reports))
+	}
+	if report.Reports[0].Orient == nil {
+		t.Error("expected orient summary even for empty vault")
+	}
+}

--- a/internal/consolidation/dream_test.go
+++ b/internal/consolidation/dream_test.go
@@ -51,7 +51,7 @@ func TestDreamOnce_LegalVaultSkipped(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
-	vault := "legal-docs"
+	vault := "legal/docs"
 	wsPrefix := store.ResolveVaultPrefix(vault)
 
 	embed := []float32{1, 0, 0}
@@ -68,8 +68,8 @@ func TestDreamOnce_LegalVaultSkipped(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(report.Skipped) != 1 || report.Skipped[0] != "legal-docs" {
-		t.Errorf("expected legal-docs in Skipped, got %v", report.Skipped)
+	if len(report.Skipped) != 1 || report.Skipped[0] != "legal/docs" {
+		t.Errorf("expected legal/docs in Skipped, got %v", report.Skipped)
 	}
 
 	if len(report.Reports) != 1 {

--- a/internal/consolidation/orient.go
+++ b/internal/consolidation/orient.go
@@ -69,7 +69,9 @@ func (w *Worker) runPhase0Orient(ctx context.Context, store *storage.PebbleStore
 	return summary, nil
 }
 
-// isLegalVault returns true if the vault name indicates it contains legal content.
+// isLegalVault returns true if the vault is the "legal" vault or uses the legal prefix convention.
+// Matches: "legal", "legal:contracts", "legal/docs" — but NOT "paralegal" or "illegal".
 func isLegalVault(vault string) bool {
-	return strings.Contains(strings.ToLower(vault), "legal")
+	v := strings.ToLower(vault)
+	return v == "legal" || strings.HasPrefix(v, "legal:") || strings.HasPrefix(v, "legal/")
 }

--- a/internal/consolidation/orient.go
+++ b/internal/consolidation/orient.go
@@ -1,0 +1,75 @@
+package consolidation
+
+import (
+	"context"
+	"strings"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// VaultSummary is the read-only output of Phase 0 (Orient).
+type VaultSummary struct {
+	Vault        string
+	EngramCount  int
+	WithEmbed    int
+	AvgRelevance float32
+	AvgStability float32
+	IsLegal      bool
+}
+
+// runPhase0Orient scans the vault to produce a VaultSummary.
+// Pure read-only -- no mutations even when DryRun is false.
+func (w *Worker) runPhase0Orient(ctx context.Context, store *storage.PebbleStore, wsPrefix [8]byte, vault string) (*VaultSummary, error) {
+	allIDs, err := scanAllEngramIDs(ctx, store, wsPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	summary := &VaultSummary{
+		Vault:       vault,
+		EngramCount: len(allIDs),
+		IsLegal:     isLegalVault(vault),
+	}
+
+	if len(allIDs) == 0 {
+		return summary, nil
+	}
+
+	engrams, err := store.GetEngrams(ctx, wsPrefix, allIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	var totalRelevance, totalStability float64
+	var count int
+	for _, eng := range engrams {
+		if eng == nil {
+			continue
+		}
+		count++
+		totalRelevance += float64(eng.Relevance)
+		totalStability += float64(eng.Stability)
+
+		embed := eng.Embedding
+		if len(embed) == 0 {
+			if loaded, err := store.GetEmbedding(ctx, wsPrefix, eng.ID); err == nil && len(loaded) > 0 {
+				embed = loaded
+			}
+		}
+		if len(embed) > 0 {
+			summary.WithEmbed++
+		}
+	}
+
+	if count > 0 {
+		summary.AvgRelevance = float32(totalRelevance / float64(count))
+		summary.AvgStability = float32(totalStability / float64(count))
+	}
+
+	return summary, nil
+}
+
+// isLegalVault returns true if the vault name indicates it contains legal content.
+func isLegalVault(vault string) bool {
+	return strings.Contains(strings.ToLower(vault), "legal")
+}

--- a/internal/consolidation/orient_test.go
+++ b/internal/consolidation/orient_test.go
@@ -1,0 +1,159 @@
+package consolidation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+func TestOrient_EmptyVault(t *testing.T) {
+	store, _, cleanup := testStoreWithDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	vault := "empty_vault"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	mock := &mockEngineInterface{store: store}
+	w := &Worker{Engine: mock}
+
+	summary, err := w.runPhase0Orient(ctx, store, wsPrefix, vault)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.EngramCount != 0 {
+		t.Errorf("EngramCount = %d, want 0", summary.EngramCount)
+	}
+	if summary.IsLegal {
+		t.Error("IsLegal should be false for vault 'empty_vault'")
+	}
+}
+
+func TestOrient_WithEngrams(t *testing.T) {
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	vault := "orient_test"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	embed := []float32{1, 0, 0}
+	writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "a", Content: "content a", Confidence: 0.8, Relevance: 0.6,
+		Stability: 20, Embedding: embed,
+	})
+	writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "b", Content: "content b", Confidence: 0.9, Relevance: 0.4,
+		Stability: 10, Embedding: embed,
+	})
+
+	mock := &mockEngineInterface{store: store}
+	w := &Worker{Engine: mock}
+
+	summary, err := w.runPhase0Orient(ctx, store, wsPrefix, vault)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.EngramCount != 2 {
+		t.Errorf("EngramCount = %d, want 2", summary.EngramCount)
+	}
+	if summary.WithEmbed != 2 {
+		t.Errorf("WithEmbed = %d, want 2", summary.WithEmbed)
+	}
+	if summary.AvgRelevance < 0.4 || summary.AvgRelevance > 0.6 {
+		t.Errorf("AvgRelevance = %f, want ~0.5", summary.AvgRelevance)
+	}
+	if summary.AvgStability < 14 || summary.AvgStability > 16 {
+		t.Errorf("AvgStability = %f, want ~15", summary.AvgStability)
+	}
+}
+
+func TestIsLegalVault(t *testing.T) {
+	tests := []struct {
+		vault string
+		want  bool
+	}{
+		{"legal", true},
+		{"Legal", true},
+		{"legal-docs", true},
+		{"my_legal", true},
+		{"LEGAL", true},
+		{"work", false},
+		{"default", false},
+		{"personal", false},
+		{"projects", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.vault, func(t *testing.T) {
+			if got := isLegalVault(tt.vault); got != tt.want {
+				t.Errorf("isLegalVault(%q) = %v, want %v", tt.vault, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDedup_ConfigurableThreshold(t *testing.T) {
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	vault := "threshold_test"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	// Two embeddings with cosine similarity ~0.90 (between 0.85 and 0.95).
+	embedA := []float32{1, 0, 0, 0}
+	embedB := []float32{0.9, 0.45, 0, 0}
+
+	writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "a", Content: "content a", Confidence: 0.9, Relevance: 0.9,
+		Stability: 30, Embedding: embedA,
+	})
+	writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "b", Content: "content b", Confidence: 0.5, Relevance: 0.5,
+		Stability: 30, Embedding: embedB,
+	})
+
+	// Verify similarity is in the expected range.
+	sim := cosineSimilarity(embedA, embedB)
+	if sim < 0.85 || sim > 0.95 {
+		t.Fatalf("test embeddings have cosine similarity %f, expected 0.85-0.95", sim)
+	}
+
+	// At default threshold (0.95), these should NOT cluster.
+	mock := &mockEngineInterface{store: store}
+	w := &Worker{Engine: mock, MaxDedup: 100, MaxTransitive: 100}
+	report := &ConsolidationReport{}
+
+	if err := w.runPhase2Dedup(ctx, store, wsPrefix, report, vault); err != nil {
+		t.Fatal(err)
+	}
+	if report.DedupClusters != 0 {
+		t.Errorf("default threshold: DedupClusters = %d, want 0", report.DedupClusters)
+	}
+
+	// At threshold 0.85, these SHOULD cluster and merge.
+	store2, db2, cleanup2 := testStoreWithDB(t)
+	defer cleanup2()
+	wsPrefix2 := store2.ResolveVaultPrefix(vault)
+
+	writeEngramWithEmbedding(t, ctx, store2, db2, wsPrefix2, &storage.Engram{
+		Concept: "a", Content: "content a", Confidence: 0.9, Relevance: 0.9,
+		Stability: 30, Embedding: embedA,
+	})
+	writeEngramWithEmbedding(t, ctx, store2, db2, wsPrefix2, &storage.Engram{
+		Concept: "b", Content: "content b", Confidence: 0.5, Relevance: 0.5,
+		Stability: 30, Embedding: embedB,
+	})
+
+	mock2 := &mockEngineInterface{store: store2}
+	w2 := &Worker{Engine: mock2, MaxDedup: 100, MaxTransitive: 100, DedupThreshold: 0.85}
+	report2 := &ConsolidationReport{}
+
+	if err := w2.runPhase2Dedup(ctx, store2, wsPrefix2, report2, vault); err != nil {
+		t.Fatal(err)
+	}
+	if report2.DedupClusters != 1 {
+		t.Errorf("0.85 threshold: DedupClusters = %d, want 1", report2.DedupClusters)
+	}
+}

--- a/internal/consolidation/orient_test.go
+++ b/internal/consolidation/orient_test.go
@@ -76,9 +76,16 @@ func TestIsLegalVault(t *testing.T) {
 	}{
 		{"legal", true},
 		{"Legal", true},
-		{"legal-docs", true},
-		{"my_legal", true},
 		{"LEGAL", true},
+		{"legal:contracts", true},
+		{"legal/docs", true},
+		{"Legal:NDA", true},
+		// These should NOT match anymore:
+		{"legal-docs", false},
+		{"my_legal", false},
+		{"paralegal", false},
+		{"illegal", false},
+		// Normal vaults:
 		{"work", false},
 		{"default", false},
 		{"personal", false},

--- a/internal/consolidation/report.go
+++ b/internal/consolidation/report.go
@@ -14,4 +14,8 @@ type ConsolidationReport struct {
 	InferredEdges  int           // new transitive associations inferred
 	DryRun         bool          // true if no mutations occurred
 	Errors         []string      // non-fatal errors encountered per phase
+
+	// Dream-specific fields (populated by DreamOnce, nil/zero for RunOnce)
+	Orient       *VaultSummary // Phase 0 vault summary
+	LegalSkipped int           // legal engrams skipped in Phase 2b
 }

--- a/internal/consolidation/worker.go
+++ b/internal/consolidation/worker.go
@@ -23,11 +23,12 @@ type EngineInterface interface {
 // Worker is the main consolidation worker that periodically runs a 5-phase
 // consolidation pipeline to reduce redundancy and strengthen associations.
 type Worker struct {
-	Engine        EngineInterface
-	Schedule      time.Duration // frequency of consolidation runs (default 6h)
-	MaxDedup      int            // max pairs to merge per run (default 100)
-	MaxTransitive int            // max inferred edges per run (default 1000)
-	DryRun        bool            // if true, no mutations occur
+	Engine         EngineInterface
+	Schedule       time.Duration // frequency of consolidation runs (default 6h)
+	MaxDedup       int           // max pairs to merge per run (default 100)
+	MaxTransitive  int           // max inferred edges per run (default 1000)
+	DryRun         bool          // if true, no mutations occur
+	DedupThreshold float32       // cosine similarity threshold for dedup (0 = use default 0.95)
 }
 
 // NewWorker creates a new consolidation worker with sensible defaults.

--- a/internal/storage/impl.go
+++ b/internal/storage/impl.go
@@ -555,7 +555,7 @@ func (ps *PebbleStore) WriteDreamState(vaultPrefix [8]byte, lastDreamAt time.Tim
 	buf := make([]byte, 16)
 	binary.BigEndian.PutUint64(buf[0:8], uint64(lastDreamAt.UnixNano()))
 	binary.BigEndian.PutUint64(buf[8:16], uint64(engramsAtDream))
-	return ps.db.Set(keys.DreamStateKey(vaultPrefix), buf, pebble.NoSync)
+	return ps.db.Set(keys.DreamStateKey(vaultPrefix), buf, pebble.Sync)
 }
 
 // ReadDreamState loads per-vault dream state from Pebble.

--- a/internal/storage/impl.go
+++ b/internal/storage/impl.go
@@ -549,6 +549,34 @@ func (ps *PebbleStore) ReadCoherence(vaultPrefix [8]byte) ([7]int64, bool, error
 	return data, true, nil
 }
 
+// WriteDreamState persists per-vault dream state to Pebble.
+// Value is 16 bytes: last_dream_at (BigEndian int64 unix nanos) + engrams_at_dream (BigEndian int64).
+func (ps *PebbleStore) WriteDreamState(vaultPrefix [8]byte, lastDreamAt time.Time, engramsAtDream int64) error {
+	buf := make([]byte, 16)
+	binary.BigEndian.PutUint64(buf[0:8], uint64(lastDreamAt.UnixNano()))
+	binary.BigEndian.PutUint64(buf[8:16], uint64(engramsAtDream))
+	return ps.db.Set(keys.DreamStateKey(vaultPrefix), buf, pebble.NoSync)
+}
+
+// ReadDreamState loads per-vault dream state from Pebble.
+// Returns (lastDreamAt, engramsAtDream, true, nil) if found, (zero, 0, false, nil) if not found.
+func (ps *PebbleStore) ReadDreamState(vaultPrefix [8]byte) (time.Time, int64, bool, error) {
+	val, closer, err := ps.db.Get(keys.DreamStateKey(vaultPrefix))
+	if errors.Is(err, pebble.ErrNotFound) {
+		return time.Time{}, 0, false, nil
+	}
+	if err != nil {
+		return time.Time{}, 0, false, fmt.Errorf("read dream state: %w", err)
+	}
+	defer closer.Close()
+	if len(val) != 16 {
+		return time.Time{}, 0, false, fmt.Errorf("dream state: unexpected value length %d", len(val))
+	}
+	nanos := int64(binary.BigEndian.Uint64(val[0:8]))
+	engramCount := int64(binary.BigEndian.Uint64(val[8:16]))
+	return time.Unix(0, nanos), engramCount, true, nil
+}
+
 // Checkpoint creates a Pebble checkpoint (consistent on-disk snapshot) at destDir.
 func (ps *PebbleStore) Checkpoint(destDir string) error {
 	return ps.db.Checkpoint(destDir)

--- a/internal/storage/impl_test.go
+++ b/internal/storage/impl_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/scrypster/muninndb/internal/storage/keys"
 	"github.com/scrypster/muninndb/internal/wal"
@@ -1110,5 +1111,111 @@ func TestBatchDelete(t *testing.T) {
 	}
 	if after != nil {
 		t.Errorf("BatchDelete: key still present after delete, value=%q", after)
+	}
+}
+
+// TestWriteReadDreamState verifies round-trip persistence of dream state.
+func TestWriteReadDreamState(t *testing.T) {
+	dir, err := os.MkdirTemp("", "muninndb-dream-state-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := OpenPebble(dir, DefaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
+	ws := store.VaultPrefix("dream-vault")
+
+	wantTime := time.Date(2026, 3, 28, 6, 0, 0, 0, time.UTC)
+	wantCount := int64(47)
+
+	if err := store.WriteDreamState(ws, wantTime, wantCount); err != nil {
+		t.Fatalf("WriteDreamState: %v", err)
+	}
+
+	gotTime, gotCount, ok, err := store.ReadDreamState(ws)
+	if err != nil {
+		t.Fatalf("ReadDreamState: %v", err)
+	}
+	if !ok {
+		t.Fatal("ReadDreamState returned ok=false after write")
+	}
+	if !gotTime.Equal(wantTime) {
+		t.Errorf("ReadDreamState time: got %v, want %v", gotTime, wantTime)
+	}
+	if gotCount != wantCount {
+		t.Errorf("ReadDreamState count: got %d, want %d", gotCount, wantCount)
+	}
+}
+
+// TestReadDreamStateMissing verifies that reading dream state for a vault
+// that has never been written returns ok=false with no error.
+func TestReadDreamStateMissing(t *testing.T) {
+	dir, err := os.MkdirTemp("", "muninndb-dream-miss-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := OpenPebble(dir, DefaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
+	ws := store.VaultPrefix("never-dreamed")
+
+	_, _, ok, err := store.ReadDreamState(ws)
+	if err != nil {
+		t.Fatalf("ReadDreamState on missing key: %v", err)
+	}
+	if ok {
+		t.Error("ReadDreamState on missing key returned ok=true, want false")
+	}
+}
+
+// TestWriteDreamStateOverwrite verifies that writing dream state twice
+// overwrites the previous value.
+func TestWriteDreamStateOverwrite(t *testing.T) {
+	dir, err := os.MkdirTemp("", "muninndb-dream-overwrite-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := OpenPebble(dir, DefaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	defer store.Close()
+	ws := store.VaultPrefix("overwrite-vault")
+
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := store.WriteDreamState(ws, t1, 10); err != nil {
+		t.Fatal(err)
+	}
+
+	t2 := time.Date(2026, 3, 28, 12, 0, 0, 0, time.UTC)
+	if err := store.WriteDreamState(ws, t2, 47); err != nil {
+		t.Fatal(err)
+	}
+
+	gotTime, gotCount, ok, err := store.ReadDreamState(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ReadDreamState returned ok=false")
+	}
+	if !gotTime.Equal(t2) {
+		t.Errorf("time: got %v, want %v", gotTime, t2)
+	}
+	if gotCount != 47 {
+		t.Errorf("count: got %d, want 47", gotCount)
 	}
 }

--- a/internal/storage/keys/keys.go
+++ b/internal/storage/keys/keys.go
@@ -748,3 +748,13 @@ func ArchiveAssocRangeEnd(ws [8]byte) []byte {
 	}
 	return end
 }
+
+// DreamStateKey returns the 9-byte Pebble key for per-vault dream state.
+// Key layout: [0x27][8-byte vault prefix]
+// Value layout: 16 bytes (last_dream_at int64 + engrams_at_dream int64, BigEndian)
+func DreamStateKey(vaultPrefix [8]byte) []byte {
+	key := make([]byte, 9)
+	key[0] = 0x27
+	copy(key[1:], vaultPrefix[:])
+	return key
+}

--- a/internal/storage/keys/keys_test.go
+++ b/internal/storage/keys/keys_test.go
@@ -52,6 +52,7 @@ func TestKeyPrefixesAreUnique(t *testing.T) {
 		{"RelationshipKey", RelationshipKey([8]byte{}, [16]byte{}, [8]byte{}, 0x01, [8]byte{})},
 		{"EntityReverseIndexKey", EntityReverseIndexKey([8]byte{}, [8]byte{}, [16]byte{})},
 		{"LastAccessIndexKey", LastAccessIndexKey([8]byte{}, 0, [16]byte{})},
+		{"DreamStateKey", DreamStateKey([8]byte{1, 2, 3, 4, 5, 6, 7, 8})},
 	}
 
 	seen := make(map[byte]string)


### PR DESCRIPTION
Merges the dream engine foundation from develop into main.

## What's included

- `muninn dream` CLI command — offline memory consolidation pass (`--dry-run`, `--force`, `--scope`)
- Phase 0 Orient — read-only vault scanning (engram count, embedding coverage, avg relevance/stability)
- Semantic dedup at lowered threshold (0.85 vs 0.95) to surface near-duplicates for future LLM review
- Dream state persistence in Pebble (`0x27` key prefix, `pebble.Sync`)
- Legal vault protection — vaults named `legal`, `legal:*`, or `legal/*` are always skipped
- Public API — `db.Dream(ctx, opts)`
- Key-space schema documented, `TestKeyPrefixesAreUnique` updated

## Notes

- Existing consolidation pipeline (`RunOnce`) is unchanged — this is fully additive
- LLM consolidation, trigger gates, bidirectional stability, and dream journal are follow-up PRs
- Contributed by @5queezer

All CI passing on develop.