### PR TITLE
panic: nil pointer dereference in TriggerWorker.sweepVault — MuninnDB crashes 30s after any SSE subscription

### DIFF
--- a/internal/engine/trigger/worker.go
+++ b/internal/engine/trigger/worker.go
@@ -330,7 +330,9 @@ func (w *TriggerWorker) sweepVault(ctx context.Context, vaultID uint32, ws [8]by
 		}
 		metaByID := make(map[storage.ULID]*storage.EngramMeta, len(metas))
 		for _, m := range metas {
-			metaByID[m.ID] = m
+    		if m != nil {
+        		metaByID[m.ID] = m
+    		}
 		}
 
 		vecScores := make(map[storage.ULID]float64, len(candidates))


### PR DESCRIPTION
## Summary

Opening an SSE subscription via `GET /api/subscribe` reliably crashes MuninnDB exactly 30 seconds later when the `TriggerWorker` periodic sweep fires. The daemon restarts via systemd, but the subscription is lost and no push events are ever delivered.

---

## Steps to Reproduce

```bash
# Terminal 1 — open a subscription
curl -N 'http://127.0.0.1:8475/api/subscribe?vault=default&context=infrastructure+changes&threshold=0.5&push_on_write=true'

# Terminal 2 — write an engram (optional; crash occurs with or without a write)
curl -X POST http://127.0.0.1:8475/api/engrams \
  -H 'Content-Type: application/json' \
  -d '{
    "concept": "test: trigger smoke test",
    "content": "Testing semantic trigger push notification",
    "tags": ["test"],
    "type": "fact",
    "entities": [{"name": "MuninnDB", "type": "service"}]
  }'

# Wait 30 seconds — MuninnDB crashes
```

---

## Expected Behavior

SSE subscriber receives push events. MuninnDB continues running.

## Actual Behavior

Exactly 30 seconds after subscribing, MuninnDB panics with a nil pointer dereference in the trigger sweep goroutine:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc183aa]

goroutine 32 [running]:
github.com/scrypster/muninndb/internal/engine/trigger.(*TriggerWorker).sweepVault(0xc000344fc0, {0x167bde0, 0xc0000c0910}, 0xd50ac99, {0xd, 0x50, 0xac, 0x99, 0x0, 0x0, ...}, ...)
	/home/runner/work/muninndb/muninndb/internal/engine/trigger/worker.go:333 +0xaaa
github.com/scrypster/muninndb/internal/engine/trigger.(*TriggerWorker).handleSweep(0xc000344fc0, {0x167bde0, 0xc0000c0910})
	/home/runner/work/muninndb/muninndb/internal/engine/trigger/worker.go:266 +0xb4
github.com/scrypster/muninndb/internal/engine/trigger.(*TriggerWorker).Run(0xc000344fc0, {0x167bde0, 0xc0000c0910})
	/home/runner/work/muninndb/muninndb/internal/engine/trigger/worker.go:89 +0x2e7
created by github.com/scrypster/muninndb/internal/engine/trigger.(*TriggerSystem).Start in goroutine 1
	/home/runner/work/muninndb/muninndb/internal/engine/trigger/system.go:425 +0x7a
```

The SSE connection receives only the initial subscription confirmation before the crash:

```
event: subscribed
data: {"id":"d21e65da-d902-4082-bd27-11836153b5ce"}
[connection drops 30 seconds later — no push events ever delivered]
```

---

## Log Sequence (from `muninn.log`)

```
time=2026-04-18T18:14:48.927-05:00 level=INFO msg=request method=POST path=/api/engrams duration_ms=3
time=2026-04-18T18:14:48.975-05:00 level=INFO msg="retroactive processor: complete" plugin=embed-ollama pass_processed=1 total_processed=625 errors=0
time=2026-04-18T18:14:53.942-05:00 level=INFO msg=request method=GET path=/api/subscribe duration_ms=7019
time=2026-04-18T18:15:10.369-05:00 level=INFO msg=request method=POST path=/api/engrams duration_ms=3
time=2026-04-18T18:15:10.406-05:00 level=INFO msg="retroactive processor: complete" plugin=embed-ollama pass_processed=1 total_processed=626 errors=0
time=2026-04-18T18:15:18.382-05:00 level=INFO msg=request method=GET path=/api/subscribe duration_ms=9017
panic: runtime error: invalid memory address or nil pointer dereference
```

Embed completed successfully on written engrams before the crash — the nil is not from a missing embedding.

---

## Notes

- The crash occurs even without writing any engrams — the sweep alone triggers it
- The Ollama embed provider is active and functioning (`nomic-embed-text`, dimension 768 confirmed)
- Iteration 8 added observability to `sweepVault` (HNSW/GetMetadata/GetEngrams error logging) but the nil pointer at line 333 appears to be a different, unguarded path
- Checked v0.4.11-alpha and v0.4.12-alpha release notes — no mention of a fix for this
- No workaround found: sweep interval is not configurable via env vars or CLI flags

---

## Impact

Semantic triggers (`/api/subscribe`) are non-functional in v0.4.10. Any attempt to use push-based memory delivery crashes the daemon within 30 seconds. This blocks the primary use case described in `semantic-triggers.md` for agent integrations.