### PR TITLE
Fix: Cluster card form spacing

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -2275,33 +2275,30 @@ Authorization = "Bearer &lt;token from %USERPROFILE%\.muninn\mcp.token&gt;"</pre
           </div>
 
           <!-- Form -->
-          <div x-show="!clusterEnableLoading" style="display:flex;flex-direction:column;gap:1rem;">
-            <div>
-              <label style="display:block;font-size:0.75rem;font-weight:500;margin-bottom:0.375rem;color:var(--text-muted);">Role</label>
-              <select x-model="clusterEnableForm.role" style="width:100%;font-size:0.875rem;border-radius:0.375rem;padding:0.5rem 0.75rem;background:var(--bg-elevated);border:1px solid var(--border);color:var(--text-primary);">
+          <div x-show="!clusterEnableLoading">
+            <div class="form-group" style="margin-bottom:1rem;">
+              <label>Role</label>
+              <select x-model="clusterEnableForm.role" class="input-field">
                 <option value="primary">Primary (Cortex)</option>
                 <option value="replica">Replica (Lobe)</option>
                 <option value="sentinel">Sentinel</option>
                 <option value="observer">Observer</option>
               </select>
             </div>
-            <div>
-              <label style="display:block;font-size:0.75rem;font-weight:500;margin-bottom:0.375rem;color:var(--text-muted);">Bind Address</label>
-              <input x-model="clusterEnableForm.bindAddr" type="text" placeholder="10.0.0.1:7777"
-                style="width:100%;font-size:0.875rem;border-radius:0.375rem;padding:0.5rem 0.75rem;background:var(--bg-elevated);border:1px solid var(--border);color:var(--text-primary);box-sizing:border-box;">
+            <div class="form-group" style="margin-bottom:1rem;">
+              <label>Bind Address</label>
+              <input x-model="clusterEnableForm.bindAddr" type="text" placeholder="10.0.0.1:7777" class="input-field">
             </div>
-            <div x-show="clusterEnableForm.role !== 'primary'">
-              <label style="display:block;font-size:0.75rem;font-weight:500;margin-bottom:0.375rem;color:var(--text-muted);">Cortex Address</label>
-              <input x-model="clusterEnableForm.cortexAddr" type="text" placeholder="10.0.0.1:7777"
-                style="width:100%;font-size:0.875rem;border-radius:0.375rem;padding:0.5rem 0.75rem;background:var(--bg-elevated);border:1px solid var(--border);color:var(--text-primary);box-sizing:border-box;">
+            <div class="form-group" x-show="clusterEnableForm.role !== 'primary'" style="margin-bottom:1rem;">
+              <label>Cortex Address</label>
+              <input x-model="clusterEnableForm.cortexAddr" type="text" placeholder="10.0.0.1:7777" class="input-field">
             </div>
-            <div>
-              <label style="display:block;font-size:0.75rem;font-weight:500;margin-bottom:0.375rem;color:var(--text-muted);">
+            <div class="form-group" style="margin-bottom:1rem;">
+              <label>
                 Cluster Secret <span style="font-weight:400;color:var(--text-muted);">(recommended)</span>
               </label>
-              <input x-model="clusterEnableForm.clusterSecret" type="password" placeholder="Leave empty for open cluster"
-                style="width:100%;font-size:0.875rem;border-radius:0.375rem;padding:0.5rem 0.75rem;background:var(--bg-elevated);border:1px solid var(--border);color:var(--text-primary);box-sizing:border-box;">
-              <p x-show="!clusterEnableForm.clusterSecret" style="margin:0.25rem 0 0;font-size:0.75rem;color:#eab308;">
+              <input x-model="clusterEnableForm.clusterSecret" type="password" placeholder="Leave empty for open cluster" class="input-field">
+              <p x-show="!clusterEnableForm.clusterSecret" style="margin:0;font-size:0.75rem;color:#eab308;">
                 &#9888; Without a secret, any node can join this cluster
               </p>
             </div>


### PR DESCRIPTION
## Summary

Fixes the Cluster page "Enable Cluster Mode" form to use consistent styling with the rest of the app, part of https://github.com/scrypster/muninndb/issues/327


## Changes

- Replaced inline label styles (`font-size:0.75rem; color:var(--text-muted)`) with `form-group` class, matching the app-wide label style (`0.875rem; var(--text-secondary)`)
- Replaced inline input/select styles with `input-field` class for consistent form element rendering
- Added `margin-bottom:1rem` between form groups to clearly separate label/input pairs
- Tightened warning text margin below the Cluster Secret input

**Before**
<img width="766" height="694" alt="image" src="https://github.com/user-attachments/assets/2030faab-1afd-42c2-9092-0419a606be59" />

**After**
<img width="760" height="816" alt="image" src="https://github.com/user-attachments/assets/55fa00ef-dee1-419d-ab25-2b6d41e2e3d5" />


## Release Checklist

- [ ] ~~`CHANGELOG.md`~~ — maintainers update this at release time, no action needed
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
