### PR TITLE
Fix: Consistent page content tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GET /api/activity-counts` endpoint returning per-day engram creation counts for a vault. Accepts `days` (1–180, default 7) and optional `until` (YYYY-MM-DD) query parameters. Malformed or out-of-range values return 400. Backed by an efficient ULID key-header scan with zero-filled contiguous day ranges.
 
 ### Changed
+- Web UI: unified tab navigation across Memories, Graph, and Settings pages with a consistent bordered-tab style replacing the previous mix of underline, button, and pill patterns.
 - Public vault unauthenticated access now runs in `full` mode. Previously, requests to an open vault with no API key ran as `observe`, silently preventing cognitive-state writes. Public vaults are now genuinely open — callers get `full` access unless they present an explicit `observe` key.
 
 ### Fixed

--- a/web/static/css/components.css
+++ b/web/static/css/components.css
@@ -438,19 +438,20 @@ html.light .app-sidebar { background: rgba(250,250,250,0.95); }
   background: var(--bg-base);
 }
 
-/* Settings sub-nav tab buttons — pill style */
+/* Content tabs — traditional tab style with shared bottom border */
 .tab-bar {
   display: flex;
-  gap: 0.375rem;
+  gap: 0.25rem;
   flex-wrap: wrap;
   margin-bottom: 1.75rem;
   margin-top: 1rem;
-  padding-bottom: 0;
+  border-bottom: 1px solid var(--border);
 }
 .tab-btn {
-  padding: 0.4rem 1rem;
-  border: 1px solid var(--border);
-  border-radius: 9999px;
+  padding: 0.5rem 1rem;
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: 0.375rem 0.375rem 0 0;
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
@@ -459,17 +460,22 @@ html.light .app-sidebar { background: rgba(250,250,250,0.95); }
   transition: color 0.15s, background 0.15s, border-color 0.15s;
   white-space: nowrap;
   line-height: 1.4;
+  margin-bottom: -1px;
+  position: relative;
 }
 .tab-btn.active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #000;
+  background: var(--bg-surface);
+  border-color: var(--border);
+  border-bottom: 1px solid var(--bg-surface);
+  color: var(--accent);
   font-weight: 600;
 }
 .tab-btn:hover:not(.active) {
-  border-color: rgba(255, 255, 255, 0.2);
   color: var(--text-primary);
   background: rgba(255, 255, 255, 0.05);
+}
+html.light .tab-btn:hover:not(.active) {
+  background: rgba(0, 0, 0, 0.04);
 }
 
 /* Vault chip — inline vault selector shown next to page titles */

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -385,13 +385,9 @@
       </div>
 
       <!-- Memories sub-tab bar (Item 1) -->
-      <div style="display:flex;gap:0.25rem;margin-bottom:1.25rem;border-bottom:1px solid var(--border);">
-        <button @click="memoriesSubTab='list'"
-          :style="memoriesSubTab==='list' ? 'border-bottom:2px solid var(--accent);font-weight:600;opacity:1;' : 'opacity:0.6;'"
-          style="padding:0.5rem 1rem;font-size:0.875rem;background:none;border:none;cursor:pointer;color:var(--text-primary);transition:opacity 0.15s;">Memories</button>
-        <button @click="memoriesSubTab='contradictions'; loadContradictions()"
-          :style="memoriesSubTab==='contradictions' ? 'border-bottom:2px solid var(--accent);font-weight:600;opacity:1;' : 'opacity:0.6;'"
-          style="padding:0.5rem 1rem;font-size:0.875rem;background:none;border:none;cursor:pointer;color:var(--text-primary);transition:opacity 0.15s;display:flex;align-items:center;gap:0.5rem;">
+      <div class="tab-bar">
+        <button class="tab-btn" :class="{ active: memoriesSubTab==='list' }" @click="memoriesSubTab='list'">Memories</button>
+        <button class="tab-btn" :class="{ active: memoriesSubTab==='contradictions' }" @click="memoriesSubTab='contradictions'; loadContradictions()" style="display:flex;align-items:center;gap:0.5rem;">
           Contradictions
           <span x-show="contradictions.length > 0"
             style="font-size:0.65rem;background:rgba(239,68,68,0.15);color:#ef4444;border-radius:9999px;padding:0.1rem 0.45rem;font-weight:700;"
@@ -733,9 +729,9 @@
       </div>
 
       <!-- Tabs -->
-      <div style="display:flex;gap:0.5rem;margin-bottom:1.5rem;border-bottom:1px solid var(--border);padding-bottom:0;">
-        <button class="btn-secondary" :style="graphTab==='memory' ? 'border-bottom:2px solid #06b6d4;padding-bottom:0.625rem;' : 'padding-bottom:0.75rem;'" @click="graphTab='memory'">Memory Graph</button>
-        <button class="btn-secondary" :style="graphTab==='entity' ? 'border-bottom:2px solid #06b6d4;padding-bottom:0.625rem;' : 'padding-bottom:0.75rem;'" @click="graphTab='entity'">Entity Graph</button>
+      <div class="tab-bar">
+        <button class="tab-btn" :class="{ active: graphTab==='memory' }" @click="graphTab='memory'">Memory Graph</button>
+        <button class="tab-btn" :class="{ active: graphTab==='entity' }" @click="graphTab='entity'">Entity Graph</button>
       </div>
 
       <!-- Memory Graph Tab -->


### PR DESCRIPTION
## Summary

Unifies tab navigation across the UI, part of https://github.com/scrypster/muninndb/issues/327

The Memories, Graph, and Settings pages each used a different tab pattern (inline underline, `btn-secondary` with border-bottom, and pill buttons respectively). This replaces all three with a single consistent bordered-tab component.


## Changes

- Replaced `.tab-bar`/`.tab-btn` pill CSS with traditional tab styling: shared bottom border on the container, top-rounded corners, surface background + accent text for active state, hover indication, and light-mode support
- Converted Memories page tabs from inline-styled underline buttons to `.tab-bar`/`.tab-btn`
- Converted Graph page tabs from `btn-secondary` underline buttons to `.tab-bar`/`.tab-btn`
- Settings page tabs already used `.tab-bar`/`.tab-btn` — now inherits the new tab style automatically
- Updated `CHANGELOG.md`

**Before**
<img width="414" height="200" alt="image" src="https://github.com/user-attachments/assets/d61a1696-0038-4784-ac54-a17f024bb16c" />
<img width="544" height="233" alt="image" src="https://github.com/user-attachments/assets/791aaab6-aa57-4275-8da3-c0fbefe8ddfd" />
<img width="751" height="224" alt="image" src="https://github.com/user-attachments/assets/0ceefb6b-623c-407e-b3bd-f04761e4080d" />


**After**
<img width="449" height="227" alt="image" src="https://github.com/user-attachments/assets/26dd9177-002d-4742-94d4-14a11ea37b21" />
<img width="449" height="227" alt="image" src="https://github.com/user-attachments/assets/60a8b8fc-f82e-4360-a62f-c05ab8c30ae9" />
<img width="751" height="224" alt="image" src="https://github.com/user-attachments/assets/eed8f728-6a9e-4d79-90dd-6716b2c25d8f" />
*note the hover state of the `Plugins` tab



## Release Checklist

- [x] `CHANGELOG.md` updated with changes
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
