### PR TITLE
feat(activation): Reciprocal Rank Fusion (RRF) as scoring alternative

### DIFF
--- a/internal/auth/plasticity.go
+++ b/internal/auth/plasticity.go
@@ -57,9 +57,6 @@ type PlasticityConfig struct {
 	// "weighted_sum" = use legacy weighted-sum scoring (DisableACTR implied).
 	// nil/empty = default (ACT-R scoring, unchanged behavior).
 	ScoringFusion *string `json:"scoring_fusion,omitempty"`
-	// RRF_K is the RRF smoothing constant (default 60). Only used when ScoringFusion="rrf".
-	// Higher k values compress rank differences; lower k values amplify top-rank advantage.
-	RRF_K *int `json:"rrf_k,omitempty"`
 }
 
 // ResolvedPlasticity is the fully-merged configuration after applying preset defaults
@@ -106,8 +103,6 @@ type ResolvedPlasticity struct {
 	RecallMode string `json:"recall_mode"`
 	// ScoringFusion selects Phase 6 scoring strategy: "" (default=ACT-R), "rrf", or "weighted_sum".
 	ScoringFusion string `json:"scoring_fusion"`
-	// RRF_K is the RRF smoothing constant (default 60). Only meaningful when ScoringFusion="rrf".
-	RRF_K int `json:"rrf_k"`
 }
 
 type plasticityPreset struct {
@@ -137,7 +132,6 @@ type plasticityPreset struct {
 	EnrichmentEnabled bool
 	RecallMode        string
 	ScoringFusion     string // "" = default (ACT-R), "rrf", "weighted_sum"
-	RRF_K             int    // default 60
 }
 
 var plasticityPresets = map[string]plasticityPreset{
@@ -166,7 +160,7 @@ var plasticityPresets = map[string]plasticityPreset{
 		InlineEnrichment:     "caller_preferred",
 		EnrichmentEnabled:    true,
 		RecallMode:           "balanced",
-		RRF_K:                60,
+
 	},
 	"reference": {
 		HebbianEnabled:       true,
@@ -193,7 +187,7 @@ var plasticityPresets = map[string]plasticityPreset{
 		InlineEnrichment:     "caller_preferred",
 		EnrichmentEnabled:    true,
 		RecallMode:           "balanced",
-		RRF_K:                60,
+
 	},
 	"scratchpad": {
 		HebbianEnabled:       false,
@@ -220,7 +214,7 @@ var plasticityPresets = map[string]plasticityPreset{
 		InlineEnrichment:     "caller_preferred",
 		EnrichmentEnabled:    true,
 		RecallMode:           "balanced",
-		RRF_K:                60,
+
 	},
 	"knowledge-graph": {
 		HebbianEnabled:       true,
@@ -247,7 +241,7 @@ var plasticityPresets = map[string]plasticityPreset{
 		InlineEnrichment:     "caller_preferred",
 		EnrichmentEnabled:    true,
 		RecallMode:           "balanced",
-		RRF_K:                60,
+
 	},
 }
 
@@ -290,7 +284,6 @@ func ResolvePlasticity(cfg *PlasticityConfig) ResolvedPlasticity {
 		EnrichmentEnabled:    p.EnrichmentEnabled,
 		RecallMode:           p.RecallMode,
 		ScoringFusion:        p.ScoringFusion,
-		RRF_K:                p.RRF_K,
 	}
 
 	if cfg == nil {
@@ -454,17 +447,6 @@ func ResolvePlasticity(cfg *PlasticityConfig) ResolvedPlasticity {
 			r.ScoringFusion = "" // invalid → default (ACT-R)
 		}
 	}
-	if cfg.RRF_K != nil {
-		k := *cfg.RRF_K
-		if k < 1 {
-			k = 1
-		}
-		if k > 1000 {
-			k = 1000
-		}
-		r.RRF_K = k
-	}
-
 	return r
 }
 

--- a/internal/auth/plasticity.go
+++ b/internal/auth/plasticity.go
@@ -51,6 +51,15 @@ type PlasticityConfig struct {
 	// RecallMode is the default recall mode for this vault: "semantic"|"recent"|"balanced"|"deep".
 	// nil = use "balanced" (engine defaults).
 	RecallMode *string `json:"recall_mode,omitempty"`
+
+	// ScoringFusion selects the Phase 6 scoring strategy.
+	// "rrf" = use Phase 3 RRF scores directly (rank-based, scale-invariant).
+	// "weighted_sum" = use legacy weighted-sum scoring (DisableACTR implied).
+	// nil/empty = default (ACT-R scoring, unchanged behavior).
+	ScoringFusion *string `json:"scoring_fusion,omitempty"`
+	// RRF_K is the RRF smoothing constant (default 60). Only used when ScoringFusion="rrf".
+	// Higher k values compress rank differences; lower k values amplify top-rank advantage.
+	RRF_K *int `json:"rrf_k,omitempty"`
 }
 
 // ResolvedPlasticity is the fully-merged configuration after applying preset defaults
@@ -95,6 +104,10 @@ type ResolvedPlasticity struct {
 	EnrichmentEnabled bool `json:"enrichment_enabled"`
 	// RecallMode is the default recall mode for this vault.
 	RecallMode string `json:"recall_mode"`
+	// ScoringFusion selects Phase 6 scoring strategy: "" (default=ACT-R), "rrf", or "weighted_sum".
+	ScoringFusion string `json:"scoring_fusion"`
+	// RRF_K is the RRF smoothing constant (default 60). Only meaningful when ScoringFusion="rrf".
+	RRF_K int `json:"rrf_k"`
 }
 
 type plasticityPreset struct {
@@ -123,6 +136,8 @@ type plasticityPreset struct {
 	InlineEnrichment  string
 	EnrichmentEnabled bool
 	RecallMode        string
+	ScoringFusion     string // "" = default (ACT-R), "rrf", "weighted_sum"
+	RRF_K             int    // default 60
 }
 
 var plasticityPresets = map[string]plasticityPreset{
@@ -151,6 +166,7 @@ var plasticityPresets = map[string]plasticityPreset{
 		InlineEnrichment:     "caller_preferred",
 		EnrichmentEnabled:    true,
 		RecallMode:           "balanced",
+		RRF_K:                60,
 	},
 	"reference": {
 		HebbianEnabled:       true,
@@ -177,6 +193,7 @@ var plasticityPresets = map[string]plasticityPreset{
 		InlineEnrichment:     "caller_preferred",
 		EnrichmentEnabled:    true,
 		RecallMode:           "balanced",
+		RRF_K:                60,
 	},
 	"scratchpad": {
 		HebbianEnabled:       false,
@@ -203,6 +220,7 @@ var plasticityPresets = map[string]plasticityPreset{
 		InlineEnrichment:     "caller_preferred",
 		EnrichmentEnabled:    true,
 		RecallMode:           "balanced",
+		RRF_K:                60,
 	},
 	"knowledge-graph": {
 		HebbianEnabled:       true,
@@ -229,6 +247,7 @@ var plasticityPresets = map[string]plasticityPreset{
 		InlineEnrichment:     "caller_preferred",
 		EnrichmentEnabled:    true,
 		RecallMode:           "balanced",
+		RRF_K:                60,
 	},
 }
 
@@ -270,6 +289,8 @@ func ResolvePlasticity(cfg *PlasticityConfig) ResolvedPlasticity {
 		InlineEnrichment:     p.InlineEnrichment,
 		EnrichmentEnabled:    p.EnrichmentEnabled,
 		RecallMode:           p.RecallMode,
+		ScoringFusion:        p.ScoringFusion,
+		RRF_K:                p.RRF_K,
 	}
 
 	if cfg == nil {
@@ -426,6 +447,23 @@ func ResolvePlasticity(cfg *PlasticityConfig) ResolvedPlasticity {
 	if cfg.RecallMode != nil && ValidRecallMode(*cfg.RecallMode) {
 		r.RecallMode = *cfg.RecallMode
 	}
+	if cfg.ScoringFusion != nil {
+		if ValidScoringFusion(*cfg.ScoringFusion) {
+			r.ScoringFusion = *cfg.ScoringFusion
+		} else {
+			r.ScoringFusion = "" // invalid → default (ACT-R)
+		}
+	}
+	if cfg.RRF_K != nil {
+		k := *cfg.RRF_K
+		if k < 1 {
+			k = 1
+		}
+		if k > 1000 {
+			k = 1000
+		}
+		r.RRF_K = k
+	}
 
 	return r
 }
@@ -465,4 +503,14 @@ func ValidRecallMode(s string) bool {
 func ValidPlasticityPreset(s string) bool {
 	_, ok := plasticityPresets[s]
 	return ok
+}
+
+// ValidScoringFusion returns true if s is a known scoring fusion mode.
+// Empty string is valid (means "use default ACT-R scoring").
+func ValidScoringFusion(s string) bool {
+	switch s {
+	case "", "rrf", "weighted_sum":
+		return true
+	}
+	return false
 }

--- a/internal/auth/rrf_plasticity_test.go
+++ b/internal/auth/rrf_plasticity_test.go
@@ -3,7 +3,7 @@ package auth
 import "testing"
 
 // ---------------------------------------------------------------------------
-// Tests for ScoringFusion and RRF_K plasticity parameters
+// Tests for ScoringFusion plasticity parameter
 // ---------------------------------------------------------------------------
 
 func TestScoringFusion_DefaultEmpty(t *testing.T) {
@@ -44,47 +44,6 @@ func TestScoringFusion_InvalidFallsToEmpty(t *testing.T) {
 	r := ResolvePlasticity(&PlasticityConfig{ScoringFusion: &mode})
 	if r.ScoringFusion != "" {
 		t.Errorf("invalid mode should fall back to empty, got %q", r.ScoringFusion)
-	}
-}
-
-func TestRRFK_DefaultIs60(t *testing.T) {
-	r := ResolvePlasticity(nil)
-	if r.RRF_K != 60 {
-		t.Errorf("default RRF_K should be 60, got %d", r.RRF_K)
-	}
-}
-
-func TestRRFK_AllPresetsDefault60(t *testing.T) {
-	presets := []string{"default", "reference", "scratchpad", "knowledge-graph"}
-	for _, name := range presets {
-		r := ResolvePlasticity(&PlasticityConfig{Preset: name})
-		if r.RRF_K != 60 {
-			t.Errorf("preset %q: RRF_K should be 60, got %d", name, r.RRF_K)
-		}
-	}
-}
-
-func TestRRFK_Override(t *testing.T) {
-	k := 40
-	r := ResolvePlasticity(&PlasticityConfig{RRF_K: &k})
-	if r.RRF_K != 40 {
-		t.Errorf("override: want RRF_K=40, got %d", r.RRF_K)
-	}
-}
-
-func TestRRFK_ClampedLow(t *testing.T) {
-	k := 0
-	r := ResolvePlasticity(&PlasticityConfig{RRF_K: &k})
-	if r.RRF_K != 1 {
-		t.Errorf("zero should clamp to 1, got %d", r.RRF_K)
-	}
-}
-
-func TestRRFK_ClampedHigh(t *testing.T) {
-	k := 10000
-	r := ResolvePlasticity(&PlasticityConfig{RRF_K: &k})
-	if r.RRF_K != 1000 {
-		t.Errorf("above 1000 should clamp to 1000, got %d", r.RRF_K)
 	}
 }
 

--- a/internal/auth/rrf_plasticity_test.go
+++ b/internal/auth/rrf_plasticity_test.go
@@ -1,0 +1,105 @@
+package auth
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// Tests for ScoringFusion and RRF_K plasticity parameters
+// ---------------------------------------------------------------------------
+
+func TestScoringFusion_DefaultEmpty(t *testing.T) {
+	r := ResolvePlasticity(nil)
+	if r.ScoringFusion != "" {
+		t.Errorf("default ScoringFusion should be empty (ACT-R), got %q", r.ScoringFusion)
+	}
+}
+
+func TestScoringFusion_AllPresetsDefaultEmpty(t *testing.T) {
+	presets := []string{"default", "reference", "scratchpad", "knowledge-graph"}
+	for _, name := range presets {
+		r := ResolvePlasticity(&PlasticityConfig{Preset: name})
+		if r.ScoringFusion != "" {
+			t.Errorf("preset %q: ScoringFusion should be empty, got %q", name, r.ScoringFusion)
+		}
+	}
+}
+
+func TestScoringFusion_OverrideRRF(t *testing.T) {
+	mode := "rrf"
+	r := ResolvePlasticity(&PlasticityConfig{ScoringFusion: &mode})
+	if r.ScoringFusion != "rrf" {
+		t.Errorf("override: want ScoringFusion=rrf, got %q", r.ScoringFusion)
+	}
+}
+
+func TestScoringFusion_OverrideWeightedSum(t *testing.T) {
+	mode := "weighted_sum"
+	r := ResolvePlasticity(&PlasticityConfig{ScoringFusion: &mode})
+	if r.ScoringFusion != "weighted_sum" {
+		t.Errorf("override: want ScoringFusion=weighted_sum, got %q", r.ScoringFusion)
+	}
+}
+
+func TestScoringFusion_InvalidFallsToEmpty(t *testing.T) {
+	mode := "invalid-scoring"
+	r := ResolvePlasticity(&PlasticityConfig{ScoringFusion: &mode})
+	if r.ScoringFusion != "" {
+		t.Errorf("invalid mode should fall back to empty, got %q", r.ScoringFusion)
+	}
+}
+
+func TestRRFK_DefaultIs60(t *testing.T) {
+	r := ResolvePlasticity(nil)
+	if r.RRF_K != 60 {
+		t.Errorf("default RRF_K should be 60, got %d", r.RRF_K)
+	}
+}
+
+func TestRRFK_AllPresetsDefault60(t *testing.T) {
+	presets := []string{"default", "reference", "scratchpad", "knowledge-graph"}
+	for _, name := range presets {
+		r := ResolvePlasticity(&PlasticityConfig{Preset: name})
+		if r.RRF_K != 60 {
+			t.Errorf("preset %q: RRF_K should be 60, got %d", name, r.RRF_K)
+		}
+	}
+}
+
+func TestRRFK_Override(t *testing.T) {
+	k := 40
+	r := ResolvePlasticity(&PlasticityConfig{RRF_K: &k})
+	if r.RRF_K != 40 {
+		t.Errorf("override: want RRF_K=40, got %d", r.RRF_K)
+	}
+}
+
+func TestRRFK_ClampedLow(t *testing.T) {
+	k := 0
+	r := ResolvePlasticity(&PlasticityConfig{RRF_K: &k})
+	if r.RRF_K != 1 {
+		t.Errorf("zero should clamp to 1, got %d", r.RRF_K)
+	}
+}
+
+func TestRRFK_ClampedHigh(t *testing.T) {
+	k := 10000
+	r := ResolvePlasticity(&PlasticityConfig{RRF_K: &k})
+	if r.RRF_K != 1000 {
+		t.Errorf("above 1000 should clamp to 1000, got %d", r.RRF_K)
+	}
+}
+
+func TestValidScoringFusion(t *testing.T) {
+	valid := []string{"", "rrf", "weighted_sum"}
+	for _, mode := range valid {
+		if !ValidScoringFusion(mode) {
+			t.Errorf("ValidScoringFusion(%q) = false, want true", mode)
+		}
+	}
+
+	invalid := []string{"actr", "cgdn", "RANDOM", "RRF"}
+	for _, mode := range invalid {
+		if ValidScoringFusion(mode) {
+			t.Errorf("ValidScoringFusion(%q) = true, want false", mode)
+		}
+	}
+}

--- a/internal/engine/activation/activation_test.go
+++ b/internal/engine/activation/activation_test.go
@@ -1200,3 +1200,95 @@ func TestPhase4_75_ArchiveRestoreRunsDuringActivation(t *testing.T) {
 		t.Logf("Phase 4.75 populated %d RestoredEdges in ActivateResult", len(result.RestoredEdges))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Test: UseRRFFusion produces different scores from ACT-R default
+// ---------------------------------------------------------------------------
+//
+// This integration test verifies that the RRF scoring path is actually reached
+// when UseRRFFusion=true is set on the Weights struct (which is how
+// engine.go wires ScoringFusion="rrf" from plasticity config). The test runs
+// the same data through both ACT-R (default) and RRF paths and asserts the
+// scores differ — proving the RRF code path was taken.
+func TestUseRRFFusion_ProducesDifferentScoresFromACTR(t *testing.T) {
+	store := newStubStore()
+
+	eng1 := &storage.Engram{
+		Concept:    "rrf integration test",
+		Content:    "test engram for rrf vs actr comparison",
+		Confidence: 0.8,
+		Stability:  30.0,
+		Relevance:  0.5,
+	}
+	store.writeEngram(eng1)
+
+	var ftsResults []activation.ScoredID
+	for id := range store.metas {
+		ftsResults = append(ftsResults, activation.ScoredID{ID: id, Score: 0.6})
+	}
+
+	// Run with ACT-R (default path)
+	ftsACTR := &stubFTS{results: ftsResults}
+	engACTR := newTestEngine(store, ftsACTR, nil)
+	resultACTR, err := engACTR.Run(context.Background(), &activation.ActivateRequest{
+		Context:    []string{"test engram"},
+		Threshold:  0.0,
+		MaxResults: 10,
+		Weights: &activation.Weights{
+			SemanticSimilarity: 0.6,
+			FullTextRelevance:  0.4,
+			UseACTR:            true,
+			ACTRDecay:          0.5,
+			ACTRHebScale:       4.0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run ACT-R: %v", err)
+	}
+
+	// Run with RRF fusion (the path wired by ScoringFusion="rrf" in plasticity).
+	// RRF scores are rank-based and small (e.g. 1/(60+1) ~ 0.016) so we use a
+	// low threshold. The engine floor-clamps Threshold<=0 to 0.05.
+	ftsRRF := &stubFTS{results: ftsResults}
+	engRRF := newTestEngine(store, ftsRRF, nil)
+	resultRRF, err := engRRF.Run(context.Background(), &activation.ActivateRequest{
+		Context:    []string{"test engram"},
+		Threshold:  0.001,
+		MaxResults: 10,
+		Weights: &activation.Weights{
+			SemanticSimilarity: 0.6,
+			FullTextRelevance:  0.4,
+			UseRRFFusion:       true,
+			DisableACTR:        true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run RRF: %v", err)
+	}
+
+	// Both paths should return results.
+	if len(resultACTR.Activations) == 0 {
+		t.Fatal("ACT-R path returned no results")
+	}
+	if len(resultRRF.Activations) == 0 {
+		t.Fatal("RRF path returned no results")
+	}
+
+	// Scores must be positive in both paths.
+	actrScore := resultACTR.Activations[0].Score
+	rrfScore := resultRRF.Activations[0].Score
+	if actrScore <= 0 {
+		t.Errorf("ACT-R score should be positive, got %v", actrScore)
+	}
+	if rrfScore <= 0 {
+		t.Errorf("RRF score should be positive, got %v", rrfScore)
+	}
+
+	// The two scoring formulas are fundamentally different (ACT-R computes
+	// base-level activation via power-law decay; RRF uses rank-based fusion).
+	// With identical inputs, their scores must differ.
+	if actrScore == rrfScore {
+		t.Errorf("ACT-R and RRF scores should differ: actr=%v rrf=%v", actrScore, rrfScore)
+	}
+	t.Logf("ACT-R score=%v, RRF score=%v (different as expected)", actrScore, rrfScore)
+}

--- a/internal/engine/activation/activation_test.go
+++ b/internal/engine/activation/activation_test.go
@@ -1292,3 +1292,107 @@ func TestUseRRFFusion_ProducesDifferentScoresFromACTR(t *testing.T) {
 	}
 	t.Logf("ACT-R score=%v, RRF score=%v (different as expected)", actrScore, rrfScore)
 }
+
+// ---------------------------------------------------------------------------
+// Test: RRF results are returned even with the default threshold (0.05).
+// This is a regression test for the ship-blocker where RRF scores (~0.04 max
+// for 2 signals) were all below the default 0.05 threshold, causing zero results.
+// The fix auto-lowers the threshold to 0.001 when UseRRFFusion is detected.
+// ---------------------------------------------------------------------------
+
+func TestRRF_ReturnsResultsWithDefaultThreshold(t *testing.T) {
+	store := newStubStore()
+
+	eng1 := &storage.Engram{
+		Concept:    "rrf threshold regression",
+		Content:    "engram that must survive default threshold with RRF scoring",
+		Confidence: 1.0,
+		Stability:  30.0,
+		Relevance:  0.8,
+	}
+	store.writeEngram(eng1)
+
+	ftsResults := []activation.ScoredID{{ID: eng1.ID, Score: 0.8}}
+	fts := &stubFTS{results: ftsResults}
+	hnsw := &stubHNSW{results: []activation.ScoredID{{ID: eng1.ID, Score: 0.7}}}
+
+	eng := newTestEngine(store, fts, hnsw)
+
+	// Threshold=0 triggers the default path (0.05) which used to filter all
+	// RRF results. After the fix, Run() detects UseRRFFusion and lowers the
+	// threshold to 0.001 automatically.
+	result, err := eng.Run(context.Background(), &activation.ActivateRequest{
+		Context:    []string{"rrf threshold"},
+		Threshold:  0, // triggers default 0.05
+		MaxResults: 10,
+		Weights: &activation.Weights{
+			UseRRFFusion: true,
+			DisableACTR:  true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result.Activations) == 0 {
+		t.Fatal("RRF with default threshold returned 0 results -- threshold auto-lowering is broken")
+	}
+	t.Logf("RRF returned %d results with auto-lowered threshold (score=%v)",
+		len(result.Activations), result.Activations[0].Score)
+}
+
+// ---------------------------------------------------------------------------
+// Test: When both UseRRFFusion and UseCGDN are enabled, RRF takes precedence
+// and CGDN is silently disabled. The guard in phase6Score logs a warning and
+// clears UseCGDN so the RRF path executes.
+// ---------------------------------------------------------------------------
+
+func TestRRF_CGDNConflict_RRFTakesPrecedence(t *testing.T) {
+	store := newStubStore()
+
+	eng1 := &storage.Engram{
+		Concept:    "conflict test",
+		Content:    "engram for RRF vs CGDN conflict test",
+		Confidence: 1.0,
+		Stability:  30.0,
+		Relevance:  0.8,
+	}
+	store.writeEngram(eng1)
+
+	ftsResults := []activation.ScoredID{{ID: eng1.ID, Score: 0.7}}
+	fts := &stubFTS{results: ftsResults}
+
+	eng := newTestEngine(store, fts, nil)
+
+	// Both RRF and CGDN enabled -- RRF should win.
+	result, err := eng.Run(context.Background(), &activation.ActivateRequest{
+		Context:    []string{"conflict test"},
+		Threshold:  0.0,
+		MaxResults: 10,
+		Weights: &activation.Weights{
+			UseRRFFusion:       true,
+			UseCGDN:            true,
+			SemanticSimilarity: 0.5,
+			FullTextRelevance:  0.5,
+			DisableACTR:        true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run with RRF+CGDN: %v", err)
+	}
+
+	// Should return results (RRF path executed, not CGDN).
+	if len(result.Activations) == 0 {
+		t.Fatal("RRF+CGDN conflict: expected results from RRF path")
+	}
+
+	// Verify the scores are RRF-scale (small, rank-based) not CGDN-scale.
+	// RRF scores for a single signal are in [0, ~0.016]; with confidence and
+	// boost multiplier, still well under 0.1.
+	score := result.Activations[0].Score
+	if score > 0.5 {
+		t.Errorf("score %v looks like CGDN (expected small RRF-scale score)", score)
+	}
+	if score <= 0 {
+		t.Errorf("score must be positive, got %v", score)
+	}
+}

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -373,6 +373,14 @@ func (e *ActivationEngine) Run(ctx context.Context, req *ActivateRequest) (*Acti
 		req.Threshold = 0.05
 	}
 
+	// After threshold default is set, adjust for RRF mode.
+	// RRF scores are typically in [0, 0.05] range -- much lower than ACT-R.
+	// Apply an RRF-appropriate threshold to avoid filtering all results.
+	w := resolveWeights(req.Weights, e.weights)
+	if w.UseRRFFusion && req.Threshold >= 0.01 {
+		req.Threshold = 0.001
+	}
+
 	// Phase 1: embed + tokenize
 	p1, err := e.phase1(ctx, req)
 	if err != nil {
@@ -1070,6 +1078,14 @@ func (e *ActivationEngine) phase6Score(
 ) (*ActivateResult, error) {
 
 	w := resolveWeights(req.Weights, e.weights)
+
+	// Guard: RRF and CGDN are mutually exclusive scoring paths.
+	// If both are enabled, RRF takes precedence (checked first below).
+	// Log the conflict so operators can fix their plasticity config.
+	if w.UseRRFFusion && w.UseCGDN {
+		slog.Warn("scoring: both RRF and CGDN enabled -- RRF takes precedence, CGDN ignored")
+		w.UseCGDN = false
+	}
 
 	type scoringCandidate struct {
 		id              storage.ULID

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -54,6 +54,11 @@ type Weights struct {
 	ACTRDecay    float32 // power-law decay exponent d (0 → default 0.5)
 	ACTRHebScale float32 // Hebbian scaling inside softplus (0 → default 4.0)
 	DisableACTR  bool    // when true, force legacy weighted-sum scoring (overrides UseACTR)
+	// RRF fusion mode: when true, use Phase 3 RRF scores directly as the scoring
+	// basis in Phase 6, bypassing ACT-R/CGDN/weighted-sum recomputation.
+	// Rank-based and scale-invariant (Cormack et al. 2009). Cognitive boosts
+	// (Hebbian, PAS transition, confidence) are applied after fusion.
+	UseRRFFusion bool
 }
 
 type resolvedWeights struct {
@@ -89,6 +94,12 @@ type resolvedWeights struct {
 	UseACTR      bool
 	ACTRDecay    float64 // power-law decay exponent d (default 0.5 per Anderson 1993)
 	ACTRHebScale float64 // Hebbian scaling factor inside softplus (default 4.0)
+
+	// RRF fusion: when UseRRFFusion=true, Phase 6 uses the Phase 3 RRF score
+	// directly as the scoring basis. Cognitive boosts (Hebbian, transition,
+	// confidence) are applied multiplicatively after fusion.
+	// This is rank-based and scale-invariant — robust to score scale mismatches.
+	UseRRFFusion bool
 }
 
 // Filter is a query filter applied in Phase 6.
@@ -1158,6 +1169,42 @@ func (e *ActivationEngine) phase6Score(
 	now := time.Now()
 	scored := make([]scoredItem, 0, len(all))
 
+	// RRF fusion path: use Phase 3 RRF scores directly as the final score basis.
+	// Rank-based and scale-invariant (Cormack et al. 2009). Cognitive boosts
+	// (Hebbian, transition, confidence) are applied after fusion.
+	if w.UseRRFFusion {
+		for _, c := range all {
+			eng := engramByID[c.id]
+			if eng == nil || !passesMetaFilter(eng, req.Filters) {
+				continue
+			}
+			final := computeRRFScore(c.rrfScore, c.hebbianBoost, c.transitionBoost, eng)
+			if final < req.Threshold {
+				continue
+			}
+			// Populate ScoreComponents for observability: report the individual
+			// signal scores so callers can understand the composition even though
+			// the final score is rank-based.
+			normalizedFTS := math.Tanh(c.ftsScore)
+			scored = append(scored, scoredItem{
+				id:    c.id,
+				final: final,
+				components: ScoreComponents{
+					SemanticSimilarity: c.vectorScore,
+					FullTextRelevance:  normalizedFTS,
+					HebbianBoost:       c.hebbianBoost,
+					TransitionBoost:    c.transitionBoost,
+					Confidence:         float64(eng.Confidence),
+					Raw:                c.rrfScore * (1.0 + c.hebbianBoost + c.transitionBoost),
+					Final:              final,
+				},
+				hopPath: c.hopPath,
+			})
+		}
+		sort.Slice(scored, func(i, j int) bool { return scored[i].final > scored[j].final })
+		goto cgdnDone
+	}
+
 	// CGDN path: two-pass scoring with divisive normalization.
 	// Pass 1 computes gated activations a(d) for all candidates; Pass 2 normalizes.
 	// This replicates lateral inhibition in hippocampal retrieval: cognitive state
@@ -1512,6 +1559,32 @@ func computeACTR(vectorScore, ftsScore, hebbianBoost, transitionBoost float64, e
 	}
 }
 
+// computeRRFScore computes the final score for a candidate using the Phase 3
+// RRF score directly as the scoring basis (Cormack et al. 2009).
+//
+// Unlike ACT-R/CGDN/weighted-sum which recompute scores from individual signal
+// components, RRF fusion uses the rank-based score from Phase 3 and applies
+// cognitive modifiers after fusion:
+//
+//   raw = rrfScore × (1 + hebbianBoost + transitionBoost)
+//   final = raw × confidence
+//
+// This is scale-invariant: documents with the same ranks but different raw score
+// magnitudes produce the same RRF score. Robust to score scale mismatches between
+// BM25 (unbounded), HNSW cosine similarity [0,1], and graph traversal scores.
+//
+// Parameters match fusedCandidate fields so the function works with both
+// fusedCandidate (Phase 3 output) and scoringCandidate (Phase 6 local type).
+func computeRRFScore(rrfScore, hebbianBoost, transitionBoost float64, eng *storage.Engram) float64 {
+	// Cognitive boost: Hebbian and transition boosts amplify the RRF score.
+	// The (1 + boost) formulation ensures zero boost = no change, and positive
+	// boosts provide multiplicative amplification proportional to association strength.
+	cognitiveMultiplier := 1.0 + hebbianBoost + transitionBoost
+	raw := rrfScore * cognitiveMultiplier
+	conf := float64(eng.Confidence)
+	return raw * conf
+}
+
 // computeGatedActivation computes the raw gated activation a(d) for CGDN.
 //
 // Formula (Hebbian-Rescue CGDN):
@@ -1605,6 +1678,7 @@ func resolveWeights(req *Weights, def DefaultWeights) resolvedWeights {
 		Recency:            float64(req.Recency),
 		UseCGDN:            req.UseCGDN,
 		UseACTR:            !req.DisableACTR,
+		UseRRFFusion:       req.UseRRFFusion,
 	}
 	// Apply CGDN defaults when enabled.
 	if req.UseCGDN {

--- a/internal/engine/activation/rrf_scoring_test.go
+++ b/internal/engine/activation/rrf_scoring_test.go
@@ -333,4 +333,21 @@ func TestResolveWeights_UseRRFFusion(t *testing.T) {
 			t.Error("default config should not use RRF fusion")
 		}
 	})
+
+	t.Run("rrf_and_cgdn_both_set", func(t *testing.T) {
+		w := resolveWeights(&Weights{
+			UseRRFFusion: true,
+			UseCGDN:      true,
+			DisableACTR:  true,
+		}, DefaultWeights{})
+		// resolveWeights propagates both flags; the guard in phase6Score
+		// clears UseCGDN at runtime. Verify both are set here (the guard
+		// is tested in the integration test TestRRF_CGDNConflict_RRFTakesPrecedence).
+		if !w.UseRRFFusion {
+			t.Error("expected UseRRFFusion=true")
+		}
+		if !w.UseCGDN {
+			t.Error("expected UseCGDN=true from resolveWeights (guard is in phase6Score)")
+		}
+	})
 }

--- a/internal/engine/activation/rrf_scoring_test.go
+++ b/internal/engine/activation/rrf_scoring_test.go
@@ -1,0 +1,336 @@
+package activation
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// ---------------------------------------------------------------------------
+// Tests for RRF scoring fusion — the alternative to ACT-R/CGDN/weighted-sum
+// in Phase 6. These tests verify the computeRRFScore function and its
+// integration into the phase6Score scoring path.
+// ---------------------------------------------------------------------------
+
+// TestRRFScore_CorrectForKnownRankings verifies the RRF formula produces
+// correct scores for known input rankings.
+// RRF score = Σ 1/(k + rank_i(d)), ranks are 1-indexed from phase3RRF.
+func TestRRFScore_CorrectForKnownRankings(t *testing.T) {
+	now := time.Now()
+	eng := makeEngram(10, 30, 1.0, now.Add(-1*time.Hour))
+
+	// A candidate ranked #1 in FTS (k=60) and #1 in HNSW (k=40):
+	// RRF = 1/(60+1) + 1/(40+1) = 1/61 + 1/41 ≈ 0.01639 + 0.02439 ≈ 0.04079
+	candidate := fusedCandidate{
+		rrfScore:    1.0/(rrfK_FTS+1) + 1.0/(rrfK_HNSW+1),
+		ftsScore:    5.0,
+		vectorScore: 0.8,
+	}
+
+	score := computeRRFScore(candidate.rrfScore, candidate.hebbianBoost, candidate.transitionBoost, eng)
+	// Score should equal rrfScore * confidence
+	expected := candidate.rrfScore * float64(eng.Confidence)
+	if math.Abs(score-expected) > 1e-9 {
+		t.Errorf("RRF score = %v, want %v", score, expected)
+	}
+}
+
+// TestRRFScore_ScaleInvariant verifies that RRF scoring is scale-invariant:
+// documents with the same ranks but different raw score magnitudes get the
+// same RRF score, since RRF depends only on rank position.
+func TestRRFScore_ScaleInvariant(t *testing.T) {
+	// Two candidate sets with different score magnitudes but same rank ordering.
+	// After phase3RRF, the rrfScore depends only on rank position.
+	setsSmall := &candidateSets{
+		fts: []ScoredID{
+			{ID: storage.ULID{1}, Score: 0.5},
+			{ID: storage.ULID{2}, Score: 0.3},
+		},
+		vector: []ScoredID{
+			{ID: storage.ULID{1}, Score: 0.4},
+			{ID: storage.ULID{2}, Score: 0.2},
+		},
+	}
+	setsLarge := &candidateSets{
+		fts: []ScoredID{
+			{ID: storage.ULID{1}, Score: 500.0},
+			{ID: storage.ULID{2}, Score: 300.0},
+		},
+		vector: []ScoredID{
+			{ID: storage.ULID{1}, Score: 0.99},
+			{ID: storage.ULID{2}, Score: 0.88},
+		},
+	}
+
+	fusedSmall := phase3RRF(setsSmall)
+	fusedLarge := phase3RRF(setsLarge)
+
+	// Both should produce the same RRF scores since rank order is identical.
+	if len(fusedSmall) != len(fusedLarge) {
+		t.Fatalf("fused lengths differ: %d vs %d", len(fusedSmall), len(fusedLarge))
+	}
+
+	// Find the candidate with ID {1} in each result.
+	var rrfSmall, rrfLarge float64
+	for _, c := range fusedSmall {
+		if c.id == (storage.ULID{1}) {
+			rrfSmall = c.rrfScore
+		}
+	}
+	for _, c := range fusedLarge {
+		if c.id == (storage.ULID{1}) {
+			rrfLarge = c.rrfScore
+		}
+	}
+
+	if math.Abs(rrfSmall-rrfLarge) > 1e-12 {
+		t.Errorf("RRF not scale-invariant: small=%v large=%v", rrfSmall, rrfLarge)
+	}
+}
+
+// TestRRFScore_MultiSignalHigherThanSingle verifies that a document appearing
+// in multiple retrieval signals scores higher than one in only a single signal.
+func TestRRFScore_MultiSignalHigherThanSingle(t *testing.T) {
+	multiID := storage.ULID{1}
+	singleID := storage.ULID{2}
+
+	sets := &candidateSets{
+		fts: []ScoredID{
+			{ID: multiID, Score: 3.0},
+			{ID: singleID, Score: 5.0}, // higher raw score, but only in FTS
+		},
+		vector: []ScoredID{
+			{ID: multiID, Score: 0.9},
+		},
+	}
+
+	fused := phase3RRF(sets)
+
+	var multiRRF, singleRRF float64
+	for _, c := range fused {
+		if c.id == multiID {
+			multiRRF = c.rrfScore
+		}
+		if c.id == singleID {
+			singleRRF = c.rrfScore
+		}
+	}
+
+	if multiRRF <= singleRRF {
+		t.Errorf("multi-signal candidate RRF (%v) should be > single-signal (%v)", multiRRF, singleRRF)
+	}
+}
+
+// TestRRFScore_K60CorrectValues verifies the RRF formula with the standard
+// k=60 constant produces known expected values.
+func TestRRFScore_K60CorrectValues(t *testing.T) {
+	// With k=60 (rrfK_FTS), rank 1 → 1/(60+1) = 1/61
+	// rank 2 → 1/(60+2) = 1/62
+	// rank 3 → 1/(60+3) = 1/63
+	sets := &candidateSets{
+		fts: []ScoredID{
+			{ID: storage.ULID{1}, Score: 10},
+			{ID: storage.ULID{2}, Score: 5},
+			{ID: storage.ULID{3}, Score: 1},
+		},
+	}
+
+	fused := phase3RRF(sets)
+
+	expected := map[storage.ULID]float64{
+		{1}: 1.0 / 61.0,
+		{2}: 1.0 / 62.0,
+		{3}: 1.0 / 63.0,
+	}
+
+	for _, c := range fused {
+		exp, ok := expected[c.id]
+		if !ok {
+			continue
+		}
+		if math.Abs(c.rrfScore-exp) > 1e-12 {
+			t.Errorf("ID %v: RRF score = %v, want %v", c.id, c.rrfScore, exp)
+		}
+	}
+}
+
+// TestRRFScore_MissingSignalContributesZero verifies that a document not present
+// in a signal's result list contributes 0 to RRF from that signal.
+func TestRRFScore_MissingSignalContributesZero(t *testing.T) {
+	// docA only in FTS, not in HNSW.
+	// Its RRF should equal only the FTS contribution.
+	docA := storage.ULID{1}
+	docB := storage.ULID{2}
+
+	sets := &candidateSets{
+		fts: []ScoredID{
+			{ID: docA, Score: 5.0},
+		},
+		vector: []ScoredID{
+			{ID: docB, Score: 0.9},
+		},
+	}
+
+	fused := phase3RRF(sets)
+
+	var docARRF float64
+	for _, c := range fused {
+		if c.id == docA {
+			docARRF = c.rrfScore
+		}
+	}
+
+	// docA should only have FTS contribution: 1/(60+1)
+	expectedFTS := 1.0 / (rrfK_FTS + 1.0)
+	if math.Abs(docARRF-expectedFTS) > 1e-12 {
+		t.Errorf("docA RRF = %v, want %v (FTS-only, no HNSW contribution)", docARRF, expectedFTS)
+	}
+}
+
+// TestRRFScore_DefaultConfigUsesACTR verifies that the default configuration
+// (no scoring_fusion override) still uses ACT-R scoring, not RRF.
+// This ensures backward compatibility.
+func TestRRFScore_DefaultConfigUsesACTR(t *testing.T) {
+	w := resolveWeights(nil, DefaultWeights{
+		SemanticSimilarity: 0.35,
+		FullTextRelevance:  0.25,
+		DecayFactor:        0.20,
+		HebbianBoost:       0.10,
+		AccessFrequency:    0.05,
+		Recency:            0.05,
+	})
+
+	// Default should use ACT-R, not RRF fusion scoring
+	if !w.UseACTR {
+		t.Error("default config should use ACT-R scoring")
+	}
+	if w.UseRRFFusion {
+		t.Error("default config should NOT use RRF fusion scoring")
+	}
+}
+
+// TestRRFScore_HebbianBoostApplied verifies that Hebbian boost is applied
+// after RRF fusion when using RRF scoring mode.
+func TestRRFScore_HebbianBoostApplied(t *testing.T) {
+	now := time.Now()
+	eng := makeEngram(10, 30, 1.0, now.Add(-1*time.Hour))
+
+	candidate := fusedCandidate{
+		rrfScore:     0.04, // typical RRF score
+		hebbianBoost: 0.8,
+	}
+	candidateNoHeb := fusedCandidate{
+		rrfScore:     0.04,
+		hebbianBoost: 0.0,
+	}
+
+	scoreWithHeb := computeRRFScore(candidate.rrfScore, candidate.hebbianBoost, candidate.transitionBoost, eng)
+	scoreNoHeb := computeRRFScore(candidateNoHeb.rrfScore, candidateNoHeb.hebbianBoost, candidateNoHeb.transitionBoost, eng)
+
+	if scoreWithHeb <= scoreNoHeb {
+		t.Errorf("Hebbian boost should increase RRF score: with=%v without=%v", scoreWithHeb, scoreNoHeb)
+	}
+}
+
+// TestRRFScore_ConfidenceModulates verifies that confidence modulates the
+// final RRF score.
+func TestRRFScore_ConfidenceModulates(t *testing.T) {
+	now := time.Now()
+	highConf := makeEngram(10, 30, 1.0, now.Add(-1*time.Hour))
+	lowConf := makeEngram(10, 30, 0.3, now.Add(-1*time.Hour))
+
+	candidate := fusedCandidate{
+		rrfScore: 0.04,
+	}
+
+	scoreHigh := computeRRFScore(candidate.rrfScore, candidate.hebbianBoost, candidate.transitionBoost, highConf)
+	scoreLow := computeRRFScore(candidate.rrfScore, candidate.hebbianBoost, candidate.transitionBoost, lowConf)
+
+	if scoreHigh <= scoreLow {
+		t.Errorf("higher confidence should give higher score: high=%v low=%v", scoreHigh, scoreLow)
+	}
+}
+
+// TestRRFScore_TransitionBoostApplied verifies that transition boost from PAS
+// is applied in RRF scoring mode.
+func TestRRFScore_TransitionBoostApplied(t *testing.T) {
+	now := time.Now()
+	eng := makeEngram(10, 30, 1.0, now.Add(-1*time.Hour))
+
+	withTrans := fusedCandidate{
+		rrfScore:        0.04,
+		transitionBoost: 0.5,
+	}
+	noTrans := fusedCandidate{
+		rrfScore:        0.04,
+		transitionBoost: 0.0,
+	}
+
+	scoreWith := computeRRFScore(withTrans.rrfScore, withTrans.hebbianBoost, withTrans.transitionBoost, eng)
+	scoreNo := computeRRFScore(noTrans.rrfScore, noTrans.hebbianBoost, noTrans.transitionBoost, eng)
+
+	if scoreWith <= scoreNo {
+		t.Errorf("transition boost should increase RRF score: with=%v without=%v", scoreWith, scoreNo)
+	}
+}
+
+// TestRRFScore_NonNegative verifies that RRF scores are always non-negative.
+func TestRRFScore_NonNegative(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name string
+		eng  *storage.Engram
+		cand fusedCandidate
+	}{
+		{
+			"zero everything",
+			makeEngram(0, 1, 0, now),
+			fusedCandidate{rrfScore: 0},
+		},
+		{
+			"zero rrfScore positive confidence",
+			makeEngram(0, 1, 1.0, now),
+			fusedCandidate{rrfScore: 0},
+		},
+		{
+			"normal values",
+			makeEngram(10, 30, 0.8, now.Add(-48*time.Hour)),
+			fusedCandidate{rrfScore: 0.04, hebbianBoost: 0.5, transitionBoost: 0.3},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			score := computeRRFScore(tc.cand.rrfScore, tc.cand.hebbianBoost, tc.cand.transitionBoost, tc.eng)
+			if score < 0 {
+				t.Errorf("RRF score = %v, want >= 0", score)
+			}
+		})
+	}
+}
+
+// TestResolveWeights_UseRRFFusion verifies that the UseRRFFusion flag is
+// correctly propagated through resolveWeights when set on the Weights struct.
+func TestResolveWeights_UseRRFFusion(t *testing.T) {
+	t.Run("explicit_rrf", func(t *testing.T) {
+		w := resolveWeights(&Weights{
+			UseRRFFusion: true,
+			DisableACTR:  true,
+		}, DefaultWeights{})
+		if !w.UseRRFFusion {
+			t.Error("expected UseRRFFusion=true")
+		}
+		if w.UseACTR {
+			t.Error("expected UseACTR=false when DisableACTR=true")
+		}
+	})
+
+	t.Run("default_no_rrf", func(t *testing.T) {
+		w := resolveWeights(nil, DefaultWeights{})
+		if w.UseRRFFusion {
+			t.Error("default config should not use RRF fusion")
+		}
+	})
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1736,6 +1736,16 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 			ACTRDecay:    actrDecay,
 			ACTRHebScale: actrHebScale,
 		}
+
+		// Wire ScoringFusion from plasticity config to activation weights.
+		if resolved.ScoringFusion == "rrf" {
+			actReq.Weights.UseRRFFusion = true
+			actReq.Weights.DisableACTR = true
+			actReq.Weights.UseACTR = false
+		} else if resolved.ScoringFusion == "weighted_sum" {
+			actReq.Weights.DisableACTR = true
+			actReq.Weights.UseACTR = false
+		}
 	}
 
 	// Gate CGDN behind vault's ExperimentalCGDN flag.

--- a/internal/mcp/guide.go
+++ b/internal/mcp/guide.go
@@ -107,6 +107,13 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 	if resolved.RetentionDays > 0 {
 		fmt.Fprintf(&b, "- Retention: %.0f days\n", resolved.RetentionDays)
 	}
+	if resolved.ScoringFusion == "rrf" {
+		fmt.Fprintf(&b, "- Scoring fusion: RRF (k=%d)\n", resolved.RRF_K)
+	} else if resolved.ScoringFusion == "weighted_sum" {
+		fmt.Fprintf(&b, "- Scoring fusion: weighted sum\n")
+	} else {
+		fmt.Fprintf(&b, "- Scoring fusion: ACT-R (default)\n")
+	}
 
 	// Memory quality guidance
 	b.WriteString("\n## Writing Effective Memories\n\n")

--- a/internal/mcp/guide.go
+++ b/internal/mcp/guide.go
@@ -108,7 +108,7 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 		fmt.Fprintf(&b, "- Retention: %.0f days\n", resolved.RetentionDays)
 	}
 	if resolved.ScoringFusion == "rrf" {
-		fmt.Fprintf(&b, "- Scoring fusion: RRF (k=%d)\n", resolved.RRF_K)
+		fmt.Fprintf(&b, "- Scoring fusion: RRF (rank-based, scale-invariant)\n")
 	} else if resolved.ScoringFusion == "weighted_sum" {
 		fmt.Fprintf(&b, "- Scoring fusion: weighted sum\n")
 	} else {


### PR DESCRIPTION
## Summary

- Adds RRF as an alternative Phase 6 scoring strategy alongside ACT-R, CGDN, and weighted-sum
- Provides a simpler, parameter-free scoring alternative to ACT-R for use cases where access frequency data is sparse (fresh vaults, low-traffic memories). Reuses existing Phase 3 RRF scores as the fusion basis, applies cognitive boosts multiplicatively after fusion
- Rank-based and scale-invariant -- eliminates score magnitude mismatches between BM25, cosine similarity, and graph scores
- New plasticity parameter: `scoring_fusion` (`"rrf"` or `"weighted_sum"`)
- Default behavior unchanged (ACT-R remains default)
- When RRF is active, threshold automatically lowered to 0.001 (RRF scores are in 0-0.05 range)
- Explicit guard when both RRF and CGDN are enabled: RRF takes precedence, CGDN is disabled with a warning log

### Why

Weighted sum scoring is sensitive to score scale differences between retrieval signals. RRF (Cormack et al. 2009) operates on ranks rather than raw scores, making it robust to scale mismatches and missing signals. Particularly useful when one signal is unavailable (e.g., no embeddings configured).

Fixes #316

## Test plan

- [x] RRF produces correct scores for known rankings
- [x] Scale invariance verified
- [x] Multi-signal > single-signal scoring
- [x] k=60 expected values validated
- [x] Missing signal contributes zero
- [x] Default config uses ACT-R (backward compatible)
- [x] Hebbian/transition boost and confidence modulation applied correctly
- [x] Non-negativity invariant
- [x] resolveWeights flag propagation
- [x] RRF returns results with default threshold (regression test for threshold bug)
- [x] RRF+CGDN conflict resolved correctly (RRF wins)
- [x] RED/GREEN verified
- [x] Full test suite passes