### PR TITLE
Fix: Plasticity card spacing and preset chart text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings page Plasticity preset and recall mode cards now have proper padding, with border-width compensation preventing layout jitter on selection.
 - Settings page Plasticity preset pill labels are now readable in light mode (switched from pastel to saturated text colors) while preserving dark-mode colors.
 - Settings page Preset Comparison radar chart no longer clips the "Associative Learning" axis label.
+- Settings page Preset Comparison radar chart web and grid lines are now visible in dark mode (increased fill opacity and grid line contrast).
 - Sidebar nav items are now scrollable when viewport height is too small, keeping the logo and footer pinned.
 - Collapsed sidebar footer icons no longer overflow into the right border; icons render borderless when collapsed and bordered when expanded.
 - "New Vault" action moved from sidebar footer into the vault picker modal to reclaim vertical space for nav items.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version label merged into the footer icon row instead of occupying its own line.
 - Sidebar footer padding and gaps tightened to maximize nav item visibility on short viewports.
 - Memories page search-mode segmented control (Balanced/Semantic/Recent/Deep) now matches adjacent button height and font size, includes dividers between options, and preserves padding when Alpine.js re-renders dynamic styles.
+- Settings page Plasticity preset and recall mode cards now have proper padding, with border-width compensation preventing layout jitter on selection.
+- Settings page Plasticity preset pill labels are now readable in light mode (switched from pastel to saturated text colors) while preserving dark-mode colors.
+- Settings page Preset Comparison radar chart no longer clips the "Associative Learning" axis label.
 - Enrich now accepts OpenAI-compatible JSON responses returned in `message.reasoning` when `message.content` is empty, including structured reasoning payloads.
 - Retry and retroactive enrichment now only mark entity and relationship stages complete after successful persistence, avoiding partial-state retries, nil-result crashes, and silent graph-write failures.
 - Entity and relationship response parsing now rejects nested wrapper keys like `meta.entities` / `meta.relationships` instead of treating them as valid empty results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public vault unauthenticated access now runs in `full` mode. Previously, requests to an open vault with no API key ran as `observe`, silently preventing cognitive-state writes. Public vaults are now genuinely open — callers get `full` access unless they present an explicit `observe` key.
 
 ### Fixed
-- Settings page Plasticity preset and recall mode cards now have proper padding, with border-width compensation preventing layout jitter on selection.
-- Settings page Plasticity preset pill labels are now readable in light mode (switched from pastel to saturated text colors) while preserving dark-mode colors.
-- Settings page Preset Comparison radar chart no longer clips the "Associative Learning" axis label.
-- Settings page Preset Comparison radar chart web and grid lines are now visible in dark mode (increased fill opacity and grid line contrast).
 - Sidebar nav items are now scrollable when viewport height is too small, keeping the logo and footer pinned.
 - Collapsed sidebar footer icons no longer overflow into the right border; icons render borderless when collapsed and bordered when expanded.
 - "New Vault" action moved from sidebar footer into the vault picker modal to reclaim vertical space for nav items.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public vault unauthenticated access now runs in `full` mode. Previously, requests to an open vault with no API key ran as `observe`, silently preventing cognitive-state writes. Public vaults are now genuinely open — callers get `full` access unless they present an explicit `observe` key.
 
 ### Fixed
+- Settings page Plasticity preset and recall mode cards now have proper padding, with border-width compensation preventing layout jitter on selection.
+- Settings page Plasticity preset pill labels are now readable in light mode (switched from pastel to saturated text colors) while preserving dark-mode colors.
+- Settings page Preset Comparison radar chart no longer clips the "Associative Learning" axis label.
 - Sidebar nav items are now scrollable when viewport height is too small, keeping the logo and footer pinned.
 - Collapsed sidebar footer icons no longer overflow into the right border; icons render borderless when collapsed and bordered when expanded.
 - "New Vault" action moved from sidebar footer into the vault picker modal to reclaim vertical space for nav items.
@@ -25,9 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version label merged into the footer icon row instead of occupying its own line.
 - Sidebar footer padding and gaps tightened to maximize nav item visibility on short viewports.
 - Memories page search-mode segmented control (Balanced/Semantic/Recent/Deep) now matches adjacent button height and font size, includes dividers between options, and preserves padding when Alpine.js re-renders dynamic styles.
-- Settings page Plasticity preset and recall mode cards now have proper padding, with border-width compensation preventing layout jitter on selection.
-- Settings page Plasticity preset pill labels are now readable in light mode (switched from pastel to saturated text colors) while preserving dark-mode colors.
-- Settings page Preset Comparison radar chart no longer clips the "Associative Learning" axis label.
 - Enrich now accepts OpenAI-compatible JSON responses returned in `message.reasoning` when `message.content` is empty, including structured reasoning payloads.
 - Retry and retroactive enrichment now only mark entity and relationship stages complete after successful persistence, avoiding partial-state retries, nil-result crashes, and silent graph-write failures.
 - Entity and relationship response parsing now rejects nested wrapper keys like `meta.entities` / `meta.relationships` instead of treating them as valid empty results.

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1985,7 +1985,7 @@ document.addEventListener('alpine:init', () => {
                 datasets: [{
                     data: this._plasticityData[p],
                     borderColor: c.border,
-                    backgroundColor: c.bg,
+                    backgroundColor: this.isDarkMode ? c.bg.replace('0.35)', '0.5)') : c.bg,
                     borderWidth: 2.5,
                     pointRadius: 5,
                     pointBackgroundColor: c.border,
@@ -1998,8 +1998,8 @@ document.addEventListener('alpine:init', () => {
                 scales: { r: {
                     min: 0, max: 1,
                     ticks: { display: false },
-                    grid: { color: this.isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)' },
-                    angleLines: { color: this.isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)' },
+                    grid: { color: this.isDarkMode ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.08)' },
+                    angleLines: { color: this.isDarkMode ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.08)' },
                     pointLabels: { color: this.isDarkMode ? '#9ca3af' : '#6b7280', font: { size: 11 } },
                 }},
                 plugins: { legend: { display: false } },
@@ -2035,7 +2035,7 @@ document.addEventListener('alpine:init', () => {
             const c = this._plasticityColors[p];
             ds.data             = this._plasticityData[p];
             ds.borderColor      = c.border;
-            ds.backgroundColor  = c.bg;
+            ds.backgroundColor  = this.isDarkMode ? c.bg.replace('0.35)', '0.5)') : c.bg;
             ds.pointBackgroundColor = c.border;
         }
         chart.update();

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1289,51 +1289,47 @@
 
                 <!-- Default -->
                 <div @click="plasticityForm.showAdvanced=false; plasticityForm.preset='default'; onPlasticityPresetChange()"
-                     :style="plasticityForm.preset==='default' && !plasticityForm.showAdvanced ? 'border:2px solid #6366f1;background:rgba(99,102,241,0.12);' : 'border:1px solid var(--border);background:var(--bg-elevated);'"
-                     style="border-radius:0.625rem;padding:0.875rem;cursor:pointer;transition:all 0.15s;">
+                     :style="'border-radius:0.625rem;cursor:pointer;transition:all 0.15s;' + (plasticityForm.preset==='default' && !plasticityForm.showAdvanced ? 'border:2px solid #6366f1;background:rgba(99,102,241,0.12);padding:calc(1.25rem - 1px);' : 'border:1px solid var(--border);background:var(--bg-elevated);padding:1.25rem;')">
                   <div style="font-weight:600;font-size:0.875rem;margin-bottom:0.25rem;">Default</div>
                   <div style="font-size:0.75rem;color:var(--text-muted);margin-bottom:0.5rem;">General use</div>
                   <div style="display:flex;gap:0.3rem;flex-wrap:wrap;">
-                    <span style="font-size:0.65rem;background:rgba(99,102,241,0.2);color:#a5b4fc;border-radius:9999px;padding:0.1rem 0.4rem;">2-hop</span>
-                    <span style="font-size:0.65rem;background:rgba(99,102,241,0.2);color:#a5b4fc;border-radius:9999px;padding:0.1rem 0.4rem;">Hebbian</span>
-                    <span style="font-size:0.65rem;background:rgba(99,102,241,0.2);color:#a5b4fc;border-radius:9999px;padding:0.1rem 0.4rem;">Temporal</span>
+                    <span :style="'font-size:0.65rem;background:rgba(99,102,241,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#a5b4fc' : '#4338ca')">2-hop</span>
+                    <span :style="'font-size:0.65rem;background:rgba(99,102,241,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#a5b4fc' : '#4338ca')">Hebbian</span>
+                    <span :style="'font-size:0.65rem;background:rgba(99,102,241,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#a5b4fc' : '#4338ca')">Temporal</span>
                   </div>
                 </div>
 
                 <!-- Reference -->
                 <div @click="plasticityForm.showAdvanced=false; plasticityForm.preset='reference'; onPlasticityPresetChange()"
-                     :style="plasticityForm.preset==='reference' && !plasticityForm.showAdvanced ? 'border:2px solid #10b981;background:rgba(16,185,129,0.12);' : 'border:1px solid var(--border);background:var(--bg-elevated);'"
-                     style="border-radius:0.625rem;padding:0.875rem;cursor:pointer;transition:all 0.15s;">
+                     :style="'border-radius:0.625rem;cursor:pointer;transition:all 0.15s;' + (plasticityForm.preset==='reference' && !plasticityForm.showAdvanced ? 'border:2px solid #10b981;background:rgba(16,185,129,0.12);padding:calc(1.25rem - 1px);' : 'border:1px solid var(--border);background:var(--bg-elevated);padding:1.25rem;')">
                   <div style="font-weight:600;font-size:0.875rem;margin-bottom:0.25rem;">Reference</div>
                   <div style="font-size:0.75rem;color:var(--text-muted);margin-bottom:0.5rem;">Docs &amp; facts</div>
                   <div style="display:flex;gap:0.3rem;flex-wrap:wrap;">
-                    <span style="font-size:0.65rem;background:rgba(16,185,129,0.2);color:#6ee7b7;border-radius:9999px;padding:0.1rem 0.4rem;">3-hop</span>
-                    <span style="font-size:0.65rem;background:rgba(16,185,129,0.2);color:#6ee7b7;border-radius:9999px;padding:0.1rem 0.4rem;">No fading</span>
+                    <span :style="'font-size:0.65rem;background:rgba(16,185,129,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#6ee7b7' : '#047857')">3-hop</span>
+                    <span :style="'font-size:0.65rem;background:rgba(16,185,129,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#6ee7b7' : '#047857')">No fading</span>
                   </div>
                 </div>
 
                 <!-- Scratchpad -->
                 <div @click="plasticityForm.showAdvanced=false; plasticityForm.preset='scratchpad'; onPlasticityPresetChange()"
-                     :style="plasticityForm.preset==='scratchpad' && !plasticityForm.showAdvanced ? 'border:2px solid #f59e0b;background:rgba(245,158,11,0.12);' : 'border:1px solid var(--border);background:var(--bg-elevated);'"
-                     style="border-radius:0.625rem;padding:0.875rem;cursor:pointer;transition:all 0.15s;">
+                     :style="'border-radius:0.625rem;cursor:pointer;transition:all 0.15s;' + (plasticityForm.preset==='scratchpad' && !plasticityForm.showAdvanced ? 'border:2px solid #f59e0b;background:rgba(245,158,11,0.12);padding:calc(1.25rem - 1px);' : 'border:1px solid var(--border);background:var(--bg-elevated);padding:1.25rem;')">
                   <div style="font-weight:600;font-size:0.875rem;margin-bottom:0.25rem;">Scratchpad</div>
                   <div style="font-size:0.75rem;color:var(--text-muted);margin-bottom:0.5rem;">Short-lived drafts</div>
                   <div style="display:flex;gap:0.3rem;flex-wrap:wrap;">
-                    <span style="font-size:0.65rem;background:rgba(245,158,11,0.2);color:#fcd34d;border-radius:9999px;padding:0.1rem 0.4rem;">Fast fading</span>
-                    <span style="font-size:0.65rem;background:rgba(245,158,11,0.2);color:#fcd34d;border-radius:9999px;padding:0.1rem 0.4rem;">No assoc.</span>
+                    <span :style="'font-size:0.65rem;background:rgba(245,158,11,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#fcd34d' : '#b45309')">Fast fading</span>
+                    <span :style="'font-size:0.65rem;background:rgba(245,158,11,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#fcd34d' : '#b45309')">No assoc.</span>
                   </div>
                 </div>
 
                 <!-- Knowledge Graph -->
                 <div @click="plasticityForm.showAdvanced=false; plasticityForm.preset='knowledge-graph'; onPlasticityPresetChange()"
-                     :style="plasticityForm.preset==='knowledge-graph' && !plasticityForm.showAdvanced ? 'border:2px solid #ec4899;background:rgba(236,72,153,0.12);' : 'border:1px solid var(--border);background:var(--bg-elevated);'"
-                     style="border-radius:0.625rem;padding:0.875rem;cursor:pointer;transition:all 0.15s;">
+                     :style="'border-radius:0.625rem;cursor:pointer;transition:all 0.15s;' + (plasticityForm.preset==='knowledge-graph' && !plasticityForm.showAdvanced ? 'border:2px solid #ec4899;background:rgba(236,72,153,0.12);padding:calc(1.25rem - 1px);' : 'border:1px solid var(--border);background:var(--bg-elevated);padding:1.25rem;')">
                   <div style="font-weight:600;font-size:0.875rem;margin-bottom:0.25rem;">Knowledge Graph</div>
                   <div style="font-size:0.75rem;color:var(--text-muted);margin-bottom:0.5rem;">Dense concepts</div>
                   <div style="display:flex;gap:0.3rem;flex-wrap:wrap;">
-                    <span style="font-size:0.65rem;background:rgba(236,72,153,0.2);color:#f9a8d4;border-radius:9999px;padding:0.1rem 0.4rem;">4-hop</span>
-                    <span style="font-size:0.65rem;background:rgba(236,72,153,0.2);color:#f9a8d4;border-radius:9999px;padding:0.1rem 0.4rem;">Strong assoc.</span>
-                    <span style="font-size:0.65rem;background:rgba(236,72,153,0.2);color:#f9a8d4;border-radius:9999px;padding:0.1rem 0.4rem;">Slow fading</span>
+                    <span :style="'font-size:0.65rem;background:rgba(236,72,153,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#f9a8d4' : '#be185d')">4-hop</span>
+                    <span :style="'font-size:0.65rem;background:rgba(236,72,153,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#f9a8d4' : '#be185d')">Strong assoc.</span>
+                    <span :style="'font-size:0.65rem;background:rgba(236,72,153,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#f9a8d4' : '#be185d')">Slow fading</span>
                   </div>
                 </div>
               </div>
@@ -1348,9 +1344,8 @@
                   {id:'deep',      label:'Deep',      desc:'4-hop graph'}
                 ]" :key="rm.id">
                   <div @click="plasticityForm.recallMode = rm.id"
-                       :style="plasticityForm.recallMode === rm.id ? 'border:2px solid var(--accent);background:rgba(99,102,241,0.12);' : 'border:1px solid var(--border);background:var(--bg-elevated);'"
-                       style="border-radius:0.625rem;padding:0.75rem;cursor:pointer;transition:all 0.15s;">
-                    <div style="font-weight:600;font-size:0.875rem;margin-bottom:0.125rem;" x-text="rm.label"></div>
+                       :style="'border-radius:0.625rem;cursor:pointer;transition:all 0.15s;' + (plasticityForm.recallMode === rm.id ? 'border:2px solid var(--accent);background:rgba(99,102,241,0.12);padding:calc(1.25rem - 1px);' : 'border:1px solid var(--border);background:var(--bg-elevated);padding:1.25rem;')">
+                    <div style="font-weight:600;font-size:0.875rem;margin-bottom:0.25rem;" x-text="rm.label"></div>
                     <div style="font-size:0.75rem;color:var(--text-muted);" x-text="rm.desc"></div>
                   </div>
                 </template>
@@ -1412,9 +1407,11 @@
             </div>
 
             <!-- Right: radar chart -->
-            <div>
+            <div style="min-width:0;overflow:visible;">
               <p style="font-size:0.8125rem;font-weight:600;color:var(--text-secondary);margin:0 0 0.75rem;text-transform:uppercase;letter-spacing:0.05em;">Preset Comparison</p>
-              <canvas id="plasticityChart" style="max-height:320px;"></canvas>
+              <div style="padding:0 1.5rem;">
+                <canvas id="plasticityChart" style="max-height:320px;"></canvas>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Fixes spacing, readability, and clipping issues in the Settings → Vault → Plasticity section, part of https://github.com/scrypster/muninndb/issues/327


## Changes

- Increased padding on preset cards (Default, Reference, Scratchpad, Knowledge Graph) and recall mode cards (Balanced, Semantic, Recent, Deep) from `0.875rem`/`0.75rem` to `1.25rem`
- Merged static `style` into Alpine `:style` bindings to prevent dynamic styles from overwriting padding on re-render
- Added `padding: calc(1.25rem - 1px)` on selected cards to compensate for the 2px vs 1px border, preventing layout jitter on selection
- Preset pill text colors now use `isDarkMode` ternary: saturated dark variants for light mode (`#4338ca`, `#047857`, `#b45309`, `#be185d`) while preserving existing pastel colors for dark mode
- Wrapped Preset Comparison radar chart canvas in a padded container to prevent "Associative Learning" label from being clipped
- Increased radar chart grid and angle line opacity from `0.08` to `0.15` in dark mode for visibility
- Increased radar chart dataset fill alpha from `0.35` to `0.5` in dark mode so the web shape is visible against the dark background
- Updated `CHANGELOG.md`

**Before**
<img width="1752" height="891" alt="image" src="https://github.com/user-attachments/assets/2efa5eac-4667-47ba-ae31-c0d1289b5666" />
<img width="901" height="627" alt="image" src="https://github.com/user-attachments/assets/e4b6f7aa-bd50-42c6-b3c8-4d81cf8dd4ac" />

**After**
<img width="2208" height="1027" alt="image" src="https://github.com/user-attachments/assets/3fbf5087-be94-4000-8b69-e6d40bd8e31b" />
<img width="959" height="627" alt="image" src="https://github.com/user-attachments/assets/289002f0-66ed-4a63-9e15-cdffea999b41" />


## Release Checklist

- [x] `CHANGELOG.md` updated with changes
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
