### PR TITLE
Fix: Dark mode drop-down option lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public vault unauthenticated access now runs in `full` mode. Previously, requests to an open vault with no API key ran as `observe`, silently preventing cognitive-state writes. Public vaults are now genuinely open — callers get `full` access unless they present an explicit `observe` key.
 
 ### Fixed
+- Native `<select>` dropdowns unreadable in dark mode — `--bg-card` CSS variable was referenced but never defined; added it to both themes and added global select/option styling for proper dark/light rendering.
 - Sidebar nav items are now scrollable when viewport height is too small, keeping the logo and footer pinned.
 - Collapsed sidebar footer icons no longer overflow into the right border; icons render borderless when collapsed and bordered when expanded.
 - "New Vault" action moved from sidebar footer into the vault picker modal to reclaim vertical space for nav items.

--- a/web/static/css/components.css
+++ b/web/static/css/components.css
@@ -105,6 +105,22 @@
 }
 .input-field:focus { border-color: var(--primary); }
 
+/* Native select & option dark-mode readability */
+select {
+  color-scheme: dark;
+}
+select option {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+html.light select {
+  color-scheme: light;
+}
+html.light select option {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
 .form-group { display: flex; flex-direction: column; gap: 0.375rem; }
 .form-group label { font-size: 0.875rem; font-weight: 500; color: var(--text-secondary); }
 

--- a/web/static/css/theme.css
+++ b/web/static/css/theme.css
@@ -3,6 +3,7 @@
   --bg-base:    #0a0a0a;
   --bg-surface: #1a1a2e;
   --bg-elevated:#16213e;
+  --bg-card:    #1e2a45;
   --border:     #2a2a4a;
   --text-primary:   #e2e8f0;
   --text-secondary: #94a3b8;
@@ -22,6 +23,7 @@ html.light {
   --bg-base:    #fafafa;
   --bg-surface: #ffffff;
   --bg-elevated:#f1f5f9;
+  --bg-card:    #f8fafc;
   --border:     #e2e8f0;
   --text-primary:   #0f172a;
   --text-secondary: #475569;


### PR DESCRIPTION
## Summary

Fix unreadable native `<select>` dropdowns in dark mode, part of https://github.com/scrypster/muninndb/issues/327

The `--bg-card` CSS variable was referenced in inline styles but never defined, causing transparent backgrounds on dropdown elements across multiple pages.


## Changes

- Define `--bg-card` custom property in both dark (`#1e2a45`) and light (`#f8fafc`) themes in `theme.css`
- Add global `select` / `select option` rules in `components.css` with proper `background`, `color`, and `color-scheme` for both dark and light modes, ensuring native option lists are also readable

**Before**
<img width="282" height="617" alt="image" src="https://github.com/user-attachments/assets/470092f0-a14a-417c-b358-76c5e9733c48" />

**After**
<img width="282" height="617" alt="image" src="https://github.com/user-attachments/assets/f7df191b-3097-4b74-9f3a-561f8d54eca9" />


## Release Checklist

- [x] `CHANGELOG.md` updated with changes
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes