### PR TITLE
Fix: Semantic Embedder & LLM Enrichment tabs UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public vault unauthenticated access now runs in `full` mode. Previously, requests to an open vault with no API key ran as `observe`, silently preventing cognitive-state writes. Public vaults are now genuinely open — callers get `full` access unless they present an explicit `observe` key.
 
 ### Fixed
-- Plugins page LLM Enrichment and Semantic Embedding provider selectors now use the `tab-bar` component for consistent bordered-tab styling with bottom border.
-- Plugins page Semantic Embedding provider selector now includes a "None" tab (matching LLM Enrichment) so the default state shows an active selection instead of no tab highlighted.
-- Plugins page LLM Enrichment "Verbose LLM logs" section no longer renders a duplicate border below the provider tabs.
 - Sidebar nav items are now scrollable when viewport height is too small, keeping the logo and footer pinned.
 - Collapsed sidebar footer icons no longer overflow into the right border; icons render borderless when collapsed and bordered when expanded.
 - "New Vault" action moved from sidebar footer into the vault picker modal to reclaim vertical space for nav items.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public vault unauthenticated access now runs in `full` mode. Previously, requests to an open vault with no API key ran as `observe`, silently preventing cognitive-state writes. Public vaults are now genuinely open — callers get `full` access unless they present an explicit `observe` key.
 
 ### Fixed
+- Plugins page LLM Enrichment and Semantic Embedding provider selectors now use the `tab-bar` component for consistent bordered-tab styling with bottom border.
+- Plugins page Semantic Embedding provider selector now includes a "None" tab (matching LLM Enrichment) so the default state shows an active selection instead of no tab highlighted.
+- Plugins page LLM Enrichment "Verbose LLM logs" section no longer renders a duplicate border below the provider tabs.
 - Sidebar nav items are now scrollable when viewport height is too small, keeping the logo and footer pinned.
 - Collapsed sidebar footer icons no longer overflow into the right border; icons render borderless when collapsed and bordered when expanded.
 - "New Vault" action moved from sidebar footer into the vault picker modal to reclaim vertical space for nav items.

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1568,7 +1568,12 @@
               <!-- Provider selector pills -->
               <div style="margin-bottom:1rem;">
                 <div style="font-size:0.8125rem;font-weight:600;color:var(--text-primary);margin-bottom:0.625rem;">Select provider</div>
-                <div style="display:flex;gap:0.5rem;flex-wrap:wrap;">
+                <div class="tab-bar" style="margin-top:0;margin-bottom:1rem;">
+                  <button
+                    @click="pluginCfg.embedProvider='none';pluginCfg.embedCmd=''"
+                    :class="pluginCfg.embedProvider==='none' ? 'tab-btn active' : 'tab-btn'">
+                    None
+                  </button>
                   <button
                     @click="pluginCfg.embedProvider='voyage';pluginCfg.embedCmd=''"
                     :class="pluginCfg.embedProvider==='voyage' ? 'tab-btn active' : 'tab-btn'"
@@ -1778,7 +1783,7 @@
               <!-- Provider selector pills -->
               <div style="margin-bottom:1rem;">
                 <div style="font-size:0.8125rem;font-weight:600;color:var(--text-primary);margin-bottom:0.625rem;">Select provider</div>
-                <div style="display:flex;gap:0.5rem;flex-wrap:wrap;">
+                <div class="tab-bar" style="margin-top:0;margin-bottom:1rem;">
                   <template x-for="opt in [{val:'none',label:'None'},{val:'ollama',label:'Ollama (local)'},{val:'openai',label:'OpenAI'},{val:'anthropic',label:'Anthropic'},{val:'google',label:'Google'}]" :key="opt.val">
                     <button
                       @click="pluginCfg.enrichProvider=opt.val;pluginCfg.enrichCmd='';if(opt.val==='google')pluginCfg.enrichModel='gemini-1.5-flash';if(opt.val==='anthropic')pluginCfg.enrichModel='claude-haiku-4-5-20251001'"
@@ -1885,7 +1890,7 @@
               </div>
 
               <!-- Verbose LLM logs -->
-              <div style="display:flex;align-items:flex-start;gap:0.75rem;padding:0.75rem 0;border-top:1px solid var(--border);">
+              <div style="display:flex;align-items:flex-start;gap:0.75rem;padding:0.75rem 0;">
                 <input type="checkbox" id="llmVerboseLogs" :checked="pluginCfg.llm_verbose_logs === true"
                   @change="pluginCfg.llm_verbose_logs = $event.target.checked || undefined"
                   style="margin-top:0.125rem;cursor:pointer;" />


### PR DESCRIPTION
## Summary

Fixes provider tab styling on the Plugins page to match the bordered-tab pattern used across the rest of the Settings UI, part of https://github.com/scrypster/muninndb/issues/327


## Changes

- Replaced inline-styled `div` wrappers with the `tab-bar` class on both the LLM Enrichment and Semantic Embedding provider selectors, adding the unified bottom border
- Added a "None" tab to the Semantic Embedding provider selector (matching LLM Enrichment) so the default unconfigured state shows an active selection
- Removed `border-top` from the "Verbose LLM logs" section that created a duplicate line below the new tab-bar border
- Updated `CHANGELOG.md`

**Before**
<img width="2197" height="549" alt="image" src="https://github.com/user-attachments/assets/e9ead931-dfb5-4987-b35e-f6873592b3d1" />

**After**
<img width="2197" height="549" alt="image" src="https://github.com/user-attachments/assets/6ade116b-35e0-4480-80ed-856e6a27530e" />


## Release Checklist

- [x] `CHANGELOG.md` updated with changes
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
