### PR TITLE
fix(ui): copyToClipboard always fails on HTTP installs with "Copy failed" toast

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -2080,13 +2080,41 @@ document.addEventListener('alpine:init', () => {
     },
 
     async copyToClipboard(text) {
+      // navigator.clipboard requires a secure context (HTTPS or localhost).
+      // Installations accessed over plain HTTP (e.g. a LAN IP like
+      // 192.168.x.x:8476) have navigator.clipboard === undefined, causing
+      // the previous implementation to always throw and show an error toast.
+      // Fall back to the legacy execCommand path for non-secure contexts.
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        try {
+          await navigator.clipboard.writeText(text);
+          this.connectCopied = true;
+          setTimeout(() => { this.connectCopied = false; }, 2000);
+          this.addNotification('success', 'Copied to clipboard');
+          return;
+        } catch (_) {
+          // Fall through to execCommand fallback.
+        }
+      }
+      // execCommand fallback — works on HTTP and older browsers.
       try {
-        await navigator.clipboard.writeText(text);
-        this.connectCopied = true;
-        setTimeout(() => { this.connectCopied = false; }, 2000);
-        this.addNotification('success', 'Copied to clipboard');
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        const ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+        if (ok) {
+          this.connectCopied = true;
+          setTimeout(() => { this.connectCopied = false; }, 2000);
+          this.addNotification('success', 'Copied to clipboard');
+        } else {
+          this.addNotification('error', 'Copy failed — please select and copy manually');
+        }
       } catch (_) {
-        this.addNotification('error', 'Copy failed — select and copy manually');
+        this.addNotification('error', 'Copy failed — please select and copy manually');
       }
     },
 

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -927,18 +927,19 @@ document.addEventListener('alpine:init', () => {
     },
 
     _copyFallback(text) {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
       try {
-        const ta = document.createElement('textarea');
-        ta.value = text;
-        ta.style.position = 'fixed';
-        ta.style.opacity = '0';
-        document.body.appendChild(ta);
         ta.select();
         const ok = document.execCommand('copy');
-        document.body.removeChild(ta);
         this.addNotification(ok ? 'success' : 'error', ok ? 'Activity data copied to clipboard' : 'Copy failed — please copy manually');
       } catch (_) {
         this.addNotification('error', 'Copy failed — please copy manually');
+      } finally {
+        document.body.removeChild(ta);
       }
     },
 
@@ -2097,15 +2098,14 @@ document.addEventListener('alpine:init', () => {
         }
       }
       // execCommand fallback — works on HTTP and older browsers.
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
       try {
-        const ta = document.createElement('textarea');
-        ta.value = text;
-        ta.style.position = 'fixed';
-        ta.style.opacity = '0';
-        document.body.appendChild(ta);
         ta.select();
         const ok = document.execCommand('copy');
-        document.body.removeChild(ta);
         if (ok) {
           this.connectCopied = true;
           setTimeout(() => { this.connectCopied = false; }, 2000);
@@ -2115,6 +2115,8 @@ document.addEventListener('alpine:init', () => {
         }
       } catch (_) {
         this.addNotification('error', 'Copy failed — please select and copy manually');
+      } finally {
+        document.body.removeChild(ta);
       }
     },
 
@@ -2478,9 +2480,29 @@ document.addEventListener('alpine:init', () => {
 
     copyToken() {
       if (!this.clusterToken?.token) return;
-      navigator.clipboard.writeText(this.clusterToken.token).catch(() => {});
-      this.clusterTokenCopied = true;
-      setTimeout(() => { this.clusterTokenCopied = false; }, 2000);
+      const text = this.clusterToken.token;
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(() => {
+          this.clusterTokenCopied = true;
+          setTimeout(() => { this.clusterTokenCopied = false; }, 2000);
+        }).catch(() => {});
+        return;
+      }
+      // execCommand fallback for non-secure contexts (plain HTTP LAN installs).
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      try {
+        ta.select();
+        if (document.execCommand('copy')) {
+          this.clusterTokenCopied = true;
+          setTimeout(() => { this.clusterTokenCopied = false; }, 2000);
+        }
+      } finally {
+        document.body.removeChild(ta);
+      }
     },
 
     async loadClusterSettings() {


### PR DESCRIPTION
## Problem

 in  uses  directly with no fallback:



The [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) requires a **secure context** — HTTPS or . Any installation accessed over plain HTTP on a LAN IP (e.g. , which is the common self-hosted setup) has . The  call throws a , which the catch block surfaces as a **"Copy failed"** error toast on every single click.

### Affected surfaces
- API key copy button ( display after creating a key)
- Connect URL / endpoint copy buttons
- Any other caller of the shared  helper

### Already fixed elsewhere — inconsistently
 (line ~911) already has the correct pattern —  never received the same treatment.

## Fix

Mirror the pattern from :

1. Check  availability before calling 
2. Fall back to a  textarea approach when the Clipboard API is unavailable or throws
3. Both paths set  and show the correct success/error notification

The  fallback works on HTTP, in older browsers, and in sandboxed iframes.

## Testing

Reproduced on a self-hosted instance at  — every Copy click showed the error toast before the fix, and worked correctly after. No automated test added (clipboard interaction requires a browser context).

Ref #327
