### PR TITLE
fix(cluster): resolve Lobe join handshake and three related cluster bugs (#361)

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -585,14 +585,29 @@ func runStartupMigrations(ctx context.Context, store *storage.PebbleStore) {
 
 // handleClusterConn reads MBP frames from an incoming cluster TCP connection
 // and dispatches them to the coordinator. Exits when the connection is closed.
+//
+// The first frame from a Lobe is always a TypeJoinRequest whose payload
+// contains the Lobe's stable node ID. We route that frame to
+// HandleIncomingJoin, which registers the live conn under the real node ID so
+// that peer.Send works immediately. All subsequent frames use that node ID.
 func handleClusterConn(conn net.Conn, coord *replication.ClusterCoordinator) {
 	defer conn.Close()
+	// Use the ephemeral remote addr until the Lobe's node ID is known.
+	fromNodeID := conn.RemoteAddr().String()
 	for {
 		frame, err := mbp.ReadFrame(conn)
 		if err != nil {
 			return // connection closed or error
 		}
-		fromNodeID := conn.RemoteAddr().String()
+		if frame.Type == mbp.TypeJoinRequest {
+			nodeID, err := coord.HandleIncomingJoin(conn, frame.Payload)
+			if err != nil {
+				log.Printf("[cluster] join error from %s: %v", fromNodeID, err)
+				return
+			}
+			fromNodeID = nodeID
+			continue
+		}
 		if err := coord.HandleIncomingFrame(fromNodeID, frame.Type, frame.Payload); err != nil {
 			log.Printf("[cluster] frame error from %s: %v", fromNodeID, err)
 		}

--- a/internal/auth/bootstrap.go
+++ b/internal/auth/bootstrap.go
@@ -27,21 +27,36 @@ func Bootstrap(store *Store, secretPath string) (secret []byte, err error) {
 
 	// Create root admin if none exists
 	if !store.AdminExists() {
-		if err = store.CreateAdmin("root", "password"); err != nil {
+		adminPassword := os.Getenv("MUNINN_ADMIN_PASSWORD")
+		if adminPassword == "" {
+			adminPassword = "password"
+		}
+		if err = store.CreateAdmin("root", adminPassword); err != nil {
 			return nil, fmt.Errorf("create root admin: %w", err)
 		}
 
-		fmt.Println("┌──────────────────────────────────────────────────┐")
-		fmt.Println("│            MuninnDB — First Run Setup             │")
-		fmt.Println("│                                                    │")
-		fmt.Println("│  Admin username : root                             │")
-		fmt.Println("│  Admin password : password                         │")
-		fmt.Println("│                                                    │")
-		fmt.Println("│  Default vault  : public (no API key required)     │")
-		fmt.Println("│                                                    │")
-		fmt.Println("│  Change your password and review vault settings    │")
-		fmt.Println("│  in the admin UI before exposing to a network.     │")
-		fmt.Println("└──────────────────────────────────────────────────┘")
+		if os.Getenv("MUNINN_ADMIN_PASSWORD") != "" {
+			fmt.Println("┌──────────────────────────────────────────────────┐")
+			fmt.Println("│            MuninnDB — First Run Setup             │")
+			fmt.Println("│                                                    │")
+			fmt.Println("│  Admin username : root                             │")
+			fmt.Println("│  Admin password : (set via MUNINN_ADMIN_PASSWORD)  │")
+			fmt.Println("│                                                    │")
+			fmt.Println("│  Default vault  : public (no API key required)     │")
+			fmt.Println("└──────────────────────────────────────────────────┘")
+		} else {
+			fmt.Println("┌──────────────────────────────────────────────────┐")
+			fmt.Println("│            MuninnDB — First Run Setup             │")
+			fmt.Println("│                                                    │")
+			fmt.Println("│  Admin username : root                             │")
+			fmt.Println("│  Admin password : password                         │")
+			fmt.Println("│                                                    │")
+			fmt.Println("│  Default vault  : public (no API key required)     │")
+			fmt.Println("│                                                    │")
+			fmt.Println("│  Change your password and review vault settings    │")
+			fmt.Println("│  in the admin UI before exposing to a network.     │")
+			fmt.Println("└──────────────────────────────────────────────────┘")
+		}
 	}
 
 	// Ensure at least one vault config exists. Covers both fresh installs

--- a/internal/replication/conn_manager.go
+++ b/internal/replication/conn_manager.go
@@ -1,6 +1,9 @@
 package replication
 
-import "sync"
+import (
+	"net"
+	"sync"
+)
 
 // FrameHandler is called when a frame of a registered type is received.
 type FrameHandler func(fromNodeID string, payload []byte) error
@@ -56,6 +59,20 @@ func (m *ConnManager) AddPeer(nodeID, addr string) {
 		_ = existing.Close()
 	}
 	m.peers[nodeID] = NewPeerConn(nodeID, addr)
+}
+
+// RegisterConn registers an already-established inbound connection as a peer.
+// Unlike AddPeer, the PeerConn wraps the live conn so Send works immediately
+// without a separate Connect call. If a peer for nodeID already exists it is
+// closed and replaced.
+func (m *ConnManager) RegisterConn(nodeID, addr string, conn net.Conn) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if existing, ok := m.peers[nodeID]; ok {
+		_ = existing.Close()
+	}
+	m.peers[nodeID] = NewPeerConnFromConn(nodeID, addr, conn)
 }
 
 // RemovePeer closes and removes the peer identified by nodeID.

--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -369,11 +370,13 @@ func (c *ClusterCoordinator) runAsCortex(ctx context.Context) error {
 		return ctx.Err()
 	}
 
-	if currentEpoch == 0 {
-		slog.Info("cluster: epoch 0, bootstrapping election", "node", c.cfg.NodeID)
-		if err := c.election.StartElection(ctx); err != nil {
-			return fmt.Errorf("cluster: bootstrap election failed: %w", err)
-		}
+	// Always start an election on normal startup (epoch 0 = first boot,
+	// epoch > 0 = restart after clean shutdown or crash before handoff).
+	// The crash-mid-handoff recovery path above handles the only case where we
+	// promote without a new election.
+	slog.Info("cluster: starting election", "node", c.cfg.NodeID, "epoch", currentEpoch)
+	if err := c.election.StartElection(ctx); err != nil {
+		return fmt.Errorf("cluster: election failed: %w", err)
 	}
 
 	<-ctx.Done()
@@ -603,6 +606,48 @@ func (c *ClusterCoordinator) checkQuorumHealth() {
 		c.nodeState.Store(uint32(StateDraining))
 		go c.handleDemotion()
 	}
+}
+
+// HandleIncomingJoin processes a TypeJoinRequest frame on a raw inbound conn
+// whose node ID is not yet known. It registers the live conn under req.NodeID
+// so that peer.Send works immediately (no dial required), processes the join
+// request, and returns the joining node's stable ID so that handleClusterConn
+// can use it for all subsequent frames on the same connection.
+func (c *ClusterCoordinator) HandleIncomingJoin(conn net.Conn, payload []byte) (string, error) {
+	var req mbp.JoinRequest
+	if err := msgpack.Unmarshal(payload, &req); err != nil {
+		return "", fmt.Errorf("unmarshal JoinRequest: %w", err)
+	}
+
+	// Register the live inbound conn so peer.Send succeeds immediately.
+	c.mgr.RegisterConn(req.NodeID, req.Addr, conn)
+	peer, ok := c.mgr.GetPeer(req.NodeID)
+	if !ok {
+		return "", fmt.Errorf("cluster: peer %s not found after RegisterConn", req.NodeID)
+	}
+
+	resp := c.joinHandler.HandleJoinRequest(req, peer)
+	respPayload, err := msgpack.Marshal(resp)
+	if err != nil {
+		return req.NodeID, fmt.Errorf("marshal JoinResponse: %w", err)
+	}
+	if err := peer.Send(mbp.TypeJoinResponse, respPayload); err != nil {
+		return req.NodeID, fmt.Errorf("cluster: send JoinResponse to %s: %w", req.NodeID, err)
+	}
+
+	if resp.NeedsSnapshot {
+		c.IncrementSnapshotCount()
+		go func() {
+			defer c.DecrementSnapshotCount()
+			ctx := context.Background()
+			if _, err := c.joinHandler.StreamSnapshot(ctx, peer); err != nil {
+				slog.Error("cluster: snapshot stream failed; closing connection so lobe can reconnect and retry",
+					"lobe", req.NodeID, "err", err)
+				_ = peer.Close()
+			}
+		}()
+	}
+	return req.NodeID, nil
 }
 
 // HandleIncomingFrame dispatches an incoming MBP frame from a peer to the right handler.

--- a/internal/replication/peer_conn.go
+++ b/internal/replication/peer_conn.go
@@ -31,6 +31,17 @@ func NewPeerConn(nodeID, addr string) *PeerConn {
 	}
 }
 
+// NewPeerConnFromConn wraps an already-established inbound TCP connection as a
+// PeerConn. Used on the Cortex side when a Lobe dials in: the conn exists but
+// the Lobe's stable listen address (addr) comes from the JoinRequest payload.
+func NewPeerConnFromConn(nodeID, addr string, conn net.Conn) *PeerConn {
+	return &PeerConn{
+		nodeID: nodeID,
+		addr:   addr,
+		conn:   conn,
+	}
+}
+
 // NodeID returns the remote node ID.
 func (p *PeerConn) NodeID() string { return p.nodeID }
 

--- a/internal/transport/rest/admin_cluster_handlers.go
+++ b/internal/transport/rest/admin_cluster_handlers.go
@@ -17,6 +17,7 @@ type enableClusterRequest struct {
 	Role          string `json:"role"`
 	BindAddr      string `json:"bind_addr"`
 	ClusterSecret string `json:"cluster_secret"`
+	Secret        string `json:"secret"`      // alias for cluster_secret
 	CortexAddr    string `json:"cortex_addr"`
 }
 
@@ -95,6 +96,11 @@ func (s *Server) handleAdminClusterEnable(w http.ResponseWriter, r *http.Request
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidClusterRequest, "cortex_addr is required for non-primary roles")
 		return
 	}
+	// Accept "secret" as a convenience alias for "cluster_secret".
+	if req.ClusterSecret == "" {
+		req.ClusterSecret = req.Secret
+	}
+
 	// Start from defaults so fields like LeaseTTL and HeartbeatMS are never
 	// persisted as zero (which would cause a crash on the next restart).
 	cfg := config.ClusterDefaults()

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -366,6 +366,14 @@ func (s *Server) enableClusterRuntime(ctx context.Context, cfg config.ClusterCon
 		if err := config.SaveClusterConfig(s.dataDir, cfg); err != nil {
 			return fmt.Errorf("persist config: %w", err)
 		}
+		// Reload after saving so auto-generated fields (NodeID) are populated
+		// before the coordinator is created. Without this, the coordinator
+		// starts with an empty NodeID and the node cannot rejoin after restart.
+		reloaded, err := config.LoadClusterConfig(s.dataDir)
+		if err != nil {
+			return fmt.Errorf("reload config after save: %w", err)
+		}
+		cfg = reloaded
 	}
 	if s.coordinatorFactory != nil {
 		coord, err := s.coordinatorFactory(ctx, cfg)


### PR DESCRIPTION
## Summary

Fixes all four bugs reported in #361.

- **Bug A** (blocking): Lobe join handshake always timed out — Cortex accepted TCP but the JoinResponse was silently dropped, leaving Lobe waiting 30 s per attempt
- **Bug B**: Cold-start with `role: primary` in `cluster.yaml` didn't promote Cortex; only hot-enable via admin API worked
- **Bug C**: `cluster enable` API didn't persist `cluster_secret` or `node_id` to `cluster.yaml`
- **Bug D**: `MUNINN_ADMIN_PASSWORD` env var was ignored; password was always hardcoded to `"password"`

## Changes

**Bug A — `handleClusterConn` passed ephemeral port as node ID**

`handleClusterConn` used `conn.RemoteAddr().String()` (e.g. `"127.0.0.1:33820"`) as `fromNodeID`. `HandleIncomingFrame` for `TypeJoinRequest` called `AddPeer(req.NodeID, req.Addr)` which creates a `PeerConn` with `conn=nil`. `peer.Send(TypeJoinResponse)` returned `ErrNotConnected` silently (`_ =`), so the Lobe never received a response and timed out.

- `internal/replication/peer_conn.go`: add `NewPeerConnFromConn` — wraps a live inbound conn
- `internal/replication/conn_manager.go`: add `RegisterConn` — registers live conn under stable node ID
- `internal/replication/coordinator.go`: add `HandleIncomingJoin(conn, payload)` — registers conn, sends JoinResponse, optionally streams snapshot
- `cmd/muninn/server.go`: `handleClusterConn` routes `TypeJoinRequest` to `HandleIncomingJoin` and updates `fromNodeID` for all subsequent frames

**Bug B — `runAsCortex` only elected when `epoch == 0`**

A clean restart left `epoch > 0` but `persistedRole == ""`, causing `runAsCortex` to skip the election and block on `<-ctx.Done()` indefinitely.

- `internal/replication/coordinator.go`: removed the `epoch == 0` guard; always starts election unless recovering from a crash-mid-handoff (`persistedRole == "cortex" && epoch > 0`)

**Bug C — hot-enable config not fully persisted**

Two sub-issues: (1) `autoNodeID` is only called in `LoadClusterConfig`, not in `enableClusterRuntime`, so the coordinator started with an empty `NodeID`; (2) the API struct expected `"cluster_secret"` but callers naturally send `"secret"`.

- `internal/transport/rest/server.go`: reload config from disk after saving so `autoNodeID` populates `NodeID` before the coordinator is created
- `internal/transport/rest/admin_cluster_handlers.go`: accept `"secret"` as a convenience alias for `"cluster_secret"`

**Bug D — `MUNINN_ADMIN_PASSWORD` not honoured**

- `internal/auth/bootstrap.go`: check `MUNINN_ADMIN_PASSWORD` env var; use it when set, fall back to `"password"`

## Release Checklist

- [ ] ~~`CHANGELOG.md`~~ — maintainers update this at release time, no action needed
- [ ] OpenAPI spec (`internal/transport/rest/openapi.yaml`) updated if API routes changed
- [ ] SDK types updated if request/response schemas changed (Python, Node, PHP)
- [ ] `docs/` updated if user-facing behavior changed
- [ ] `go build ./...` clean
- [ ] `go vet ./...` clean
- [ ] `go test ./...` passes

## Test plan

- [ ] Two-instance repro from #361 — Lobe should join within 1 s instead of timing out
- [ ] Cold-start with `role: primary` in `cluster.yaml` — Cortex should promote on startup
- [ ] `cluster enable` API with `"secret": "..."` — verify `cluster.yaml` contains `cluster_secret` and a non-empty `node_id`
- [ ] `MUNINN_ADMIN_PASSWORD=mysecret` on first run — verify login with `root`/`mysecret` works