### PR TITLE
fix(enrich): prevent infinite retry loops that deadlock the circuit breaker

### DIFF
--- a/internal/plugin/admin.go
+++ b/internal/plugin/admin.go
@@ -175,9 +175,11 @@ func (h *AdminHandler) handleAdd(w http.ResponseWriter, ctx context.Context, req
 		flagBit = DigestEnrich
 	}
 
-	skipFlags := uint8(0)
+	var skipFlags uint8
 	if flagBit == DigestEmbed {
 		skipFlags = DigestEmbedFailed
+	} else {
+		skipFlags = DigestEnrichFailed
 	}
 	total, err := h.store.CountWithoutFlag(ctx, flagBit, skipFlags)
 	if err != nil {

--- a/internal/plugin/retroactive.go
+++ b/internal/plugin/retroactive.go
@@ -10,7 +10,15 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/engine/circuit"
 )
+
+// errLLMFailed is an unexported sentinel wrapping errors that originate from
+// the LLM call itself (bad output, nil result, parse error). It signals a
+// permanent failure for the engram — distinct from transient failures (circuit
+// open, context cancelled) and storage errors (persistence after a successful
+// LLM call). Only the enrich path uses this sentinel.
+var errLLMFailed = errors.New("enrich: llm call failed")
 
 // pollInterval is how often the processor checks for newly written, unembedded engrams.
 const pollInterval = 3 * time.Second
@@ -108,12 +116,13 @@ func (rp *RetroactiveProcessor) Mode() string {
 }
 
 // skipFlags returns the digest flags that should be excluded from scanning.
-// Embed processors skip DigestEmbedFailed engrams to avoid infinite retry loops.
+// Both embed and enrich processors skip permanently-failed engrams to prevent
+// infinite retry loops that trip the circuit breaker and block other memories.
 func (rp *RetroactiveProcessor) skipFlags() uint8 {
 	if rp.flagBit == DigestEmbed {
 		return DigestEmbedFailed
 	}
-	return 0
+	return DigestEnrichFailed
 }
 
 func (rp *RetroactiveProcessor) run(ctx context.Context) {
@@ -434,6 +443,17 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 			rp.statsMu.Lock()
 			rp.stats.Errors++
 			rp.statsMu.Unlock()
+			// LLM-originated failures (bad output, parse error) are permanent for
+			// this engram. Mark DigestEnrichFailed so the processor does not retry
+			// it indefinitely, which would trip the circuit breaker and block
+			// enrichment for all other memories. Storage/persistence errors are NOT
+			// marked — they are transient and should be retried when storage recovers.
+			if errors.Is(err, errLLMFailed) {
+				if flagErr := rp.store.SetDigestFlag(ctx, eng.ID, DigestEnrichFailed); flagErr != nil {
+					slog.Warn("retroactive processor: failed to set DigestEnrichFailed",
+						"plugin", rp.plugin.Name(), "engram_id", eng.ID.String(), "error", flagErr)
+				}
+			}
 			continue
 		}
 
@@ -535,10 +555,17 @@ func (rp *RetroactiveProcessor) processEnrichEngram(ctx context.Context, eng *En
 		// Call Enrich for missing fields.
 		result, err := enrich.Enrich(ctx, eng)
 		if err != nil {
-			return err
+			// Transient: circuit open, context cancelled/deadline exceeded.
+			// Do not wrap — the caller must not mark the engram as permanently failed.
+			if errors.Is(err, circuit.ErrOpen) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
+			// Permanent LLM failure (bad output, HTTP error, parse error).
+			// Wrap with errLLMFailed so the caller can mark DigestEnrichFailed.
+			return fmt.Errorf("%w: %v", errLLMFailed, err)
 		}
 		if result == nil {
-			return fmt.Errorf("enrich returned nil result")
+			return errLLMFailed
 		}
 
 		// Only overwrite fields the caller didn't provide.

--- a/internal/plugin/retroactive_test.go
+++ b/internal/plugin/retroactive_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/engine/circuit"
 )
 
 // ---------------------------------------------------------------------------
@@ -312,6 +313,14 @@ func TestRetroactiveProcessor_ProcessBatchEnrichError(t *testing.T) {
 	if stats.Errors != 1 {
 		t.Errorf("expected Errors=1, got %d", stats.Errors)
 	}
+	// LLM errors are permanent: DigestEnrichFailed must be set to prevent
+	// infinite retry loops that trip the circuit breaker (regression test for #390).
+	if store.setFlagCalls != 1 {
+		t.Errorf("expected DigestEnrichFailed flag to be set after LLM error, got %d calls", store.setFlagCalls)
+	}
+	if len(store.setFlags) == 0 || store.setFlags[0] != DigestEnrichFailed {
+		t.Errorf("expected flag %d (DigestEnrichFailed), got %v", DigestEnrichFailed, store.setFlags)
+	}
 }
 
 func TestRetroactiveProcessor_ProcessBatchEnrichNilResult(t *testing.T) {
@@ -321,6 +330,8 @@ func TestRetroactiveProcessor_ProcessBatchEnrichNilResult(t *testing.T) {
 	store := &mockPluginStore{countResult: 1, scanResult: iter}
 	enrichPlugin := &enrichMockForRetro{
 		mockPlugin: mockPlugin{name: "enrich-nil", tier: TierEnrich},
+		// enrichResult and enrichErr both zero: Enrich returns (nil, nil).
+		// processEnrichEngram treats nil result as a permanent LLM failure.
 	}
 	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
 
@@ -333,8 +344,12 @@ func TestRetroactiveProcessor_ProcessBatchEnrichNilResult(t *testing.T) {
 	if stats.Errors != 1 {
 		t.Errorf("expected Errors=1, got %d", stats.Errors)
 	}
-	if store.setFlagCalls != 0 {
-		t.Errorf("expected no digest flags to be set on nil result, got %d calls", store.setFlagCalls)
+	// Nil result is a permanent LLM failure: DigestEnrichFailed must be set.
+	if store.setFlagCalls != 1 {
+		t.Errorf("expected DigestEnrichFailed flag to be set on nil result, got %d calls", store.setFlagCalls)
+	}
+	if len(store.setFlags) == 0 || store.setFlags[0] != DigestEnrichFailed {
+		t.Errorf("expected flag %d, got %v", DigestEnrichFailed, store.setFlags)
 	}
 }
 
@@ -768,5 +783,89 @@ func TestRetroactiveProcessor_ProcessBatchNilEngram(t *testing.T) {
 	// Only the non-nil engram should be processed
 	if enrichPlugin.callCount != 1 {
 		t.Errorf("expected 1 enrich call (skipping nil), got %d", enrichPlugin.callCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Regression tests for issue #390: ghost queue + circuit breaker deadlock
+// ---------------------------------------------------------------------------
+
+// TestRetroactiveProcessor_CircuitOpen_NoEnrichFailedFlag verifies that when
+// the circuit breaker is open (transient systemic failure), the engram is NOT
+// marked with DigestEnrichFailed. The circuit will reset on its own; the engram
+// should be retried once the provider recovers.
+func TestRetroactiveProcessor_CircuitOpen_NoEnrichFailedFlag(t *testing.T) {
+	eng := &Engram{Concept: "valid", Content: "content"}
+	iter := &mockIterator{engrams: []*Engram{eng}}
+
+	store := &mockPluginStore{countResult: 1, scanResult: iter}
+	enrichPlugin := &enrichMockForRetro{
+		mockPlugin: mockPlugin{name: "enrich-circuit", tier: TierEnrich},
+		enrichErr:  circuit.ErrOpen, // circuit breaker is open — transient
+	}
+	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
+
+	ok := rp.processBatch(context.Background())
+	if !ok {
+		t.Error("processBatch should return true even when circuit is open")
+	}
+
+	stats := rp.Stats()
+	if stats.Errors != 1 {
+		t.Errorf("expected Errors=1, got %d", stats.Errors)
+	}
+	// Circuit-open is transient: DigestEnrichFailed must NOT be set.
+	if store.setFlagCalls != 0 {
+		t.Errorf("DigestEnrichFailed must not be set for circuit-open errors, got %d flag calls", store.setFlagCalls)
+	}
+}
+
+// TestRetroactiveProcessor_PersistenceError_NoEnrichFailedFlag verifies that
+// when enrichment succeeds (LLM returns valid output) but storage persistence
+// fails, the engram is NOT marked with DigestEnrichFailed. The storage error is
+// transient; the engram should be retried when storage recovers.
+func TestRetroactiveProcessor_PersistenceError_NoEnrichFailedFlag(t *testing.T) {
+	eng := &Engram{Concept: "valid", Content: "content"}
+	iter := &mockIterator{engrams: []*Engram{eng}}
+
+	store := &mockPluginStore{
+		countResult: 1,
+		scanResult:  iter,
+		linkErr:     errors.New("storage unavailable"), // persistence fails, not LLM
+	}
+	enrichPlugin := &enrichMockForRetro{
+		mockPlugin: mockPlugin{name: "enrich-persist-fail", tier: TierEnrich},
+		enrichResult: &EnrichmentResult{
+			Summary: "good summary",
+			Entities: []ExtractedEntity{
+				{Name: "postgres", Type: "database", Confidence: 0.9},
+			},
+		},
+	}
+	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
+
+	ok := rp.processBatch(context.Background())
+	if !ok {
+		t.Error("processBatch should return true even with persistence errors")
+	}
+
+	// Storage error: DigestEnrichFailed must NOT be set — the engram should be
+	// retried when storage recovers.
+	if store.setFlagCalls != 0 {
+		t.Errorf("DigestEnrichFailed must not be set for storage errors, got %d flag calls (flags: %v)", store.setFlagCalls, store.setFlags)
+	}
+}
+
+// TestRetroactiveProcessor_SkipFlags_Enrich verifies that the enrich processor
+// passes DigestEnrichFailed as skipFlags so engrams that failed LLM enrichment
+// are excluded from future scans. This is the core fix for the infinite-retry
+// loop that tripped the circuit breaker in issue #390.
+func TestRetroactiveProcessor_SkipFlags_Enrich(t *testing.T) {
+	rp := NewRetroactiveProcessor(&mockPluginStore{}, &enrichMockForRetro{
+		mockPlugin: mockPlugin{name: "enrich-skipflags", tier: TierEnrich},
+	}, DigestEnrich)
+
+	if got := rp.skipFlags(); got != DigestEnrichFailed {
+		t.Errorf("enrich processor skipFlags() = %d, want DigestEnrichFailed (%d)", got, DigestEnrichFailed)
 	}
 }

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -69,6 +69,16 @@ const (
 	// Engrams with this flag are skipped by the embed retroactive processor so
 	// they are not retried indefinitely.
 	DigestEmbedFailed uint8 = 0x80
+
+	// DigestEnrichFailed is set when LLM enrichment permanently fails for an engram
+	// (e.g. the LLM returns unparseable output). Engrams with this flag are skipped
+	// by the enrich retroactive processor to prevent infinite retry loops that trip
+	// the circuit breaker and block enrichment for all other memories.
+	//
+	// Shares the same bit as DigestEmbedFailed (the flag byte is full). Either
+	// failure type marks the engram as permanently failed for automated processing.
+	// An operator can clear it via the admin API retry endpoint.
+	DigestEnrichFailed uint8 = DigestEmbedFailed
 )
 
 // PluginStatus represents the runtime state of a registered plugin.

--- a/internal/storage/plugin_store.go
+++ b/internal/storage/plugin_store.go
@@ -37,6 +37,17 @@ func (ps *PebbleStore) CountWithoutFlag(ctx context.Context, flag, skipFlags uin
 		var id [16]byte
 		copy(id[:], k[9:25])
 
+		// Skip soft-deleted and archived engrams — mirrors ScanWithoutFlag so
+		// CountWithoutFlag and the scan agree on what is actually pending.
+		val := make([]byte, len(iter.Value()))
+		copy(val, iter.Value())
+		if erfEng, decErr := erf.Decode(val); decErr == nil {
+			eng := fromERFEngram(erfEng)
+			if eng.State == StateSoftDeleted || eng.State == StateArchived {
+				continue
+			}
+		}
+
 		raw, err := ps.getDigestFlagsRaw(id)
 		if (err != nil || raw&flag == 0) && (skipFlags == 0 || raw&skipFlags == 0) {
 			count++


### PR DESCRIPTION
## Summary

Fixes three related bugs reported in #390 that caused enrichment to stall permanently after soft-deleted engrams entered the retroactive processor queue.

**Bug 1 — Phantom count:** `CountWithoutFlag` included soft-deleted engrams (no state check) but `ScanWithoutFlag` skipped them, producing inflated "pending" totals that caused confusing logs and idle back-off churn.

**Bug 2 — Infinite retry:** `skipFlags()` returned `0` for enrich processors — unlike embed which skips `DigestEmbedFailed`. A single bad engram (LLM returning malformed JSON for deleted content) was retried 25,000+ times per session with no circuit breaker protection for the engram itself.

**Bug 3 — Circuit breaker deadlock:** After 5 consecutive failures the breaker opened. On reset, the same bad engram was always first in scan order, immediately re-tripping the breaker and blocking all enrichment for new memories. Naturally resolved by Bug 2's fix.

## Changes

- **`types.go`**: Add `DigestEnrichFailed = DigestEmbedFailed` (0x80). Flag byte is full; shares the bit with embed failures — documented.
- **`retroactive.go`**: `skipFlags()` returns `DigestEnrichFailed` for enrich. `processEnrichEngram` wraps LLM errors with `errLLMFailed` sentinel (excluding transient: circuit open, context cancelled/deadline). `processBatch` marks `DigestEnrichFailed` on `errLLMFailed`; storage/persistence errors left unmarked to allow retry.
- **`admin.go`**: `skipFlags` also uses `DigestEnrichFailed` for the enrich tier count.
- **`plugin_store.go`**: `CountWithoutFlag` now decodes ERF to skip soft-deleted/archived engrams — matches `ScanWithoutFlag`.

## Test plan

- [x] `TestRetroactiveProcessor_CircuitOpen_NoEnrichFailedFlag` — circuit open = no flag
- [x] `TestRetroactiveProcessor_PersistenceError_NoEnrichFailedFlag` — storage failure = no flag
- [x] `TestRetroactiveProcessor_SkipFlags_Enrich` — verifies skipFlags returns DigestEnrichFailed
- [x] Updated `TestRetroactiveProcessor_ProcessBatchEnrichError` — verifies DigestEnrichFailed IS set on LLM error
- [x] Updated `TestRetroactiveProcessor_ProcessBatchEnrichNilResult` — verifies DigestEnrichFailed IS set on nil result
- [x] `go test ./internal/plugin/... ./internal/storage/...` all pass

Closes #390.