### PR TITLE
fix(mcp): add 30-second SSE keepalive ping to prevent idle disconnect

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -348,11 +348,16 @@ func (s *MCPServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("mcp: SSE stream open", "session", sessionID[:8])
 	ctx := r.Context()
+	keepalive := time.NewTicker(30 * time.Second)
+	defer keepalive.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			slog.Info("mcp: SSE stream closed", "session", sessionID[:8])
 			return
+		case <-keepalive.C:
+			fmt.Fprintf(w, ": keepalive\n\n")
+			flusher.Flush()
 		case data, ok := <-ch:
 			if !ok {
 				slog.Info("mcp: SSE channel closed", "session", sessionID[:8])


### PR DESCRIPTION
## Problem

MCP SSE streams disconnect after ~5 minutes of inactivity. The root cause is proxy and load-balancer idle timeouts — when no data flows on the SSE connection, intermediary infrastructure closes it silently.

Claude Code clients (and other MCP consumers) see this as an unexpected `Interrupted` error with no visible explanation, often mid-session after a long-running tool call or period of thinking.

## Fix

Add a 30-second ticker to `handleSSE` that emits an SSE comment line:

```
: keepalive
```

SSE comment lines (starting with `:\ ) are part of the SSE spec and are silently ignored by all compliant clients. They do however keep the TCP connection alive and satisfy proxy idle-timeout requirements.

```go
keepalive := time.NewTicker(30 * time.Second)
defer keepalive.Stop()
for {
    select {
    case <-ctx.Done():
        return
    case <-keepalive.C:
        fmt.Fprintf(w, ": keepalive\n\n")
        flusher.Flush()
    case data, ok := <-ch:
        ...
    }
}
```

## Impact

- No behaviour change for clients
- Prevents silent disconnects on installations behind nginx, Traefik, AWS ALB, or any proxy with a default 60s/5min idle timeout
- Particularly affects Claude Code users on remote servers where sessions run long
- 5 lines changed, zero risk of regression

## Testing

`go test ./internal/mcp/...` passes.

Observed fix on a live ThinkDB instance — sessions that previously disconnected every ~5 minutes have been stable since applying this patch.