### PR TITLE
Fix: Form button group hover state

### DIFF
--- a/web/static/css/components.css
+++ b/web/static/css/components.css
@@ -59,6 +59,15 @@
 }
 .btn-ghost:hover { background: var(--bg-elevated); }
 
+/* Segmented control buttons */
+.seg-btn:hover:not(.seg-active) {
+  background: rgba(255, 255, 255, 0.05) !important;
+  color: var(--text-primary) !important;
+}
+html.light .seg-btn:hover:not(.seg-active) {
+  background: rgba(0, 0, 0, 0.04) !important;
+}
+
 /* Badges */
 .badge-success  { background: rgba(34,197,94,0.15);  color: var(--success); border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; }
 .badge-danger   { background: rgba(239,68,68,0.15);  color: var(--danger);  border-radius: 9999px; padding: 0.125rem 0.625rem; font-size: 0.75rem; font-weight: 600; }

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -441,16 +441,16 @@
           @keydown.enter="searchMemories()" style="flex:1;min-width:200px;" />
         <!-- Recall mode segmented control (Item 3: tooltips) -->
         <div style="display:inline-flex;border:1px solid var(--border);border-radius:0.5rem;overflow:hidden;">
-          <button @click="searchMode = 'balanced'"
+          <button @click="searchMode = 'balanced'" class="seg-btn" :class="searchMode === 'balanced' && 'seg-active'"
             :style="'padding:0.5rem 1rem;border:none;border-right:1px solid var(--border);cursor:pointer;transition:all 0.15s;font-weight:600;' + (searchMode === 'balanced' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')"
             title="Blend keyword + semantic search with temporal decay (default)">Balanced</button>
-          <button @click="searchMode = 'semantic'"
+          <button @click="searchMode = 'semantic'" class="seg-btn" :class="searchMode === 'semantic' && 'seg-active'"
             :style="'padding:0.5rem 1rem;border:none;border-right:1px solid var(--border);cursor:pointer;transition:all 0.15s;font-weight:600;' + (searchMode === 'semantic' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')"
             title="Pure vector similarity — best for concept matching">Semantic</button>
-          <button @click="searchMode = 'recent'"
+          <button @click="searchMode = 'recent'" class="seg-btn" :class="searchMode === 'recent' && 'seg-active'"
             :style="'padding:0.5rem 1rem;border:none;border-right:1px solid var(--border);cursor:pointer;transition:all 0.15s;font-weight:600;' + (searchMode === 'recent' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')"
             title="Prioritize recently created memories">Recent</button>
-          <button @click="searchMode = 'deep'"
+          <button @click="searchMode = 'deep'" class="seg-btn" :class="searchMode === 'deep' && 'seg-active'"
             :style="'padding:0.5rem 1rem;border:none;cursor:pointer;transition:all 0.15s;font-weight:600;' + (searchMode === 'deep' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')"
             title="Exhaustive graph traversal — slower but finds distant connections">Deep</button>
         </div>
@@ -1962,11 +1962,11 @@
         <div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:1rem;">
           <span style="font-size:0.875rem;font-weight:500;color:var(--text-muted);">Platform:</span>
           <div style="display:inline-flex;border:1px solid var(--border);border-radius:0.5rem;overflow:hidden;">
-            <button @click="connectPlatform='macos'"
+            <button @click="connectPlatform='macos'" class="seg-btn" :class="connectPlatform==='macos' && 'seg-active'"
               :style="'padding:0.5rem 1rem;font-size:0.8125rem;border:none;border-right:1px solid var(--border);cursor:pointer;transition:all 0.15s;font-weight:600;' + (connectPlatform==='macos' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')">macOS</button>
-            <button @click="connectPlatform='linux'"
+            <button @click="connectPlatform='linux'" class="seg-btn" :class="connectPlatform==='linux' && 'seg-active'"
               :style="'padding:0.5rem 1rem;font-size:0.8125rem;border:none;border-right:1px solid var(--border);cursor:pointer;transition:all 0.15s;font-weight:600;' + (connectPlatform==='linux' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')">Linux</button>
-            <button @click="connectPlatform='windows'"
+            <button @click="connectPlatform='windows'" class="seg-btn" :class="connectPlatform==='windows' && 'seg-active'"
               :style="'padding:0.5rem 1rem;font-size:0.8125rem;border:none;cursor:pointer;transition:all 0.15s;font-weight:600;' + (connectPlatform==='windows' ? 'background:var(--accent);color:#fff;' : 'background:var(--bg-elevated);color:var(--text-secondary);')">Windows</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Adds hover feedback to segmented control button groups on the Memories and Settings pages, matching the existing tab hover behavior, part of https://github.com/scrypster/muninndb/issues/327


## Changes

- Added `.seg-btn` / `.seg-active` CSS classes in `components.css` with hover styles matching `.tab-btn:hover:not(.active)` — subtle gray background shift for both dark and light modes
- Applied `seg-btn` class and dynamic `seg-active` class to all search mode buttons (Balanced/Semantic/Recent/Deep) on the Memories page
- Applied `seg-btn` class and dynamic `seg-active` class to all Platform buttons (macOS/Linux/Windows) on the Settings → Connect page
- Hover is suppressed on the currently active button via `:not(.seg-active)`

**Example hover state**
<img width="608" height="107" alt="image" src="https://github.com/user-attachments/assets/b5252939-b1fc-4c41-96f0-1b4cddda40cb" />
<img width="608" height="107" alt="image" src="https://github.com/user-attachments/assets/7ec140f6-cadf-4b2a-b3b7-cc17febdfe5e" />


## Release Checklist

- [ ] ~~`CHANGELOG.md`~~ — maintainers update this at release time, no action needed
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
