### PR TITLE
Feat: Link MuninnDB sidebar icon to project homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Sidebar logo icon now links to [muninndb.com](https://muninndb.com) (opens in new tab).
 - Dashboard activity panel overhaul: selectable timeframe presets (7d–180d, capped at 180 days), end-date picker, dynamic x-axis tick grouping based on chart width, and a raw data table toggle with copy-to-clipboard. Includes loading, error, and empty-state feedback.
 - `GET /api/activity-counts` endpoint returning per-day engram creation counts for a vault. Accepts `days` (1–180, default 7) and optional `until` (YYYY-MM-DD) query parameters. Malformed or out-of-range values return 400. Backed by an efficient ULID key-header scan with zero-filled contiguous day ranges.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Sidebar logo icon now links to [muninndb.com](https://muninndb.com) (opens in new tab).
 - Dashboard activity panel overhaul: selectable timeframe presets (7d–180d, capped at 180 days), end-date picker, dynamic x-axis tick grouping based on chart width, and a raw data table toggle with copy-to-clipboard. Includes loading, error, and empty-state feedback.
 - `GET /api/activity-counts` endpoint returning per-day engram creation counts for a vault. Accepts `days` (1–180, default 7) and optional `until` (YYYY-MM-DD) query parameters. Malformed or out-of-range values return 400. Backed by an efficient ULID key-header scan with zero-filled contiguous day ranges.
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -40,7 +40,7 @@
 
     <!-- Logo (top of sidebar, replaces toggle) -->
     <div class="sidebar-logo">
-      <img src="/static/logo.jpg" alt="MuninnDB" />
+      <a href="https://muninndb.com" target="_blank" rel="noopener"><img src="/static/logo.jpg" alt="MuninnDB" /></a>
       <span class="sidebar-label" style="font-weight:700;font-size:0.9375rem;letter-spacing:0.01em;">MuninnDB</span>
     </div>
 


### PR DESCRIPTION
## Summary

Makes the MuninnDB logo icon in the sidebar a link to the project homepage, part of https://github.com/scrypster/muninndb/issues/327

## Changes

- Wrapped the sidebar logo `<img>` in an `<a>` tag linking to https://muninndb.com (opens in a new tab)
- Only the icon is a link; the "MuninnDB" text label remains plain text
- Updated `CHANGELOG.md`

## Release Checklist

- [x] `CHANGELOG.md` updated with changes
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
