### PR TITLE
fix(rest): delete phantom vaults that exist only in auth config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.4.10] - 2026-04-02
+
 ### Added
 - Dashboard activity panel overhaul: selectable timeframe presets (7d–180d, capped at 180 days), end-date picker, dynamic x-axis tick grouping based on chart width, and a raw data table toggle with copy-to-clipboard. Includes loading, error, and empty-state feedback.
 - `GET /api/activity-counts` endpoint returning per-day engram creation counts for a vault. Accepts `days` (1–180, default 7) and optional `until` (YYYY-MM-DD) query parameters. Malformed or out-of-range values return 400. Backed by an efficient ULID key-header scan with zero-filled contiguous day ranges.
@@ -33,6 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vault-scoped REST routes are setup to deprecate vault passed in the body in a later release.
 - REST read responses now include `memory_type: 0` for fact-classified memories instead of omitting the field.
 - Observe-mode API keys now return `403` on semantically mutating REST and gRPC routes while preserving access to read-like POST endpoints such as activation, traversal, explanation, and batch link reads.
+- ACT-R scoring: `bLevelCap` prevents base-level saturation in fresh vaults; two-pass per-query normalization ensures scores stay in [0, 1] range.
+- Archived engrams (dream engine) now filtered at all retrieval points — query, find-by-entity, trigger worker sweeps.
+- Dormant flag now gated on `!UseACTR`; in ACT-R mode the flag is derived from activation score rather than the Ebbinghaus relevance field.
+- Web UI: form class consistency, segmented control hover state, uniform input/button sizing, memory filter bar density, page title branding, logs page full-width layout, observability view hash routing.
+- SSE keepalive uses spec-compliant comment frame (`: keepalive`) to prevent proxy idle timeouts.
+- Entity type allowlist expanded from 8 to 14 types; unknown types pass through without coercion.
+- Clipboard API guarded by secure-context check with `execCommand` fallback for HTTP installs.
+- Pebble `ErrNotFound` distinguished from other errors in embed migration path.
 
 ---
 
@@ -186,7 +198,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Comparison Links
 
-[Unreleased]: https://github.com/scrypster/muninndb/compare/v0.2.6...HEAD
+[Unreleased]: https://github.com/scrypster/muninndb/compare/v0.4.10...HEAD
+[0.4.10]: https://github.com/scrypster/muninndb/compare/v0.4.9-alpha...v0.4.10
 [0.2.6]: https://github.com/scrypster/muninndb/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/scrypster/muninndb/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/scrypster/muninndb/compare/v0.2.3...v0.2.4

--- a/internal/consolidation/dream.go
+++ b/internal/consolidation/dream.go
@@ -60,7 +60,8 @@ func (w *Worker) DreamOnce(ctx context.Context, opts DreamOpts) (*DreamReport, e
 		MaxDedup:       w.MaxDedup,
 		MaxTransitive:  w.MaxTransitive,
 		DryRun:         opts.DryRun,
-		DedupThreshold: 0.85,
+		DedupThreshold:    0.85,
+		MinDedupVaultSize: w.MinDedupVaultSize,
 	}
 
 	for _, vault := range vaults {
@@ -102,7 +103,22 @@ func (w *Worker) DreamOnce(ctx context.Context, opts DreamOpts) (*DreamReport, e
 		}
 
 		// Phase 2: Semantic Deduplication (threshold 0.85 in dream mode)
-		if err := dw.runPhase2Dedup(ctx, store, wsPrefix, report, vault); err != nil {
+		//
+		// Guard: skip dedup when the vault is too small. Removing even a single
+		// cluster from a small vault can shift the per-query normalization anchor
+		// in the ACT-R scoring path, flipping top-1 results for unrelated queries.
+		// At MinDedupVaultSize (default 20) a 3-engram cluster removal represents
+		// at most a 15% reduction; below this threshold the landscape is too
+		// sensitive to dedup mutations to guarantee retrieval recall is preserved.
+		// See: https://github.com/scrypster/muninndb/issues/311
+		minSize := dw.MinDedupVaultSize
+		if minSize <= 0 {
+			minSize = 20
+		}
+		if summary != nil && summary.EngramCount < minSize {
+			slog.Info("dream: skipping phase 2 dedup — vault below minimum size",
+				"vault", vault, "engrams", summary.EngramCount, "min", minSize)
+		} else if err := dw.runPhase2Dedup(ctx, store, wsPrefix, report, vault); err != nil {
 			slog.Warn("dream: phase 2 (dedup) failed", "vault", vault, "error", err)
 			report.Errors = append(report.Errors, "phase2_dedup: "+err.Error())
 		}

--- a/internal/consolidation/dream.go
+++ b/internal/consolidation/dream.go
@@ -115,9 +115,19 @@ func (w *Worker) DreamOnce(ctx context.Context, opts DreamOpts) (*DreamReport, e
 		if minSize <= 0 {
 			minSize = 20
 		}
-		if summary != nil && summary.EngramCount < minSize {
+		// embedCount is the number of engrams that actually participate in
+		// dedup (Phase 2 operates only on embedding-bearing engrams). Using
+		// WithEmbed rather than EngramCount avoids counting embed-less engrams
+		// that would never affect the normalization anchor.
+		// When summary is nil (Phase 0 failed), vault size is unknown — skip
+		// dedup defensively rather than proceeding blind.
+		embedCount := 0
+		if summary != nil {
+			embedCount = summary.WithEmbed
+		}
+		if summary == nil || embedCount < minSize {
 			slog.Info("dream: skipping phase 2 dedup — vault below minimum size",
-				"vault", vault, "engrams", summary.EngramCount, "min", minSize)
+				"vault", vault, "engrams_with_embed", embedCount, "min", minSize)
 		} else if err := dw.runPhase2Dedup(ctx, store, wsPrefix, report, vault); err != nil {
 			slog.Warn("dream: phase 2 (dedup) failed", "vault", vault, "error", err)
 			report.Errors = append(report.Errors, "phase2_dedup: "+err.Error())

--- a/internal/consolidation/dream_guard_test.go
+++ b/internal/consolidation/dream_guard_test.go
@@ -1,0 +1,413 @@
+package consolidation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// TestDream_SmallVault_SkipsDedup verifies that Phase 2 dedup is skipped when
+// the vault has fewer engrams than MinDedupVaultSize. This guards against the
+// normalization anchor flip documented in issue #311: removing even a small
+// duplicate cluster from a <20 engram vault can shift the per-query
+// normalization landscape and flip top-1 recall results.
+func TestDream_SmallVault_SkipsDedup(t *testing.T) {
+	t.Parallel()
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "small-vault-guard"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	// Write a vault that's below MinDedupVaultSize (default 20) but contains
+	// a clear duplicate pair (cosine >= 0.95) that WOULD be merged if dedup ran.
+	// We use 9 engrams: below the 20-engram threshold.
+	dup := []float32{1.0, 0.0, 0.0, 0.0}
+	dupClose := []float32{0.97, 0.24310, 0.0, 0.0} // cosine ≈ 0.97
+
+	var dupAID, dupBID storage.ULID
+	for i := 0; i < 9; i++ {
+		embed := []float32{0, 0, float32(i + 1), 0}
+		if i == 0 {
+			embed = dup
+		} else if i == 1 {
+			embed = dupClose
+		}
+		eng := &storage.Engram{
+			Concept: "engram", Content: "content", Confidence: 0.8, Relevance: 0.7, Stability: 20,
+			Embedding: embed,
+		}
+		id := writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, eng)
+		if i == 0 {
+			dupAID = id
+		} else if i == 1 {
+			dupBID = id
+		}
+	}
+
+	mock := &mockEngineInterface{store: store}
+	w := NewWorker(mock)
+	// MinDedupVaultSize defaults to 20; vault has 9 engrams — guard must fire.
+
+	report, err := w.DreamOnce(ctx, DreamOpts{Force: true, Scope: vault})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Reports) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(report.Reports))
+	}
+
+	// Phase 2 must not have run — MergedEngrams must be zero.
+	if report.Reports[0].MergedEngrams != 0 {
+		t.Errorf("small vault: MergedEngrams = %d, want 0 (guard should have skipped dedup)",
+			report.Reports[0].MergedEngrams)
+	}
+
+	// Both engrams (including the duplicate pair) must still be active.
+	for _, id := range []storage.ULID{dupAID, dupBID} {
+		eng, err := store.GetEngram(ctx, wsPrefix, id)
+		if err != nil {
+			t.Fatalf("GetEngram %v: %v", id, err)
+		}
+		if eng.State == storage.StateArchived {
+			t.Errorf("engram %v was archived in a small vault — guard should have prevented this", id)
+		}
+	}
+}
+
+// TestDream_SufficientVault_RunsDedup verifies that Phase 2 dedup DOES run when
+// the vault meets MinDedupVaultSize, and correctly archives the lower-quality
+// member of a duplicate pair while preserving the representative.
+func TestDream_SufficientVault_RunsDedup(t *testing.T) {
+	t.Parallel()
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "sufficient-vault-dedup"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	// Build a vault at exactly MinDedupVaultSize (20 engrams) with one clear
+	// duplicate pair. All other engrams are orthogonal (unique class).
+	dup := []float32{1.0, 0.0, 0.0, 0.0}
+	dupClose := []float32{0.97, 0.24310, 0.0, 0.0} // cosine ≈ 0.97
+
+	representativeEng := &storage.Engram{
+		Concept: "dup-representative", Content: "France's capital is Paris.",
+		Confidence: 0.9, Relevance: 0.85, Stability: 30, Embedding: dup,
+	}
+	memberEng := &storage.Engram{
+		Concept: "dup-member", Content: "Paris is the capital of France.",
+		Confidence: 0.5, Relevance: 0.5, Stability: 20, Embedding: dupClose,
+	}
+
+	repID := writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, representativeEng)
+	memID := writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, memberEng)
+
+	// Pad to 20 engrams with orthogonal unique engrams.
+	for i := 0; i < 18; i++ {
+		embed := make([]float32, 20)
+		embed[i+2] = 1.0 // orthogonal unit vector in 20-dim space
+		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+			Concept: "unique", Content: "unique content", Confidence: 0.8, Relevance: 0.7,
+			Stability: 25, Embedding: embed,
+		})
+	}
+
+	mock := &mockEngineInterface{store: store}
+	w := NewWorker(mock)
+
+	report, err := w.DreamOnce(ctx, DreamOpts{Force: true, Scope: vault})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Reports) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(report.Reports))
+	}
+
+	// Dedup must have run and merged exactly 1 pair.
+	if report.Reports[0].MergedEngrams != 1 {
+		t.Errorf("MergedEngrams = %d, want 1", report.Reports[0].MergedEngrams)
+	}
+
+	// Representative (higher confidence*relevance = 0.9*0.85 = 0.765) must be active.
+	rep, err := store.GetEngram(ctx, wsPrefix, repID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.State == storage.StateArchived {
+		t.Error("representative engram was archived — wrong member elected")
+	}
+
+	// Member (lower confidence*relevance = 0.5*0.5 = 0.25) must be archived.
+	mem, err := store.GetEngram(ctx, wsPrefix, memID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mem.State != storage.StateArchived {
+		t.Errorf("member engram state = %v, want StateArchived", mem.State)
+	}
+}
+
+// TestDream_Dedup_PreservesUniqueEngrams verifies that engrams with low cross-similarity
+// (the "unique" class) are never archived by Phase 2, regardless of vault size.
+func TestDream_Dedup_PreservesUniqueEngrams(t *testing.T) {
+	t.Parallel()
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "unique-preservation"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	// Build a 20-engram vault using the synthetic vault helper.
+	// The helper writes 9 labeled engrams; pad to 20 with neutrals.
+	entries := buildSyntheticVault(t, ctx, store, db, wsPrefix)
+	for i := 0; i < 11; i++ {
+		embed := make([]float32, 20)
+		embed[i+4] = 1.0
+		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+			Concept: "pad", Content: "padding engram", Confidence: 0.6, Relevance: 0.5,
+			Stability: 20, Embedding: embed,
+		})
+	}
+
+	mock := &mockEngineInterface{store: store}
+	w := NewWorker(mock)
+
+	_, err := w.DreamOnce(ctx, DreamOpts{Force: true, Scope: vault})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// All unique-class engrams must still be active.
+	for _, class := range []syntheticClass{classUniqueA, classUniqueB, classLowAccessUnique} {
+		for _, id := range findByClass(entries, class) {
+			eng, err := store.GetEngram(ctx, wsPrefix, id)
+			if err != nil {
+				t.Fatalf("GetEngram %v: %v", id, err)
+			}
+			if eng.State == storage.StateArchived {
+				t.Errorf("unique engram (class %d, id %v) was archived — information loss", class, id)
+			}
+		}
+	}
+}
+
+// TestDream_NearDuplicates_NotAutoMerged verifies that engrams in the 0.85–0.95
+// cosine similarity band are NOT automatically archived at the default 0.95 threshold.
+// These require human or LLM review (Phase 2b, future PR).
+func TestDream_NearDuplicates_NotAutoMerged(t *testing.T) {
+	t.Parallel()
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "near-dup-review-band"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	entries := buildSyntheticVault(t, ctx, store, db, wsPrefix)
+	for i := 0; i < 11; i++ {
+		embed := make([]float32, 20)
+		embed[i+4] = 1.0
+		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+			Concept: "pad", Content: "padding", Confidence: 0.6, Relevance: 0.5,
+			Stability: 20, Embedding: embed,
+		})
+	}
+
+	mock := &mockEngineInterface{store: store}
+	w := NewWorker(mock) // default threshold 0.95
+
+	_, err := w.DreamOnce(ctx, DreamOpts{Force: true, Scope: vault})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Both near-duplicate engrams must remain active — cosine 0.90 < threshold 0.95.
+	for _, class := range []syntheticClass{classNearDuplicateA, classNearDuplicateB} {
+		for _, id := range findByClass(entries, class) {
+			eng, err := store.GetEngram(ctx, wsPrefix, id)
+			if err != nil {
+				t.Fatalf("GetEngram %v: %v", id, err)
+			}
+			if eng.State == storage.StateArchived {
+				t.Errorf("near-duplicate engram %v was auto-archived; cosine=0.90 is below the 0.95 threshold and requires review", id)
+			}
+		}
+	}
+}
+
+// TestDream_LegalVault_ZeroWrites verifies that legal-scoped vaults receive zero
+// mutations across all dream phases. The vault name "legal/contracts" must match
+// the isLegalVault() prefix convention.
+func TestDream_LegalVault_ZeroWrites(t *testing.T) {
+	t.Parallel()
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "legal/contracts"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	// Write a clear duplicate pair into the legal vault — if dedup ran, one would be archived.
+	dup  := []float32{1.0, 0.0, 0.0, 0.0}
+	dupClose := []float32{0.97, 0.24310, 0.0, 0.0}
+	id1 := writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "clause-a", Content: "Party A agrees to pay Party B.", Confidence: 0.9,
+		Relevance: 0.9, Stability: 40, Embedding: dup,
+	})
+	id2 := writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "clause-a-copy", Content: "Party A shall pay Party B.", Confidence: 0.85,
+		Relevance: 0.85, Stability: 35, Embedding: dupClose,
+	})
+
+	mock := &mockEngineInterface{store: store}
+	w := NewWorker(mock)
+
+	report, err := w.DreamOnce(ctx, DreamOpts{Force: true, Scope: vault})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Vault must appear in Skipped list.
+	if len(report.Skipped) != 1 || report.Skipped[0] != vault {
+		t.Errorf("expected %q in Skipped, got %v", vault, report.Skipped)
+	}
+	if len(report.Reports) != 1 || report.Reports[0].MergedEngrams != 0 {
+		t.Errorf("legal vault: MergedEngrams = %d, want 0", report.Reports[0].MergedEngrams)
+	}
+
+	// Both engrams must be untouched.
+	for _, id := range []storage.ULID{id1, id2} {
+		eng, err := store.GetEngram(ctx, wsPrefix, id)
+		if err != nil {
+			t.Fatalf("GetEngram %v: %v", id, err)
+		}
+		if eng.State != storage.StateActive {
+			t.Errorf("legal vault engram %v state = %v, want StateActive (legal vaults must not be touched)", id, eng.State)
+		}
+	}
+}
+
+// TestDream_LegalAdjacent_IsProcessed verifies that vaults whose names contain
+// "legal" as a substring (e.g. "paralegal-notes") are NOT classified as legal
+// vaults and ARE processed normally by the dream engine.
+// This guards against an overly broad legal-vault check that would silence
+// legitimate vaults via substring match.
+func TestDream_LegalAdjacent_IsProcessed(t *testing.T) {
+	t.Parallel()
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "paralegal-notes"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	// Write 20 engrams including a clear duplicate pair. If the vault is incorrectly
+	// treated as legal, dedup will be skipped and MergedEngrams will be 0.
+	dup     := []float32{1.0, 0.0, 0.0, 0.0}
+	dupClose := []float32{0.97, 0.24310, 0.0, 0.0}
+
+	writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "note-a", Content: "The hearing is on Monday.", Confidence: 0.9,
+		Relevance: 0.85, Stability: 30, Embedding: dup,
+	})
+	writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "note-a-dup", Content: "Monday is when the hearing takes place.", Confidence: 0.5,
+		Relevance: 0.5, Stability: 20, Embedding: dupClose,
+	})
+	for i := 0; i < 18; i++ {
+		embed := make([]float32, 20)
+		embed[i+2] = 1.0
+		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+			Concept: "unique", Content: "unique note", Confidence: 0.7, Relevance: 0.6,
+			Stability: 22, Embedding: embed,
+		})
+	}
+
+	mock := &mockEngineInterface{store: store}
+	w := NewWorker(mock)
+
+	report, err := w.DreamOnce(ctx, DreamOpts{Force: true, Scope: vault})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// "paralegal-notes" must NOT be in the Skipped list.
+	for _, skipped := range report.Skipped {
+		if skipped == vault {
+			t.Errorf("vault %q was incorrectly classified as legal and skipped", vault)
+		}
+	}
+
+	// Dedup must have run and merged the duplicate pair.
+	if len(report.Reports) != 1 || report.Reports[0].MergedEngrams == 0 {
+		t.Errorf("paralegal-notes vault: MergedEngrams = %d, want > 0 (vault should be processed normally)",
+			report.Reports[0].MergedEngrams)
+	}
+}
+
+// TestDream_MinDedupVaultSize_Configurable verifies that MinDedupVaultSize is
+// respected when set explicitly on the Worker. A vault of 15 engrams with a
+// MinDedupVaultSize of 10 must run dedup; the same vault with MinDedupVaultSize
+// of 20 must skip it.
+func TestDream_MinDedupVaultSize_Configurable(t *testing.T) {
+	t.Parallel()
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "configurable-guard"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	dup     := []float32{1.0, 0.0, 0.0, 0.0}
+	dupClose := []float32{0.97, 0.24310, 0.0, 0.0}
+
+	writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "d-a", Content: "content a", Confidence: 0.9, Relevance: 0.8,
+		Stability: 25, Embedding: dup,
+	})
+	writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "d-b", Content: "content b", Confidence: 0.5, Relevance: 0.5,
+		Stability: 20, Embedding: dupClose,
+	})
+	for i := 0; i < 13; i++ {
+		embed := make([]float32, 15)
+		embed[i+2] = 1.0
+		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+			Concept: "u", Content: "u", Confidence: 0.7, Relevance: 0.6,
+			Stability: 20, Embedding: embed,
+		})
+	}
+	// vault now has 15 engrams
+
+	mock := &mockEngineInterface{store: store}
+
+	// With MinDedupVaultSize=10: 15 >= 10, dedup runs.
+	w1 := NewWorker(mock)
+	w1.MinDedupVaultSize = 10
+	report1, err := w1.DreamOnce(ctx, DreamOpts{DryRun: true, Force: true, Scope: vault})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// In DryRun the dedup logic runs (clusters are found) but no mutations occur.
+	// DedupClusters > 0 confirms Phase 2 was reached and found the pair.
+	if report1.Reports[0].DedupClusters == 0 {
+		t.Errorf("MinDedupVaultSize=10, vault=15: expected DedupClusters > 0 (dedup should have run)")
+	}
+
+	// With MinDedupVaultSize=20: 15 < 20, dedup skipped.
+	w2 := NewWorker(mock)
+	w2.MinDedupVaultSize = 20
+	report2, err := w2.DreamOnce(ctx, DreamOpts{DryRun: true, Force: true, Scope: vault})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report2.Reports[0].DedupClusters != 0 || report2.Reports[0].MergedEngrams != 0 {
+		t.Errorf("MinDedupVaultSize=20, vault=15: DedupClusters=%d MergedEngrams=%d, want both 0 (guard should skip)",
+			report2.Reports[0].DedupClusters, report2.Reports[0].MergedEngrams)
+	}
+}

--- a/internal/consolidation/dream_guard_test.go
+++ b/internal/consolidation/dream_guard_test.go
@@ -253,7 +253,7 @@ func TestDream_LegalVault_ZeroWrites(t *testing.T) {
 	wsPrefix := store.ResolveVaultPrefix(vault)
 
 	// Write a clear duplicate pair into the legal vault — if dedup ran, one would be archived.
-	dup  := []float32{1.0, 0.0, 0.0, 0.0}
+	dup      := []float32{1.0, 0.0, 0.0, 0.0}
 	dupClose := []float32{0.97, 0.24310, 0.0, 0.0}
 	id1 := writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
 		Concept: "clause-a", Content: "Party A agrees to pay Party B.", Confidence: 0.9,
@@ -308,7 +308,7 @@ func TestDream_LegalAdjacent_IsProcessed(t *testing.T) {
 
 	// Write 20 engrams including a clear duplicate pair. If the vault is incorrectly
 	// treated as legal, dedup will be skipped and MergedEngrams will be 0.
-	dup     := []float32{1.0, 0.0, 0.0, 0.0}
+	dup      := []float32{1.0, 0.0, 0.0, 0.0}
 	dupClose := []float32{0.97, 0.24310, 0.0, 0.0}
 
 	writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
@@ -351,63 +351,160 @@ func TestDream_LegalAdjacent_IsProcessed(t *testing.T) {
 }
 
 // TestDream_MinDedupVaultSize_Configurable verifies that MinDedupVaultSize is
-// respected when set explicitly on the Worker. A vault of 15 engrams with a
-// MinDedupVaultSize of 10 must run dedup; the same vault with MinDedupVaultSize
-// of 20 must skip it.
+// respected when set explicitly on the Worker. Two independent stores/vaults of
+// 15 engrams are used: one processed with MinDedupVaultSize=10 (dedup runs) and
+// one with MinDedupVaultSize=20 (dedup skips). Using separate stores ensures the
+// two worker instances do not share state even if DryRun semantics change.
 func TestDream_MinDedupVaultSize_Configurable(t *testing.T) {
+	t.Parallel()
+
+	dup      := []float32{1.0, 0.0, 0.0, 0.0}
+	dupClose := []float32{0.97, 0.24310, 0.0, 0.0}
+
+	// sub-test: MinDedupVaultSize=10, vault=15 engrams -> dedup runs.
+	t.Run("threshold_below_vault", func(t *testing.T) {
+		t.Parallel()
+		store, db, cleanup := testStoreWithDB(t)
+		defer cleanup()
+		ctx := context.Background()
+		const vault = "configurable-guard-low"
+		wsPrefix := store.ResolveVaultPrefix(vault)
+		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+			Concept: "d-a", Content: "content a", Confidence: 0.9, Relevance: 0.8,
+			Stability: 25, Embedding: dup,
+		})
+		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+			Concept: "d-b", Content: "content b", Confidence: 0.5, Relevance: 0.5,
+			Stability: 20, Embedding: dupClose,
+		})
+		for i := 0; i < 13; i++ {
+			embed := make([]float32, 15)
+			embed[i+2] = 1.0
+			writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+				Concept: "u", Content: "u", Confidence: 0.7, Relevance: 0.6,
+				Stability: 20, Embedding: embed,
+			})
+		}
+		mock := &mockEngineInterface{store: store}
+		w := NewWorker(mock)
+		w.MinDedupVaultSize = 10
+		report, err := w.DreamOnce(ctx, DreamOpts{DryRun: true, Force: true, Scope: vault})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// DedupClusters > 0 confirms Phase 2 was reached and found the pair.
+		if report.Reports[0].DedupClusters == 0 {
+			t.Errorf("MinDedupVaultSize=10, vault=15: expected DedupClusters > 0 (dedup should have run)")
+		}
+	})
+
+	// sub-test: MinDedupVaultSize=20, vault=15 engrams -> dedup skips.
+	t.Run("threshold_above_vault", func(t *testing.T) {
+		t.Parallel()
+		store, db, cleanup := testStoreWithDB(t)
+		defer cleanup()
+		ctx := context.Background()
+		const vault = "configurable-guard-high"
+		wsPrefix := store.ResolveVaultPrefix(vault)
+		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+			Concept: "d-a", Content: "content a", Confidence: 0.9, Relevance: 0.8,
+			Stability: 25, Embedding: dup,
+		})
+		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+			Concept: "d-b", Content: "content b", Confidence: 0.5, Relevance: 0.5,
+			Stability: 20, Embedding: dupClose,
+		})
+		for i := 0; i < 13; i++ {
+			embed := make([]float32, 15)
+			embed[i+2] = 1.0
+			writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+				Concept: "u", Content: "u", Confidence: 0.7, Relevance: 0.6,
+				Stability: 20, Embedding: embed,
+			})
+		}
+		mock := &mockEngineInterface{store: store}
+		w := NewWorker(mock)
+		w.MinDedupVaultSize = 20
+		report, err := w.DreamOnce(ctx, DreamOpts{DryRun: true, Force: true, Scope: vault})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if report.Reports[0].DedupClusters != 0 || report.Reports[0].MergedEngrams != 0 {
+			t.Errorf("MinDedupVaultSize=20, vault=15: DedupClusters=%d MergedEngrams=%d, want both 0 (guard should skip)",
+				report.Reports[0].DedupClusters, report.Reports[0].MergedEngrams)
+		}
+	})
+}
+
+// TestDream_WithEmbedCount_GuardIgnoresNoEmbedEngrams verifies that the vault-size
+// guard uses WithEmbed (embedding-bearing engrams) rather than EngramCount (all
+// engrams). A vault with 25 total engrams but only 8 with embeddings must fire
+// the guard (8 < 20) even though EngramCount would pass it (25 >= 20).
+//
+// This covers the blocking issue from the PR #359 review: EngramCount includes
+// embed-less engrams that never participate in dedup and do not affect the
+// normalization anchor.
+func TestDream_WithEmbedCount_GuardIgnoresNoEmbedEngrams(t *testing.T) {
 	t.Parallel()
 	store, db, cleanup := testStoreWithDB(t)
 	defer cleanup()
 	ctx := context.Background()
 
-	const vault = "configurable-guard"
+	const vault = "embed-count-guard"
 	wsPrefix := store.ResolveVaultPrefix(vault)
 
-	dup     := []float32{1.0, 0.0, 0.0, 0.0}
+	dup      := []float32{1.0, 0.0, 0.0, 0.0}
 	dupClose := []float32{0.97, 0.24310, 0.0, 0.0}
 
+	// 8 engrams WITH embeddings (including a duplicate pair that WOULD merge if dedup ran).
 	writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
-		Concept: "d-a", Content: "content a", Confidence: 0.9, Relevance: 0.8,
+		Concept: "dup-a", Content: "content a", Confidence: 0.9, Relevance: 0.8,
 		Stability: 25, Embedding: dup,
 	})
 	writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
-		Concept: "d-b", Content: "content b", Confidence: 0.5, Relevance: 0.5,
+		Concept: "dup-b", Content: "content b", Confidence: 0.5, Relevance: 0.5,
 		Stability: 20, Embedding: dupClose,
 	})
-	for i := 0; i < 13; i++ {
-		embed := make([]float32, 15)
+	for i := 0; i < 6; i++ {
+		embed := make([]float32, 10)
 		embed[i+2] = 1.0
 		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
-			Concept: "u", Content: "u", Confidence: 0.7, Relevance: 0.6,
+			Concept: "unique", Content: "unique", Confidence: 0.7, Relevance: 0.6,
 			Stability: 20, Embedding: embed,
 		})
 	}
-	// vault now has 15 engrams
+	// WithEmbed = 8
+
+	// 17 engrams WITHOUT embeddings — inflates EngramCount to 25 but contributes
+	// nothing to WithEmbed and has no effect on the normalization anchor.
+	for i := 0; i < 17; i++ {
+		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+			Concept: "no-embed", Content: "no embedding engram",
+			Confidence: 0.5, Relevance: 0.5, Stability: 10,
+			// Embedding intentionally absent
+		})
+	}
+	// EngramCount = 25, WithEmbed = 8
 
 	mock := &mockEngineInterface{store: store}
+	w := NewWorker(mock) // MinDedupVaultSize = 20
 
-	// With MinDedupVaultSize=10: 15 >= 10, dedup runs.
-	w1 := NewWorker(mock)
-	w1.MinDedupVaultSize = 10
-	report1, err := w1.DreamOnce(ctx, DreamOpts{DryRun: true, Force: true, Scope: vault})
+	report, err := w.DreamOnce(ctx, DreamOpts{Force: true, Scope: vault})
 	if err != nil {
 		t.Fatal(err)
 	}
-	// In DryRun the dedup logic runs (clusters are found) but no mutations occur.
-	// DedupClusters > 0 confirms Phase 2 was reached and found the pair.
-	if report1.Reports[0].DedupClusters == 0 {
-		t.Errorf("MinDedupVaultSize=10, vault=15: expected DedupClusters > 0 (dedup should have run)")
+	if len(report.Reports) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(report.Reports))
 	}
 
-	// With MinDedupVaultSize=20: 15 < 20, dedup skipped.
-	w2 := NewWorker(mock)
-	w2.MinDedupVaultSize = 20
-	report2, err := w2.DreamOnce(ctx, DreamOpts{DryRun: true, Force: true, Scope: vault})
-	if err != nil {
-		t.Fatal(err)
+	// Guard must fire: WithEmbed=8 < MinDedupVaultSize=20.
+	// MergedEngrams and DedupClusters must both be 0.
+	if report.Reports[0].MergedEngrams != 0 {
+		t.Errorf("embed-count-guard: MergedEngrams = %d, want 0 (WithEmbed=8 should have triggered guard)",
+			report.Reports[0].MergedEngrams)
 	}
-	if report2.Reports[0].DedupClusters != 0 || report2.Reports[0].MergedEngrams != 0 {
-		t.Errorf("MinDedupVaultSize=20, vault=15: DedupClusters=%d MergedEngrams=%d, want both 0 (guard should skip)",
-			report2.Reports[0].DedupClusters, report2.Reports[0].MergedEngrams)
+	if report.Reports[0].DedupClusters != 0 {
+		t.Errorf("embed-count-guard: DedupClusters = %d, want 0 (guard should have prevented dedup)",
+			report.Reports[0].DedupClusters)
 	}
 }

--- a/internal/consolidation/synthetic_vault_test.go
+++ b/internal/consolidation/synthetic_vault_test.go
@@ -1,0 +1,246 @@
+package consolidation
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// syntheticClass identifies the labeled class of a synthetic engram.
+// Each class maps to a specific success criterion in issue #311.
+type syntheticClass int
+
+const (
+	classDuplicateA       syntheticClass = iota // cosine >= 0.95 — representative (higher confidence)
+	classDuplicateB                             // cosine >= 0.95 — should be archived after dedup
+	classNearDuplicateA                         // cosine 0.85–0.95 — review band, must NOT be auto-merged
+	classNearDuplicateB                         // cosine 0.85–0.95 — review band, must NOT be auto-merged
+	classUniqueA                                // orthogonal — must survive dedup unchanged
+	classUniqueB                                // orthogonal — must survive dedup unchanged
+	classTemporalOld                            // same entity, older fact — may be superseded
+	classTemporalNew                            // same entity, newer fact — should win
+	classLowAccessUnique                        // rarely accessed, old — must not be weakened
+)
+
+// syntheticVaultEntry is one labeled engram in a synthetic vault.
+type syntheticVaultEntry struct {
+	ID    storage.ULID
+	Class syntheticClass
+}
+
+// buildSyntheticVault writes a controlled set of labeled engrams into the store
+// and returns the entries with their assigned IDs.
+//
+// Embedding design (all unit vectors in R^4, cosine similarities are exact):
+//
+//	dupA  = [1, 0, 0, 0]
+//	dupB  = [0.97, 0.2431, 0, 0]               cosine(dupA, dupB) = 0.97   >= 0.95 ✓
+//	nearA = [0, 1, 0, 0]
+//	nearB = [0, 0.90, 0.4359, 0]               cosine(nearA, nearB) = 0.90  0.85–0.95 ✓
+//	uniA  = [0, 0, 1, 0]                        orthogonal to dupA, dupB, nearA, nearB
+//	uniB  = [0, 0, 0, 1]                        orthogonal to all above
+//	temporal/lowAccess: spread direction, low cross-similarity with all above
+//
+// See https://github.com/scrypster/muninndb/issues/311 for labeled-class definitions.
+func buildSyntheticVault(
+	t *testing.T,
+	ctx context.Context,
+	store *storage.PebbleStore,
+	db *pebble.DB,
+	wsPrefix [8]byte,
+) []syntheticVaultEntry {
+	t.Helper()
+
+	// Unit vectors — all cosine similarities verified analytically.
+	dupAEmbed   := []float32{1.000000, 0.000000, 0.000000, 0.000000}
+	dupBEmbed   := []float32{0.970000, 0.243105, 0.000000, 0.000000}  // cosine(dupA,dupB) = 0.9700
+	nearAEmbed  := []float32{0.000000, 1.000000, 0.000000, 0.000000}
+	nearBEmbed  := []float32{0.000000, 0.900000, 0.435890, 0.000000}  // cosine(nearA,nearB) = 0.9000
+	uniAEmbed   := []float32{0.000000, 0.000000, 1.000000, 0.000000}
+	uniBEmbed   := []float32{0.000000, 0.000000, 0.000000, 1.000000}
+	temporalEmbed := []float32{0.300000, 0.300000, 0.300000, 0.854400}
+	lowAccEmbed := []float32{0.200000, 0.200000, 0.200000, 0.938083}
+
+	// Verify cosine similarities at runtime to catch any float precision issues.
+	if got := cosineF32(dupAEmbed, dupBEmbed); got < 0.95 {
+		t.Fatalf("synthetic: dupA/dupB cosine = %.4f, want >= 0.95", got)
+	}
+	if got := cosineF32(nearAEmbed, nearBEmbed); got < 0.85 || got >= 0.95 {
+		t.Fatalf("synthetic: nearA/nearB cosine = %.4f, want 0.85–0.95", got)
+	}
+
+	now := time.Now()
+	old := now.Add(-60 * 24 * time.Hour) // 60 days ago
+
+	type spec struct {
+		class   syntheticClass
+		engram  *storage.Engram
+		embed   []float32
+	}
+
+	specs := []spec{
+		{
+			class: classDuplicateA,
+			engram: &storage.Engram{
+				Concept:     "duplicate-representative",
+				Content:     "The capital of France is Paris.",
+				Confidence:  0.9,
+				Relevance:   0.8,
+				Stability:   30,
+				AccessCount: 5,
+				LastAccess:  now,
+			},
+			embed: dupAEmbed,
+		},
+		{
+			class: classDuplicateB,
+			engram: &storage.Engram{
+				Concept:     "duplicate-member",
+				Content:     "Paris is the capital city of France.",
+				Confidence:  0.5, // lower — will be archived, not the representative
+				Relevance:   0.5,
+				Stability:   20,
+				AccessCount: 2,
+				LastAccess:  now,
+			},
+			embed: dupBEmbed,
+		},
+		{
+			class: classNearDuplicateA,
+			engram: &storage.Engram{
+				Concept:     "near-dup-a",
+				Content:     "Tony works as a software engineer in Dublin.",
+				Confidence:  0.8,
+				Relevance:   0.7,
+				Stability:   25,
+				AccessCount: 3,
+				LastAccess:  now,
+			},
+			embed: nearAEmbed,
+		},
+		{
+			class: classNearDuplicateB,
+			engram: &storage.Engram{
+				Concept:     "near-dup-b",
+				Content:     "Tony is a software developer based in Dublin.",
+				Confidence:  0.75,
+				Relevance:   0.65,
+				Stability:   22,
+				AccessCount: 2,
+				LastAccess:  now,
+			},
+			embed: nearBEmbed,
+		},
+		{
+			class: classUniqueA,
+			engram: &storage.Engram{
+				Concept:     "unique-a",
+				Content:     "The API rate limit is 1000 requests per minute.",
+				Confidence:  0.95,
+				Relevance:   0.9,
+				Stability:   40,
+				AccessCount: 8,
+				LastAccess:  now,
+			},
+			embed: uniAEmbed,
+		},
+		{
+			class: classUniqueB,
+			engram: &storage.Engram{
+				Concept:     "unique-b",
+				Content:     "Database backups run every Sunday at 02:00 UTC.",
+				Confidence:  0.9,
+				Relevance:   0.85,
+				Stability:   35,
+				AccessCount: 6,
+				LastAccess:  now,
+			},
+			embed: uniBEmbed,
+		},
+		{
+			class: classTemporalOld,
+			engram: &storage.Engram{
+				Concept:     "temporal-old",
+				Content:     "Alice lives in Berlin.",
+				Confidence:  0.7,
+				Relevance:   0.6,
+				Stability:   15,
+				AccessCount: 1,
+				CreatedAt:   old,
+				LastAccess:  old,
+			},
+			embed: temporalEmbed,
+		},
+		{
+			class: classTemporalNew,
+			engram: &storage.Engram{
+				Concept:     "temporal-new",
+				Content:     "Alice moved to Madrid.",
+				Confidence:  0.9,
+				Relevance:   0.85,
+				Stability:   30,
+				AccessCount: 4,
+				CreatedAt:   now,
+				LastAccess:  now,
+			},
+			embed: temporalEmbed, // same semantic direction — intentional
+		},
+		{
+			class: classLowAccessUnique,
+			engram: &storage.Engram{
+				Concept:     "low-access-unique",
+				Content:     "The signing key rotation period is 90 days.",
+				Confidence:  0.95,
+				Relevance:   0.9,
+				Stability:   50,
+				AccessCount: 1,  // rarely accessed
+				CreatedAt:   old,
+				LastAccess:  old, // last accessed 60 days ago
+			},
+			embed: lowAccEmbed,
+		},
+	}
+
+	var entries []syntheticVaultEntry
+	for _, s := range specs {
+		id := writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, s.engram)
+		entries = append(entries, syntheticVaultEntry{ID: id, Class: s.class})
+	}
+	return entries
+}
+
+// findByClass returns the IDs of all entries with the given class.
+func findByClass(entries []syntheticVaultEntry, class syntheticClass) []storage.ULID {
+	var ids []storage.ULID
+	for _, e := range entries {
+		if e.Class == class {
+			ids = append(ids, e.ID)
+		}
+	}
+	return ids
+}
+
+// cosineF32 computes cosine similarity between two float32 slices.
+// Duplicates cosineSimilarity() but avoids a package-level name collision in tests.
+func cosineF32(a, b []float32) float32 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, magA, magB float64
+	for i := range a {
+		fa, fb := float64(a[i]), float64(b[i])
+		dot += fa * fb
+		magA += fa * fa
+		magB += fb * fb
+	}
+	magA = math.Sqrt(magA)
+	magB = math.Sqrt(magB)
+	if magA == 0 || magB == 0 {
+		return 0
+	}
+	return float32(dot / (magA * magB))
+}

--- a/internal/consolidation/worker.go
+++ b/internal/consolidation/worker.go
@@ -23,22 +23,24 @@ type EngineInterface interface {
 // Worker is the main consolidation worker that periodically runs a 5-phase
 // consolidation pipeline to reduce redundancy and strengthen associations.
 type Worker struct {
-	Engine         EngineInterface
-	Schedule       time.Duration // frequency of consolidation runs (default 6h)
-	MaxDedup       int           // max pairs to merge per run (default 100)
-	MaxTransitive  int           // max inferred edges per run (default 1000)
-	DryRun         bool          // if true, no mutations occur
-	DedupThreshold float32       // cosine similarity threshold for dedup (0 = use default 0.95)
+	Engine            EngineInterface
+	Schedule          time.Duration // frequency of consolidation runs (default 6h)
+	MaxDedup          int           // max pairs to merge per run (default 100)
+	MaxTransitive     int           // max inferred edges per run (default 1000)
+	DryRun            bool          // if true, no mutations occur
+	DedupThreshold    float32       // cosine similarity threshold for dedup (0 = use default 0.95)
+	MinDedupVaultSize int           // minimum active engrams required to run Phase 2 dedup (default 20)
 }
 
 // NewWorker creates a new consolidation worker with sensible defaults.
 func NewWorker(engine EngineInterface) *Worker {
 	return &Worker{
-		Engine:        engine,
-		Schedule:      6 * time.Hour,
-		MaxDedup:      100,
-		MaxTransitive: 1000,
-		DryRun:        false,
+		Engine:            engine,
+		Schedule:          6 * time.Hour,
+		MaxDedup:          100,
+		MaxTransitive:     1000,
+		DryRun:            false,
+		MinDedupVaultSize: 20,
 	}
 }
 

--- a/internal/consolidation/worker.go
+++ b/internal/consolidation/worker.go
@@ -63,6 +63,9 @@ func (w *Worker) RunOnce(ctx context.Context, vault string) (*ConsolidationRepor
 	}
 
 	// Phase 2: Semantic Deduplication
+	// TODO(#311-followup): RunOnce (background scheduler path) calls runPhase2Dedup
+	// directly without a vault-size guard. Small vaults processed via the scheduler
+	// are still vulnerable to the normalization anchor flip. Track as a follow-up.
 	if err := w.runPhase2Dedup(ctx, store, wsPrefix, report, vault); err != nil {
 		slog.Warn("consolidation: phase 2 (dedup) failed", "vault", vault, "error", err)
 		report.Errors = append(report.Errors, "phase2_dedup: "+err.Error())

--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -729,7 +729,10 @@ func (s *Server) handleDeleteVault(w http.ResponseWriter, r *http.Request) {
 				if cfgs, cfgErr := s.authStore.ListVaultConfigs(); cfgErr == nil {
 					for _, cfg := range cfgs {
 						if cfg.Name == name {
-							_ = s.authStore.DeleteVaultConfig(name)
+							if delErr := s.authStore.DeleteVaultConfig(name); delErr != nil {
+								s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, delErr.Error())
+								return
+							}
 							w.WriteHeader(http.StatusNoContent)
 							return
 						}

--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -723,6 +723,19 @@ func (s *Server) handleDeleteVault(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.engine.DeleteVault(r.Context(), name); err != nil {
 		if errors.Is(err, engine.ErrVaultNotFound) {
+			// Vault may exist only in auth config (created via UI but no engrams written yet).
+			// Clean up the phantom vault so the UI can remove it cleanly.
+			if s.authStore != nil {
+				if cfgs, cfgErr := s.authStore.ListVaultConfigs(); cfgErr == nil {
+					for _, cfg := range cfgs {
+						if cfg.Name == name {
+							_ = s.authStore.DeleteVaultConfig(name)
+							w.WriteHeader(http.StatusNoContent)
+							return
+						}
+					}
+				}
+			}
 			s.sendError(r, w, http.StatusNotFound, ErrVaultNotFound, err.Error())
 			return
 		}

--- a/internal/transport/rest/admin_vault_handlers_test.go
+++ b/internal/transport/rest/admin_vault_handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/scrypster/muninndb/internal/auth"
 	"github.com/scrypster/muninndb/internal/engine"
 	"github.com/scrypster/muninndb/internal/engine/vaultjob"
 )
@@ -113,6 +114,43 @@ func TestHandleDeleteVault_NotFound(t *testing.T) {
 	w := serveVault(srv, "DELETE", "/api/admin/vaults/missing", nil, nil)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+
+func TestHandleDeleteVault_PhantomVault_AuthConfigOnly(t *testing.T) {
+	// Vault exists in auth config but was never written to Pebble (phantom vault).
+	// DELETE should clean up the auth config entry and return 204, not 404.
+	store := newTestAuthStore(t)
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "phantom"}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+	eng := &vaultErrEngine{deleteErr: fmt.Errorf("vault %q: %w", "phantom", engine.ErrVaultNotFound)}
+	srv := NewServer("localhost:0", eng, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+	w := serveVault(srv, "DELETE", "/api/admin/vaults/phantom", nil, nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for phantom vault, got %d: %s", w.Code, w.Body.String())
+	}
+	// Confirm the auth config entry was removed.
+	cfgs, err := store.ListVaultConfigs()
+	if err != nil {
+		t.Fatalf("ListVaultConfigs: %v", err)
+	}
+	for _, cfg := range cfgs {
+		if cfg.Name == "phantom" {
+			t.Fatal("phantom vault config was not removed from auth store")
+		}
+	}
+}
+
+func TestHandleDeleteVault_NotFound_NoAuthConfig(t *testing.T) {
+	// Vault exists in neither engine nor auth config — should return 404.
+	store := newTestAuthStore(t)
+	eng := &vaultErrEngine{deleteErr: fmt.Errorf("vault %q: %w", "ghost", engine.ErrVaultNotFound)}
+	srv := NewServer("localhost:0", eng, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+	w := serveVault(srv, "DELETE", "/api/admin/vaults/ghost", nil, nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for truly missing vault, got %d: %s", w.Code, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- `handleListVaults` merges two sources: Pebble vault names **and** auth store vault configs. This means a vault created via `PUT /api/admin/vaults/config` (or the UI settings page) shows in the dropdown even if no engrams have ever been written to it.
- `handleDeleteVault` calls `engine.DeleteVault` → `clearVault` → `store.ListVaultNames()`, which only checks Pebble. If the vault never had an engram written (or a `Hello` MCP call), it was never registered in Pebble via `WriteVaultName`, so `clearVault` returns `ErrVaultNotFound` → **404** — even though the vault is visible in the UI.
- This creates a stuck state: user can see the vault, cannot delete it.

## Fix

When `engine.DeleteVault` returns `ErrVaultNotFound`, check whether the vault exists in the auth store config. If found, delete the auth config entry and return **204**. If neither storage layer knows the vault, return **404** as before.

## Tests

Two new tests in `admin_vault_handlers_test.go`:
- `TestHandleDeleteVault_PhantomVault_AuthConfigOnly` — expects 204 and confirms auth config entry is removed
- `TestHandleDeleteVault_NotFound_NoAuthConfig` — expects 404 for a vault that exists in neither engine nor auth config

## How to reproduce (before fix)

1. Go to UI Settings → create a new vault via the vault config form (gives it a name, sets visibility, etc.)
2. Do **not** write any engrams to it
3. Try to delete it from the UI → "Error: 404" toast