### PR TITLE
feat(plugin): add X-Client-Name: MuninnDB header to all LLM requests (#363)

### DIFF
--- a/internal/plugin/embed/cohere.go
+++ b/internal/plugin/embed/cohere.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
 )
 
 type CohereProvider struct {
@@ -52,7 +54,7 @@ func (p *CohereProvider) Init(ctx context.Context, cfg ProviderHTTPConfig) (int,
 	}
 	p.client = &http.Client{
 		Timeout:   10 * time.Second,
-		Transport: transport,
+		Transport: plugin.WrapTransport(transport),
 	}
 
 	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/internal/plugin/embed/google.go
+++ b/internal/plugin/embed/google.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
 )
 
 type GoogleProvider struct {
@@ -72,7 +74,7 @@ func (p *GoogleProvider) Init(ctx context.Context, cfg ProviderHTTPConfig) (int,
 	}
 	p.client = &http.Client{
 		Timeout:   10 * time.Second,
-		Transport: transport,
+		Transport: plugin.WrapTransport(transport),
 	}
 
 	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/internal/plugin/embed/jina.go
+++ b/internal/plugin/embed/jina.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"sort"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
 )
 
 type JinaProvider struct {
@@ -54,7 +56,7 @@ func (p *JinaProvider) Init(ctx context.Context, cfg ProviderHTTPConfig) (int, e
 	}
 	p.client = &http.Client{
 		Timeout:   10 * time.Second,
-		Transport: transport,
+		Transport: plugin.WrapTransport(transport),
 	}
 
 	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/internal/plugin/embed/mistral.go
+++ b/internal/plugin/embed/mistral.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"sort"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
 )
 
 type MistralProvider struct {
@@ -54,7 +56,7 @@ func (p *MistralProvider) Init(ctx context.Context, cfg ProviderHTTPConfig) (int
 	}
 	p.client = &http.Client{
 		Timeout:   10 * time.Second,
-		Transport: transport,
+		Transport: plugin.WrapTransport(transport),
 	}
 
 	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/internal/plugin/embed/ollama.go
+++ b/internal/plugin/embed/ollama.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
 )
 
 // OllamaProvider implements Provider for local Ollama instances.
@@ -77,7 +79,7 @@ func (p *OllamaProvider) Init(ctx context.Context, cfg ProviderHTTPConfig) (int,
 	// No client-level Timeout: all requests carry per-request context deadlines
 	// (set in probeEmbedEndpoint, embedBatchNew, etc.). A global Timeout would
 	// override context deadlines and silently kill large batch requests.
-	p.client = &http.Client{Transport: transport}
+	p.client = &http.Client{Transport: plugin.WrapTransport(transport)}
 
 	// Probe connectivity with root GET
 	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/internal/plugin/embed/openai.go
+++ b/internal/plugin/embed/openai.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"sort"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
 )
 
 type OpenAIProvider struct {
@@ -55,7 +57,7 @@ func (p *OpenAIProvider) Init(ctx context.Context, cfg ProviderHTTPConfig) (int,
 	}
 	p.client = &http.Client{
 		Timeout:   10 * time.Second,
-		Transport: transport,
+		Transport: plugin.WrapTransport(transport),
 	}
 
 	// Embed probe text to detect dimension

--- a/internal/plugin/embed/voyage.go
+++ b/internal/plugin/embed/voyage.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"sort"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
 )
 
 type VoyageProvider struct {
@@ -55,7 +57,7 @@ func (p *VoyageProvider) Init(ctx context.Context, cfg ProviderHTTPConfig) (int,
 	}
 	p.client = &http.Client{
 		Timeout:   10 * time.Second,
-		Transport: transport,
+		Transport: plugin.WrapTransport(transport),
 	}
 
 	// Embed probe text to detect dimension

--- a/internal/plugin/enrich/anthropic.go
+++ b/internal/plugin/enrich/anthropic.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
 )
 
 // AnthropicLLMProvider is an HTTP client for Anthropic's /v1/messages endpoint.
@@ -44,7 +46,8 @@ type anthropicMessagesResponse struct {
 func NewAnthropicLLMProvider() *AnthropicLLMProvider {
 	return &AnthropicLLMProvider{
 		client: &http.Client{
-			Timeout: 300 * time.Second,
+			Timeout:   300 * time.Second,
+			Transport: plugin.WrapTransport(nil),
 		},
 	}
 }

--- a/internal/plugin/enrich/google.go
+++ b/internal/plugin/enrich/google.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
 )
 
 // GoogleLLMProvider is an HTTP client for Google's Gemini generateContent endpoint.
@@ -56,7 +58,10 @@ type googleGenerateResponse struct {
 // NewGoogleLLMProvider creates a new Google Gemini provider.
 func NewGoogleLLMProvider() *GoogleLLMProvider {
 	return &GoogleLLMProvider{
-		client: &http.Client{Timeout: 300 * time.Second},
+		client: &http.Client{
+			Timeout:   300 * time.Second,
+			Transport: plugin.WrapTransport(nil),
+		},
 	}
 }
 

--- a/internal/plugin/enrich/ollama.go
+++ b/internal/plugin/enrich/ollama.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
 )
 
 // OllamaLLMProvider is an HTTP client for Ollama's /api/chat endpoint.
@@ -45,7 +47,8 @@ type ollamaChatResponse struct {
 func NewOllamaLLMProvider() *OllamaLLMProvider {
 	return &OllamaLLMProvider{
 		client: &http.Client{
-			Timeout: 300 * time.Second,
+			Timeout:   300 * time.Second,
+			Transport: plugin.WrapTransport(nil),
 		},
 	}
 }

--- a/internal/plugin/enrich/openai.go
+++ b/internal/plugin/enrich/openai.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
 )
 
 // OpenAILLMProvider is an HTTP client for OpenAI's /v1/chat/completions endpoint.
@@ -51,7 +53,8 @@ type openaiChatResponse struct {
 func NewOpenAILLMProvider() *OpenAILLMProvider {
 	return &OpenAILLMProvider{
 		client: &http.Client{
-			Timeout: 300 * time.Second,
+			Timeout:   300 * time.Second,
+			Transport: plugin.WrapTransport(nil),
 		},
 	}
 }

--- a/internal/plugin/transport.go
+++ b/internal/plugin/transport.go
@@ -1,0 +1,31 @@
+package plugin
+
+import "net/http"
+
+// muninnTransport is an http.RoundTripper that injects MuninnDB identification
+// headers on every outbound request to an LLM provider. This lets self-hosters
+// see "MuninnDB" in their LLM runner logs instead of the generic Go client name.
+type muninnTransport struct {
+	base http.RoundTripper
+}
+
+// RoundTrip clones the request, sets X-Client-Name and User-Agent, then
+// delegates to the base transport.
+func (t *muninnTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r := req.Clone(req.Context())
+	r.Header.Set("X-Client-Name", "MuninnDB")
+	if r.Header.Get("User-Agent") == "" {
+		r.Header.Set("User-Agent", "MuninnDB")
+	}
+	return t.base.RoundTrip(r)
+}
+
+// WrapTransport wraps base with MuninnDB identification headers. If base is
+// nil, http.DefaultTransport is used. All embed and enrich provider HTTP
+// clients should pass their transport through this wrapper.
+func WrapTransport(base http.RoundTripper) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &muninnTransport{base: base}
+}


### PR DESCRIPTION
## Summary

Closes #363. Self-hosters running local LLM backends (LM Studio, Ollama, etc.) want to identify MuninnDB traffic in their request logs instead of seeing the generic `Go-http-client/1.1`.

## Changes

Added `internal/plugin/transport.go` — a single `RoundTripper` wrapper (`plugin.WrapTransport`) that injects:
- `X-Client-Name: MuninnDB` on every outbound LLM request
- `User-Agent: MuninnDB` when no User-Agent is already set

Wired into all 11 providers via their `http.Client.Transport`:

**Embed (7):** OpenAI, Cohere, Google, Jina, Mistral, Voyage, Ollama
**Enrich (4):** OpenAI, Anthropic, Google, Ollama

The wrapper is a thin `http.RoundTripper` shim — zero impact on connection pooling, timeouts, or rate limiting. Providers with an existing custom `*http.Transport` wrap it directly; providers using `http.DefaultTransport` pass `nil` and the wrapper substitutes `http.DefaultTransport` as the base.

## What the reporter will see

**Before:**
```
User-Agent: Go-http-client/1.1
```

**After:**
```
X-Client-Name: MuninnDB
User-Agent: MuninnDB
```

## Release Checklist

- [ ] ~~`CHANGELOG.md`~~ — maintainers update this at release time, no action needed
- [ ] OpenAPI spec (`internal/transport/rest/openapi.yaml`) updated if API routes changed
- [ ] SDK types updated if request/response schemas changed (Python, Node, PHP)
- [ ] `docs/` updated if user-facing behavior changed
- [ ] `go build ./...` clean
- [ ] `go vet ./...` clean
- [ ] `go test ./...` passes