### PR TITLE
feat(cognitive): hybrid exponential + power-law decay model

### DIFF
--- a/internal/auth/plasticity.go
+++ b/internal/auth/plasticity.go
@@ -51,6 +51,11 @@ type PlasticityConfig struct {
 	// RecallMode is the default recall mode for this vault: "semantic"|"recent"|"balanced"|"deep".
 	// nil = use "balanced" (engine defaults).
 	RecallMode *string `json:"recall_mode,omitempty"`
+
+	// Hybrid decay model parameters
+	DecayModel          *string  `json:"decay_model,omitempty"`           // "exponential" (default) or "hybrid"
+	PowerLawExponent    *float64 `json:"power_law_exponent,omitempty"`    // power-law exponent (default 0.5)
+	DecayTransitionDays *float64 `json:"decay_transition_days,omitempty"` // days before switching to power-law (default 3.0)
 }
 
 // ResolvedPlasticity is the fully-merged configuration after applying preset defaults
@@ -95,6 +100,10 @@ type ResolvedPlasticity struct {
 	EnrichmentEnabled bool `json:"enrichment_enabled"`
 	// RecallMode is the default recall mode for this vault.
 	RecallMode string `json:"recall_mode"`
+	// Hybrid decay model parameters
+	DecayModel          string  `json:"decay_model"`           // "exponential" or "hybrid"
+	PowerLawExponent    float64 `json:"power_law_exponent"`    // power-law exponent (default 0.5)
+	DecayTransitionDays float64 `json:"decay_transition_days"` // transition point in days (default 3.0)
 }
 
 type plasticityPreset struct {
@@ -120,9 +129,12 @@ type plasticityPreset struct {
 	AssocMinWeight       float32
 	ArchiveThreshold     float64
 	BehaviorMode         string
-	InlineEnrichment  string
-	EnrichmentEnabled bool
-	RecallMode        string
+	InlineEnrichment    string
+	EnrichmentEnabled   bool
+	RecallMode          string
+	DecayModel          string
+	PowerLawExponent    float64
+	DecayTransitionDays float64
 }
 
 var plasticityPresets = map[string]plasticityPreset{
@@ -151,6 +163,9 @@ var plasticityPresets = map[string]plasticityPreset{
 		InlineEnrichment:     "caller_preferred",
 		EnrichmentEnabled:    true,
 		RecallMode:           "balanced",
+		DecayModel:           "exponential",
+		PowerLawExponent:     0.5,
+		DecayTransitionDays:  3.0,
 	},
 	"reference": {
 		HebbianEnabled:       true,
@@ -177,6 +192,9 @@ var plasticityPresets = map[string]plasticityPreset{
 		InlineEnrichment:     "caller_preferred",
 		EnrichmentEnabled:    true,
 		RecallMode:           "balanced",
+		DecayModel:           "exponential",
+		PowerLawExponent:     0.5,
+		DecayTransitionDays:  3.0,
 	},
 	"scratchpad": {
 		HebbianEnabled:       false,
@@ -203,6 +221,9 @@ var plasticityPresets = map[string]plasticityPreset{
 		InlineEnrichment:     "caller_preferred",
 		EnrichmentEnabled:    true,
 		RecallMode:           "balanced",
+		DecayModel:           "exponential",
+		PowerLawExponent:     0.5,
+		DecayTransitionDays:  3.0,
 	},
 	"knowledge-graph": {
 		HebbianEnabled:       true,
@@ -229,6 +250,9 @@ var plasticityPresets = map[string]plasticityPreset{
 		InlineEnrichment:     "caller_preferred",
 		EnrichmentEnabled:    true,
 		RecallMode:           "balanced",
+		DecayModel:           "exponential",
+		PowerLawExponent:     0.5,
+		DecayTransitionDays:  3.0,
 	},
 }
 
@@ -270,6 +294,9 @@ func ResolvePlasticity(cfg *PlasticityConfig) ResolvedPlasticity {
 		InlineEnrichment:     p.InlineEnrichment,
 		EnrichmentEnabled:    p.EnrichmentEnabled,
 		RecallMode:           p.RecallMode,
+		DecayModel:           p.DecayModel,
+		PowerLawExponent:     p.PowerLawExponent,
+		DecayTransitionDays:  p.DecayTransitionDays,
 	}
 
 	if cfg == nil {
@@ -426,6 +453,33 @@ func ResolvePlasticity(cfg *PlasticityConfig) ResolvedPlasticity {
 	if cfg.RecallMode != nil && ValidRecallMode(*cfg.RecallMode) {
 		r.RecallMode = *cfg.RecallMode
 	}
+	if cfg.DecayModel != nil {
+		if validDecayModel(*cfg.DecayModel) {
+			r.DecayModel = *cfg.DecayModel
+		} else {
+			r.DecayModel = "exponential"
+		}
+	}
+	if cfg.PowerLawExponent != nil {
+		v := *cfg.PowerLawExponent
+		if v < 0.01 {
+			v = 0.01
+		}
+		if v > 2.0 {
+			v = 2.0
+		}
+		r.PowerLawExponent = v
+	}
+	if cfg.DecayTransitionDays != nil {
+		v := *cfg.DecayTransitionDays
+		if v < 0.1 {
+			v = 0.1
+		}
+		if v > 30.0 {
+			v = 30.0
+		}
+		r.DecayTransitionDays = v
+	}
 
 	return r
 }
@@ -450,6 +504,15 @@ var validInlineEnrichments = map[string]bool{
 
 func validInlineEnrichment(s string) bool {
 	return validInlineEnrichments[s]
+}
+
+var validDecayModels = map[string]bool{
+	"exponential": true,
+	"hybrid":      true,
+}
+
+func validDecayModel(s string) bool {
+	return validDecayModels[s]
 }
 
 // ValidRecallMode returns true if s is a known recall mode name.

--- a/internal/auth/plasticity_test.go
+++ b/internal/auth/plasticity_test.go
@@ -498,3 +498,100 @@ func TestPlasticityConfig_ArchiveThreshold_Override(t *testing.T) {
 		t.Errorf("overridden ArchiveThreshold: got %v, want 0.10", r.ArchiveThreshold)
 	}
 }
+
+// --- Hybrid decay model plasticity tests ---
+
+func TestPlasticityConfig_DecayModel_DefaultExponential(t *testing.T) {
+	r := ResolvePlasticity(nil)
+	if r.DecayModel != "exponential" {
+		t.Errorf("default DecayModel: got %q, want %q", r.DecayModel, "exponential")
+	}
+}
+
+func TestPlasticityConfig_DecayModel_AllPresetsDefaultExponential(t *testing.T) {
+	presets := []string{"default", "reference", "scratchpad", "knowledge-graph"}
+	for _, name := range presets {
+		r := ResolvePlasticity(&PlasticityConfig{Preset: name})
+		if r.DecayModel != "exponential" {
+			t.Errorf("preset %q: DecayModel = %q, want %q", name, r.DecayModel, "exponential")
+		}
+	}
+}
+
+func TestPlasticityConfig_DecayModel_OverrideHybrid(t *testing.T) {
+	model := "hybrid"
+	r := ResolvePlasticity(&PlasticityConfig{DecayModel: &model})
+	if r.DecayModel != "hybrid" {
+		t.Errorf("override: DecayModel = %q, want %q", r.DecayModel, "hybrid")
+	}
+}
+
+func TestPlasticityConfig_DecayModel_InvalidFallsToExponential(t *testing.T) {
+	model := "invalid-model"
+	r := ResolvePlasticity(&PlasticityConfig{DecayModel: &model})
+	if r.DecayModel != "exponential" {
+		t.Errorf("invalid model should fall to exponential, got %q", r.DecayModel)
+	}
+}
+
+func TestPlasticityConfig_PowerLawExponent_Default(t *testing.T) {
+	r := ResolvePlasticity(nil)
+	if r.PowerLawExponent != 0.5 {
+		t.Errorf("default PowerLawExponent: got %v, want 0.5", r.PowerLawExponent)
+	}
+}
+
+func TestPlasticityConfig_PowerLawExponent_Override(t *testing.T) {
+	val := 0.7
+	r := ResolvePlasticity(&PlasticityConfig{PowerLawExponent: &val})
+	if r.PowerLawExponent != 0.7 {
+		t.Errorf("override PowerLawExponent: got %v, want 0.7", r.PowerLawExponent)
+	}
+}
+
+func TestPlasticityConfig_PowerLawExponent_ClampLow(t *testing.T) {
+	val := -1.0
+	r := ResolvePlasticity(&PlasticityConfig{PowerLawExponent: &val})
+	if r.PowerLawExponent != 0.01 {
+		t.Errorf("negative PowerLawExponent should clamp to 0.01, got %v", r.PowerLawExponent)
+	}
+}
+
+func TestPlasticityConfig_PowerLawExponent_ClampHigh(t *testing.T) {
+	val := 5.0
+	r := ResolvePlasticity(&PlasticityConfig{PowerLawExponent: &val})
+	if r.PowerLawExponent != 2.0 {
+		t.Errorf("high PowerLawExponent should clamp to 2.0, got %v", r.PowerLawExponent)
+	}
+}
+
+func TestPlasticityConfig_DecayTransitionDays_Default(t *testing.T) {
+	r := ResolvePlasticity(nil)
+	if r.DecayTransitionDays != 3.0 {
+		t.Errorf("default DecayTransitionDays: got %v, want 3.0", r.DecayTransitionDays)
+	}
+}
+
+func TestPlasticityConfig_DecayTransitionDays_Override(t *testing.T) {
+	val := 5.0
+	r := ResolvePlasticity(&PlasticityConfig{DecayTransitionDays: &val})
+	if r.DecayTransitionDays != 5.0 {
+		t.Errorf("override DecayTransitionDays: got %v, want 5.0", r.DecayTransitionDays)
+	}
+}
+
+func TestPlasticityConfig_DecayTransitionDays_ClampLow(t *testing.T) {
+	val := 0.0
+	r := ResolvePlasticity(&PlasticityConfig{DecayTransitionDays: &val})
+	if r.DecayTransitionDays != 0.1 {
+		t.Errorf("zero DecayTransitionDays should clamp to 0.1, got %v", r.DecayTransitionDays)
+	}
+}
+
+func TestPlasticityConfig_DecayTransitionDays_ClampHigh(t *testing.T) {
+	val := 100.0
+	r := ResolvePlasticity(&PlasticityConfig{DecayTransitionDays: &val})
+	if r.DecayTransitionDays != 30.0 {
+		t.Errorf("high DecayTransitionDays should clamp to 30.0, got %v", r.DecayTransitionDays)
+	}
+}

--- a/internal/cognitive/decay.go
+++ b/internal/cognitive/decay.go
@@ -56,6 +56,56 @@ func EbbinghausWithFloor(daysSinceAccess, stability, floor float64) float64 {
 	return r
 }
 
+// HybridRetention computes retention using either pure exponential or a hybrid
+// exponential + power-law model.
+//
+// For decayModel "exponential" (or any unrecognized value), this is identical
+// to EbbinghausWithFloor — pure exponential decay with a floor.
+//
+// For decayModel "hybrid":
+//   - t < transitionDays: R = e^(-t/S)  (exponential, same as Ebbinghaus)
+//   - t >= transitionDays: R = R_transition * (t/transitionDays)^(-powerLawExponent)
+//     where R_transition = e^(-transitionDays/S) ensures continuity at the boundary.
+//
+// The power-law tail decays more slowly than the exponential, preserving older
+// memories that survive the initial fast-decay phase.
+//
+// Academic basis: Wixted & Ebbesen (1991), Wixted (2004), Anderson & Schooler (1991).
+func HybridRetention(daysSinceAccess, stability, floor float64, decayModel string, powerLawExponent, transitionDays float64) float64 {
+	if stability <= 0 {
+		stability = DefaultStability
+	}
+
+	if decayModel != "hybrid" {
+		// Default / exponential / unknown: pure Ebbinghaus
+		r := math.Exp(-daysSinceAccess / stability)
+		if r < floor {
+			return floor
+		}
+		return r
+	}
+
+	// Hybrid model
+	if daysSinceAccess < transitionDays {
+		// Exponential phase (t < transitionDays)
+		r := math.Exp(-daysSinceAccess / stability)
+		if r < floor {
+			return floor
+		}
+		return r
+	}
+
+	// Power-law phase (t >= transitionDays)
+	// R_transition ensures continuity: the power-law starts exactly where
+	// the exponential left off at t = transitionDays.
+	rTransition := math.Exp(-transitionDays / stability)
+	r := rTransition * math.Pow(daysSinceAccess/transitionDays, -powerLawExponent)
+	if r < floor {
+		return floor
+	}
+	return r
+}
+
 // ComputeStability computes new stability from access count and spacing.
 func ComputeStability(accessCount uint32, avgDaysBetweenAccesses float64) float64 {
 	base := math.Log1p(float64(accessCount)) * StabilityGrowthRate

--- a/internal/cognitive/decay.go
+++ b/internal/cognitive/decay.go
@@ -42,6 +42,13 @@ type DecayCandidate struct {
 	AccessCount uint32
 	Stability   float32
 	Relevance   float32 // current relevance at submission time; used as oldVal in OnDecayUpdate
+
+	// Per-vault hybrid decay model parameters (from ResolvedPlasticity).
+	// When DecayModel is empty or "exponential", HybridRetention falls back
+	// to pure Ebbinghaus — identical to the previous behavior.
+	DecayModel          string
+	PowerLawExponent    float64
+	DecayTransitionDays float64
 }
 
 // EbbinghausWithFloor computes the Ebbinghaus retention with a floor value.
@@ -72,6 +79,9 @@ func EbbinghausWithFloor(daysSinceAccess, stability, floor float64) float64 {
 //
 // Academic basis: Wixted & Ebbesen (1991), Wixted (2004), Anderson & Schooler (1991).
 func HybridRetention(daysSinceAccess, stability, floor float64, decayModel string, powerLawExponent, transitionDays float64) float64 {
+	if daysSinceAccess < 0 {
+		daysSinceAccess = 0
+	}
 	if stability <= 0 {
 		stability = DefaultStability
 	}
@@ -227,7 +237,7 @@ func (dw *DecayWorker) processBatch(ctx context.Context, batch []DecayCandidate)
 	now := time.Now()
 	for _, c := range batch {
 		daysSince := now.Sub(c.LastAccess).Hours() / 24.0
-		newRelevance := EbbinghausWithFloor(daysSince, float64(c.Stability), DefaultFloor)
+		newRelevance := HybridRetention(daysSince, float64(c.Stability), DefaultFloor, c.DecayModel, c.PowerLawExponent, c.DecayTransitionDays)
 
 		// Average spacing = total lifespan / number of accesses.
 		// Using lifespan (now - CreatedAt) divided by AccessCount gives the true

--- a/internal/cognitive/decay_test.go
+++ b/internal/cognitive/decay_test.go
@@ -283,3 +283,118 @@ func TestHybridRetention_ZeroStabilityUsesDefault(t *testing.T) {
 		t.Errorf("zero stability should use default: got %v, want %v", got, want)
 	}
 }
+
+// TestHybridRetention_NegativeDaysClampedToZero verifies that negative
+// daysSinceAccess is clamped to zero (retention = 1.0).
+func TestHybridRetention_NegativeDaysClampedToZero(t *testing.T) {
+	for _, model := range []string{"exponential", "hybrid"} {
+		got := HybridRetention(-5.0, 14.0, DefaultFloor, model, 0.5, 3.0)
+		if math.Abs(got-1.0) > 1e-12 {
+			t.Errorf("model=%s: negative days should clamp to 0 (retention=1.0), got %v", model, got)
+		}
+	}
+}
+
+// TestProcessBatch_HybridDecayModel is an integration test verifying the full
+// chain: DecayCandidate with DecayModel="hybrid" -> processBatch -> HybridRetention.
+// This is the test that would have caught the dead-code issue where processBatch
+// was calling EbbinghausWithFloor directly instead of HybridRetention.
+func TestProcessBatch_HybridDecayModel(t *testing.T) {
+	ws := [8]byte{0xAA, 0xBB, 0xCC, 0xDD, 0, 0, 0, 0}
+	id := [16]byte{1, 2, 3, 4}
+
+	var capturedRelevance float32
+
+	store := &stubDecayStore{
+		onUpdateRelevance: func(ctx context.Context, gotWS [8]byte, gotID [16]byte, rel, stab float32) error {
+			capturedRelevance = rel
+			return nil
+		},
+	}
+
+	dw := NewDecayWorker(store)
+	ctx := context.Background()
+
+	// Use 60 days since last access. With stability=14 and transition=3,
+	// the hybrid model retains significantly more than pure exponential
+	// at this time horizon (power-law heavy tail).
+	lastAccess := time.Now().Add(-60 * 24 * time.Hour)
+
+	batch := []DecayCandidate{{
+		WS:                  ws,
+		ID:                  id,
+		CreatedAt:           time.Now().Add(-90 * 24 * time.Hour),
+		LastAccess:          lastAccess,
+		AccessCount:         5,
+		Stability:           DefaultStability,
+		DecayModel:          "hybrid",
+		PowerLawExponent:    0.5,
+		DecayTransitionDays: 3.0,
+	}}
+	if err := dw.processBatch(ctx, batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+
+	// Compute the expected hybrid retention value.
+	daysSince := time.Since(lastAccess).Hours() / 24.0
+	expectedHybrid := HybridRetention(daysSince, DefaultStability, DefaultFloor, "hybrid", 0.5, 3.0)
+	expectedExponential := EbbinghausWithFloor(daysSince, DefaultStability, DefaultFloor)
+
+	// The hybrid value must differ from pure exponential at 60 days.
+	// This is the key assertion: if processBatch were still calling
+	// EbbinghausWithFloor, capturedRelevance would equal expectedExponential.
+	if math.Abs(float64(capturedRelevance)-expectedExponential) < 0.001 {
+		t.Errorf("processBatch appears to use exponential, not hybrid: got %v, exponential would be %v",
+			capturedRelevance, expectedExponential)
+	}
+
+	// The captured relevance should match what HybridRetention computes.
+	if math.Abs(float64(capturedRelevance)-expectedHybrid) > 0.01 {
+		t.Errorf("processBatch hybrid relevance: got %v, want ~%v", capturedRelevance, expectedHybrid)
+	}
+
+	// Sanity: hybrid retains more than exponential at 60 days.
+	if expectedHybrid <= expectedExponential {
+		t.Errorf("hybrid (%v) should retain more than exponential (%v) at 60 days",
+			expectedHybrid, expectedExponential)
+	}
+}
+
+// TestProcessBatch_DefaultDecayModel verifies that processBatch with an empty
+// DecayModel (the default) produces the same result as EbbinghausWithFloor,
+// ensuring backward compatibility.
+func TestProcessBatch_DefaultDecayModel(t *testing.T) {
+	ws := [8]byte{0xAA, 0xBB, 0xCC, 0xDD, 0, 0, 0, 0}
+	id := [16]byte{1, 2, 3, 4}
+
+	var capturedRelevance float32
+
+	store := &stubDecayStore{
+		onUpdateRelevance: func(ctx context.Context, gotWS [8]byte, gotID [16]byte, rel, stab float32) error {
+			capturedRelevance = rel
+			return nil
+		},
+	}
+
+	dw := NewDecayWorker(store)
+	ctx := context.Background()
+
+	lastAccess := time.Now().Add(-24 * time.Hour)
+	batch := []DecayCandidate{{
+		WS:          ws,
+		ID:          id,
+		CreatedAt:   time.Now().Add(-30 * 24 * time.Hour),
+		LastAccess:  lastAccess,
+		AccessCount: 5,
+		Stability:   DefaultStability,
+		// DecayModel intentionally left empty — should default to exponential.
+	}}
+	if err := dw.processBatch(ctx, batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+
+	expected := EbbinghausWithFloor(1.0, DefaultStability, DefaultFloor)
+	if math.Abs(float64(capturedRelevance)-expected) > 0.01 {
+		t.Errorf("default decay model should match Ebbinghaus: got %v, want ~%v", capturedRelevance, expected)
+	}
+}

--- a/internal/cognitive/decay_test.go
+++ b/internal/cognitive/decay_test.go
@@ -140,3 +140,146 @@ func (s *stubDecayStore) UpdateRelevance(ctx context.Context, ws [8]byte, id [16
 	}
 	return nil
 }
+
+// --- Hybrid decay model tests ---
+
+// TestHybridRetention_ExponentialModelMatchesCurrent verifies that "exponential"
+// model produces identical results to the original EbbinghausWithFloor.
+func TestHybridRetention_ExponentialModelMatchesCurrent(t *testing.T) {
+	stability := 14.0
+	floor := DefaultFloor
+	for _, days := range []float64{0, 0.5, 1, 3, 7, 14, 30, 100, 1000} {
+		want := EbbinghausWithFloor(days, stability, floor)
+		got := HybridRetention(days, stability, floor, "exponential", 0.5, 3.0)
+		if math.Abs(got-want) > 1e-12 {
+			t.Errorf("exponential model at days=%v: got %v, want %v", days, got, want)
+		}
+	}
+}
+
+// TestHybridRetention_HybridUsesExponentialBeforeTransition verifies that
+// the hybrid model matches pure exponential for t < TransitionDays.
+func TestHybridRetention_HybridUsesExponentialBeforeTransition(t *testing.T) {
+	stability := 14.0
+	floor := DefaultFloor
+	transitionDays := 3.0
+	for _, days := range []float64{0, 0.1, 0.5, 1.0, 2.0, 2.99} {
+		want := EbbinghausWithFloor(days, stability, floor)
+		got := HybridRetention(days, stability, floor, "hybrid", 0.5, transitionDays)
+		if math.Abs(got-want) > 1e-12 {
+			t.Errorf("hybrid model before transition at days=%v: got %v, want %v", days, got, want)
+		}
+	}
+}
+
+// TestHybridRetention_HybridUsesPowerLawAfterTransition verifies that
+// the hybrid model uses power-law decay for t >= TransitionDays.
+func TestHybridRetention_HybridUsesPowerLawAfterTransition(t *testing.T) {
+	stability := 14.0
+	floor := DefaultFloor
+	transitionDays := 3.0
+	powerLawExponent := 0.5
+
+	rTransition := math.Exp(-transitionDays / stability)
+
+	for _, days := range []float64{3.0, 5.0, 10.0, 30.0, 100.0} {
+		// Expected: R_transition * (t / transitionDays)^(-powerLawExponent)
+		expectedPowerLaw := rTransition * math.Pow(days/transitionDays, -powerLawExponent)
+		if expectedPowerLaw < floor {
+			expectedPowerLaw = floor
+		}
+		got := HybridRetention(days, stability, floor, "hybrid", powerLawExponent, transitionDays)
+		if math.Abs(got-expectedPowerLaw) > 1e-12 {
+			t.Errorf("hybrid model power-law at days=%v: got %v, want %v", days, got, expectedPowerLaw)
+		}
+	}
+}
+
+// TestHybridRetention_ContinuityAtTransition verifies there is no discontinuous
+// jump at the transition point between exponential and power-law phases.
+func TestHybridRetention_ContinuityAtTransition(t *testing.T) {
+	stability := 14.0
+	floor := DefaultFloor
+	transitionDays := 3.0
+
+	// Value just before transition
+	justBefore := HybridRetention(transitionDays-1e-9, stability, floor, "hybrid", 0.5, transitionDays)
+	// Value exactly at transition
+	atTransition := HybridRetention(transitionDays, stability, floor, "hybrid", 0.5, transitionDays)
+	// Value just after transition
+	justAfter := HybridRetention(transitionDays+1e-9, stability, floor, "hybrid", 0.5, transitionDays)
+
+	// The jump from just-before to at-transition should be negligible
+	if math.Abs(justBefore-atTransition) > 1e-6 {
+		t.Errorf("discontinuity at transition: justBefore=%v, atTransition=%v, delta=%v",
+			justBefore, atTransition, math.Abs(justBefore-atTransition))
+	}
+	// The jump from at-transition to just-after should also be negligible
+	if math.Abs(atTransition-justAfter) > 1e-6 {
+		t.Errorf("discontinuity after transition: atTransition=%v, justAfter=%v, delta=%v",
+			atTransition, justAfter, math.Abs(atTransition-justAfter))
+	}
+}
+
+// TestHybridRetention_FloorAppliesInPowerLaw verifies that the floor constraint
+// is enforced even in the power-law phase for very large t values.
+func TestHybridRetention_FloorAppliesInPowerLaw(t *testing.T) {
+	stability := 14.0
+	floor := DefaultFloor
+	// Very large time where power-law would go below floor
+	days := 1e6
+	got := HybridRetention(days, stability, floor, "hybrid", 0.5, 3.0)
+	if got < floor {
+		t.Errorf("hybrid retention below floor: got %v, want >= %v", got, floor)
+	}
+	if math.Abs(got-floor) > 1e-9 {
+		t.Errorf("hybrid retention at extreme t should equal floor: got %v, want %v", got, floor)
+	}
+}
+
+// TestHybridRetention_PowerLawRetainsMoreThanExponential verifies that the
+// power-law tail retains more than pure exponential for large t values.
+// This is the core motivation for the hybrid model.
+//
+// Note: near the transition point, the power-law may still be below exponential
+// (the crossover depends on stability and exponent). The advantage of the heavy
+// tail emerges for sufficiently large t. With stability=14 and transition=3,
+// the crossover is around t~23 days; beyond that, power-law retains more.
+func TestHybridRetention_PowerLawRetainsMoreThanExponential(t *testing.T) {
+	stability := 14.0
+	floor := DefaultFloor
+
+	// At large t values, the power-law heavy tail preserves more than exponential.
+	for _, days := range []float64{30.0, 60.0, 100.0, 365.0} {
+		expo := HybridRetention(days, stability, floor, "exponential", 0.5, 3.0)
+		hybrid := HybridRetention(days, stability, floor, "hybrid", 0.5, 3.0)
+		if hybrid < expo {
+			t.Errorf("at days=%v: hybrid (%v) should be >= exponential (%v)", days, hybrid, expo)
+		}
+	}
+}
+
+// TestHybridRetention_UnknownModelFallsToExponential verifies that an unknown
+// decay model name defaults to exponential behavior.
+func TestHybridRetention_UnknownModelFallsToExponential(t *testing.T) {
+	stability := 14.0
+	floor := DefaultFloor
+	days := 10.0
+	want := EbbinghausWithFloor(days, stability, floor)
+	got := HybridRetention(days, stability, floor, "unknown", 0.5, 3.0)
+	if math.Abs(got-want) > 1e-12 {
+		t.Errorf("unknown model should fall back to exponential: got %v, want %v", got, want)
+	}
+}
+
+// TestHybridRetention_ZeroStabilityUsesDefault verifies that zero stability
+// falls back to DefaultStability in the hybrid model.
+func TestHybridRetention_ZeroStabilityUsesDefault(t *testing.T) {
+	floor := DefaultFloor
+	days := 5.0
+	got := HybridRetention(days, 0, floor, "hybrid", 0.5, 3.0)
+	want := HybridRetention(days, DefaultStability, floor, "hybrid", 0.5, 3.0)
+	if math.Abs(got-want) > 1e-12 {
+		t.Errorf("zero stability should use default: got %v, want %v", got, want)
+	}
+}

--- a/internal/mcp/guide.go
+++ b/internal/mcp/guide.go
@@ -100,6 +100,11 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 	fmt.Fprintf(&b, "- Predictive activation (PAS): %s\n", enabledStr(resolved.PredictiveActivation))
 	fmt.Fprintf(&b, "- Graph hop depth: %d\n", resolved.HopDepth)
 	fmt.Fprintf(&b, "- Temporal decay: %s\n", enabledStr(resolved.TemporalEnabled))
+	if resolved.DecayModel == "hybrid" {
+		fmt.Fprintf(&b, "- Decay model: hybrid (exponential + power-law, transition at %.0f days, exponent %.2f)\n", resolved.DecayTransitionDays, resolved.PowerLawExponent)
+	} else {
+		fmt.Fprintf(&b, "- Decay model: exponential (classic Ebbinghaus)\n")
+	}
 	fmt.Fprintf(&b, "- Inline enrichment: %s\n", resolved.InlineEnrichment)
 	if resolved.MaxEngrams > 0 {
 		fmt.Fprintf(&b, "- Max engrams: %d\n", resolved.MaxEngrams)

--- a/internal/mcp/guide.go
+++ b/internal/mcp/guide.go
@@ -101,7 +101,7 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 	fmt.Fprintf(&b, "- Graph hop depth: %d\n", resolved.HopDepth)
 	fmt.Fprintf(&b, "- Temporal decay: %s\n", enabledStr(resolved.TemporalEnabled))
 	if resolved.DecayModel == "hybrid" {
-		fmt.Fprintf(&b, "- Decay model: hybrid (exponential + power-law, transition at %.0f days, exponent %.2f)\n", resolved.DecayTransitionDays, resolved.PowerLawExponent)
+		fmt.Fprintf(&b, "- Decay model: hybrid (exponential + power-law, transition at %.1f days, exponent %.2f)\n", resolved.DecayTransitionDays, resolved.PowerLawExponent)
 	} else {
 		fmt.Fprintf(&b, "- Decay model: exponential (classic Ebbinghaus)\n")
 	}


### PR DESCRIPTION
## Summary

- Adds `HybridRetention()` function with two decay models:
  - **exponential** (default): identical to existing `EbbinghausWithFloor()` — backward compatible
  - **hybrid**: exponential for t < transition days, continuous power-law tail for t >= transition days
- Mathematical continuity at the transition point (no discontinuous jump)
- New plasticity parameters: `decay_model`, `power_law_exponent` (default 0.5), `decay_transition_days` (default 3.0)
- All presets default to `"exponential"` — zero behavior change without opt-in

### Why

Pure Ebbinghaus exponential decay drops off too aggressively for long-term memories. Empirical research (Wixted & Ebbesen 1991, Wixted 2004) shows power-law decay better matches human forgetting curves for memories older than a few days. The heavy tail preserves important older memories without requiring frequent access.

Fixes #314

## Test plan

- [x] Exponential model matches current behavior exactly
- [x] Hybrid model uses exponential for t < 3 days
- [x] Hybrid model uses power-law for t >= 3 days
- [x] Continuity at transition point verified
- [x] Floor constraint enforced in power-law phase
- [x] Power-law retention > exponential retention for large t
- [x] Plasticity parameter defaults, overrides, and clamping
- [x] RED/GREEN verified
- [x] Full cognitive + auth test suite passes