### PR TITLE
chore: remove CHANGELOG from contributor PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 ## Release Checklist
 
-- [ ] `CHANGELOG.md` updated with changes
+- [ ] ~~`CHANGELOG.md`~~ — maintainers update this at release time, no action needed
 - [ ] OpenAPI spec (`internal/transport/rest/openapi.yaml`) updated if API routes changed
 - [ ] SDK types updated if request/response schemas changed (Python, Node, PHP)
 - [ ] `docs/` updated if user-facing behavior changed


### PR DESCRIPTION
## Summary

Contributors updating `CHANGELOG.md` in every PR causes recurring merge conflicts when multiple PRs are in flight simultaneously — the `### Fixed` section is a single point of contention that every PR touches.

Maintainers will update `CHANGELOG.md` at release time from merged PR titles and descriptions. Contributors no longer need to touch it.

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md`: replaced the CHANGELOG checkbox with a note explaining maintainers handle it at release time