### PR TITLE
fix(mcp): enforce mk_ vault isolation in open-server mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,7 @@ jobs:
           node-version: '20'
 
       - name: Lint OpenAPI spec
-        run: npx --yes @redocly/cli@latest lint internal/transport/rest/openapi.yaml
+        run: npx --yes @redocly/cli@1.25.14 lint internal/transport/rest/openapi.yaml
 
       - name: Check route count parity (informational)
         run: |

--- a/internal/mcp/auth_mk_test.go
+++ b/internal/mcp/auth_mk_test.go
@@ -191,6 +191,62 @@ func TestAuthFromRequest_EmptyRequiredToken(t *testing.T) {
 	}
 }
 
+// TestAuthFromRequest_OpenServer_ValidMkKey verifies that a valid mk_ key is
+// fully enforced (vault pinned) even when no static token is configured.
+// This is the regression test for the open-server vault isolation bypass.
+func TestAuthFromRequest_OpenServer_ValidMkKey(t *testing.T) {
+	store := newMockKeyStore(auth.APIKey{
+		ID:    "vaultkey1",
+		Vault: "personal",
+		Mode:  "full",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer mk_vaultkey1")
+
+	a := authFromRequest(req, "", store) // no static token = open-server mode
+
+	if !a.Authorized {
+		t.Fatal("valid mk_ key must be authorized in open-server mode")
+	}
+	if !a.IsAPIKey {
+		t.Error("expected IsAPIKey=true")
+	}
+	if a.Vault != "personal" {
+		t.Errorf("expected vault=personal, got %q", a.Vault)
+	}
+}
+
+// TestAuthFromRequest_OpenServer_InvalidMkKey verifies that an invalid mk_ key
+// is rejected (not silently upgraded to open access) in open-server mode.
+func TestAuthFromRequest_OpenServer_InvalidMkKey(t *testing.T) {
+	store := newMockKeyStore() // empty — no valid keys
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer mk_badkey")
+
+	a := authFromRequest(req, "", store) // no static token = open-server mode
+
+	if a.Authorized {
+		t.Error("invalid mk_ key must not fall through to open access")
+	}
+}
+
+// TestAuthFromRequest_OpenServer_NoKey verifies that a request with no token
+// still gets open access when no static token is configured and no mk_ key is
+// presented (plain open-server mode, unchanged behaviour).
+func TestAuthFromRequest_OpenServer_NoKey(t *testing.T) {
+	store := newMockKeyStore()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+
+	a := authFromRequest(req, "", store)
+
+	if !a.Authorized {
+		t.Error("no key presented in open-server mode must still authorize")
+	}
+	if a.IsAPIKey {
+		t.Error("expected IsAPIKey=false for unauthenticated open-server request")
+	}
+}
+
 // --- resolveVault unit tests ---
 
 func TestResolveVault_PinnedVault_ArgAbsent(t *testing.T) {

--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -41,30 +41,20 @@ const maxTokenLen = 4096
 // authFromRequest extracts the Bearer token from the Authorization header and
 // authenticates it in priority order:
 //
-//  1. Static mdb_ token (constant-time compare) — backward compatible, no vault pinning.
-//  2. mk_ vault API key (via apiKeyStore.ValidateAPIKey) — vault-pinned, mode-enforced.
+//  1. mk_ vault API key (via apiKeyStore.ValidateAPIKey) — vault-pinned, mode-enforced.
+//     Checked first so vault isolation applies even when no static token is configured.
+//  2. Static mdb_ token (constant-time compare) — backward compatible, no vault pinning.
+//  3. Open-server mode — if no static token configured and no mk_ key present, allow.
 //
-// Returns AuthContext{Authorized: true} if the server has no token configured.
 // apiKeyStore may be nil to disable mk_ key auth (legacy mode).
 func authFromRequest(r *http.Request, requiredToken string, apiKeyStore apiKeyValidator) AuthContext {
-	if requiredToken == "" {
-		return AuthContext{Authorized: true}
-	}
 	header := r.Header.Get("Authorization")
 	token, found := strings.CutPrefix(header, "Bearer ")
-	if !found || token == "" {
-		return AuthContext{Authorized: false}
-	}
-	// Reject absurdly long tokens before any crypto work.
-	if len(token) > maxTokenLen {
-		return AuthContext{Authorized: false}
-	}
-	// 1. Static token — always tried first (constant-time to prevent timing attacks).
-	if subtle.ConstantTimeCompare([]byte(token), []byte(requiredToken)) == 1 {
-		return AuthContext{Token: token, Authorized: true}
-	}
-	// 2. Vault API key — only attempted for mk_ prefixed tokens when store is available.
-	if apiKeyStore != nil && strings.HasPrefix(token, "mk_") {
+
+	// 1. mk_ vault API key — always checked first, regardless of whether a static
+	// token is configured. Presenting a scoped key is an explicit opt-in to vault
+	// isolation; an invalid or revoked key must never fall through to open access.
+	if found && token != "" && strings.HasPrefix(token, "mk_") && apiKeyStore != nil {
 		if key, err := apiKeyStore.ValidateAPIKey(token); err == nil {
 			return AuthContext{
 				Token:      token,
@@ -74,6 +64,25 @@ func authFromRequest(r *http.Request, requiredToken string, apiKeyStore apiKeyVa
 				IsAPIKey:   true,
 			}
 		}
+		// Invalid mk_ key: fail-closed. Do not fall through to open-server mode.
+		return AuthContext{Authorized: false}
+	}
+
+	// 2. Open-server mode — no static token required and no mk_ key presented.
+	if requiredToken == "" {
+		return AuthContext{Authorized: true}
+	}
+
+	// 3. Static token validation.
+	if !found || token == "" {
+		return AuthContext{Authorized: false}
+	}
+	// Reject absurdly long tokens before any crypto work.
+	if len(token) > maxTokenLen {
+		return AuthContext{Authorized: false}
+	}
+	if subtle.ConstantTimeCompare([]byte(token), []byte(requiredToken)) == 1 {
+		return AuthContext{Token: token, Authorized: true}
 	}
 	return AuthContext{Authorized: false}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -383,9 +383,9 @@ func (s *MCPServer) handleSSEMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Re-validate auth on every POST — defense in depth against session ID leakage.
-	// If the server requires a token, every POST must present a valid Bearer token
-	// that matches the session's auth identity.
-	if s.token != "" {
+	// Run whenever any auth mechanism is active (static token or mk_ key store),
+	// not just when a static token is configured.
+	if s.token != "" || s.authKeys != nil {
 		a := authFromRequest(r, s.token, s.authKeys)
 		if !a.Authorized {
 			w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

Fixes a vault isolation bypass in the MCP server when no static token is configured.

**Root cause:** `authFromRequest` checked `requiredToken == ""` before checking for `mk_` vault-scoped keys. In open-server mode (no `~/.muninn/mcp.token`, no `MUNINN_MCP_TOKEN`, no `--mcp-token` flag), the function returned `AuthContext{Authorized: true, Vault: ""}` immediately — the `mk_` key in the client's config was never validated, vault pinning never applied, and any caller could access any vault by naming it in tool args.

**Two fixes:**

1. **`authFromRequest`** (`context.go`) — `mk_` key validation is now priority 1, before the open-server early return. An invalid/revoked `mk_` key fails-closed and does not fall through to open access.

2. **`handleSSEMessage`** (`server.go`) — auth re-validation guard widened from `s.token != ""` to `s.token != "" || s.authKeys != nil` so defense-in-depth applies when `mk_` keys are in use.

**Three regression tests added** covering: valid `mk_` key in open-server mode (vault pinned), invalid `mk_` key in open-server mode (rejected, not upgraded to open access), and no key in open-server mode (open access preserved for backward compat).

Fixes #368

## Test plan

- [ ] All existing MCP auth tests pass
- [ ] Three new regression tests pass
- [ ] CI green