### PR TITLE
fix(enrich): expand entity type allowlist and pass through unknown types

### DIFF
--- a/internal/plugin/enrich/parse.go
+++ b/internal/plugin/enrich/parse.go
@@ -267,10 +267,18 @@ func validateAndDedupeEntities(entities []plugin.ExtractedEntity) []plugin.Extra
 	return result
 }
 
-// normalizeEntityType validates and normalizes entity type strings.
+// normalizeEntityType normalizes entity type strings to lowercase and
+// validates against the known types recognised by the UI colour map.
+// Known types are returned as-is after normalisation. Unknown types are
+// returned as their normalised string rather than being silently coerced
+// to "service", which would corrupt semantic information and cause the
+// graph UI to display incorrect colours for any type not in the original
+// eight-item allowlist (e.g. "technology", "location", "concept", "event").
 func normalizeEntityType(t string) string {
 	t = strings.ToLower(strings.TrimSpace(t))
 
+	// Allowlist mirrors the entity types recognised by the UI colour map
+	// in web/static/js/app.js:getEntityTypeColor. Extend both together.
 	validTypes := map[string]bool{
 		"person":       true,
 		"organization": true,
@@ -280,14 +288,23 @@ func normalizeEntityType(t string) string {
 		"language":     true,
 		"database":     true,
 		"service":      true,
+		"technology":   true,
+		"location":     true,
+		"concept":      true,
+		"product":      true,
+		"event":        true,
+		"other":        true,
 	}
 
-	if validTypes[t] {
+	if validTypes[t] || t == "" {
 		return t
 	}
 
-	// Default to "service" for unknown types
-	return "service"
+	// Pass through unrecognised types rather than coercing to "service".
+	// This preserves the LLM's semantic intent and avoids silent data
+	// corruption when new types are added to the UI before the allowlist
+	// is updated.
+	return t
 }
 
 // validateRelationships validates relationship fields.

--- a/internal/plugin/enrich/parse_test.go
+++ b/internal/plugin/enrich/parse_test.go
@@ -146,18 +146,46 @@ func TestParseRelationships_ValidJSON(t *testing.T) {
 // TestNormalizeEntityType tests entity type normalization and validation.
 func TestNormalizeEntityType_Valid(t *testing.T) {
 	tests := map[string]string{
+		// Known types — returned as-is after normalisation.
 		"person":       "person",
 		"PERSON":       "person",
 		"database":     "database",
 		"tool":         "tool",
-		"unknown":      "service", // should normalize to service
 		"ORGANIZATION": "organization",
+		// UI-colour-map types that were previously missing from the allowlist
+		// and were silently coerced to "service".
+		"technology": "technology",
+		"location":   "location",
+		"concept":    "concept",
+		"product":    "product",
+		"event":      "event",
+		// Unknown types are passed through (not coerced to "service").
+		"unknown":  "unknown",
+		"library":  "library",
+		"LIBRARY":  "library", // still normalised to lowercase
 	}
 
 	for input, expected := range tests {
 		result := normalizeEntityType(input)
 		if result != expected {
-			t.Fatalf("normalizeEntityType(%q): expected %q, got %q", input, expected, result)
+			t.Errorf("normalizeEntityType(%q): got %q, want %q", input, result, expected)
+		}
+	}
+}
+
+// TestNormalizeEntityType_UnknownPassThrough verifies that unknown entity types
+// are returned as their normalised string rather than silently coerced to
+// "service". This prevents data corruption when an LLM returns a valid semantic
+// type (e.g. "library", "concept", "event") that is not yet in the allowlist.
+func TestNormalizeEntityType_UnknownPassThrough(t *testing.T) {
+	unknownTypes := []string{"library", "algorithm", "protocol", "api", "config", "file"}
+	for _, typ := range unknownTypes {
+		result := normalizeEntityType(typ)
+		if result == "service" {
+			t.Errorf("normalizeEntityType(%q) = %q, must not coerce unknown types to \"service\"", typ, result)
+		}
+		if result != typ {
+			t.Errorf("normalizeEntityType(%q) = %q, want pass-through %q", typ, result, typ)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

 in  has two related bugs.

### Bug 1 — Allowlist is out of sync with the UI colour map

The function only recognises **8 types**:



But  in  has **14 named types**:



The six types present in the UI but absent from the allowlist — , , , , ,  — are silently coerced to . This causes:

- **Wrong graph colours**: e.g. a  entity (should be indigo ) displays as  (cyan )
- **Corrupted semantic metadata**: stored type no longer reflects what the LLM extracted

### Bug 2 — Unknown types silently coerced to "service"

Any type not in the allowlist is mapped to  with no warning. An LLM returning , , , , or any other valid semantic type has its output silently overwritten with a meaningless default.

## Fix

1. Expand the allowlist to all 14 types recognised by  — keeping the two sources in sync
2. Return the normalised (lowercase, trimmed) string for unrecognised types instead of coercing to  — this preserves LLM semantic intent and is forward-compatible with future type additions

## Tests

- Updated  to cover previously-missing UI types and correct the  case
- Added  as a regression guard

All enrich tests pass: 

## Note

The UI colour map () and the allowlist in  should be kept in sync. Consider a shared constant or comment cross-reference to prevent future drift.