### PR TITLE
fix(engine): return 400 for invalid inline association target_id in /api/engrams

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -892,7 +892,7 @@ func (e *Engine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteRe
 	for i, a := range req.Associations {
 		targetID, err := storage.ParseULID(a.TargetID)
 		if err != nil {
-			return nil, fmt.Errorf("parse target id: %w", err)
+			return nil, fmt.Errorf("%w: association target_id %q: %v", ErrInvalidID, a.TargetID, err)
 		}
 		assocs[i] = storage.Association{
 			TargetID:      targetID,

--- a/internal/transport/rest/coverage_boost_test.go
+++ b/internal/transport/rest/coverage_boost_test.go
@@ -510,6 +510,29 @@ func (e *writeErrorEngine) Write(_ context.Context, _ *WriteRequest) (*WriteResp
 	return nil, errors.New("write failed")
 }
 
+type writeInvalidIDEngine struct{ MockEngine }
+
+func (e *writeInvalidIDEngine) Write(_ context.Context, _ *WriteRequest) (*WriteResponse, error) {
+	return nil, fmt.Errorf("%w: association target_id %q: parse ulid: bad", engine.ErrInvalidID, "not-a-ulid")
+}
+
+func TestCreateEngram_InvalidAssociationTargetID_Returns400(t *testing.T) {
+	// Regression test for #399: invalid target_id in inline associations must return
+	// 400 Bad Request, not 500 Internal Server Error.
+	eng := &writeInvalidIDEngine{}
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+
+	body := `{"concept":"test","content":"test","associations":[{"target_id":"not-a-ulid","rel_type":1}]}`
+	req := httptest.NewRequest("POST", "/api/engrams", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid association target_id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // handleEvolve — error paths (75%)
 // ---------------------------------------------------------------------------

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -645,6 +645,10 @@ func (s *Server) handleCreateEngram(w http.ResponseWriter, r *http.Request) {
 	req.Vault = vault
 	resp, err := s.engine.Write(r.Context(), &req)
 	if err != nil {
+		if errors.Is(err, engine.ErrInvalidID) {
+			s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, err.Error())
+			return
+		}
 		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
 		return
 	}


### PR DESCRIPTION
## Summary

Closes #399. Follow-up to #398 (same bug class).

`POST /api/engrams` with an invalid `target_id` in the inline `associations` array returned HTTP 500. The fix wraps the parse error with `ErrInvalidID` in `engine.Write()` and adds the handler branch.

**Audit of all other parse-error sites in engine.go:**
- `handleGetEngram`, `handleDeleteEngram`, `handleSetState`, `handleEvolve`, `handleRestore` — pre-validate IDs via `isValidEngramID()` at the REST boundary. Safe.
- `engine.Consolidate` — user-supplied IDs go through `Forget()` which surfaces failures as warnings, not top-level errors. Safe.
- `engine.Decide` — evidence IDs go through `Link()` (which already returns `ErrInvalidID`); failures become warnings. Safe.
- `engine.WriteBatch` — per-item association parse errors go into `errs[i]`, returned as `"status":"error"` per item at 201. Safe.

Only `engine.Write` inline associations had an unguarded 500 path.

## Test plan
- [ ] `TestCreateEngram_InvalidAssociationTargetID_Returns400` — asserts 400
- [ ] `TestCreateEngram_EngineError` — still asserts 500 for real storage errors
- [ ] `go build ./...` — clean