### PR TITLE
Fix: Consistent form element heights

### DIFF
--- a/web/static/css/components.css
+++ b/web/static/css/components.css
@@ -101,6 +101,9 @@
   color: var(--text-primary);
   padding: 0.5rem 0.75rem;
   width: 100%;
+  height: 2.375rem;
+  font-size: 0.875rem;
+  font-family: inherit;
   outline: none;
   transition: border-color 0.15s;
 }


### PR DESCRIPTION
## Summary

Fixes mismatched form element heights on the API Keys "Create New API Key" card, part of https://github.com/scrypster/muninndb/issues/327


## Changes

- Added explicit `height: 2.375rem` to `.input-field` class so `<input>` and `<select>` elements render at the same height
- Added `font-size: 0.875rem` and `font-family: inherit` to `.input-field` to normalize browser defaults across input types

**Before**
<img width="937" height="278" alt="image" src="https://github.com/user-attachments/assets/89a85f0e-278f-45b9-aa6b-be31518f5e6e" />

**After**
<img width="937" height="278" alt="image" src="https://github.com/user-attachments/assets/43eae5ab-82fa-4b6f-a756-55d8507eb442" />


## Release Checklist

- [ ] ~~`CHANGELOG.md`~~ — maintainers update this at release time, no action needed
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
