### PR TITLE
Fix: Memories search filter button group UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public vault unauthenticated access now runs in `full` mode. Previously, requests to an open vault with no API key ran as `observe`, silently preventing cognitive-state writes. Public vaults are now genuinely open — callers get `full` access unless they present an explicit `observe` key.
 
 ### Fixed
-- Memories page search-mode segmented control (Balanced/Semantic/Recent/Deep) now matches adjacent button height, includes dividers between options, and preserves padding when Alpine.js re-renders dynamic styles.
+- Memories page search-mode segmented control (Balanced/Semantic/Recent/Deep) now matches adjacent button height and font size, includes dividers between options, and preserves padding when Alpine.js re-renders dynamic styles.
 - Enrich now accepts OpenAI-compatible JSON responses returned in `message.reasoning` when `message.content` is empty, including structured reasoning payloads.
 - Retry and retroactive enrichment now only mark entity and relationship stages complete after successful persistence, avoiding partial-state retries, nil-result crashes, and silent graph-write failures.
 - Entity and relationship response parsing now rejects nested wrapper keys like `meta.entities` / `meta.relationships` instead of treating them as valid empty results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public vault unauthenticated access now runs in `full` mode. Previously, requests to an open vault with no API key ran as `observe`, silently preventing cognitive-state writes. Public vaults are now genuinely open — callers get `full` access unless they present an explicit `observe` key.
 
 ### Fixed
+- Memories page search-mode segmented control (Balanced/Semantic/Recent/Deep) now matches adjacent button height, includes dividers between options, and preserves padding when Alpine.js re-renders dynamic styles.
 - Enrich now accepts OpenAI-compatible JSON responses returned in `message.reasoning` when `message.content` is empty, including structured reasoning payloads.
 - Retry and retroactive enrichment now only mark entity and relationship stages complete after successful persistence, avoiding partial-state retries, nil-result crashes, and silent graph-write failures.
 - Entity and relationship response parsing now rejects nested wrapper keys like `meta.entities` / `meta.relationships` instead of treating them as valid empty results.

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -448,7 +448,7 @@
         <input id="memory-search-input" data-testid="input-search" class="input-field" placeholder="Search memories… (semantic, try natural language)" x-model="searchQuery"
           @keydown.enter="searchMemories()" style="flex:1;min-width:200px;" />
         <!-- Recall mode segmented control (Item 3: tooltips) -->
-        <div style="display:inline-flex;border:1px solid var(--border);border-radius:0.5rem;overflow:hidden;font-size:0.75rem;">
+        <div style="display:inline-flex;border:1px solid var(--border);border-radius:0.5rem;overflow:hidden;">
           <button @click="searchMode = 'balanced'"
             :style="'padding:0.5rem 1rem;border:none;border-right:1px solid var(--border);cursor:pointer;transition:all 0.15s;font-weight:600;' + (searchMode === 'balanced' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')"
             title="Blend keyword + semantic search with temporal decay (default)">Balanced</button>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -448,22 +448,18 @@
         <input id="memory-search-input" data-testid="input-search" class="input-field" placeholder="Search memories… (semantic, try natural language)" x-model="searchQuery"
           @keydown.enter="searchMemories()" style="flex:1;min-width:200px;" />
         <!-- Recall mode segmented control (Item 3: tooltips) -->
-        <div style="display:inline-flex;border:1px solid var(--border);border-radius:0.375rem;overflow:hidden;font-size:0.75rem;">
+        <div style="display:inline-flex;border:1px solid var(--border);border-radius:0.5rem;overflow:hidden;font-size:0.75rem;">
           <button @click="searchMode = 'balanced'"
-            :style="searchMode === 'balanced' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);'"
-            style="padding:0.25rem 0.625rem;border:none;cursor:pointer;transition:all 0.15s;"
+            :style="'padding:0.5rem 1rem;border:none;border-right:1px solid var(--border);cursor:pointer;transition:all 0.15s;font-weight:600;' + (searchMode === 'balanced' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')"
             title="Blend keyword + semantic search with temporal decay (default)">Balanced</button>
           <button @click="searchMode = 'semantic'"
-            :style="searchMode === 'semantic' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);'"
-            style="padding:0.25rem 0.625rem;border:none;cursor:pointer;transition:all 0.15s;"
+            :style="'padding:0.5rem 1rem;border:none;border-right:1px solid var(--border);cursor:pointer;transition:all 0.15s;font-weight:600;' + (searchMode === 'semantic' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')"
             title="Pure vector similarity — best for concept matching">Semantic</button>
           <button @click="searchMode = 'recent'"
-            :style="searchMode === 'recent' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);'"
-            style="padding:0.25rem 0.625rem;border:none;cursor:pointer;transition:all 0.15s;"
+            :style="'padding:0.5rem 1rem;border:none;border-right:1px solid var(--border);cursor:pointer;transition:all 0.15s;font-weight:600;' + (searchMode === 'recent' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')"
             title="Prioritize recently created memories">Recent</button>
           <button @click="searchMode = 'deep'"
-            :style="searchMode === 'deep' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);'"
-            style="padding:0.25rem 0.625rem;border:none;cursor:pointer;transition:all 0.15s;"
+            :style="'padding:0.5rem 1rem;border:none;cursor:pointer;transition:all 0.15s;font-weight:600;' + (searchMode === 'deep' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')"
             title="Exhaustive graph traversal — slower but finds distant connections">Deep</button>
         </div>
         <button class="btn-primary" @click="searchMemories()">Search</button>


### PR DESCRIPTION
## Summary

Fixes Memories search filter button group UI, part of https://github.com/scrypster/muninndb/issues/327
 
The search-mode segmented control (Balanced / Semantic / Recent / Deep) on the Memories page had mismatched height, no dividers between options, and missing padding compared to neighboring buttons.


## Changes

- Increased button padding from `0.25rem 0.625rem` to `0.5rem 1rem` to match `btn-primary` / `btn-secondary` height
- Added `border-right: 1px solid var(--border)` dividers between segmented options
- Removed `font-size:0.75rem` override to match other button styles
- Added `font-weight: 600` to match other button styles
- Merged static `style` into Alpine `:style` binding to prevent dynamic styles from overwriting padding/border on re-render
- Updated container `border-radius` from `0.375rem` to `0.5rem` for consistency

**Before**
<img width="2264" height="307" alt="image" src="https://github.com/user-attachments/assets/24440929-18b9-43ed-9d65-24cd550f0c8a" />

**After**
<img width="2264" height="307" alt="image" src="https://github.com/user-attachments/assets/a84a091b-21c7-476e-a204-6a3856fd46ac" />


## Release Checklist

- [x] `CHANGELOG.md` updated with changes
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
