### PR TITLE
Fix: Settings page button group styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version label merged into the footer icon row instead of occupying its own line.
 - Sidebar footer padding and gaps tightened to maximize nav item visibility on short viewports.
 - Memories page search-mode segmented control (Balanced/Semantic/Recent/Deep) now matches adjacent button height and font size, includes dividers between options, and preserves padding when Alpine.js re-renders dynamic styles.
-- Settings page Platform toggle (macOS/Linux/Windows) now uses consistent button group styling with proper padding, dividers, font weight, and increased label size.
 - Enrich now accepts OpenAI-compatible JSON responses returned in `message.reasoning` when `message.content` is empty, including structured reasoning payloads.
 - Retry and retroactive enrichment now only mark entity and relationship stages complete after successful persistence, avoiding partial-state retries, nil-result crashes, and silent graph-write failures.
 - Entity and relationship response parsing now rejects nested wrapper keys like `meta.entities` / `meta.relationships` instead of treating them as valid empty results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version label merged into the footer icon row instead of occupying its own line.
 - Sidebar footer padding and gaps tightened to maximize nav item visibility on short viewports.
 - Memories page search-mode segmented control (Balanced/Semantic/Recent/Deep) now matches adjacent button height and font size, includes dividers between options, and preserves padding when Alpine.js re-renders dynamic styles.
+- Settings page Platform toggle (macOS/Linux/Windows) now uses consistent button group styling with proper padding, dividers, font weight, and increased label size.
 - Enrich now accepts OpenAI-compatible JSON responses returned in `message.reasoning` when `message.content` is empty, including structured reasoning payloads.
 - Retry and retroactive enrichment now only mark entity and relationship stages complete after successful persistence, avoiding partial-state retries, nil-result crashes, and silent graph-write failures.
 - Entity and relationship response parsing now rejects nested wrapper keys like `meta.entities` / `meta.relationships` instead of treating them as valid empty results.

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1942,17 +1942,14 @@
 
         <!-- Platform toggle -->
         <div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:1rem;">
-          <span style="font-size:0.8125rem;color:var(--text-muted);">Platform:</span>
-          <div style="display:flex;border:1px solid var(--border);border-radius:0.375rem;overflow:hidden;">
+          <span style="font-size:0.875rem;font-weight:500;color:var(--text-muted);">Platform:</span>
+          <div style="display:inline-flex;border:1px solid var(--border);border-radius:0.5rem;overflow:hidden;">
             <button @click="connectPlatform='macos'"
-              :style="connectPlatform==='macos' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);'"
-              style="padding:0.25rem 0.75rem;font-size:0.8125rem;border:none;cursor:pointer;">macOS</button>
+              :style="'padding:0.5rem 1rem;font-size:0.8125rem;border:none;border-right:1px solid var(--border);cursor:pointer;transition:all 0.15s;font-weight:600;' + (connectPlatform==='macos' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')">macOS</button>
             <button @click="connectPlatform='linux'"
-              :style="connectPlatform==='linux' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);'"
-              style="padding:0.25rem 0.75rem;font-size:0.8125rem;border:none;border-left:1px solid var(--border);cursor:pointer;">Linux</button>
+              :style="'padding:0.5rem 1rem;font-size:0.8125rem;border:none;border-right:1px solid var(--border);cursor:pointer;transition:all 0.15s;font-weight:600;' + (connectPlatform==='linux' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')">Linux</button>
             <button @click="connectPlatform='windows'"
-              :style="connectPlatform==='windows' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);'"
-              style="padding:0.25rem 0.75rem;font-size:0.8125rem;border:none;border-left:1px solid var(--border);cursor:pointer;">Windows</button>
+              :style="'padding:0.5rem 1rem;font-size:0.8125rem;border:none;cursor:pointer;transition:all 0.15s;font-weight:600;' + (connectPlatform==='windows' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')">Windows</button>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Fixes Settings page Platform button group UI to match the style established in #328, part of https://github.com/scrypster/muninndb/issues/327

The platform toggle (macOS / Linux / Windows) on the Settings → Connect page had the same issues as the Memories search-mode control: undersized padding, missing dividers between inactive options, and static `style` attributes that Alpine.js overwrites on re-render.


## Changes

- Increased button padding from `0.25rem 0.75rem` to `0.5rem 1rem`
- Added `border-right: 1px solid var(--border)` dividers between options (except last)
- Added `font-weight: 600` and `transition: all 0.15s` to match other button groups
- Merged static `style` into Alpine `:style` binding to prevent dynamic styles from overwriting padding/border on re-render
- Updated container `border-radius` from `0.375rem` to `0.5rem` for consistency
- Bumped "Platform:" label font size from `0.8125rem` to `0.875rem` with `font-weight: 500` to better balance with the larger buttons
- Updated `CHANGELOG.md`

**Before**
<img width="414" height="95" alt="image" src="https://github.com/user-attachments/assets/4feb7264-5bd0-48a4-a219-4df0cd7280db" />

**After**
<img width="527" height="122" alt="image" src="https://github.com/user-attachments/assets/981457d1-14b8-4364-b6d4-119d32554964" />


## Release Checklist

- [x] `CHANGELOG.md` updated with changes
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
