### PR TITLE
Feat: Overhaul memory details UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Memory detail panel now has an expand/collapse toggle (chevron on the left border) that widens the panel to 80% for viewing large memories.
+
+### Changed
+- Memory detail panel: moved Edit and Link Memory actions inline with the Content label as compact teal-colored text buttons, matching the existing Tags Edit button style.
+- Memory detail panel: reduced content text font size to 0.875rem for consistency with labels and other field values.
+
 - Dashboard activity panel overhaul: selectable timeframe presets (7d–180d, capped at 180 days), end-date picker, dynamic x-axis tick grouping based on chart width, and a raw data table toggle with copy-to-clipboard. Includes loading, error, and empty-state feedback.
 - `GET /api/activity-counts` endpoint returning per-day engram creation counts for a vault. Accepts `days` (1–180, default 7) and optional `until` (YYYY-MM-DD) query parameters. Malformed or out-of-range values return 400. Backed by an efficient ULID key-header scan with zero-filled contiguous day ranges.
 
@@ -18,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public vault unauthenticated access now runs in `full` mode. Previously, requests to an open vault with no API key ran as `observe`, silently preventing cognitive-state writes. Public vaults are now genuinely open — callers get `full` access unless they present an explicit `observe` key.
 
 ### Fixed
+- Memory detail panel tag badges no longer break mid-word at hyphens (`white-space: nowrap`) and wrap correctly as whole units using inline-block layout.
+- Memory detail panel tag badges now select individually on double-click instead of selecting across multiple badges (`user-select: all`).
+- Memory detail panel Created timestamp font size now matches its label.
 - Sidebar nav items are now scrollable when viewport height is too small, keeping the logo and footer pinned.
 - Collapsed sidebar footer icons no longer overflow into the right border; icons render borderless when collapsed and bordered when expanded.
 - "New Vault" action moved from sidebar footer into the vault picker modal to reclaim vertical space for nav items.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Memory detail panel now has an expand/collapse toggle (chevron on the left border) that widens the panel to 80% for viewing large memories.
-
-### Changed
-- Memory detail panel: moved Edit and Link Memory actions inline with the Content label as compact teal-colored text buttons, matching the existing Tags Edit button style.
-- Memory detail panel: reduced content text font size to 0.875rem for consistency with labels and other field values.
-
 - Dashboard activity panel overhaul: selectable timeframe presets (7d–180d, capped at 180 days), end-date picker, dynamic x-axis tick grouping based on chart width, and a raw data table toggle with copy-to-clipboard. Includes loading, error, and empty-state feedback.
 - `GET /api/activity-counts` endpoint returning per-day engram creation counts for a vault. Accepts `days` (1–180, default 7) and optional `until` (YYYY-MM-DD) query parameters. Malformed or out-of-range values return 400. Backed by an efficient ULID key-header scan with zero-filled contiguous day ranges.
 
@@ -24,9 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public vault unauthenticated access now runs in `full` mode. Previously, requests to an open vault with no API key ran as `observe`, silently preventing cognitive-state writes. Public vaults are now genuinely open — callers get `full` access unless they present an explicit `observe` key.
 
 ### Fixed
-- Memory detail panel tag badges no longer break mid-word at hyphens (`white-space: nowrap`) and wrap correctly as whole units using inline-block layout.
-- Memory detail panel tag badges now select individually on double-click instead of selecting across multiple badges (`user-select: all`).
-- Memory detail panel Created timestamp font size now matches its label.
 - Sidebar nav items are now scrollable when viewport height is too small, keeping the logo and footer pinned.
 - Collapsed sidebar footer icons no longer overflow into the right border; icons render borderless when collapsed and bordered when expanded.
 - "New Vault" action moved from sidebar footer into the vault picker modal to reclaim vertical space for nav items.

--- a/web/static/css/components.css
+++ b/web/static/css/components.css
@@ -62,8 +62,9 @@
 /* Badges */
 .badge-success  { background: rgba(34,197,94,0.15);  color: var(--success); border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; }
 .badge-danger   { background: rgba(239,68,68,0.15);  color: var(--danger);  border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; }
-.badge-warning  { display: inline-block; background: rgba(245,158,11,0.15); color: var(--warning); border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; white-space: nowrap; margin: 0.125rem; user-select: all; }
-.badge-info     { display: inline-block; background: rgba(59,130,246,0.15); color: var(--info);    border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; white-space: nowrap; margin: 0.125rem; user-select: all; }
+.badge-warning  { background: rgba(245,158,11,0.15); color: var(--warning); border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; }
+.badge-info     { background: rgba(59,130,246,0.15); color: var(--info);    border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; }
+.badge-tag      { display: inline-block; white-space: nowrap; margin: 0.125rem; user-select: all; }
 .badge-active   { background: rgba(16,185,129,0.15); color: #10b981; }
 .badge-idle     { background: rgba(234,179,8,0.15);  color: #eab308; }
 .badge-dormant  { background: rgba(100,116,139,0.15); color: #64748b; }

--- a/web/static/css/components.css
+++ b/web/static/css/components.css
@@ -62,8 +62,8 @@
 /* Badges */
 .badge-success  { background: rgba(34,197,94,0.15);  color: var(--success); border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; }
 .badge-danger   { background: rgba(239,68,68,0.15);  color: var(--danger);  border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; }
-.badge-warning  { background: rgba(245,158,11,0.15); color: var(--warning); border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; }
-.badge-info     { background: rgba(59,130,246,0.15); color: var(--info);    border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; }
+.badge-warning  { display: inline-block; background: rgba(245,158,11,0.15); color: var(--warning); border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; white-space: nowrap; margin: 0.125rem; user-select: all; }
+.badge-info     { display: inline-block; background: rgba(59,130,246,0.15); color: var(--info);    border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; white-space: nowrap; margin: 0.125rem; user-select: all; }
 .badge-active   { background: rgba(16,185,129,0.15); color: #10b981; }
 .badge-idle     { background: rgba(234,179,8,0.15);  color: #eab308; }
 .badge-dormant  { background: rgba(100,116,139,0.15); color: #64748b; }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -49,6 +49,7 @@ document.addEventListener('alpine:init', () => {
     memoriesLoading: false,
     memoryFilters: { sort: 'created', tags: '', state: '', minConf: 0, maxConf: 0 },
     selectedMemory: null,
+    detailExpanded: false,
     showNewMemoryModal: false,
     newMemoryForm: { concept: '', content: '', tagsRaw: '', confidence: 0.8 },
     confirmForgetId: null,

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -578,13 +578,31 @@
 
       <!-- Detail panel (slide-in) -->
       <div x-show="selectedMemory !== null"
-        style="position:fixed;right:0;top:0;height:100vh;width:400px;background:var(--bg-surface);border-left:1px solid var(--border);padding:1.5rem;overflow-y:auto;z-index:40;"
+        :style="'position:fixed;right:0;top:0;height:100vh;z-index:40;transition:width 0.2s ease;width:' + (detailExpanded ? '80%' : '400px') + ';'"
         x-transition:enter="transition ease-out duration-200"
         x-transition:enter-start="transform translate-x-full"
         x-transition:enter-end="transform translate-x-0"
         x-transition:leave="transition ease-in duration-150"
         x-transition:leave-start="transform translate-x-0"
         x-transition:leave-end="transform translate-x-full">
+        <!-- Expand/collapse toggle on left border -->
+        <!-- Expand/collapse: semicircle on left border -->
+        <button @click="detailExpanded = !detailExpanded"
+          style="position:absolute;left:0;top:50%;transform:translate(-50%,-50%);width:1.75rem;height:1.75rem;border:none;background:none;cursor:pointer;padding:0;z-index:42;"
+          :title="detailExpanded ? 'Collapse panel' : 'Expand panel'">
+          <!-- Left half with border -->
+          <div style="position:absolute;inset:0;border-radius:50%;border:1px solid var(--border);background:var(--bg-surface);clip-path:inset(-1px 50% -1px -1px);pointer-events:none;"></div>
+          <!-- Right half without border, covers panel border -->
+          <div style="position:absolute;inset:0;border-radius:50%;background:var(--bg-surface);clip-path:inset(0 0 0 50%);pointer-events:none;"></div>
+          <!-- Chevron -->
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+            style="position:absolute;top:50%;left:50%;color:var(--text-muted);pointer-events:none;"
+            :style="'position:absolute;top:50%;left:50%;color:var(--text-muted);pointer-events:none;transform:translate(-50%,-50%)' + (detailExpanded ? ' rotate(180deg)' : '')">
+            <polyline points="15 18 9 12 15 6"></polyline>
+          </svg>
+        </button>
+        <!-- Scrollable content -->
+        <div style="height:100%;background:var(--bg-surface);border-left:1px solid var(--border);padding:1.5rem;overflow-y:auto;">
         <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem;">
           <!-- Item 7: Prev/Next navigation -->
           <div style="display:flex;align-items:center;gap:0.375rem;flex:1;min-width:0;">
@@ -601,19 +619,18 @@
               :style="selectedMemoryIndex() >= memories.length - 1 ? 'opacity:0.3;cursor:not-allowed;' : ''"
               title="Next memory">&rsaquo;</button>
           </div>
-          <button class="btn-ghost" @click="selectedMemory=null" style="flex-shrink:0;">✕</button>
-        </div>
-        <!-- Action buttons row -->
-        <div x-show="selectedMemory && !editingMemory" style="display:flex;gap:0.5rem;margin-bottom:1rem;">
-          <button class="btn-ghost" style="font-size:0.8125rem;padding:0.25rem 0.625rem;" @click="startEditMemory()">Edit</button>
-          <button class="btn-ghost" style="font-size:0.8125rem;padding:0.25rem 0.625rem;" @click="openLinkModal(selectedMemory.id)">Link</button>
+          <button class="btn-ghost" @click="selectedMemory=null;detailExpanded=false" style="flex-shrink:0;">✕</button>
         </div>
         <template x-if="selectedMemory">
           <div>
             <div class="form-group" style="margin-bottom:1rem;">
-              <label>Content</label>
+              <div style="display:flex;align-items:center;gap:0.5rem;">
+                <label style="margin:0;">Content</label>
+                <button x-show="!editingMemory" class="btn-ghost" style="font-size:0.75rem;padding:0.1rem 0.4rem;color:var(--primary);" @click="startEditMemory()">Edit</button>
+                <button x-show="!editingMemory" class="btn-ghost" style="font-size:0.75rem;padding:0.1rem 0.4rem;color:var(--primary);" @click="openLinkModal(selectedMemory.id)">Link Memory</button>
+              </div>
               <!-- Read-only view -->
-              <p x-show="!editingMemory" style="color:var(--text-primary);line-height:1.6;white-space:pre-wrap;" x-text="selectedMemory.content"></p>
+              <p x-show="!editingMemory" style="color:var(--text-primary);font-size:0.875rem;line-height:1.6;white-space:pre-wrap;" x-text="selectedMemory.content"></p>
               <!-- Edit mode -->
               <template x-if="editingMemory">
                 <div>
@@ -643,12 +660,12 @@
               <div class="confidence-bar"><div class="confidence-fill" :style="'width:' + Math.round((selectedMemory.confidence || 0) * 100) + '%'"></div></div>
             </div>
             <div class="form-group" style="margin-bottom:1rem;">
-              <div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.375rem;">
+              <div style="display:flex;align-items:center;gap:0.5rem;">
                 <label style="margin:0;">Tags</label>
-                <button x-show="!editingTags" class="btn-ghost" style="font-size:0.75rem;padding:0.1rem 0.4rem;" @click="startEditTags()">Edit</button>
+                <button x-show="!editingTags" class="btn-ghost" style="font-size:0.75rem;padding:0.1rem 0.4rem;color:var(--primary);" @click="startEditTags()">Edit</button>
               </div>
               <!-- Read-only tag chips -->
-              <div x-show="!editingTags" style="display:flex;flex-wrap:wrap;gap:0.25rem;">
+              <div x-show="!editingTags" style="line-height:1.8;">
                 <template x-for="tag in (selectedMemory.tags || [])" :key="tag">
                   <span class="badge-warning" x-text="tag"></span>
                 </template>
@@ -687,7 +704,7 @@
             </div>
             <div class="form-group">
               <label>Created</label>
-              <span style="color:var(--text-secondary);" x-text="selectedMemory.createdAt ? new Date(selectedMemory.createdAt * 1000).toLocaleString() : 'unknown'"></span>
+              <span style="color:var(--text-secondary);font-size:0.875rem;" x-text="selectedMemory.createdAt ? new Date(selectedMemory.createdAt * 1000).toLocaleString() : 'unknown'"></span>
             </div>
             <div class="form-group" style="margin-top:1rem;">
               <label>Lifecycle State</label>
@@ -705,6 +722,7 @@
             </div>
           </div>
         </template>
+        </div><!-- /scrollable content -->
       </div>
     </div>
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -667,7 +667,7 @@
               <!-- Read-only tag chips -->
               <div x-show="!editingTags" style="line-height:1.8;">
                 <template x-for="tag in (selectedMemory.tags || [])" :key="tag">
-                  <span class="badge-warning" x-text="tag"></span>
+                  <span class="badge-warning badge-tag" x-text="tag"></span>
                 </template>
                 <span x-show="!(selectedMemory.tags && selectedMemory.tags.length)" style="color:var(--text-muted);font-size:0.875rem;">none</span>
               </div>


### PR DESCRIPTION
## Summary

Overhauls the memory detail panel with an expand/collapse toggle, improved tag wrapping, and refined button/typography consistency as part of https://github.com/scrypster/muninndb/issues/327


## Changes

- Added expand/collapse chevron toggle on the detail panel's left border that widens the panel from 400px to 80% for viewing large memories
  - Chevron renders as a semicircle with only the left-half arc visible, seamlessly flowing with the vertical divider
  - Panel resets to collapsed on close
- Moved Edit and Link Memory buttons inline with the Content label as compact teal-colored (`var(--primary)`) text buttons, matching the Tags Edit style
- Renamed "Link" button to "Link Memory"
- Tag badges in the detail panel now use a scoped `.badge-tag` modifier class (`inline-block`, `white-space: nowrap`, `user-select: all`) so they wrap as whole units and select individually on double-click — without affecting badges elsewhere in the app
- Reduced memory content text to `0.875rem` to match labels and other field values
- Created timestamp font size matched to its label at `0.875rem`
- Updated `CHANGELOG.md`

**Before**
*Note the horizontal scroll bar to render the tags
<img width="3197" height="1826" alt="image" src="https://github.com/user-attachments/assets/ea3ae653-89d3-4388-aafe-7bc388f3ef76" />

**After**
<img width="3197" height="1162" alt="image" src="https://github.com/user-attachments/assets/289520a7-ce66-4e76-affc-e64a053ee8de" />
<img width="3197" height="1162" alt="image" src="https://github.com/user-attachments/assets/c076295d-6956-48a8-9041-05c24efea9cf" />


### Large memory content
<img width="3197" height="1516" alt="image" src="https://github.com/user-attachments/assets/339ddf18-2124-49de-8c28-f091d3cccb06" />
<img width="3197" height="1516" alt="image" src="https://github.com/user-attachments/assets/7635001c-5646-4349-ab68-2eefdb6925b1" />


## Release Checklist

- [x] `CHANGELOG.md` updated with changes
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes