### PR TITLE
fix(storage): ClearEmbedFlagsForVault silently skips freshly imported engrams

### DIFF
--- a/internal/storage/embed_migration.go
+++ b/internal/storage/embed_migration.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/cockroachdb/pebble"
@@ -76,7 +77,10 @@ func (ps *PebbleStore) ClearEmbedFlagsForVault(ctx context.Context, ws [8]byte) 
 		copy(id[:], k[9:25])
 
 		raw, err := ps.getDigestFlagsRaw(id)
-		noRecord := err != nil
+		noRecord := errors.Is(err, pebble.ErrNotFound)
+		if err != nil && !noRecord {
+			return cleared, fmt.Errorf("clear embed flags: get digest: %w", err)
+		}
 		if noRecord {
 			raw = 0
 		}

--- a/internal/storage/embed_migration.go
+++ b/internal/storage/embed_migration.go
@@ -76,14 +76,18 @@ func (ps *PebbleStore) ClearEmbedFlagsForVault(ctx context.Context, ws [8]byte) 
 		copy(id[:], k[9:25])
 
 		raw, err := ps.getDigestFlagsRaw(id)
-		if err != nil {
-			// No digest record yet. Write a zero record so the RetroactiveProcessor
-			// treats this engram as pending (Bug 3 fix: imported engrams are now
-			// explicitly queued for embedding).
+		noRecord := err != nil
+		if noRecord {
 			raw = 0
 		}
-		if raw&embedMask == 0 {
-			// Both embed flags already clear — nothing to do.
+
+		// If an existing record already has both flags clear, there is nothing to
+		// do — skip it. But if there is NO record at all (noRecord), we must fall
+		// through and write the zero record so the RetroactiveProcessor explicitly
+		// sees this engram as pending embedding (fixes the silent skip introduced
+		// by the Bug 3 guard: raw=0 caused raw&embedMask==0 to be true, meaning
+		// the zero write was never reached for freshly imported engrams).
+		if !noRecord && raw&embedMask == 0 {
 			continue
 		}
 

--- a/internal/storage/embed_migration_test.go
+++ b/internal/storage/embed_migration_test.go
@@ -193,3 +193,106 @@ func TestGetSetEmbedModel(t *testing.T) {
 		t.Errorf("GetEmbedModel after clear = %q, want empty", model)
 	}
 }
+
+// TestClearEmbedFlagsForVault_NoRecord verifies that engrams with no existing
+// digest record (e.g. freshly imported via vault import) are counted and have a
+// zero record written by ClearEmbedFlagsForVault. Without this, the
+// RetroactiveProcessor never sees them as pending and silently skips them.
+//
+// Regression test for the self-defeating Bug 3 guard: the original fix set
+// raw=0 for missing records but then fell through to `if raw&embedMask == 0`
+// which is always true for raw=0, causing a `continue` that prevented the
+// zero write from ever being reached.
+func TestClearEmbedFlagsForVault_NoRecord(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("embed-flags-no-record")
+
+	// Write an engram but do NOT set any digest flags — simulates a freshly
+	// imported engram that has never been through the embed pipeline.
+	eng := &Engram{Concept: "imported", Content: "freshly imported engram"}
+	id, err := store.WriteEngram(ctx, ws, eng)
+	if err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+
+	// Confirm no digest record exists before the call.
+	_, err = store.GetDigestFlags(ctx, id)
+	if err == nil {
+		t.Fatal("expected ErrNotFound for digest flags before clear, got nil")
+	}
+
+	// ClearEmbedFlagsForVault should write a zero record and count it.
+	cleared, err := store.ClearEmbedFlagsForVault(ctx, ws)
+	if err != nil {
+		t.Fatalf("ClearEmbedFlagsForVault: %v", err)
+	}
+	if cleared != 1 {
+		t.Errorf("cleared = %d, want 1 (imported engram with no digest record must be counted)", cleared)
+	}
+
+	// Zero record must now exist — GetDigestFlags returns (0, nil), not ErrNotFound.
+	flags, err := store.GetDigestFlags(ctx, id)
+	if err != nil {
+		t.Fatalf("GetDigestFlags after clear: %v (want zero record, not ErrNotFound)", err)
+	}
+	if flags != 0 {
+		t.Errorf("flags = 0x%02x, want 0x00 after zero-record write", flags)
+	}
+
+	// Second call must be idempotent: record exists with flags clear → cleared=0.
+	cleared2, err := store.ClearEmbedFlagsForVault(ctx, ws)
+	if err != nil {
+		t.Fatalf("ClearEmbedFlagsForVault (second call): %v", err)
+	}
+	if cleared2 != 0 {
+		t.Errorf("second call cleared = %d, want 0 (idempotent after zero record written)", cleared2)
+	}
+}
+
+// TestClearEmbedFlagsForVault_DigestEmbedFailed verifies that DigestEmbedFailed
+// (0x80) is cleared in addition to DigestEmbed (0x02). Without this, a single
+// transient embed failure permanently blocks an engram from ever being
+// re-embedded, even after an explicit reembed operation.
+func TestClearEmbedFlagsForVault_DigestEmbedFailed(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("embed-flags-failed")
+
+	eng := &Engram{Concept: "failed-embed", Content: "embed attempt previously failed"}
+	id, err := store.WriteEngram(ctx, ws, eng)
+	if err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+
+	const DigestEmbedFailed uint8 = 0x80
+	if err := store.SetDigestFlag(ctx, id, DigestEmbedFailed); err != nil {
+		t.Fatalf("SetDigestFlag(DigestEmbedFailed): %v", err)
+	}
+
+	// Verify flag is set before clearing.
+	flags, err := store.GetDigestFlags(ctx, id)
+	if err != nil {
+		t.Fatalf("GetDigestFlags before clear: %v", err)
+	}
+	if flags&DigestEmbedFailed == 0 {
+		t.Fatal("expected DigestEmbedFailed set before clear")
+	}
+
+	cleared, err := store.ClearEmbedFlagsForVault(ctx, ws)
+	if err != nil {
+		t.Fatalf("ClearEmbedFlagsForVault: %v", err)
+	}
+	if cleared != 1 {
+		t.Errorf("cleared = %d, want 1", cleared)
+	}
+
+	// DigestEmbedFailed must be cleared.
+	flags, err = store.GetDigestFlags(ctx, id)
+	if err != nil {
+		t.Fatalf("GetDigestFlags after clear: %v", err)
+	}
+	if flags&DigestEmbedFailed != 0 {
+		t.Errorf("DigestEmbedFailed (0x80) still set after clear: flags = 0x%02x", flags)
+	}
+}


### PR DESCRIPTION
## Problem

The Bug 3 fix introduced in #290 (commit `152b242`) is self-defeating. The intent was to write a zero digest record for engrams that have no existing `0x11` record (freshly imported via vault import), so the `RetroactiveProcessor` can see them as pending embedding.

The implementation sets `raw = 0` for missing records but immediately hits a guard that fires for any zero value:

```go
raw, err := ps.getDigestFlagsRaw(id)
if err != nil {
    raw = 0  // intent: fall through and write zero record
}
if raw&embedMask == 0 {
    continue  // BUG: raw=0 makes this always true — zero write never reached
}
```

Result: freshly imported engrams still have no `0x11` record after `ClearEmbedFlagsForVault` runs. The `RetroactiveProcessor` silently skips them, so a vault import followed by reembed never actually embeds the imported engrams.

## Fix

Track whether the record was absent and only skip when an *existing* record already has both flags clear:

```go
noRecord := err != nil
if noRecord {
    raw = 0
}
// Only skip if existing record has both flags clear.
// If no record: fall through to write the zero record.
if !noRecord && raw&embedMask == 0 {
    continue
}
```

## Tests added

- `TestClearEmbedFlagsForVault_NoRecord` — engram with no digest record is counted and gets a zero record written; second call is idempotent (`cleared=0`)
- `TestClearEmbedFlagsForVault_DigestEmbedFailed` — `DigestEmbedFailed` (0x80) is cleared (regression coverage for Bug 4)

All storage tests pass: `go test ./internal/storage/...`

## Related

Fixes the silent skip regression introduced by the Bug 3 guard in #290.