### PR TITLE
fix(activation): Dormant flag should be false in ACT-R mode

### DIFF
--- a/internal/engine/activation/activation_test.go
+++ b/internal/engine/activation/activation_test.go
@@ -323,27 +323,27 @@ func TestActivationLogRingBuffer(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Test 4: Engram with very low relevance (0.01) comes back Dormant == true
+// Test 4: Dormant flag respects scoring mode
 // ---------------------------------------------------------------------------
 
-func TestDormantFlagSetWhenRelevanceLow(t *testing.T) {
+func TestDormantFlag_ACTRMode_AlwaysFalse(t *testing.T) {
 	store := newStubStore()
-	dormant := &storage.Engram{
+	eng := &storage.Engram{
 		Concept:    "dormant engram",
 		Content:    "barely alive",
 		Confidence: 1.0,
 		Stability:  30.0,
-		// Relevance 0.01 is well below minFloor*1.1 = 0.05*1.1 = 0.055
-		Relevance: 0.01,
+		Relevance:  0.01, // well below minFloor*1.1 = 0.055
 	}
-	store.writeEngram(dormant)
+	store.writeEngram(eng)
 
-	fts := &stubFTS{results: []activation.ScoredID{{ID: dormant.ID, Score: 0.8}}}
-	hnsw := &stubHNSW{results: []activation.ScoredID{{ID: dormant.ID, Score: 0.8}}}
+	fts := &stubFTS{results: []activation.ScoredID{{ID: eng.ID, Score: 0.8}}}
+	hnsw := &stubHNSW{results: []activation.ScoredID{{ID: eng.ID, Score: 0.8}}}
 
-	eng := newTestEngine(store, fts, hnsw)
+	e := newTestEngine(store, fts, hnsw)
 
-	result, err := eng.Run(context.Background(), &activation.ActivateRequest{
+	// Default mode is ACT-R — Dormant should be false regardless of Relevance.
+	result, err := e.Run(context.Background(), &activation.ActivateRequest{
 		Context:    []string{"barely alive"},
 		Threshold:  0.0,
 		MaxResults: 5,
@@ -351,21 +351,58 @@ func TestDormantFlagSetWhenRelevanceLow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if len(result.Activations) == 0 {
-		t.Fatal("expected dormant engram to appear in results")
+	for _, a := range result.Activations {
+		if a.Engram.ID == eng.ID && a.Dormant {
+			t.Error("ACT-R mode: Dormant should be false (dormancy is implicit via scoring)")
+		}
 	}
+}
 
+func TestDormantFlag_LegacyMode_SetWhenRelevanceLow(t *testing.T) {
+	store := newStubStore()
+	eng := &storage.Engram{
+		Concept:    "dormant engram",
+		Content:    "barely alive",
+		Confidence: 1.0,
+		Stability:  30.0,
+		Relevance:  0.01,
+	}
+	store.writeEngram(eng)
+
+	fts := &stubFTS{results: []activation.ScoredID{{ID: eng.ID, Score: 0.8}}}
+	hnsw := &stubHNSW{results: []activation.ScoredID{{ID: eng.ID, Score: 0.8}}}
+
+	e := newTestEngine(store, fts, hnsw)
+
+	// Legacy weighted-sum mode (DisableACTR) — Dormant should reflect Relevance.
+	result, err := e.Run(context.Background(), &activation.ActivateRequest{
+		Context:    []string{"barely alive"},
+		Threshold:  0.0,
+		MaxResults: 5,
+		Weights: &activation.Weights{
+			DisableACTR:        true,
+			SemanticSimilarity: 0.35,
+			FullTextRelevance:  0.25,
+			DecayFactor:        0.20,
+			HebbianBoost:       0.10,
+			AccessFrequency:    0.05,
+			Recency:            0.05,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
 	found := false
 	for _, a := range result.Activations {
-		if a.Engram.ID == dormant.ID {
+		if a.Engram.ID == eng.ID {
 			found = true
 			if !a.Dormant {
-				t.Errorf("engram with Relevance=0.01: Dormant=false, want true")
+				t.Error("legacy mode: engram with Relevance=0.01 should be Dormant=true")
 			}
 		}
 	}
 	if !found {
-		t.Fatal("dormant engram not found in activations")
+		t.Fatal("engram not found in results")
 	}
 }
 

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -1335,7 +1335,7 @@ cgdnDone:
 		}
 		var why string
 		if req.IncludeWhy {
-			why = buildWhy(eng, s.components, s.hopPath, hopConcepts, p1.queryStr)
+			why = buildWhy(eng, s.components, s.hopPath, hopConcepts, p1.queryStr, w.UseACTR)
 		}
 		activations = append(activations, ScoredEngram{
 			Engram:      eng,
@@ -1633,7 +1633,7 @@ func resolveWeights(req *Weights, def DefaultWeights) resolvedWeights {
 	return rw
 }
 
-func buildWhy(eng *storage.Engram, c ScoreComponents, hopPath []storage.ULID, hopConcepts []string, queryStr string) string {
+func buildWhy(eng *storage.Engram, c ScoreComponents, hopPath []storage.ULID, hopConcepts []string, queryStr string, useACTR bool) string {
 	var parts []string
 
 	signals := map[string]float64{
@@ -1683,7 +1683,7 @@ func buildWhy(eng *storage.Engram, c ScoreComponents, hopPath []storage.ULID, ho
 		parts = append(parts, fmt.Sprintf("confidence is low (%.0f%%)", c.Confidence*100))
 	}
 
-	if eng.Relevance <= minFloor*1.1 {
+	if !useACTR && eng.Relevance <= minFloor*1.1 {
 		parts = append(parts, "dormant (low decay relevance)")
 	}
 

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -1344,7 +1344,7 @@ cgdnDone:
 			Why:         why,
 			HopPath:     append([]storage.ULID(nil), s.hopPath...),
 			HopConcepts: hopConcepts,
-			Dormant:     eng.Relevance <= minFloor*1.1,
+			Dormant:     !w.UseACTR && eng.Relevance <= minFloor*1.1,
 		})
 	}
 

--- a/internal/engine/activation/helpers_test.go
+++ b/internal/engine/activation/helpers_test.go
@@ -1451,6 +1451,7 @@ func TestPhase6Score_DormantFlag(t *testing.T) {
 	fused := []fusedCandidate{{id: eng1.ID, rrfScore: 0.5, ftsScore: 1.0}}
 	p1 := &phase1Result{queryStr: "test"}
 
+	// Default mode is ACT-R — Dormant should be false (dormancy is implicit).
 	result, err := e.phase6Score(context.Background(), &ActivateRequest{
 		MaxResults: 10, Threshold: 0.0,
 	}, [8]byte{}, fused, nil, p1)
@@ -1459,8 +1460,27 @@ func TestPhase6Score_DormantFlag(t *testing.T) {
 		t.Fatalf("phase6Score: %v", err)
 	}
 	for _, a := range result.Activations {
+		if a.Engram.ID == eng1.ID && a.Dormant {
+			t.Error("ACT-R mode: engram should not be marked Dormant (dormancy is implicit via scoring)")
+		}
+	}
+
+	// Legacy mode (DisableACTR) — Dormant should reflect Relevance.
+	result2, err := e.phase6Score(context.Background(), &ActivateRequest{
+		MaxResults: 10, Threshold: 0.0,
+		Weights: &Weights{
+			DisableACTR:        true,
+			SemanticSimilarity: 0.35,
+			FullTextRelevance:  0.25,
+			DecayFactor:        0.20,
+		},
+	}, [8]byte{}, fused, nil, p1)
+	if err != nil {
+		t.Fatalf("phase6Score legacy: %v", err)
+	}
+	for _, a := range result2.Activations {
 		if a.Engram.ID == eng1.ID && !a.Dormant {
-			t.Error("engram with low Relevance should have Dormant=true")
+			t.Error("legacy mode: engram with Relevance=0.01 should have Dormant=true")
 		}
 	}
 }

--- a/internal/engine/activation/helpers_test.go
+++ b/internal/engine/activation/helpers_test.go
@@ -2,6 +2,7 @@ package activation
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -328,7 +329,7 @@ func TestComputeComponents_CachedLastAccess(t *testing.T) {
 func TestBuildWhy_SemanticDominant(t *testing.T) {
 	eng := &storage.Engram{Relevance: 0.5}
 	c := ScoreComponents{SemanticSimilarity: 0.9, FullTextRelevance: 0.1, DecayFactor: 0.1, Confidence: 0.8}
-	why := buildWhy(eng, c, nil, nil, "test query")
+	why := buildWhy(eng, c, nil, nil, "test query", true)
 	if why == "" {
 		t.Error("expected non-empty why string")
 	}
@@ -337,7 +338,7 @@ func TestBuildWhy_SemanticDominant(t *testing.T) {
 func TestBuildWhy_FTSDominant(t *testing.T) {
 	eng := &storage.Engram{Relevance: 0.5}
 	c := ScoreComponents{SemanticSimilarity: 0.1, FullTextRelevance: 0.9, DecayFactor: 0.1, Confidence: 0.8}
-	why := buildWhy(eng, c, nil, nil, "test query that is very long and exceeds forty characters for truncation testing")
+	why := buildWhy(eng, c, nil, nil, "test query that is very long and exceeds forty characters for truncation testing", true)
 	if why == "" {
 		t.Error("expected non-empty why string")
 	}
@@ -348,7 +349,7 @@ func TestBuildWhy_WithHopPath(t *testing.T) {
 	c := ScoreComponents{HebbianBoost: 0.9, Confidence: 0.8}
 	path := []storage.ULID{{1}, {2}, {3}}
 	concepts := []string{"alpha", "beta", "gamma"}
-	why := buildWhy(eng, c, path, concepts, "")
+	why := buildWhy(eng, c, path, concepts, "", true)
 	if why == "" {
 		t.Error("expected non-empty why string with hops")
 	}
@@ -357,18 +358,24 @@ func TestBuildWhy_WithHopPath(t *testing.T) {
 func TestBuildWhy_LowConfidence(t *testing.T) {
 	eng := &storage.Engram{Relevance: 0.5}
 	c := ScoreComponents{SemanticSimilarity: 0.8, Confidence: 0.3}
-	why := buildWhy(eng, c, nil, nil, "test")
+	why := buildWhy(eng, c, nil, nil, "test", true)
 	if why == "" {
 		t.Error("expected non-empty why string")
 	}
 }
 
-func TestBuildWhy_DormantEngram(t *testing.T) {
+func TestBuildWhy_DormantEngram_LegacyMode(t *testing.T) {
 	eng := &storage.Engram{Relevance: minFloor * 1.05}
 	c := ScoreComponents{DecayFactor: 0.9, Confidence: 0.8}
-	why := buildWhy(eng, c, nil, nil, "")
-	if why == "" {
-		t.Error("expected non-empty why string for dormant engram")
+	// Legacy mode: dormant annotation should appear.
+	why := buildWhy(eng, c, nil, nil, "", false)
+	if !strings.Contains(why, "dormant") {
+		t.Error("legacy mode: expected dormant annotation for low-relevance engram")
+	}
+	// ACT-R mode: dormant annotation should NOT appear.
+	why2 := buildWhy(eng, c, nil, nil, "", true)
+	if strings.Contains(why2, "dormant") {
+		t.Error("ACT-R mode: dormant annotation should not appear")
 	}
 }
 
@@ -376,7 +383,7 @@ func TestBuildWhy_HopPathWithoutConcepts(t *testing.T) {
 	eng := &storage.Engram{Relevance: 0.5}
 	c := ScoreComponents{HebbianBoost: 0.9, Confidence: 0.8}
 	path := []storage.ULID{{1}, {2}}
-	why := buildWhy(eng, c, path, nil, "")
+	why := buildWhy(eng, c, path, nil, "", true)
 	if why == "" {
 		t.Error("expected non-empty why string")
 	}


### PR DESCRIPTION
## Summary

One-line fix: `Dormant: !w.UseACTR && eng.Relevance <= minFloor*1.1`

In ACT-R mode (the default), the `Dormant` flag was derived from `eng.Relevance` (Ebbinghaus decay output). This contradicts ACT-R scoring for frequently-accessed old engrams — ACT-R scores them highly but the Ebbinghaus worker has already decayed `Relevance` below the floor, marking them dormant.

In ACT-R mode, dormancy is now always `false` — it's implicit via scoring (low ACT-R base-level = below threshold = not returned). In legacy weighted-sum mode, `Dormant` still reflects `Relevance` as before.

Fixes #348

## Test plan

- [x] ACT-R mode: `Dormant=false` regardless of `Relevance` (2 tests)
- [x] Legacy mode: `Dormant=true` when `Relevance` below floor (2 tests)
- [x] RED/GREEN verified
- [x] Full activation suite passes (235 tests)