### PR TITLE
ci: opt into Node.js 24 for all actions ahead of June 2026 forced migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main, develop]
 
+# Opt into Node.js 24 for all actions now, ahead of the forced migration
+# on June 2, 2026. Silences deprecation warnings for actions/checkout,
+# actions/setup-node, actions/cache, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # ── Go: build + test ────────────────────────────────────────────────────
   go:


### PR DESCRIPTION
## Summary

- Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the workflow level to silence deprecation warnings across all jobs (`actions/checkout`, `actions/setup-node`, `actions/setup-go`, `actions/cache`, `actions/upload-artifact`).

GitHub is forcing Node.js 24 on June 2, 2026 and removing Node 20 on September 16, 2026. This opts in now rather than waiting for the forced migration.

## Test plan

- [ ] CI passes with no Node.js 20 deprecation warnings