### PR TITLE
Fix: Logs page use full viewport width

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -167,7 +167,7 @@
   </button>
 
   <!-- Main content area -->
-  <main class="app-main">
+  <main class="app-main" :style="currentView === 'logs' ? 'max-width:none;' : ''">
 
     <!-- ── Dashboard View ───────────────────────────────────────────── -->
     <div x-show="currentView==='dashboard'">


### PR DESCRIPTION
## Summary

Removes the `max-width: 1400px` constraint on the Server Logs page so log entries use the full available viewport width, part of https://github.com/scrypster/muninndb/issues/327


## Changes

- Added dynamic `:style` binding on `<main class="app-main">` that sets `max-width: none` when `currentView === 'logs'`
- All other pages retain the existing `1400px` max-width

**Before**
<img width="3103" height="1097" alt="image" src="https://github.com/user-attachments/assets/efc09586-6cfd-48b2-b209-07e8dec4a5db" />

**After**
<img width="3110" height="1098" alt="image" src="https://github.com/user-attachments/assets/3566cd2c-f420-4ad6-9c42-9238ef958767" />



## Release Checklist

- [ ] ~~`CHANGELOG.md`~~ — maintainers update this at release time, no action needed
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change (visual-only)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
