### PR TITLE
Fix: Enable observability page

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -264,7 +264,7 @@ document.addEventListener('alpine:init', () => {
         const parts = hash.split('/');
         const raw = parts[0];
         // Only use known views
-        const known = ['dashboard', 'memories', 'graph', 'session', 'settings', 'logs', 'cluster'];
+        const known = ['dashboard', 'memories', 'graph', 'session', 'observability', 'settings', 'logs', 'cluster'];
         this.currentView = known.includes(raw) ? raw : 'dashboard';
 
         // Parse settings sub-tab if entering settings view


### PR DESCRIPTION
## Summary

Fixes the Observability page being unreachable — clicking it in the sidebar silently redirected to Dashboard, part of https://github.com/scrypster/muninndb/issues/327


## Changes

- Added `'observability'` to the `known` views array in the hash router (`app.js:267`), which was accidentally omitted
- The Observability page template and sidebar nav item were already fully implemented; only the router entry was missing


## Release Checklist

- [ ] ~~`CHANGELOG.md`~~ — maintainers update this at release time, no action needed
- [ ] ~~OpenAPI spec updated~~ — no API changes
- [ ] ~~SDK types updated~~ — no schema changes
- [ ] ~~`docs/` updated~~ — no user-facing behavior change
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
