### PR TITLE
fix(trigger): guard against nil metadata entries in sweepVault + handleCognitive

### DIFF
--- a/internal/engine/trigger/worker.go
+++ b/internal/engine/trigger/worker.go
@@ -167,6 +167,9 @@ func (w *TriggerWorker) handleCognitive(ctx context.Context, event CognitiveEven
 		return
 	}
 	meta := metas[0]
+	if meta == nil {
+		return
+	}
 
 	for _, sub := range subs {
 		sub.mu.Lock()
@@ -330,9 +333,10 @@ func (w *TriggerWorker) sweepVault(ctx context.Context, vaultID uint32, ws [8]by
 		}
 		metaByID := make(map[storage.ULID]*storage.EngramMeta, len(metas))
 		for _, m := range metas {
-    		if m != nil {
-        		metaByID[m.ID] = m
-    		}
+			if m == nil {
+				continue
+			}
+			metaByID[m.ID] = m
 		}
 
 		vecScores := make(map[storage.ULID]float64, len(candidates))

--- a/internal/engine/trigger/worker.go
+++ b/internal/engine/trigger/worker.go
@@ -330,7 +330,9 @@ func (w *TriggerWorker) sweepVault(ctx context.Context, vaultID uint32, ws [8]by
 		}
 		metaByID := make(map[storage.ULID]*storage.EngramMeta, len(metas))
 		for _, m := range metas {
-			metaByID[m.ID] = m
+    		if m != nil {
+        		metaByID[m.ID] = m
+    		}
 		}
 
 		vecScores := make(map[storage.ULID]float64, len(candidates))

--- a/internal/engine/trigger/worker_test.go
+++ b/internal/engine/trigger/worker_test.go
@@ -39,6 +39,26 @@ func (m *mockTriggerStore) GetMetadata(_ context.Context, _ [8]byte, ids []stora
 	return out, nil
 }
 
+// mockTriggerStoreWithNils mirrors the real storage.GetMetadata contract: it
+// returns a nil entry for every requested ID that is not in the metas map.
+// Used to reproduce the sweepVault nil-dereference (issue #393).
+type mockTriggerStoreWithNils struct {
+	mockTriggerStore
+}
+
+func (m *mockTriggerStoreWithNils) GetMetadata(_ context.Context, _ [8]byte, ids []storage.ULID) ([]*storage.EngramMeta, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*storage.EngramMeta, len(ids))
+	for i, id := range ids {
+		if meta, ok := m.metas[id]; ok {
+			out[i] = meta
+		}
+		// else out[i] stays nil — same contract as real storage
+	}
+	return out, nil
+}
+
 func (m *mockTriggerStore) GetEngrams(_ context.Context, _ [8]byte, ids []storage.ULID) ([]*storage.Engram, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -58,7 +78,6 @@ func (m *mockTriggerStore) GetEmbedding(_ context.Context, _ [8]byte, _ storage.
 func (m *mockTriggerStore) VaultPrefix(_ string) [8]byte {
 	return [8]byte{}
 }
-
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -322,4 +341,60 @@ func TestTriggerWorker_ChannelClose(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("TriggerWorker.Run did not exit after channel close")
 	}
+}
+
+// TestSweepVault_NilMetadataEntry is a regression test for issue #393.
+//
+// The real storage.GetMetadata contract returns nil for engrams that have been
+// deleted or whose keys are missing — callers must nil-check each entry.
+// HNSW can reference stale IDs (indexed before deletion), so sweepVault was
+// crashing with a nil pointer dereference when it tried to access m.ID without
+// checking for nil. This test uses mockTriggerStoreWithNils (same nil contract)
+// to reproduce the crash condition and verify the fix.
+func TestSweepVault_NilMetadataEntry(t *testing.T) {
+	registry := newRegistry()
+	deliver := &DeliveryRouter{registry: registry}
+
+	// staleID is in the HNSW index but has been deleted from storage — GetMetadata
+	// will return nil for it (real contract; reproduced by mockTriggerStoreWithNils).
+	staleID := storage.NewULID()
+	store := &mockTriggerStoreWithNils{
+		mockTriggerStore: mockTriggerStore{
+			metas:   make(map[storage.ULID]*storage.EngramMeta),
+			engrams: make(map[storage.ULID]*storage.Engram),
+		},
+	}
+	// Intentionally do NOT add staleID to store.metas — it simulates a deleted engram.
+
+	hnsw := &mockHNSW{results: []ScoredID{{ID: staleID, Score: 0.9}}}
+
+	sub := &Subscription{
+		ID:             "sweep-nil-sub",
+		VaultID:        5,
+		Context:        []string{"nil metadata test"},
+		Threshold:      0.0,
+		DeltaThreshold: 0.0,
+		embedding:      []float32{0.5, 0.5, 0.5, 0.5},
+		expiresAt:      time.Now().Add(1 * time.Hour),
+		Deliver: func(_ context.Context, _ *ActivationPush) error {
+			return nil
+		},
+		pushedScores: make(map[storage.ULID]float64),
+		rateLimiter:  newTokenBucket(10),
+	}
+	registry.Add(sub)
+
+	worker := &TriggerWorker{
+		registry:     registry,
+		embedCache:   newEmbedCache(),
+		store:        store,
+		hnsw:         hnsw,
+		deliver:      deliver,
+		writeEvents:  make(chan *EngramEvent, 1),
+		cogEvents:    make(chan CognitiveEvent, 1),
+		contraEvents: make(chan ContradictEvent, 1),
+	}
+
+	// Must not panic.
+	worker.handleSweep(context.Background())
 }


### PR DESCRIPTION
## Summary

Fixes the nil pointer dereference crash reported in #393.

`GetMetadata` returns nil slots for engrams that have been deleted after being indexed by HNSW (documented storage contract: *"Missing engrams are returned as nil; callers must check"*). `sweepVault` built its `metaByID` map without guarding against nil, causing a guaranteed panic ~30 s after any SSE subscription was opened.

**Fixes:**
- `sweepVault`: skip nil entries when building `metaByID` map (the crash site)
- `handleCognitive`: early return when `metas[0]` is nil (same class of bug, latent)

**Regression test:** `TestSweepVault_NilMetadataEntry` — reproduces the exact crash path using a mock that models the real storage nil contract (`mockTriggerStoreWithNils`). HNSW returns a candidate ID absent from metadata storage; test verifies no panic.

## Credit

Original fix by @zephyr325 in #393. This PR preserves their commit, fixes indentation to Go tab convention, adds the `handleCognitive` guard found during code review, and adds the regression test.

Closes #393.

## Test plan

- [x] `go test ./internal/engine/trigger/...` passes
- [x] `TestSweepVault_NilMetadataEntry` specifically exercises the crash path
- [x] All existing trigger tests unaffected