### PR TITLE
fix(engine): exclude archived engrams from all retrieval paths

### DIFF
--- a/internal/engine/activation/activation_test.go
+++ b/internal/engine/activation/activation_test.go
@@ -1433,3 +1433,115 @@ func TestRRF_CGDNConflict_RRFTakesPrecedence(t *testing.T) {
 		t.Errorf("score must be positive, got %v", score)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Archived engram filtering — regression tests for the StateArchived leak
+// ---------------------------------------------------------------------------
+
+// TestArchivedEngram_ExcludedFromRecall verifies that engrams with
+// StateArchived are not returned by activation/recall. The dream engine
+// archives consolidated engrams; they must not surface in normal recall
+// even though they are still present in the HNSW index.
+func TestArchivedEngram_ExcludedFromRecall(t *testing.T) {
+	store := newStubStore()
+
+	active := &storage.Engram{
+		Concept:    "active engram",
+		Content:    "this is active",
+		Confidence: 1.0,
+		Stability:  30.0,
+		State:      storage.StateActive,
+	}
+	archived := &storage.Engram{
+		Concept:    "archived engram",
+		Content:    "this was archived by dream engine",
+		Confidence: 1.0,
+		Stability:  30.0,
+		State:      storage.StateArchived,
+	}
+	store.writeEngram(active)
+	store.writeEngram(archived)
+
+	// Both appear as HNSW candidates (HNSW has no delete — defense-in-depth filter needed).
+	fts := &stubFTS{results: []activation.ScoredID{
+		{ID: active.ID, Score: 0.9},
+		{ID: archived.ID, Score: 0.9},
+	}}
+	hnsw := &stubHNSW{results: []activation.ScoredID{
+		{ID: active.ID, Score: 0.9},
+		{ID: archived.ID, Score: 0.9},
+	}}
+
+	eng := newTestEngine(store, fts, hnsw)
+	result, err := eng.Run(context.Background(), &activation.ActivateRequest{
+		Context:    []string{"engram"},
+		Threshold:  0.0,
+		MaxResults: 10,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, a := range result.Activations {
+		if a.Engram != nil && a.Engram.ID == archived.ID {
+			t.Errorf("archived engram appeared in recall results — StateArchived must be filtered")
+		}
+	}
+	var found bool
+	for _, a := range result.Activations {
+		if a.Engram != nil && a.Engram.ID == active.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("active engram missing from recall results")
+	}
+}
+
+// TestSoftDeletedEngram_ExcludedFromRecall verifies the existing soft-delete
+// filter still works after the archived-filter change (regression guard).
+func TestSoftDeletedEngram_ExcludedFromRecall(t *testing.T) {
+	store := newStubStore()
+
+	active := &storage.Engram{
+		Concept:    "active",
+		Content:    "active content",
+		Confidence: 1.0,
+		Stability:  30.0,
+		State:      storage.StateActive,
+	}
+	deleted := &storage.Engram{
+		Concept:    "deleted",
+		Content:    "soft deleted content",
+		Confidence: 1.0,
+		Stability:  30.0,
+		State:      storage.StateSoftDeleted,
+	}
+	store.writeEngram(active)
+	store.writeEngram(deleted)
+
+	fts := &stubFTS{results: []activation.ScoredID{
+		{ID: active.ID, Score: 0.9},
+		{ID: deleted.ID, Score: 0.9},
+	}}
+	hnsw := &stubHNSW{results: []activation.ScoredID{
+		{ID: active.ID, Score: 0.9},
+		{ID: deleted.ID, Score: 0.9},
+	}}
+
+	eng := newTestEngine(store, fts, hnsw)
+	result, err := eng.Run(context.Background(), &activation.ActivateRequest{
+		Context:    []string{"content"},
+		Threshold:  0.0,
+		MaxResults: 10,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, a := range result.Activations {
+		if a.Engram != nil && a.Engram.ID == deleted.ID {
+			t.Errorf("soft-deleted engram appeared in recall results")
+		}
+	}
+}

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -1162,7 +1162,7 @@ func (e *ActivationEngine) phase6Score(
 	// Filter out soft-deleted engrams (defense-in-depth; HNSW has no delete method).
 	var active []*storage.Engram
 	for _, eng := range allEngrams {
-		if eng != nil && eng.State != storage.StateSoftDeleted {
+		if eng != nil && eng.State != storage.StateSoftDeleted && eng.State != storage.StateArchived {
 			active = append(active, eng)
 		}
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2094,6 +2094,9 @@ func (e *Engine) Link(ctx context.Context, req *mbp.LinkRequest) (*mbp.LinkRespo
 		if meta.State == storage.StateSoftDeleted {
 			return nil, ErrEngramSoftDeleted
 		}
+		if meta.State == storage.StateArchived {
+			return nil, ErrEngramArchived
+		}
 	}
 
 	assoc := &storage.Association{
@@ -2372,8 +2375,8 @@ func (e *Engine) Restore(ctx context.Context, vault, id string) (*storage.Engram
 		}
 		return nil, fmt.Errorf("restore: %w", err)
 	}
-	if eng.State != storage.StateSoftDeleted {
-		return nil, fmt.Errorf("restore: engram %s is not soft-deleted (state=%d)", id, eng.State)
+	if eng.State != storage.StateSoftDeleted && eng.State != storage.StateArchived {
+		return nil, fmt.Errorf("restore: engram %s is not soft-deleted or archived (state=%d)", id, eng.State)
 	}
 	meta := &storage.EngramMeta{
 		State:       storage.StateActive,

--- a/internal/engine/engine_entity_timeline.go
+++ b/internal/engine/engine_entity_timeline.go
@@ -69,8 +69,8 @@ func (e *Engine) GetEntityTimeline(ctx context.Context, vault string, entityName
 			return nil // skip missing/deleted
 		}
 
-		// Skip soft-deleted engrams.
-		if eng.State == storage.StateSoftDeleted {
+		// Skip soft-deleted and archived engrams.
+		if eng.State == storage.StateSoftDeleted || eng.State == storage.StateArchived {
 			return nil
 		}
 

--- a/internal/engine/engine_find_by_entity.go
+++ b/internal/engine/engine_find_by_entity.go
@@ -33,7 +33,7 @@ func (e *Engine) FindByEntity(ctx context.Context, vault, entityName string, lim
 		if err != nil || eng == nil {
 			return nil // skip missing/deleted
 		}
-		if eng.State == storage.StateSoftDeleted {
+		if eng.State == storage.StateSoftDeleted || eng.State == storage.StateArchived {
 			return nil
 		}
 		results = append(results, eng)

--- a/internal/engine/engine_find_by_entity_test.go
+++ b/internal/engine/engine_find_by_entity_test.go
@@ -1,0 +1,110 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindByEntity_ExcludesArchived verifies that archived engrams do not appear
+// in FindByEntity results.
+func TestFindByEntity_ExcludesArchived(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "find-by-entity-archived"
+	ws := eng.store.ResolveVaultPrefix(vault)
+
+	// Write two engrams and link both to the same entity.
+	engA := &storage.Engram{Concept: "active-engram", Content: "This one stays active"}
+	idA, err := eng.store.WriteEngram(ctx, ws, engA)
+	require.NoError(t, err)
+
+	engB := &storage.Engram{Concept: "archived-engram", Content: "This one gets archived"}
+	idB, err := eng.store.WriteEngram(ctx, ws, engB)
+	require.NoError(t, err)
+
+	err = eng.store.UpsertEntityRecord(ctx, storage.EntityRecord{
+		Name:   "SharedEntity",
+		Type:   "concept",
+		Source: "inline",
+	}, "inline")
+	require.NoError(t, err)
+	err = eng.store.WriteEntityEngramLink(ctx, ws, idA, "SharedEntity")
+	require.NoError(t, err)
+	err = eng.store.WriteEntityEngramLink(ctx, ws, idB, "SharedEntity")
+	require.NoError(t, err)
+
+	// Archive engram B.
+	err = eng.UpdateLifecycleState(ctx, vault, idB.String(), "archived")
+	require.NoError(t, err)
+
+	// FindByEntity must return only the active engram.
+	results, err := eng.FindByEntity(ctx, vault, "SharedEntity", 50)
+	require.NoError(t, err)
+
+	var foundActive, foundArchived bool
+	for _, r := range results {
+		if r.ID == idA {
+			foundActive = true
+		}
+		if r.ID == idB {
+			foundArchived = true
+		}
+	}
+	require.True(t, foundActive, "active engram A should appear in FindByEntity results")
+	require.False(t, foundArchived, "archived engram B should NOT appear in FindByEntity results")
+}
+
+// TestFindByEntity_ExcludesSoftDeleted verifies that soft-deleted engrams do not
+// appear in FindByEntity results.
+func TestFindByEntity_ExcludesSoftDeleted(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "find-by-entity-softdeleted"
+	ws := eng.store.ResolveVaultPrefix(vault)
+
+	engA := &storage.Engram{Concept: "active-engram", Content: "This one stays active"}
+	idA, err := eng.store.WriteEngram(ctx, ws, engA)
+	require.NoError(t, err)
+
+	engB := &storage.Engram{Concept: "deleted-engram", Content: "This one gets deleted"}
+	idB, err := eng.store.WriteEngram(ctx, ws, engB)
+	require.NoError(t, err)
+
+	err = eng.store.UpsertEntityRecord(ctx, storage.EntityRecord{
+		Name:   "SharedEntity2",
+		Type:   "concept",
+		Source: "inline",
+	}, "inline")
+	require.NoError(t, err)
+	err = eng.store.WriteEntityEngramLink(ctx, ws, idA, "SharedEntity2")
+	require.NoError(t, err)
+	err = eng.store.WriteEntityEngramLink(ctx, ws, idB, "SharedEntity2")
+	require.NoError(t, err)
+
+	err = eng.store.SoftDelete(ctx, ws, idB)
+	require.NoError(t, err)
+
+	results, err := eng.FindByEntity(ctx, vault, "SharedEntity2", 50)
+	require.NoError(t, err)
+
+	var foundActive, foundDeleted bool
+	for _, r := range results {
+		if r.ID == idA {
+			foundActive = true
+		}
+		if r.ID == idB {
+			foundDeleted = true
+		}
+	}
+	require.True(t, foundActive, "active engram A should appear in FindByEntity results")
+	require.False(t, foundDeleted, "soft-deleted engram B should NOT appear in FindByEntity results")
+}

--- a/internal/engine/engine_list.go
+++ b/internal/engine/engine_list.go
@@ -62,6 +62,12 @@ func (e *Engine) ListEngrams(ctx context.Context, params ListEngramsParams) (*Li
 				return nil
 			}
 		}
+		// Always exclude archived unless explicitly requested.
+		if eng.State == storage.StateArchived {
+			if stateFilter == nil || *stateFilter != storage.StateArchived {
+				return nil
+			}
+		}
 
 		// State filter.
 		if stateFilter != nil && eng.State != *stateFilter {

--- a/internal/engine/engine_traverse_entity_test.go
+++ b/internal/engine/engine_traverse_entity_test.go
@@ -289,3 +289,60 @@ func TestTraverse_FollowEntities_SoftDeletedViaEntity(t *testing.T) {
 	}
 	require.False(t, foundB, "soft-deleted engram B should NOT appear in traversal, even via entity hop")
 }
+
+
+// TestTraverse_FollowEntities_ArchivedViaEntity verifies that archived engrams
+// are excluded from traversal results, even when follow_entities=true.
+func TestTraverse_FollowEntities_ArchivedViaEntity(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "traverse-entity-archived"
+	ws := eng.store.ResolveVaultPrefix(vault)
+
+	// Write engram A and link it to entity "ArchivedEntity".
+	engramA := &storage.Engram{
+		Concept: "engram-A",
+		Content: "First engram linked to ArchivedEntity",
+	}
+	idA, err := eng.store.WriteEngram(ctx, ws, engramA)
+	require.NoError(t, err)
+
+	err = eng.store.UpsertEntityRecord(ctx, storage.EntityRecord{
+		Name:   "ArchivedEntity",
+		Type:   "concept",
+		Source: "inline",
+	}, "inline")
+	require.NoError(t, err)
+	err = eng.store.WriteEntityEngramLink(ctx, ws, idA, "ArchivedEntity")
+	require.NoError(t, err)
+
+	// Write engram B and link it to entity "ArchivedEntity".
+	engramB := &storage.Engram{
+		Concept: "engram-B",
+		Content: "Second engram linked to ArchivedEntity",
+	}
+	idB, err := eng.store.WriteEngram(ctx, ws, engramB)
+	require.NoError(t, err)
+	err = eng.store.WriteEntityEngramLink(ctx, ws, idB, "ArchivedEntity")
+	require.NoError(t, err)
+
+	// Archive engram B via lifecycle state transition.
+	err = eng.UpdateLifecycleState(ctx, vault, idB.String(), "archived")
+	require.NoError(t, err)
+
+	// Traverse from A with follow_entities=true and max_depth=2.
+	// B is reachable via entity link, but since it is archived, it must NOT appear.
+	nodes, _, err := eng.Traverse(ctx, vault, idA.String(), 2, 100, true)
+	require.NoError(t, err)
+
+	foundB := false
+	for _, n := range nodes {
+		if n.ID == idB {
+			foundB = true
+		}
+	}
+	require.False(t, foundB, "archived engram B should NOT appear in traversal, even via entity hop")
+}

--- a/internal/engine/engine_vault.go
+++ b/internal/engine/engine_vault.go
@@ -20,6 +20,10 @@ var ErrEngramNotFound = errors.New("engram not found")
 // been soft-deleted. Use errors.Is to check for this error in callers.
 var ErrEngramSoftDeleted = errors.New("engram is soft-deleted")
 
+// ErrEngramArchived is returned when an operation targets an engram that has
+// been archived. Use errors.Is to check for this error in callers.
+var ErrEngramArchived = errors.New("engram is archived")
+
 // ErrVaultNameCollision is returned when a rename or clone targets a vault name
 // that already exists. Use errors.Is to check for this error in callers.
 var ErrVaultNameCollision = errors.New("vault name already exists")

--- a/internal/engine/engine_where_left_off.go
+++ b/internal/engine/engine_where_left_off.go
@@ -26,7 +26,7 @@ func (e *Engine) WhereLeftOff(ctx context.Context, vault string, limit int) ([]*
 		if err != nil || eng == nil {
 			return nil
 		}
-		if eng.State == storage.StateSoftDeleted || eng.State == storage.StateCompleted {
+		if eng.State == storage.StateSoftDeleted || eng.State == storage.StateCompleted || eng.State == storage.StateArchived {
 			return nil
 		}
 		results = append(results, eng)

--- a/internal/engine/entity_ops.go
+++ b/internal/engine/entity_ops.go
@@ -60,7 +60,7 @@ func (e *Engine) GetEntityAggregate(ctx context.Context, vault, entityName strin
 		if err != nil || eng == nil {
 			return nil // skip missing/deleted
 		}
-		if eng.State == storage.StateSoftDeleted {
+		if eng.State == storage.StateSoftDeleted || eng.State == storage.StateArchived {
 			return nil
 		}
 		engrams = append(engrams, eng)

--- a/internal/engine/query.go
+++ b/internal/engine/query.go
@@ -146,7 +146,7 @@ func (e *Engine) Traverse(ctx context.Context, vault, startID string, maxHops, m
 			}
 			eng := engrams[i]
 			if eng != nil {
-				if eng.State != storage.StateSoftDeleted {
+				if eng.State != storage.StateSoftDeleted && eng.State != storage.StateArchived {
 					nodes = append(nodes, TraversalNode{
 						ID:      eng.ID,
 						Concept: eng.Concept,

--- a/internal/engine/tree.go
+++ b/internal/engine/tree.go
@@ -470,7 +470,7 @@ func (e *Engine) recallTreeNode(
 			// Filter out: missing metadata (hard-deleted ghost), completed, or
 			// soft-deleted children. StateSoftDeleted != StateCompleted so both
 			// states must be checked explicitly.
-			if !ok || meta == nil || meta.State == storage.StateCompleted || meta.State == storage.StateSoftDeleted {
+			if !ok || meta == nil || meta.State == storage.StateCompleted || meta.State == storage.StateSoftDeleted || meta.State == storage.StateArchived {
 				continue
 			}
 		}

--- a/internal/engine/trigger/worker.go
+++ b/internal/engine/trigger/worker.go
@@ -355,7 +355,7 @@ func (w *TriggerWorker) sweepVault(ctx context.Context, vaultID uint32, ws [8]by
 		for _, sub := range group.subs {
 			for _, c := range candidates {
 				meta := metaByID[c.ID]
-				if meta == nil || meta.State == storage.StateSoftDeleted {
+				if meta == nil || meta.State == storage.StateSoftDeleted || meta.State == storage.StateArchived {
 					continue
 				}
 
@@ -378,7 +378,7 @@ func (w *TriggerWorker) sweepVault(ctx context.Context, vaultID uint32, ws [8]by
 				}
 
 				eng := engramByID[c.ID]
-				if eng == nil || eng.State == storage.StateSoftDeleted {
+				if eng == nil || eng.State == storage.StateSoftDeleted || eng.State == storage.StateArchived {
 					continue
 				}
 

--- a/internal/engine/trigger/worker.go
+++ b/internal/engine/trigger/worker.go
@@ -240,7 +240,7 @@ func (w *TriggerWorker) handleContradiction(ctx context.Context, event Contradic
 
 		for _, id := range []storage.ULID{event.EngramA, event.EngramB} {
 			eng := byID[id]
-			if eng == nil || eng.State == storage.StateSoftDeleted {
+			if eng == nil || eng.State == storage.StateSoftDeleted || eng.State == storage.StateArchived {
 				continue
 			}
 			w.deliver.Send(sub, &ActivationPush{


### PR DESCRIPTION
## Problem

`StateArchived` engrams were passing through 6 retrieval and delivery guards that only checked `StateSoftDeleted`. The dream engine archives engrams during consolidation — without this fix those archived engrams remain visible in recall results, graph traversal, entity searches, and real-time trigger push notifications.

Noted in #331: *"Separate bug fixed in my fork: `activate()` only filtered `StateSoftDeleted`, not `StateArchived`. Dream engine archives engrams but they remained visible in recall."*

## Affected paths

| File | Guard |
|------|-------|
| `internal/engine/activation/engine.go` | Main recall / activation (phase 6 filter) |
| `internal/engine/query.go` | Graph traversal nodes |
| `internal/engine/engine_find_by_entity.go` | Find-by-entity scan |
| `internal/engine/trigger/worker.go` | Contradiction push delivery |
| `internal/engine/trigger/worker.go` | Threshold meta check |
| `internal/engine/trigger/worker.go` | Threshold engram delivery |

The correct pattern (`StateSoftDeleted || StateArchived`) was already used in `engine_entity_boost.go` and `storage/plugin_store.go` — this change makes the remaining retrieval paths consistent.

## Fix

Add `|| eng.State == storage.StateArchived` (or `&& eng.State != storage.StateArchived`) to each of the 6 guards. No logic changes — purely additive.

## Tests

- `TestArchivedEngram_ExcludedFromRecall` — archived engram appears as HNSW candidate but must not appear in recall results.
- `TestSoftDeletedEngram_ExcludedFromRecall` — regression guard verifying the existing soft-delete filter was not disturbed.

Full test suite passes.