### PR TITLE
Fix: Vault actions buttons styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public vault unauthenticated access now runs in `full` mode. Previously, requests to an open vault with no API key ran as `observe`, silently preventing cognitive-state writes. Public vaults are now genuinely open — callers get `full` access unless they present an explicit `observe` key.
 
 ### Fixed
-- Vault Actions "Export Vault" and "Reindex FTS" buttons now render with their intended colored borders instead of appearing unstyled (Alpine `:style` was overwriting static `style` attributes).
 - Sidebar nav items are now scrollable when viewport height is too small, keeping the logo and footer pinned.
 - Collapsed sidebar footer icons no longer overflow into the right border; icons render borderless when collapsed and bordered when expanded.
 - "New Vault" action moved from sidebar footer into the vault picker modal to reclaim vertical space for nav items.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public vault unauthenticated access now runs in `full` mode. Previously, requests to an open vault with no API key ran as `observe`, silently preventing cognitive-state writes. Public vaults are now genuinely open — callers get `full` access unless they present an explicit `observe` key.
 
 ### Fixed
+- Vault Actions "Export Vault" and "Reindex FTS" buttons now render with their intended colored borders instead of appearing unstyled (Alpine `:style` was overwriting static `style` attributes).
 - Sidebar nav items are now scrollable when viewport height is too small, keeping the logo and footer pinned.
 - Collapsed sidebar footer icons no longer overflow into the right border; icons render borderless when collapsed and bordered when expanded.
 - "New Vault" action moved from sidebar footer into the vault picker modal to reclaim vertical space for nav items.

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1452,9 +1452,8 @@
               Merge Into…
             </button>
             <button @click="exportVault()" :disabled="vaultExporting"
-                    style="padding:0.5rem 1rem;font-size:0.875rem;font-weight:500;border-radius:0.5rem;border:1px solid #34d399;color:#10b981;background:transparent;cursor:pointer;transition:background 0.15s;"
-                    onmouseover="this.style.background='rgba(52,211,153,0.08)'" onmouseout="this.style.background='transparent'"
-                    :style="vaultExporting ? 'opacity:0.55;cursor:not-allowed;' : ''">
+                    :style="'padding:0.5rem 1rem;font-size:0.875rem;font-weight:500;border-radius:0.5rem;border:1px solid #34d399;color:#10b981;background:transparent;cursor:pointer;transition:background 0.15s;' + (vaultExporting ? 'opacity:0.55;cursor:not-allowed;' : '')"
+                    onmouseover="this.style.background='rgba(52,211,153,0.08)'" onmouseout="this.style.background='transparent'">
               <span x-text="vaultExporting ? 'Exporting…' : 'Export Vault'"></span>
             </button>
             <button @click="openImportModal()"
@@ -1463,9 +1462,8 @@
               Import Vault…
             </button>
             <button @click="reindexFTS()" :disabled="reindexing"
-                    style="padding:0.5rem 1rem;font-size:0.875rem;font-weight:500;border-radius:0.5rem;border:1px solid #60a5fa;color:#3b82f6;background:transparent;cursor:pointer;transition:background 0.15s;"
-                    onmouseover="this.style.background='rgba(96,165,250,0.08)'" onmouseout="this.style.background='transparent'"
-                    :style="reindexing ? 'opacity:0.55;cursor:not-allowed;' : ''">
+                    :style="'padding:0.5rem 1rem;font-size:0.875rem;font-weight:500;border-radius:0.5rem;border:1px solid #60a5fa;color:#3b82f6;background:transparent;cursor:pointer;transition:background 0.15s;' + (reindexing ? 'opacity:0.55;cursor:not-allowed;' : '')"
+                    onmouseover="this.style.background='rgba(96,165,250,0.08)'" onmouseout="this.style.background='transparent'">
               <span x-text="reindexing ? 'Reindexing…' : 'Reindex FTS'"></span>
             </button>
           </div>


### PR DESCRIPTION
## Summary

Fixes "Export Vault" and "Reindex FTS" buttons in Vault Actions appearing unstyled (no border, no colored text), part of https://github.com/scrypster/muninndb/issues/327


## Changes

- Merged static `style` into Alpine `:style` bindings for Export Vault and Reindex FTS buttons to prevent the disabled-state `:style` from overwriting border and color styles
- Export Vault retains its original green border (`#34d399`) and text (`#10b981`)
- Reindex FTS retains its original blue border (`#60a5fa`) and text (`#3b82f6`)
- Updated `CHANGELOG.md`

**Before**
<img width="938" height="363" alt="image" src="https://github.com/user-attachments/assets/088e246e-f907-41b7-a62c-22e7165049ea" />
<img width="938" height="363" alt="image" src="https://github.com/user-attachments/assets/2ae3e35a-cd4d-4f81-973a-cfed870cd4f1" />

**After**
<img width="938" height="363" alt="image" src="https://github.com/user-attachments/assets/7a7d618b-a5f7-4571-81c8-f1cd77ef2ba0" />
<img width="938" height="363" alt="image" src="https://github.com/user-attachments/assets/ae6aaab4-e21c-441f-aba5-f88e3aa97841" />


## Release Checklist

- [x] `CHANGELOG.md` updated with changes
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
