### PR TITLE
fix(rest): return 400 instead of 500 for invalid engram IDs in /api/link

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2162,12 +2162,12 @@ func (e *Engine) Link(ctx context.Context, req *mbp.LinkRequest) (*mbp.LinkRespo
 
 	sourceID, err := storage.ParseULID(req.SourceID)
 	if err != nil {
-		return nil, fmt.Errorf("parse source id: %w", err)
+		return nil, fmt.Errorf("%w: source_id %q: %v", ErrInvalidID, req.SourceID, err)
 	}
 
 	targetID, err := storage.ParseULID(req.TargetID)
 	if err != nil {
-		return nil, fmt.Errorf("parse target id: %w", err)
+		return nil, fmt.Errorf("%w: target_id %q: %v", ErrInvalidID, req.TargetID, err)
 	}
 
 	// Guard: reject links to/from soft-deleted engrams. A single batched

--- a/internal/engine/engine_vault.go
+++ b/internal/engine/engine_vault.go
@@ -28,6 +28,11 @@ var ErrEngramArchived = errors.New("engram is archived")
 // that already exists. Use errors.Is to check for this error in callers.
 var ErrVaultNameCollision = errors.New("vault name already exists")
 
+// ErrInvalidID is returned when a caller passes an ID that cannot be parsed as
+// a valid ULID. Use errors.Is to check for this error in callers; REST handlers
+// map it to HTTP 400 Bad Request.
+var ErrInvalidID = errors.New("invalid engram id")
+
 // ClearVault removes all memories from a vault. The vault name remains registered.
 // It evicts all in-memory state (HNSW, FTS IDF cache, novelty fingerprints, coherence
 // counters, activity tracking) and adjusts the global engramCount.

--- a/internal/transport/rest/coverage_boost_test.go
+++ b/internal/transport/rest/coverage_boost_test.go
@@ -382,6 +382,29 @@ func (e *linkGenericErrorEngine) Link(_ context.Context, _ *mbp.LinkRequest) (*L
 	return nil, errors.New("generic link error")
 }
 
+type linkInvalidIDEngine struct{ MockEngine }
+
+func (e *linkInvalidIDEngine) Link(_ context.Context, _ *mbp.LinkRequest) (*LinkResponse, error) {
+	return nil, fmt.Errorf("%w: source_id %q: parse ulid: bad", engine.ErrInvalidID, "nonexistent-1")
+}
+
+func TestHandleLink_InvalidID_Returns400(t *testing.T) {
+	// Regression test for #395: invalid (non-ULID) source_id or target_id must
+	// return 400 Bad Request, not 500 Internal Server Error.
+	eng := &linkInvalidIDEngine{}
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+
+	body := `{"source_id":"nonexistent-1","target_id":"nonexistent-2","rel_type":1}`
+	req := httptest.NewRequest("POST", "/api/link", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // handleStats — error path (60% → better coverage)
 // ---------------------------------------------------------------------------

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -837,6 +837,10 @@ func (s *Server) handleLink(w http.ResponseWriter, r *http.Request) {
 	}
 	resp, err := s.engine.Link(r.Context(), mbpReq)
 	if err != nil {
+		if errors.Is(err, engine.ErrInvalidID) {
+			s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, err.Error())
+			return
+		}
 		if errors.Is(err, engine.ErrEngramNotFound) {
 			s.sendError(r, w, http.StatusNotFound, ErrEngramNotFound, err.Error())
 			return


### PR DESCRIPTION
## Summary

Fixes #395. Reported by @Jehu — `POST /api/link` returned HTTP 500 with a generic internal error when `source_id` or `target_id` could not be parsed as a valid ULID.

**Root cause:** `engine.Link()` wrapped ULID parse failures with `fmt.Errorf("parse source id: %w", err)`. This error did not satisfy `errors.Is(err, ErrEngramNotFound)`, so the REST handler fell through to the catch-all 500 path.

**Fix:**
- Add `ErrInvalidID` sentinel to the engine error package
- Wrap ULID parse errors in `engine.Link()` with `ErrInvalidID`
- Add `errors.Is(err, engine.ErrInvalidID)` branch in `handleLink` → HTTP 400

Valid-format ULIDs that reference non-existent engrams already returned 404 correctly via the existing nil-meta path.

## Test plan
- [ ] `go test ./internal/transport/rest/... -run TestHandleLink` — all pass including new `TestHandleLink_InvalidID_Returns400`
- [ ] `go test ./internal/engine/...` — no regressions