### PR TITLE
feat(mcp): return instructions in initialize response

### DIFF
--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -11,6 +11,15 @@ import (
 
 const mcpSessionHeader = "Mcp-Session-Id"
 
+// mcpInstructions is returned in the initialize response to tell MCP clients
+// how to use MuninnDB. Kept concise — call muninn_guide for the full guide.
+const mcpInstructions = `MuninnDB is a long-term memory server for AI agents. ` +
+	`Use muninn_where_left_off at session start. ` +
+	`Store with muninn_remember (include type, summary, entities). ` +
+	`Update with muninn_evolve, not forget+remember. ` +
+	`Keep memories atomic — one concept each. ` +
+	`Call muninn_guide for the full reference.`
+
 // apiKeyValidator is the subset of auth.Store used by MCP for vault key auth.
 // Using an interface keeps the mcp package testable without a live Pebble store.
 type apiKeyValidator interface {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -589,6 +589,7 @@ func (s *MCPServer) handleInitialize(w http.ResponseWriter, req *JSONRPCRequest)
 			"name":    "muninn",
 			"version": "1.0.0",
 		},
+		"instructions": mcpInstructions,
 	})
 }
 

--- a/internal/mcp/server_coverage_test.go
+++ b/internal/mcp/server_coverage_test.go
@@ -36,6 +36,10 @@ func TestHandleRPC_Initialize(t *testing.T) {
 	if _, ok := result["protocolVersion"]; !ok {
 		t.Error("response missing 'protocolVersion'")
 	}
+	instr, ok := result["instructions"].(string)
+	if !ok || instr == "" {
+		t.Error("response missing 'instructions'")
+	}
 }
 
 func TestHandleRPC_Ping(t *testing.T) {


### PR DESCRIPTION
## Problem

MCP clients that support `instructions` in the initialize response (Claude Code, Cursor, etc.) display them as server-level guidance. MuninnDB doesn't set this field — clients connect with zero context about how to use the server.

Evidence: Claude Code shows instructions from other MCP servers (e.g. Nexus CRM, context7) in its system context, but MuninnDB is absent from the list because it never sends the field.

Without `instructions`, clients either need manual CLAUDE.md configuration or must stumble onto `muninn_guide` by chance.

## Solution

Add a concise `instructions` string (~290 chars) to the initialize response. Covers the essentials: session start, enrichment fields, evolve over forget+remember, atomic memories, and a pointer to `muninn_guide` for the full reference.

Deliberately kept short — this string lands in every client's context window on every connect.

## Changes

- `context.go` — `mcpInstructions` constant
- `server.go` — include in initialize response
- `server_coverage_test.go` — assert field is present

## How to test

```bash
go test ./internal/mcp/ -run TestHandleRPC_Initialize -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)