### PR TITLE
Fix: Nav bar cut-off on smaller screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public vault unauthenticated access now runs in `full` mode. Previously, requests to an open vault with no API key ran as `observe`, silently preventing cognitive-state writes. Public vaults are now genuinely open — callers get `full` access unless they present an explicit `observe` key.
 
 ### Fixed
+- Sidebar nav items are now scrollable when viewport height is too small, keeping the logo and footer pinned.
+- Collapsed sidebar footer icons no longer overflow into the right border.
+- "New Vault" action moved from sidebar footer into the vault picker modal to reclaim vertical space.
+- Sidebar footer icons (theme toggle, keyboard shortcuts) replaced with consistent SVG icons in bordered containers.
 - Enrich now accepts OpenAI-compatible JSON responses returned in `message.reasoning` when `message.content` is empty, including structured reasoning payloads.
 - Retry and retroactive enrichment now only mark entity and relationship stages complete after successful persistence, avoiding partial-state retries, nil-result crashes, and silent graph-write failures.
 - Entity and relationship response parsing now rejects nested wrapper keys like `meta.entities` / `meta.relationships` instead of treating them as valid empty results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Sidebar nav items are now scrollable when viewport height is too small, keeping the logo and footer pinned.
-- Collapsed sidebar footer icons no longer overflow into the right border.
-- "New Vault" action moved from sidebar footer into the vault picker modal to reclaim vertical space.
-- Sidebar footer icons (theme toggle, keyboard shortcuts) replaced with consistent SVG icons in bordered containers.
+- Collapsed sidebar footer icons no longer overflow into the right border; icons render borderless when collapsed and bordered when expanded.
+- "New Vault" action moved from sidebar footer into the vault picker modal to reclaim vertical space for nav items.
+- Sidebar footer icons (theme toggle, keyboard shortcuts) replaced with consistent SVG icons matching the existing icon family.
+- Version label merged into the footer icon row instead of occupying its own line.
+- Sidebar footer padding and gaps tightened to maximize nav item visibility on short viewports.
 - Enrich now accepts OpenAI-compatible JSON responses returned in `message.reasoning` when `message.content` is empty, including structured reasoning payloads.
 - Retry and retroactive enrichment now only mark entity and relationship stages complete after successful persistence, avoiding partial-state retries, nil-result crashes, and silent graph-write failures.
 - Entity and relationship response parsing now rejects nested wrapper keys like `meta.entities` / `meta.relationships` instead of treating them as valid empty results.

--- a/web/static/css/components.css
+++ b/web/static/css/components.css
@@ -336,10 +336,9 @@ html.light .app-sidebar { background: rgba(250,250,250,0.95); }
 .sidebar-footer-row {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.25rem;
+  justify-content: space-evenly;
   width: 100%;
-  padding: 0 0.375rem;
+  padding: 0;
 }
 .app-sidebar.expanded .sidebar-footer-row {
   gap: 0.75rem;
@@ -363,16 +362,22 @@ html.light .app-sidebar { background: rgba(250,250,250,0.95); }
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 20px;
+  height: 20px;
   border-radius: 0.375rem;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
+  background: transparent;
+  border: none;
   color: var(--text-muted);
   cursor: pointer;
   padding: 0;
   flex-shrink: 0;
   transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.app-sidebar.expanded .sidebar-footer-icon {
+  width: 28px;
+  height: 28px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
 }
 .sidebar-footer-icon:hover {
   color: var(--primary);

--- a/web/static/css/components.css
+++ b/web/static/css/components.css
@@ -185,6 +185,8 @@ html.light .app-sidebar { background: rgba(250,250,250,0.95); }
   gap: 0.125rem;
   padding: 0.5rem 0;
   flex: 1;
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .sidebar-item {
@@ -222,12 +224,16 @@ html.light .app-sidebar { background: rgba(250,250,250,0.95); }
 /* Sidebar footer */
 .sidebar-footer {
   border-top: 1px solid var(--border);
-  padding: 0.625rem 0;
+  padding: 0.375rem 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.25rem;
   flex-shrink: 0;
+}
+.sidebar-footer .sidebar-item {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
 }
 
 /* Sidebar vault picker button — mirrors sidebar-item style */
@@ -237,7 +243,7 @@ html.light .app-sidebar { background: rgba(250,250,250,0.95); }
   align-items: center;
   gap: 0.875rem;
   width: 100%;
-  padding: 0.75rem 0;
+  padding: 0.5rem 0;
   padding-left: 18px;
   padding-right: 12px;
   background: transparent;
@@ -253,31 +259,6 @@ html.light .app-sidebar { background: rgba(250,250,250,0.95); }
 }
 .sidebar-vault-btn:hover { color: var(--primary); background: rgba(6,182,212,0.06); }
 
-/* New vault button — icon only when collapsed, full label when expanded */
-.sidebar-newvault-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  padding: 0.625rem 0;
-  background: transparent;
-  border: none;
-  color: var(--text-muted);
-  font-family: inherit;
-  font-size: 0.875rem;
-  cursor: pointer;
-  transition: color 0.15s, background 0.15s;
-}
-.sidebar-newvault-btn:hover { color: var(--primary); background: rgba(6,182,212,0.06); }
-.sidebar-newvault-btn .sidebar-newvault-label { display: none; }
-.app-sidebar.expanded .sidebar-newvault-btn {
-  justify-content: flex-start;
-  gap: 0.875rem;
-  padding-left: 18px;
-  font-weight: 500;
-  color: var(--text-secondary);
-}
-.app-sidebar.expanded .sidebar-newvault-btn .sidebar-newvault-label { display: inline; }
 
 /* Shared vault picker dropdown */
 .vault-picker-dropdown {
@@ -356,9 +337,47 @@ html.light .app-sidebar { background: rgba(250,250,250,0.95); }
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem;
+  gap: 0.25rem;
   width: 100%;
+  padding: 0 0.375rem;
+}
+.app-sidebar.expanded .sidebar-footer-row {
+  gap: 0.75rem;
   padding: 0 0.75rem;
+}
+
+.sidebar-version-label {
+  font-size: 0.625rem;
+  color: var(--text-muted);
+  opacity: 0.5;
+  user-select: none;
+  white-space: nowrap;
+  display: none;
+}
+.app-sidebar.expanded .sidebar-version-label {
+  display: inline;
+}
+
+/* Sidebar footer icon buttons */
+.sidebar-footer-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 0.375rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.sidebar-footer-icon:hover {
+  color: var(--primary);
+  border-color: var(--primary);
+  background: rgba(6,182,212,0.08);
 }
 
 /* Main content area */

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -125,22 +125,18 @@
         <span class="vault-item-name" x-text="vault"></span>
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="flex-shrink:0;opacity:0.35;"><path d="M6 9l6 6 6-6"/></svg>
       </button>
-      <!-- New Vault button (icon only when collapsed, full label when expanded) -->
-      <button class="sidebar-newvault-btn" @click="createVault()" title="New Vault">
-        <svg class="sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-        <span class="sidebar-newvault-label">New Vault</span>
-      </button>
-
-      <!-- Live dot + theme toggle (always visible) -->
+      <!-- Live dot + theme toggle + help (always visible) -->
       <div class="sidebar-footer-row">
         <span class="ws-dot" :class="liveConnected ? 'connected' : 'disconnected'"
           :title="liveConnected ? 'Live connected' : 'Reconnecting...'"></span>
-        <button class="btn-ghost" style="font-size:1.125rem;padding:0.25rem 0.375rem;line-height:1;" @click="toggleTheme()" title="Toggle theme">◐</button>
-        <button class="btn-ghost" style="font-size:0.8125rem;padding:0.25rem 0.375rem;line-height:1;opacity:0.6;" @click="showShortcutsHelp=true" title="Keyboard shortcuts (?)">?</button>
+        <button class="sidebar-footer-icon" @click="toggleTheme()" title="Toggle theme">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z"/></svg>
+        </button>
+        <button class="sidebar-footer-icon" @click="showShortcutsHelp=true" title="Keyboard shortcuts (?)">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        </button>
+        <span x-show="appVersion" x-text="appVersion" class="sidebar-version-label"></span>
       </div>
-
-      <!-- Version label -->
-      <span x-show="appVersion" x-text="appVersion" style="font-size:0.625rem;color:var(--text-muted);opacity:0.5;user-select:none;"></span>
 
       <!-- Sign out (visible when authenticated) -->
       <button class="sidebar-item" x-show="isAuthenticated" @click="showSignOutConfirm = true" title="Sign out">
@@ -2765,6 +2761,13 @@ Authorization = "Bearer &lt;token from %USERPROFILE%\.muninn\mcp.token&gt;"</pre
           </div>
         </template>
         <div x-show="vaults.filter(v => v.toLowerCase().includes(vaultPickerSearch.toLowerCase())).length===0" style="padding:1.25rem;text-align:center;color:var(--text-muted);font-size:0.875rem;">No vaults found</div>
+      </div>
+      <!-- New Vault action -->
+      <div style="border-top:1px solid var(--border);padding:0.5rem;">
+        <button class="vault-modal-item" style="width:100%;border-radius:0.375rem;" @click="vaultModalOpen=false; vaultPickerSearch=''; createVault()">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink:0;opacity:0.5;"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          <span>New Vault</span>
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Fixes sidebar navigation accessibility on small viewports and cleans up the sidebar footer layout to maximize space, part of https://github.com/scrypster/muninndb/issues/327


## Changes

- Make `.sidebar-nav` scrollable (`overflow-y: auto`) so nav items are accessible when viewport height is too small
- Fix collapsed sidebar footer row spacing so icons no longer overflow the right border
- Replace text-based theme (`◐`) and help (`?`) buttons with consistent SVG icons; borderless when collapsed, bordered containers when expanded
- Move "New Vault" button from sidebar footer into the vault picker modal
- Merge version label into the footer icon row (visible only when expanded)
- Use `space-evenly` distribution for collapsed footer icons
- Tighten footer padding/gap to reclaim vertical space for nav items
- Remove unused `.sidebar-newvault-btn` CSS rules

### Scrollable nav items
**Before**
Nav bar footer was not visible if viewport height was too small, nav bar items also inaccessible when out of view
<img width="690" height="1216" alt="image" src="https://github.com/user-attachments/assets/ea87d855-e13d-404a-abb7-f0ad48f2bc35" />
**After**
<img width="453" height="644" alt="image" src="https://github.com/user-attachments/assets/34ef1891-edf3-4477-903d-87c6f019c2cd" />

### Vault picker
**Before**
Moved `New Vault` nav bar link into vault picker modal
<img width="865" height="505" alt="image" src="https://github.com/user-attachments/assets/89d1e628-f077-45a5-98b4-2261a1191e79" />
**After**
<img width="799" height="567" alt="image" src="https://github.com/user-attachments/assets/182ddca3-c98e-4f1e-aaa0-bddc13f691c6" />

### Nav bar footer
**Before**
Consolidated nav bar icons & app version, added border around them.
<img width="806" height="814" alt="image" src="https://github.com/user-attachments/assets/e3db30df-a9d2-470f-9c22-5f10207738b3" />
**After**
Note the hover state on the theme button
<img width="453" height="246" alt="image" src="https://github.com/user-attachments/assets/bb98658c-a2f8-4223-a252-81af30c10da4" />
<img width="140" height="238" alt="image" src="https://github.com/user-attachments/assets/1f3f9d91-3dd8-40dc-851e-6d68330c8f8f" />

## Release Checklist

- [x] `CHANGELOG.md` updated with changes
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
