### PR TITLE
fix(cluster): address Opus review findings from #364

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -586,14 +586,24 @@ func runStartupMigrations(ctx context.Context, store *storage.PebbleStore) {
 // handleClusterConn reads MBP frames from an incoming cluster TCP connection
 // and dispatches them to the coordinator. Exits when the connection is closed.
 //
-// The first frame from a Lobe is always a TypeJoinRequest whose payload
-// contains the Lobe's stable node ID. We route that frame to
-// HandleIncomingJoin, which registers the live conn under the real node ID so
-// that peer.Send works immediately. All subsequent frames use that node ID.
+// Protocol: the first frame MUST be TypeJoinRequest. On success, ownership of
+// conn transfers to the PeerConn inside ConnManager (HandleIncomingJoin →
+// RegisterConn). After that, this goroutine no longer closes conn on exit —
+// the coordinator's cleanup owns it. If the join fails or a protocol violation
+// occurs, this goroutine closes conn via the deferred call.
 func handleClusterConn(conn net.Conn, coord *replication.ClusterCoordinator) {
-	defer conn.Close()
-	// Use the ephemeral remote addr until the Lobe's node ID is known.
-	fromNodeID := conn.RemoteAddr().String()
+	// connOwned flips to false once HandleIncomingJoin succeeds and the
+	// PeerConn takes ownership, preventing a double-close on goroutine exit.
+	connOwned := true
+	defer func() {
+		if connOwned {
+			conn.Close()
+		}
+	}()
+
+	fromNodeID := conn.RemoteAddr().String() // ephemeral until join completes
+	joined := false
+
 	for {
 		frame, err := mbp.ReadFrame(conn)
 		if err != nil {
@@ -606,7 +616,15 @@ func handleClusterConn(conn net.Conn, coord *replication.ClusterCoordinator) {
 				return
 			}
 			fromNodeID = nodeID
+			joined = true
+			connOwned = false // PeerConn now owns conn
 			continue
+		}
+		// Reject any frame that arrives before the join handshake completes.
+		// A well-behaved Lobe always sends TypeJoinRequest first.
+		if !joined {
+			log.Printf("[cluster] unexpected frame type 0x%02x from %s before join; closing", frame.Type, fromNodeID)
+			return
 		}
 		if err := coord.HandleIncomingFrame(fromNodeID, frame.Type, frame.Payload); err != nil {
 			log.Printf("[cluster] frame error from %s: %v", fromNodeID, err)

--- a/internal/auth/bootstrap.go
+++ b/internal/auth/bootstrap.go
@@ -27,7 +27,8 @@ func Bootstrap(store *Store, secretPath string) (secret []byte, err error) {
 
 	// Create root admin if none exists
 	if !store.AdminExists() {
-		adminPassword := os.Getenv("MUNINN_ADMIN_PASSWORD")
+		envPassword := os.Getenv("MUNINN_ADMIN_PASSWORD")
+		adminPassword := envPassword
 		if adminPassword == "" {
 			adminPassword = "password"
 		}
@@ -35,7 +36,7 @@ func Bootstrap(store *Store, secretPath string) (secret []byte, err error) {
 			return nil, fmt.Errorf("create root admin: %w", err)
 		}
 
-		if os.Getenv("MUNINN_ADMIN_PASSWORD") != "" {
+		if envPassword != "" {
 			fmt.Println("┌──────────────────────────────────────────────────┐")
 			fmt.Println("│            MuninnDB — First Run Setup             │")
 			fmt.Println("│                                                    │")

--- a/internal/replication/conn_manager.go
+++ b/internal/replication/conn_manager.go
@@ -61,18 +61,20 @@ func (m *ConnManager) AddPeer(nodeID, addr string) {
 	m.peers[nodeID] = NewPeerConn(nodeID, addr)
 }
 
-// RegisterConn registers an already-established inbound connection as a peer.
-// Unlike AddPeer, the PeerConn wraps the live conn so Send works immediately
-// without a separate Connect call. If a peer for nodeID already exists it is
-// closed and replaced.
-func (m *ConnManager) RegisterConn(nodeID, addr string, conn net.Conn) {
+// RegisterConn registers an already-established inbound connection as a peer
+// and returns the new PeerConn. Unlike AddPeer, the PeerConn wraps the live
+// conn so Send works immediately without a separate Connect call. If a peer
+// for nodeID already exists it is closed and replaced.
+func (m *ConnManager) RegisterConn(nodeID, addr string, conn net.Conn) *PeerConn {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if existing, ok := m.peers[nodeID]; ok {
 		_ = existing.Close()
 	}
-	m.peers[nodeID] = NewPeerConnFromConn(nodeID, addr, conn)
+	p := NewPeerConnFromConn(nodeID, addr, conn)
+	m.peers[nodeID] = p
+	return p
 }
 
 // RemovePeer closes and removes the peer identified by nodeID.

--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -620,11 +620,9 @@ func (c *ClusterCoordinator) HandleIncomingJoin(conn net.Conn, payload []byte) (
 	}
 
 	// Register the live inbound conn so peer.Send succeeds immediately.
-	c.mgr.RegisterConn(req.NodeID, req.Addr, conn)
-	peer, ok := c.mgr.GetPeer(req.NodeID)
-	if !ok {
-		return "", fmt.Errorf("cluster: peer %s not found after RegisterConn", req.NodeID)
-	}
+	// RegisterConn returns the PeerConn it created under the write lock,
+	// eliminating the TOCTOU gap of a separate GetPeer call.
+	peer := c.mgr.RegisterConn(req.NodeID, req.Addr, conn)
 
 	resp := c.joinHandler.HandleJoinRequest(req, peer)
 	respPayload, err := msgpack.Marshal(resp)
@@ -692,45 +690,6 @@ func (c *ClusterCoordinator) HandleIncomingFrame(fromNodeID string, frameType ui
 			return fmt.Errorf("unmarshal CortexClaim: %w", err)
 		}
 		c.election.HandleCortexClaim(claim)
-		return nil
-
-	case mbp.TypeJoinRequest:
-		var req mbp.JoinRequest
-		if err := msgpack.Unmarshal(payload, &req); err != nil {
-			return fmt.Errorf("unmarshal JoinRequest: %w", err)
-		}
-		peer, ok := c.mgr.GetPeer(fromNodeID)
-		if !ok {
-			// Create a peer for the joining node
-			c.mgr.AddPeer(req.NodeID, req.Addr)
-			peer, ok = c.mgr.GetPeer(req.NodeID)
-			if !ok {
-				return errors.New("failed to create peer for joining node")
-			}
-		}
-		resp := c.joinHandler.HandleJoinRequest(req, peer)
-		respPayload, err := msgpack.Marshal(resp)
-		if err != nil {
-			return fmt.Errorf("marshal JoinResponse: %w", err)
-		}
-		_ = peer.Send(mbp.TypeJoinResponse, respPayload)
-
-		// Phase 2: stream snapshot immediately after JoinResponse on same conn.
-		if resp.NeedsSnapshot {
-			c.IncrementSnapshotCount()
-			go func() {
-				defer c.DecrementSnapshotCount()
-				ctx := context.Background()
-				if _, err := c.joinHandler.StreamSnapshot(ctx, peer); err != nil {
-					slog.Error("cluster: snapshot stream failed; closing connection so lobe can reconnect and retry",
-						"lobe", req.NodeID, "err", err)
-					// Close the connection so the Lobe's blocking reads return an
-					// error immediately. Without this, the Lobe waits forever for
-					// a snapshot that was never completed.
-					_ = peer.Close()
-				}
-			}()
-		}
 		return nil
 
 	case mbp.TypeLeave:


### PR DESCRIPTION
## Summary

Follow-up to #364. Addresses five items flagged in the post-merge Opus review.

## Changes

**Medium: Double-close on conn (`handleClusterConn`)**

After `HandleIncomingJoin` succeeds, ownership of `conn` transfers to the `PeerConn` inside `ConnManager`. The old `defer conn.Close()` would still fire when the goroutine exited, double-closing the same fd (benign on most OS implementations, but wrong and potentially dangerous if the fd is reassigned). Fixed with a `connOwned` flag that flips to `false` on successful join, making the deferred close a no-op.

**Medium: TOCTOU gap in `HandleIncomingJoin`**

`RegisterConn` released its write lock before `GetPeer` acquired a read lock, leaving a window where a concurrent `RemovePeer` or second `RegisterConn` for the same node could invalidate the result. Fixed by having `RegisterConn` return the `*PeerConn` it creates under the write lock — no separate lookup needed.

**Low: Dead `TypeJoinRequest` case in `HandleIncomingFrame`**

Unreachable from production (intercepted by `handleClusterConn`), and still contained the original broken `AddPeer` / disconnected-`PeerConn` pattern from the Bug A root cause. Removed entirely — the `default` case now handles it with an explicit error.

**Low: Defensive pre-join frame guard**

`handleClusterConn` now rejects any frame type other than `TypeJoinRequest` that arrives before the join handshake completes, closing the connection immediately. A well-behaved Lobe always joins first; a malformed or misbehaving client was previously able to send arbitrary frames with a garbage node ID.

**Nit: `bootstrap.go` double `os.Getenv` call**

`MUNINN_ADMIN_PASSWORD` was read twice. Captured once into `envPassword`.

## Release Checklist

- [ ] ~~`CHANGELOG.md`~~ — maintainers update this at release time, no action needed
- [ ] OpenAPI spec (`internal/transport/rest/openapi.yaml`) updated if API routes changed
- [ ] SDK types updated if request/response schemas changed (Python, Node, PHP)
- [ ] `docs/` updated if user-facing behavior changed
- [ ] `go build ./...` clean
- [ ] `go vet ./...` clean
- [ ] `go test ./...` passes