### PR TITLE
fix(replication): cluster join always fails with "peer not connected" (#377)

### DIFF
--- a/internal/auth/bootstrap.go
+++ b/internal/auth/bootstrap.go
@@ -7,9 +7,12 @@ import (
 )
 
 // Bootstrap ensures an admin user, session secret, and default vault config exist.
-// On first run, creates "root" with the default password "password", sets the
-// "default" vault to public (no API key required), and prints a reminder to
-// change the password. Subsequent runs are no-ops.
+// On first run, creates "root" with the default password "password" (or the value
+// of MUNINN_ADMIN_PASSWORD if set), sets the "default" vault to public (no API key
+// required), and prints a reminder to change the password.
+// On subsequent runs, if MUNINN_ADMIN_PASSWORD is set it is applied to the existing
+// "root" account so that containerised/automated deployments can rotate the password
+// via environment variable without a first-run wipe.
 // secretPath is where the session signing secret is persisted (e.g. dataDir/auth_secret).
 func Bootstrap(store *Store, secretPath string) (secret []byte, err error) {
 	// Load or generate session secret
@@ -25,9 +28,10 @@ func Bootstrap(store *Store, secretPath string) (secret []byte, err error) {
 		slog.Info("generated new session secret", "path", secretPath)
 	}
 
+	envPassword := os.Getenv("MUNINN_ADMIN_PASSWORD")
+
 	// Create root admin if none exists
 	if !store.AdminExists() {
-		envPassword := os.Getenv("MUNINN_ADMIN_PASSWORD")
 		adminPassword := envPassword
 		if adminPassword == "" {
 			adminPassword = "password"
@@ -57,6 +61,15 @@ func Bootstrap(store *Store, secretPath string) (secret []byte, err error) {
 			fmt.Println("│  Change your password and review vault settings    │")
 			fmt.Println("│  in the admin UI before exposing to a network.     │")
 			fmt.Println("└──────────────────────────────────────────────────┘")
+		}
+	} else if envPassword != "" {
+		// Existing instance: MUNINN_ADMIN_PASSWORD is set — update the root password
+		// so operators can rotate credentials via environment variable.
+		if changeErr := store.ChangeAdminPassword("root", envPassword); changeErr != nil {
+			slog.Warn("failed to apply MUNINN_ADMIN_PASSWORD to existing root account",
+				"err", changeErr)
+		} else {
+			slog.Info("root admin password updated from MUNINN_ADMIN_PASSWORD")
 		}
 	}
 

--- a/internal/auth/bootstrap_test.go
+++ b/internal/auth/bootstrap_test.go
@@ -79,6 +79,63 @@ func TestBootstrap_Idempotent(t *testing.T) {
 	}
 }
 
+// TestBootstrap_EnvPasswordAppliedOnExistingInstance is a regression test for
+// MUNINN_ADMIN_PASSWORD being silently ignored on existing (non-first-run) instances.
+// When the env var is set at startup and an admin already exists, Bootstrap must
+// update the root password so that containerised deployments can rotate credentials.
+func TestBootstrap_EnvPasswordAppliedOnExistingInstance(t *testing.T) {
+	store := newTestStore(t)
+	tmpDir := t.TempDir()
+	secretPath := filepath.Join(tmpDir, "auth_secret")
+
+	// First bootstrap — creates root with default "password".
+	if _, err := auth.Bootstrap(store, secretPath); err != nil {
+		t.Fatalf("Bootstrap first run: %v", err)
+	}
+
+	// Simulate operator setting MUNINN_ADMIN_PASSWORD before restarting an
+	// existing instance.
+	t.Setenv("MUNINN_ADMIN_PASSWORD", "my-secure-password")
+
+	// Second bootstrap — existing instance with env var set.
+	if _, err := auth.Bootstrap(store, secretPath); err != nil {
+		t.Fatalf("Bootstrap second run: %v", err)
+	}
+
+	// The new password from the env var must now be valid.
+	if err := store.ValidateAdmin("root", "my-secure-password"); err != nil {
+		t.Errorf("regression: MUNINN_ADMIN_PASSWORD not applied to existing instance: %v", err)
+	}
+	// The old default password must no longer work.
+	if err := store.ValidateAdmin("root", "password"); err == nil {
+		t.Error("regression: old default password still valid after MUNINN_ADMIN_PASSWORD was set")
+	}
+}
+
+// TestBootstrap_EnvPasswordNotSetIdempotent verifies that when MUNINN_ADMIN_PASSWORD
+// is NOT set, a second bootstrap does not overwrite a manually-changed password.
+func TestBootstrap_EnvPasswordNotSetIdempotent(t *testing.T) {
+	store := newTestStore(t)
+	tmpDir := t.TempDir()
+	secretPath := filepath.Join(tmpDir, "auth_secret")
+
+	if _, err := auth.Bootstrap(store, secretPath); err != nil {
+		t.Fatalf("Bootstrap first run: %v", err)
+	}
+	if err := store.ChangeAdminPassword("root", "manual-change"); err != nil {
+		t.Fatalf("ChangeAdminPassword: %v", err)
+	}
+
+	// Env var is not set — second bootstrap must not touch the password.
+	if _, err := auth.Bootstrap(store, secretPath); err != nil {
+		t.Fatalf("Bootstrap second run: %v", err)
+	}
+
+	if err := store.ValidateAdmin("root", "manual-change"); err != nil {
+		t.Errorf("manually-set password was overwritten when MUNINN_ADMIN_PASSWORD is unset: %v", err)
+	}
+}
+
 // TestBootstrap_SecretFileExists verifies that if a secret file already exists
 // Bootstrap reuses it without overwriting.
 func TestBootstrap_SecretFileExists(t *testing.T) {

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -1123,10 +1123,14 @@ func (e *ActivationEngine) phase6Score(
 			if _, dup := seen[t.id]; dup {
 				continue
 			}
-			// Map BFS propagated score to hebbianBoost so the ACT-R/CGDN spreading
-			// activation term fires. vectorScore is computed after engrams are loaded.
+			// Route the BFS propagated score to both rrfScore (for RRF mode) and
+			// hebbianBoost (for ACT-R/CGDN spreading activation).
+			// rrfScore must be non-zero: RRF final = rrfScore × (1 + hebbianBoost + ...)
+			// so zero rrfScore silences traversed candidates in RRF mode at any threshold > 0.
+			// vectorScore is computed after engrams are loaded.
 			all = append(all, scoringCandidate{
 				id:           t.id,
+				rrfScore:     t.propagated,
 				hebbianBoost: math.Min(t.propagated, 1.0),
 				hopPath:      t.hopPath,
 				relType:      t.relType,

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -1096,6 +1096,7 @@ func (e *ActivationEngine) phase6Score(
 		rrfScore        float64
 		hopPath         []storage.ULID
 		relType         uint16
+		isTraversed     bool // true for BFS-only candidates; vectorScore is computed post-load
 	}
 
 	// Deduplicate: fused candidates take priority; traversed candidates are
@@ -1122,11 +1123,14 @@ func (e *ActivationEngine) phase6Score(
 			if _, dup := seen[t.id]; dup {
 				continue
 			}
+			// Map BFS propagated score to hebbianBoost so the ACT-R/CGDN spreading
+			// activation term fires. vectorScore is computed after engrams are loaded.
 			all = append(all, scoringCandidate{
-				id:       t.id,
-				rrfScore: t.propagated,
-				hopPath:  t.hopPath,
-				relType:  t.relType,
+				id:           t.id,
+				hebbianBoost: math.Min(t.propagated, 1.0),
+				hopPath:      t.hopPath,
+				relType:      t.relType,
+				isTraversed:  true,
 			})
 		}
 	}
@@ -1172,6 +1176,22 @@ func (e *ActivationEngine) phase6Score(
 	for _, eng := range allEngrams {
 		if eng != nil {
 			engramByID[eng.ID] = eng
+		}
+	}
+
+	// Compute vectorScore for BFS-traversed candidates now that engrams are loaded.
+	// Fused candidates already have vectorScore from the Phase 2 HNSW search.
+	// Traversed candidates get cosine similarity against the query embedding so that
+	// ACT-R/CGDN contentMatch is non-zero and the BFS spreading activation can take effect.
+	// ftsScore is left at zero: BM25 requires corpus-level IDF statistics unavailable here.
+	if len(p1.embedding) > 0 {
+		for i := range all {
+			if !all[i].isTraversed {
+				continue
+			}
+			if eng := engramByID[all[i].id]; eng != nil && len(eng.Embedding) > 0 {
+				all[i].vectorScore = float64(cosineSimilarity32(p1.embedding, eng.Embedding))
+			}
 		}
 	}
 
@@ -1491,6 +1511,31 @@ func softplus(x float64) float64 {
 		return x // avoid overflow: softplus(x) ≈ x for large x
 	}
 	return math.Log1p(math.Exp(x))
+}
+
+// cosineSimilarity32 computes cosine similarity between two float32 vectors.
+// Returns 0 for empty or mismatched-length inputs.
+// Uses the same unrolled 4-wide dot product as the HNSW index for consistency.
+func cosineSimilarity32(a, b []float32) float32 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, na, nb float32
+	i := 0
+	for ; i+3 < len(a); i += 4 {
+		dot += a[i]*b[i] + a[i+1]*b[i+1] + a[i+2]*b[i+2] + a[i+3]*b[i+3]
+		na += a[i]*a[i] + a[i+1]*a[i+1] + a[i+2]*a[i+2] + a[i+3]*a[i+3]
+		nb += b[i]*b[i] + b[i+1]*b[i+1] + b[i+2]*b[i+2] + b[i+3]*b[i+3]
+	}
+	for ; i < len(a); i++ {
+		dot += a[i] * b[i]
+		na += a[i] * a[i]
+		nb += b[i] * b[i]
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (float32(math.Sqrt(float64(na))) * float32(math.Sqrt(float64(nb))))
 }
 
 // computeACTR computes the ACT-R scoring components for a candidate engram.

--- a/internal/engine/activation/helpers_test.go
+++ b/internal/engine/activation/helpers_test.go
@@ -1468,6 +1468,61 @@ func TestPhase6Score_TraversedCandidateACTR_NoEmbedding(t *testing.T) {
 	}
 }
 
+// TestPhase6Score_TraversedCandidateRRF_NonZeroScore is a regression test for a bug
+// introduced in the original #392 fix: setting hebbianBoost but leaving rrfScore=0 caused
+// traversed candidates to score 0 in RRF mode (final = rrfScore × (1+hebbianBoost) = 0),
+// silently filtering them out at any threshold > 0. The fix sets rrfScore = t.propagated
+// alongside hebbianBoost so RRF mode still scores traversed candidates.
+func TestPhase6Score_TraversedCandidateRRF_NonZeroScore(t *testing.T) {
+	store := newInternalStubStore()
+	e := newTestActivationEngine(store)
+	defer e.Close()
+
+	eng1 := &storage.Engram{
+		Concept: "seed", Content: "seed content",
+		Confidence: 1.0, Stability: 30.0, State: storage.StateActive,
+	}
+	eng2 := &storage.Engram{
+		Concept: "discovered", Content: "discovered via BFS",
+		Confidence: 1.0, Stability: 30.0, State: storage.StateActive,
+	}
+	store.addEngram(eng1)
+	store.addEngram(eng2)
+
+	fused := []fusedCandidate{{id: eng1.ID, rrfScore: 0.5, ftsScore: 1.0}}
+	traversed := []traversedCandidate{{
+		id:         eng2.ID,
+		propagated: 0.3,
+		hopPath:    []storage.ULID{eng1.ID, eng2.ID},
+		relType:    uint16(storage.RelSupports),
+	}}
+	p1 := &phase1Result{queryStr: "test"}
+
+	result, err := e.phase6Score(context.Background(), &ActivateRequest{
+		MaxResults: 10,
+		Threshold:  0.01, // above zero: filtered if rrfScore is 0
+		Weights:    &Weights{UseRRFFusion: true},
+	}, [8]byte{}, fused, traversed, p1)
+	if err != nil {
+		t.Fatalf("phase6Score: %v", err)
+	}
+
+	var traversedScore float64
+	found := false
+	for _, a := range result.Activations {
+		if a.Engram.ID == eng2.ID {
+			found = true
+			traversedScore = a.Score
+		}
+	}
+	if !found {
+		t.Error("traversed candidate should appear in RRF mode results at threshold=0.01")
+	}
+	if traversedScore <= 0 {
+		t.Errorf("traversed candidate score should be > 0 in RRF mode with propagated=0.3, got %f", traversedScore)
+	}
+}
+
 // TestCosineSimilarity32 verifies the cosineSimilarity32 helper used in the BFS fix.
 func TestCosineSimilarity32(t *testing.T) {
 	cases := []struct {

--- a/internal/engine/activation/helpers_test.go
+++ b/internal/engine/activation/helpers_test.go
@@ -1352,6 +1352,194 @@ func TestPhase6Score_WithTraversedCandidates(t *testing.T) {
 	}
 }
 
+// TestPhase6Score_TraversedCandidateACTR_NonZeroScore verifies the fix for issue #371:
+// BFS-traversed candidates must receive a non-zero ACT-R score when both the query and
+// engram have embeddings. Before the fix, vectorScore was 0 for all traversed candidates,
+// making contentMatch=0 and therefore ACT-R raw=0 regardless of the BFS propagated score.
+func TestPhase6Score_TraversedCandidateACTR_NonZeroScore(t *testing.T) {
+	store := newInternalStubStore()
+	e := newTestActivationEngine(store)
+	defer e.Close()
+
+	// Seed engram: directly matched by query (in fused set).
+	eng1 := &storage.Engram{
+		Concept: "microservices", Content: "Project Alpha uses microservices",
+		Confidence: 1.0, Stability: 30.0, State: storage.StateActive,
+		Embedding: []float32{1, 0, 0},
+	}
+	// Traversed engram: discovered via BFS from eng1, not directly matched but related.
+	// Embedding is non-orthogonal to the query so cosine similarity > 0.
+	eng2 := &storage.Engram{
+		Concept: "scaling issues", Content: "Microservices cause scaling issues in our infrastructure",
+		Confidence: 1.0, Stability: 30.0, State: storage.StateActive,
+		Embedding: []float32{0.6, 0.8, 0},
+	}
+	store.addEngram(eng1)
+	store.addEngram(eng2)
+
+	fused := []fusedCandidate{{id: eng1.ID, rrfScore: 0.5, vectorScore: 1.0, ftsScore: 1.5}}
+	traversed := []traversedCandidate{{
+		id:         eng2.ID,
+		propagated: 0.3,
+		hopPath:    []storage.ULID{eng1.ID, eng2.ID},
+		relType:    uint16(storage.RelSupports),
+	}}
+	// Query embedding points in the same general direction as eng2 (non-zero cosine similarity).
+	p1 := &phase1Result{
+		queryStr:  "risks for Project Alpha",
+		embedding: []float32{1, 0, 0},
+	}
+
+	result, err := e.phase6Score(context.Background(), &ActivateRequest{
+		MaxResults: 10,
+		Threshold:  0.01, // non-zero: proves score > 0, not just "engram passed nil-check"
+	}, [8]byte{}, fused, traversed, p1)
+	if err != nil {
+		t.Fatalf("phase6Score: %v", err)
+	}
+
+	var traversedScore float64
+	for _, a := range result.Activations {
+		if a.Engram.ID == eng2.ID {
+			traversedScore = a.Score
+		}
+	}
+	if traversedScore <= 0 {
+		t.Errorf("traversed candidate score should be > 0 with embeddings and propagated=0.3, got %f", traversedScore)
+	}
+	// Verify vectorScore was computed and wired into components.
+	for _, a := range result.Activations {
+		if a.Engram.ID == eng2.ID {
+			if a.Components.SemanticSimilarity <= 0 {
+				t.Errorf("traversed candidate SemanticSimilarity should be > 0, got %f", a.Components.SemanticSimilarity)
+			}
+			if a.Components.HebbianBoost <= 0 {
+				t.Errorf("traversed candidate HebbianBoost should be > 0 (from BFS propagated score), got %f", a.Components.HebbianBoost)
+			}
+		}
+	}
+}
+
+// TestPhase6Score_TraversedCandidateACTR_NoEmbedding verifies backward compatibility:
+// traversed candidates without embeddings (or without a query embedding) still pass
+// through at threshold=0.0, preserving existing behaviour for deployments without HNSW.
+func TestPhase6Score_TraversedCandidateACTR_NoEmbedding(t *testing.T) {
+	store := newInternalStubStore()
+	e := newTestActivationEngine(store)
+	defer e.Close()
+
+	eng1 := &storage.Engram{
+		Concept: "seed", Content: "seed content",
+		Confidence: 1.0, Stability: 30.0, State: storage.StateActive,
+	}
+	eng2 := &storage.Engram{
+		Concept: "discovered", Content: "discovered via BFS — no embedding",
+		Confidence: 1.0, Stability: 30.0, State: storage.StateActive,
+		// no Embedding field — vectorScore will remain 0
+	}
+	store.addEngram(eng1)
+	store.addEngram(eng2)
+
+	fused := []fusedCandidate{{id: eng1.ID, rrfScore: 0.5, ftsScore: 1.0}}
+	traversed := []traversedCandidate{{
+		id:         eng2.ID,
+		propagated: 0.3,
+		hopPath:    []storage.ULID{eng1.ID, eng2.ID},
+		relType:    uint16(storage.RelSupports),
+	}}
+	p1 := &phase1Result{queryStr: "test"} // no query embedding
+
+	result, err := e.phase6Score(context.Background(), &ActivateRequest{
+		MaxResults: 10,
+		Threshold:  0.0,
+	}, [8]byte{}, fused, traversed, p1)
+	if err != nil {
+		t.Fatalf("phase6Score: %v", err)
+	}
+
+	found := false
+	for _, a := range result.Activations {
+		if a.Engram.ID == eng2.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("traversed candidate should appear at threshold=0.0 even without embeddings")
+	}
+}
+
+// TestCosineSimilarity32 verifies the cosineSimilarity32 helper used in the BFS fix.
+func TestCosineSimilarity32(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b []float32
+		want float32
+		tol  float32
+	}{
+		{
+			name: "identical unit vectors",
+			a:    []float32{1, 0, 0},
+			b:    []float32{1, 0, 0},
+			want: 1.0,
+			tol:  1e-6,
+		},
+		{
+			name: "orthogonal vectors",
+			a:    []float32{1, 0, 0},
+			b:    []float32{0, 1, 0},
+			want: 0.0,
+			tol:  1e-6,
+		},
+		{
+			name: "opposite vectors",
+			a:    []float32{1, 0, 0},
+			b:    []float32{-1, 0, 0},
+			want: -1.0,
+			tol:  1e-6,
+		},
+		{
+			name: "45-degree angle",
+			a:    []float32{1, 0},
+			b:    []float32{1, 1},
+			want: float32(1.0 / 1.4142135), // 1/√2 ≈ 0.7071
+			tol:  1e-5,
+		},
+		{
+			name: "empty vectors",
+			a:    []float32{},
+			b:    []float32{},
+			want: 0.0,
+			tol:  0,
+		},
+		{
+			name: "mismatched lengths",
+			a:    []float32{1, 2},
+			b:    []float32{1},
+			want: 0.0,
+			tol:  0,
+		},
+		{
+			name: "zero vector",
+			a:    []float32{0, 0, 0},
+			b:    []float32{1, 0, 0},
+			want: 0.0,
+			tol:  0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cosineSimilarity32(tc.a, tc.b)
+			diff := got - tc.want
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff > tc.tol {
+				t.Errorf("cosineSimilarity32(%v, %v) = %f, want %f (tol %f)", tc.a, tc.b, got, tc.want, tc.tol)
+			}
+		})
+	}
+}
+
 func TestPhase6Score_IncludeWhy(t *testing.T) {
 	store := newInternalStubStore()
 	e := newTestActivationEngine(store)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2162,12 +2162,12 @@ func (e *Engine) Link(ctx context.Context, req *mbp.LinkRequest) (*mbp.LinkRespo
 
 	sourceID, err := storage.ParseULID(req.SourceID)
 	if err != nil {
-		return nil, fmt.Errorf("parse source id: %w", err)
+		return nil, fmt.Errorf("%w: source_id %q: %v", ErrInvalidID, req.SourceID, err)
 	}
 
 	targetID, err := storage.ParseULID(req.TargetID)
 	if err != nil {
-		return nil, fmt.Errorf("parse target id: %w", err)
+		return nil, fmt.Errorf("%w: target_id %q: %v", ErrInvalidID, req.TargetID, err)
 	}
 
 	// Guard: reject links to/from soft-deleted engrams. A single batched

--- a/internal/engine/engine_vault.go
+++ b/internal/engine/engine_vault.go
@@ -28,6 +28,11 @@ var ErrEngramArchived = errors.New("engram is archived")
 // that already exists. Use errors.Is to check for this error in callers.
 var ErrVaultNameCollision = errors.New("vault name already exists")
 
+// ErrInvalidID is returned when a caller passes an ID that cannot be parsed as
+// a valid ULID. Use errors.Is to check for this error in callers; REST handlers
+// map it to HTTP 400 Bad Request.
+var ErrInvalidID = errors.New("invalid engram id")
+
 // ClearVault removes all memories from a vault. The vault name remains registered.
 // It evicts all in-memory state (HNSW, FTS IDF cache, novelty fingerprints, coherence
 // counters, activity tracking) and adjusts the global engramCount.

--- a/internal/engine/trigger/worker.go
+++ b/internal/engine/trigger/worker.go
@@ -167,6 +167,9 @@ func (w *TriggerWorker) handleCognitive(ctx context.Context, event CognitiveEven
 		return
 	}
 	meta := metas[0]
+	if meta == nil {
+		return
+	}
 
 	for _, sub := range subs {
 		sub.mu.Lock()
@@ -330,9 +333,10 @@ func (w *TriggerWorker) sweepVault(ctx context.Context, vaultID uint32, ws [8]by
 		}
 		metaByID := make(map[storage.ULID]*storage.EngramMeta, len(metas))
 		for _, m := range metas {
-    		if m != nil {
-        		metaByID[m.ID] = m
-    		}
+			if m == nil {
+				continue
+			}
+			metaByID[m.ID] = m
 		}
 
 		vecScores := make(map[storage.ULID]float64, len(candidates))

--- a/internal/engine/trigger/worker.go
+++ b/internal/engine/trigger/worker.go
@@ -330,7 +330,9 @@ func (w *TriggerWorker) sweepVault(ctx context.Context, vaultID uint32, ws [8]by
 		}
 		metaByID := make(map[storage.ULID]*storage.EngramMeta, len(metas))
 		for _, m := range metas {
-			metaByID[m.ID] = m
+    		if m != nil {
+        		metaByID[m.ID] = m
+    		}
 		}
 
 		vecScores := make(map[storage.ULID]float64, len(candidates))

--- a/internal/engine/trigger/worker_test.go
+++ b/internal/engine/trigger/worker_test.go
@@ -39,6 +39,26 @@ func (m *mockTriggerStore) GetMetadata(_ context.Context, _ [8]byte, ids []stora
 	return out, nil
 }
 
+// mockTriggerStoreWithNils mirrors the real storage.GetMetadata contract: it
+// returns a nil entry for every requested ID that is not in the metas map.
+// Used to reproduce the sweepVault nil-dereference (issue #393).
+type mockTriggerStoreWithNils struct {
+	mockTriggerStore
+}
+
+func (m *mockTriggerStoreWithNils) GetMetadata(_ context.Context, _ [8]byte, ids []storage.ULID) ([]*storage.EngramMeta, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*storage.EngramMeta, len(ids))
+	for i, id := range ids {
+		if meta, ok := m.metas[id]; ok {
+			out[i] = meta
+		}
+		// else out[i] stays nil — same contract as real storage
+	}
+	return out, nil
+}
+
 func (m *mockTriggerStore) GetEngrams(_ context.Context, _ [8]byte, ids []storage.ULID) ([]*storage.Engram, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -58,7 +78,6 @@ func (m *mockTriggerStore) GetEmbedding(_ context.Context, _ [8]byte, _ storage.
 func (m *mockTriggerStore) VaultPrefix(_ string) [8]byte {
 	return [8]byte{}
 }
-
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -322,4 +341,60 @@ func TestTriggerWorker_ChannelClose(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("TriggerWorker.Run did not exit after channel close")
 	}
+}
+
+// TestSweepVault_NilMetadataEntry is a regression test for issue #393.
+//
+// The real storage.GetMetadata contract returns nil for engrams that have been
+// deleted or whose keys are missing — callers must nil-check each entry.
+// HNSW can reference stale IDs (indexed before deletion), so sweepVault was
+// crashing with a nil pointer dereference when it tried to access m.ID without
+// checking for nil. This test uses mockTriggerStoreWithNils (same nil contract)
+// to reproduce the crash condition and verify the fix.
+func TestSweepVault_NilMetadataEntry(t *testing.T) {
+	registry := newRegistry()
+	deliver := &DeliveryRouter{registry: registry}
+
+	// staleID is in the HNSW index but has been deleted from storage — GetMetadata
+	// will return nil for it (real contract; reproduced by mockTriggerStoreWithNils).
+	staleID := storage.NewULID()
+	store := &mockTriggerStoreWithNils{
+		mockTriggerStore: mockTriggerStore{
+			metas:   make(map[storage.ULID]*storage.EngramMeta),
+			engrams: make(map[storage.ULID]*storage.Engram),
+		},
+	}
+	// Intentionally do NOT add staleID to store.metas — it simulates a deleted engram.
+
+	hnsw := &mockHNSW{results: []ScoredID{{ID: staleID, Score: 0.9}}}
+
+	sub := &Subscription{
+		ID:             "sweep-nil-sub",
+		VaultID:        5,
+		Context:        []string{"nil metadata test"},
+		Threshold:      0.0,
+		DeltaThreshold: 0.0,
+		embedding:      []float32{0.5, 0.5, 0.5, 0.5},
+		expiresAt:      time.Now().Add(1 * time.Hour),
+		Deliver: func(_ context.Context, _ *ActivationPush) error {
+			return nil
+		},
+		pushedScores: make(map[storage.ULID]float64),
+		rateLimiter:  newTokenBucket(10),
+	}
+	registry.Add(sub)
+
+	worker := &TriggerWorker{
+		registry:     registry,
+		embedCache:   newEmbedCache(),
+		store:        store,
+		hnsw:         hnsw,
+		deliver:      deliver,
+		writeEvents:  make(chan *EngramEvent, 1),
+		cogEvents:    make(chan CognitiveEvent, 1),
+		contraEvents: make(chan ContradictEvent, 1),
+	}
+
+	// Must not panic.
+	worker.handleSweep(context.Background())
 }

--- a/internal/plugin/admin.go
+++ b/internal/plugin/admin.go
@@ -175,9 +175,11 @@ func (h *AdminHandler) handleAdd(w http.ResponseWriter, ctx context.Context, req
 		flagBit = DigestEnrich
 	}
 
-	skipFlags := uint8(0)
+	var skipFlags uint8
 	if flagBit == DigestEmbed {
 		skipFlags = DigestEmbedFailed
+	} else {
+		skipFlags = DigestEnrichFailed
 	}
 	total, err := h.store.CountWithoutFlag(ctx, flagBit, skipFlags)
 	if err != nil {

--- a/internal/plugin/retroactive.go
+++ b/internal/plugin/retroactive.go
@@ -10,7 +10,15 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/engine/circuit"
 )
+
+// errLLMFailed is an unexported sentinel wrapping errors that originate from
+// the LLM call itself (bad output, nil result, parse error). It signals a
+// permanent failure for the engram — distinct from transient failures (circuit
+// open, context cancelled) and storage errors (persistence after a successful
+// LLM call). Only the enrich path uses this sentinel.
+var errLLMFailed = errors.New("enrich: llm call failed")
 
 // pollInterval is how often the processor checks for newly written, unembedded engrams.
 const pollInterval = 3 * time.Second
@@ -108,12 +116,13 @@ func (rp *RetroactiveProcessor) Mode() string {
 }
 
 // skipFlags returns the digest flags that should be excluded from scanning.
-// Embed processors skip DigestEmbedFailed engrams to avoid infinite retry loops.
+// Both embed and enrich processors skip permanently-failed engrams to prevent
+// infinite retry loops that trip the circuit breaker and block other memories.
 func (rp *RetroactiveProcessor) skipFlags() uint8 {
 	if rp.flagBit == DigestEmbed {
 		return DigestEmbedFailed
 	}
-	return 0
+	return DigestEnrichFailed
 }
 
 func (rp *RetroactiveProcessor) run(ctx context.Context) {
@@ -434,6 +443,17 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 			rp.statsMu.Lock()
 			rp.stats.Errors++
 			rp.statsMu.Unlock()
+			// LLM-originated failures (bad output, parse error) are permanent for
+			// this engram. Mark DigestEnrichFailed so the processor does not retry
+			// it indefinitely, which would trip the circuit breaker and block
+			// enrichment for all other memories. Storage/persistence errors are NOT
+			// marked — they are transient and should be retried when storage recovers.
+			if errors.Is(err, errLLMFailed) {
+				if flagErr := rp.store.SetDigestFlag(ctx, eng.ID, DigestEnrichFailed); flagErr != nil {
+					slog.Warn("retroactive processor: failed to set DigestEnrichFailed",
+						"plugin", rp.plugin.Name(), "engram_id", eng.ID.String(), "error", flagErr)
+				}
+			}
 			continue
 		}
 
@@ -535,10 +555,17 @@ func (rp *RetroactiveProcessor) processEnrichEngram(ctx context.Context, eng *En
 		// Call Enrich for missing fields.
 		result, err := enrich.Enrich(ctx, eng)
 		if err != nil {
-			return err
+			// Transient: circuit open, context cancelled/deadline exceeded.
+			// Do not wrap — the caller must not mark the engram as permanently failed.
+			if errors.Is(err, circuit.ErrOpen) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
+			// Permanent LLM failure (bad output, HTTP error, parse error).
+			// Wrap with errLLMFailed so the caller can mark DigestEnrichFailed.
+			return fmt.Errorf("%w: %v", errLLMFailed, err)
 		}
 		if result == nil {
-			return fmt.Errorf("enrich returned nil result")
+			return errLLMFailed
 		}
 
 		// Only overwrite fields the caller didn't provide.

--- a/internal/plugin/retroactive_test.go
+++ b/internal/plugin/retroactive_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/engine/circuit"
 )
 
 // ---------------------------------------------------------------------------
@@ -312,6 +313,14 @@ func TestRetroactiveProcessor_ProcessBatchEnrichError(t *testing.T) {
 	if stats.Errors != 1 {
 		t.Errorf("expected Errors=1, got %d", stats.Errors)
 	}
+	// LLM errors are permanent: DigestEnrichFailed must be set to prevent
+	// infinite retry loops that trip the circuit breaker (regression test for #390).
+	if store.setFlagCalls != 1 {
+		t.Errorf("expected DigestEnrichFailed flag to be set after LLM error, got %d calls", store.setFlagCalls)
+	}
+	if len(store.setFlags) == 0 || store.setFlags[0] != DigestEnrichFailed {
+		t.Errorf("expected flag %d (DigestEnrichFailed), got %v", DigestEnrichFailed, store.setFlags)
+	}
 }
 
 func TestRetroactiveProcessor_ProcessBatchEnrichNilResult(t *testing.T) {
@@ -321,6 +330,8 @@ func TestRetroactiveProcessor_ProcessBatchEnrichNilResult(t *testing.T) {
 	store := &mockPluginStore{countResult: 1, scanResult: iter}
 	enrichPlugin := &enrichMockForRetro{
 		mockPlugin: mockPlugin{name: "enrich-nil", tier: TierEnrich},
+		// enrichResult and enrichErr both zero: Enrich returns (nil, nil).
+		// processEnrichEngram treats nil result as a permanent LLM failure.
 	}
 	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
 
@@ -333,8 +344,12 @@ func TestRetroactiveProcessor_ProcessBatchEnrichNilResult(t *testing.T) {
 	if stats.Errors != 1 {
 		t.Errorf("expected Errors=1, got %d", stats.Errors)
 	}
-	if store.setFlagCalls != 0 {
-		t.Errorf("expected no digest flags to be set on nil result, got %d calls", store.setFlagCalls)
+	// Nil result is a permanent LLM failure: DigestEnrichFailed must be set.
+	if store.setFlagCalls != 1 {
+		t.Errorf("expected DigestEnrichFailed flag to be set on nil result, got %d calls", store.setFlagCalls)
+	}
+	if len(store.setFlags) == 0 || store.setFlags[0] != DigestEnrichFailed {
+		t.Errorf("expected flag %d, got %v", DigestEnrichFailed, store.setFlags)
 	}
 }
 
@@ -768,5 +783,89 @@ func TestRetroactiveProcessor_ProcessBatchNilEngram(t *testing.T) {
 	// Only the non-nil engram should be processed
 	if enrichPlugin.callCount != 1 {
 		t.Errorf("expected 1 enrich call (skipping nil), got %d", enrichPlugin.callCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Regression tests for issue #390: ghost queue + circuit breaker deadlock
+// ---------------------------------------------------------------------------
+
+// TestRetroactiveProcessor_CircuitOpen_NoEnrichFailedFlag verifies that when
+// the circuit breaker is open (transient systemic failure), the engram is NOT
+// marked with DigestEnrichFailed. The circuit will reset on its own; the engram
+// should be retried once the provider recovers.
+func TestRetroactiveProcessor_CircuitOpen_NoEnrichFailedFlag(t *testing.T) {
+	eng := &Engram{Concept: "valid", Content: "content"}
+	iter := &mockIterator{engrams: []*Engram{eng}}
+
+	store := &mockPluginStore{countResult: 1, scanResult: iter}
+	enrichPlugin := &enrichMockForRetro{
+		mockPlugin: mockPlugin{name: "enrich-circuit", tier: TierEnrich},
+		enrichErr:  circuit.ErrOpen, // circuit breaker is open — transient
+	}
+	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
+
+	ok := rp.processBatch(context.Background())
+	if !ok {
+		t.Error("processBatch should return true even when circuit is open")
+	}
+
+	stats := rp.Stats()
+	if stats.Errors != 1 {
+		t.Errorf("expected Errors=1, got %d", stats.Errors)
+	}
+	// Circuit-open is transient: DigestEnrichFailed must NOT be set.
+	if store.setFlagCalls != 0 {
+		t.Errorf("DigestEnrichFailed must not be set for circuit-open errors, got %d flag calls", store.setFlagCalls)
+	}
+}
+
+// TestRetroactiveProcessor_PersistenceError_NoEnrichFailedFlag verifies that
+// when enrichment succeeds (LLM returns valid output) but storage persistence
+// fails, the engram is NOT marked with DigestEnrichFailed. The storage error is
+// transient; the engram should be retried when storage recovers.
+func TestRetroactiveProcessor_PersistenceError_NoEnrichFailedFlag(t *testing.T) {
+	eng := &Engram{Concept: "valid", Content: "content"}
+	iter := &mockIterator{engrams: []*Engram{eng}}
+
+	store := &mockPluginStore{
+		countResult: 1,
+		scanResult:  iter,
+		linkErr:     errors.New("storage unavailable"), // persistence fails, not LLM
+	}
+	enrichPlugin := &enrichMockForRetro{
+		mockPlugin: mockPlugin{name: "enrich-persist-fail", tier: TierEnrich},
+		enrichResult: &EnrichmentResult{
+			Summary: "good summary",
+			Entities: []ExtractedEntity{
+				{Name: "postgres", Type: "database", Confidence: 0.9},
+			},
+		},
+	}
+	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
+
+	ok := rp.processBatch(context.Background())
+	if !ok {
+		t.Error("processBatch should return true even with persistence errors")
+	}
+
+	// Storage error: DigestEnrichFailed must NOT be set — the engram should be
+	// retried when storage recovers.
+	if store.setFlagCalls != 0 {
+		t.Errorf("DigestEnrichFailed must not be set for storage errors, got %d flag calls (flags: %v)", store.setFlagCalls, store.setFlags)
+	}
+}
+
+// TestRetroactiveProcessor_SkipFlags_Enrich verifies that the enrich processor
+// passes DigestEnrichFailed as skipFlags so engrams that failed LLM enrichment
+// are excluded from future scans. This is the core fix for the infinite-retry
+// loop that tripped the circuit breaker in issue #390.
+func TestRetroactiveProcessor_SkipFlags_Enrich(t *testing.T) {
+	rp := NewRetroactiveProcessor(&mockPluginStore{}, &enrichMockForRetro{
+		mockPlugin: mockPlugin{name: "enrich-skipflags", tier: TierEnrich},
+	}, DigestEnrich)
+
+	if got := rp.skipFlags(); got != DigestEnrichFailed {
+		t.Errorf("enrich processor skipFlags() = %d, want DigestEnrichFailed (%d)", got, DigestEnrichFailed)
 	}
 }

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -69,6 +69,16 @@ const (
 	// Engrams with this flag are skipped by the embed retroactive processor so
 	// they are not retried indefinitely.
 	DigestEmbedFailed uint8 = 0x80
+
+	// DigestEnrichFailed is set when LLM enrichment permanently fails for an engram
+	// (e.g. the LLM returns unparseable output). Engrams with this flag are skipped
+	// by the enrich retroactive processor to prevent infinite retry loops that trip
+	// the circuit breaker and block enrichment for all other memories.
+	//
+	// Shares the same bit as DigestEmbedFailed (the flag byte is full). Either
+	// failure type marks the engram as permanently failed for automated processing.
+	// An operator can clear it via the admin API retry endpoint.
+	DigestEnrichFailed uint8 = DigestEmbedFailed
 )
 
 // PluginStatus represents the runtime state of a registered plugin.

--- a/internal/replication/join.go
+++ b/internal/replication/join.go
@@ -150,8 +150,12 @@ func (h *JoinHandler) HandleJoinRequest(req mbp.JoinRequest, conn *PeerConn) mbp
 	cb := h.OnLobeJoined
 	h.mu.Unlock()
 
-	// Register with ConnManager outside the members lock to avoid lock ordering issues.
-	h.mgr.AddPeer(req.NodeID, req.Addr)
+	// NOTE: do NOT call h.mgr.AddPeer here. The coordinator already called
+	// mgr.RegisterConn(nodeID, addr, conn) with the live inbound TCP connection
+	// before invoking HandleJoinRequest. Calling AddPeer would close that live
+	// connection and replace it with a disconnected PeerConn{conn: nil},
+	// causing the immediately-following peer.Send(JoinResponse) to return
+	// ErrNotConnected.
 
 	if cb != nil {
 		cb(info)

--- a/internal/replication/join_test.go
+++ b/internal/replication/join_test.go
@@ -116,12 +116,19 @@ func TestJoinHandler_HandleJoinRequest_Success(t *testing.T) {
 	}
 
 	req := mbp.JoinRequest{
-		NodeID:      "lobe-1",
-		Addr:        "127.0.0.1:9001",
-		LastApplied: 0,
+		NodeID:          "lobe-1",
+		Addr:            "127.0.0.1:9001",
+		LastApplied:     0,
+		ProtocolVersion: mbp.CurrentProtocolVersion,
 	}
 
-	resp := handler.HandleJoinRequest(req, nil)
+	// Simulate what the coordinator does: register the live inbound conn BEFORE
+	// calling HandleJoinRequest, then pass that PeerConn into the handler.
+	cortexConn, lobeConn := net.Pipe()
+	t.Cleanup(func() { cortexConn.Close(); lobeConn.Close() })
+	peer := mgr.RegisterConn(req.NodeID, req.Addr, cortexConn)
+
+	resp := handler.HandleJoinRequest(req, peer)
 
 	if !resp.Accepted {
 		t.Fatalf("expected Accepted=true, got false: %s", resp.RejectReason)
@@ -147,9 +154,79 @@ func TestJoinHandler_HandleJoinRequest_Success(t *testing.T) {
 		t.Errorf("joinedInfo.NodeID = %q, want lobe-1", joinedInfo.NodeID)
 	}
 
-	// Peer should be registered in ConnManager.
-	if _, ok := mgr.GetPeer("lobe-1"); !ok {
-		t.Error("lobe-1 not registered in ConnManager")
+	// The peer registered before HandleJoinRequest must still be connected —
+	// HandleJoinRequest must NOT call AddPeer (which would close the live conn).
+	if !peer.IsConnected() {
+		t.Error("PeerConn is not connected after HandleJoinRequest — AddPeer must not be called inside HandleJoinRequest")
+	}
+	p, ok := mgr.GetPeer("lobe-1")
+	if !ok {
+		t.Error("lobe-1 not found in ConnManager")
+	}
+	if p != peer {
+		t.Error("ConnManager returned a different PeerConn — live conn was replaced")
+	}
+}
+
+// TestJoinHandler_HandleJoinRequest_LiveConnPreserved is a regression test for
+// the bug where HandleJoinRequest called h.mgr.AddPeer(), closing the live
+// inbound PeerConn that the coordinator registered via RegisterConn before
+// invoking HandleJoinRequest. After the fix, the live conn must survive the
+// call and remain usable for peer.Send().
+func TestJoinHandler_HandleJoinRequest_LiveConnPreserved(t *testing.T) {
+	es := newTestEpochStore(t)
+	if err := es.ForceSet(1); err != nil {
+		t.Fatalf("ForceSet: %v", err)
+	}
+
+	repLog := newTestRepLog(t)
+	mgr := NewConnManager("cortex-1")
+	handler := NewJoinHandler("cortex-1", "", es, repLog, mgr)
+
+	req := mbp.JoinRequest{
+		NodeID:          "test-lobe",
+		Addr:            "127.0.0.1:9100",
+		LastApplied:     0,
+		ProtocolVersion: mbp.CurrentProtocolVersion,
+	}
+
+	// Simulate coordinator: register the live inbound conn first.
+	cortexSide, lobeSide := net.Pipe()
+	t.Cleanup(func() { cortexSide.Close(); lobeSide.Close() })
+	peer := mgr.RegisterConn(req.NodeID, req.Addr, cortexSide)
+
+	// Drain the lobe side in the background so peer.Send doesn't block.
+	readErrs := make(chan error, 1)
+	go func() {
+		f, err := mbp.ReadFrame(lobeSide)
+		_ = f
+		readErrs <- err
+	}()
+
+	resp := handler.HandleJoinRequest(req, peer)
+	if !resp.Accepted {
+		t.Fatalf("HandleJoinRequest rejected: %s", resp.RejectReason)
+	}
+
+	// The live conn must still be open — not closed by AddPeer inside HandleJoinRequest.
+	if !peer.IsConnected() {
+		t.Fatal("regression: PeerConn was closed inside HandleJoinRequest (AddPeer called on live conn)")
+	}
+
+	// Send must succeed; before the fix it returned ErrNotConnected.
+	payload := []byte("ping")
+	if err := peer.Send(mbp.TypePing, payload); err != nil {
+		t.Fatalf("peer.Send after HandleJoinRequest: %v (regression: AddPeer closed the live conn)", err)
+	}
+
+	// Verify the lobe side received the frame.
+	select {
+	case err := <-readErrs:
+		if err != nil {
+			t.Fatalf("lobe side read error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for frame on lobe side")
 	}
 }
 

--- a/internal/storage/plugin_store.go
+++ b/internal/storage/plugin_store.go
@@ -37,6 +37,17 @@ func (ps *PebbleStore) CountWithoutFlag(ctx context.Context, flag, skipFlags uin
 		var id [16]byte
 		copy(id[:], k[9:25])
 
+		// Skip soft-deleted and archived engrams — mirrors ScanWithoutFlag so
+		// CountWithoutFlag and the scan agree on what is actually pending.
+		val := make([]byte, len(iter.Value()))
+		copy(val, iter.Value())
+		if erfEng, decErr := erf.Decode(val); decErr == nil {
+			eng := fromERFEngram(erfEng)
+			if eng.State == StateSoftDeleted || eng.State == StateArchived {
+				continue
+			}
+		}
+
 		raw, err := ps.getDigestFlagsRaw(id)
 		if (err != nil || raw&flag == 0) && (skipFlags == 0 || raw&skipFlags == 0) {
 			count++

--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -729,7 +729,10 @@ func (s *Server) handleDeleteVault(w http.ResponseWriter, r *http.Request) {
 				if cfgs, cfgErr := s.authStore.ListVaultConfigs(); cfgErr == nil {
 					for _, cfg := range cfgs {
 						if cfg.Name == name {
-							_ = s.authStore.DeleteVaultConfig(name)
+							if delErr := s.authStore.DeleteVaultConfig(name); delErr != nil {
+								s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, delErr.Error())
+								return
+							}
 							w.WriteHeader(http.StatusNoContent)
 							return
 						}

--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -723,6 +723,19 @@ func (s *Server) handleDeleteVault(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.engine.DeleteVault(r.Context(), name); err != nil {
 		if errors.Is(err, engine.ErrVaultNotFound) {
+			// Vault may exist only in auth config (created via UI but no engrams written yet).
+			// Clean up the phantom vault so the UI can remove it cleanly.
+			if s.authStore != nil {
+				if cfgs, cfgErr := s.authStore.ListVaultConfigs(); cfgErr == nil {
+					for _, cfg := range cfgs {
+						if cfg.Name == name {
+							_ = s.authStore.DeleteVaultConfig(name)
+							w.WriteHeader(http.StatusNoContent)
+							return
+						}
+					}
+				}
+			}
 			s.sendError(r, w, http.StatusNotFound, ErrVaultNotFound, err.Error())
 			return
 		}

--- a/internal/transport/rest/admin_vault_handlers_test.go
+++ b/internal/transport/rest/admin_vault_handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/scrypster/muninndb/internal/auth"
 	"github.com/scrypster/muninndb/internal/engine"
 	"github.com/scrypster/muninndb/internal/engine/vaultjob"
 )
@@ -113,6 +114,43 @@ func TestHandleDeleteVault_NotFound(t *testing.T) {
 	w := serveVault(srv, "DELETE", "/api/admin/vaults/missing", nil, nil)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+
+func TestHandleDeleteVault_PhantomVault_AuthConfigOnly(t *testing.T) {
+	// Vault exists in auth config but was never written to Pebble (phantom vault).
+	// DELETE should clean up the auth config entry and return 204, not 404.
+	store := newTestAuthStore(t)
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "phantom"}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+	eng := &vaultErrEngine{deleteErr: fmt.Errorf("vault %q: %w", "phantom", engine.ErrVaultNotFound)}
+	srv := NewServer("localhost:0", eng, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+	w := serveVault(srv, "DELETE", "/api/admin/vaults/phantom", nil, nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for phantom vault, got %d: %s", w.Code, w.Body.String())
+	}
+	// Confirm the auth config entry was removed.
+	cfgs, err := store.ListVaultConfigs()
+	if err != nil {
+		t.Fatalf("ListVaultConfigs: %v", err)
+	}
+	for _, cfg := range cfgs {
+		if cfg.Name == "phantom" {
+			t.Fatal("phantom vault config was not removed from auth store")
+		}
+	}
+}
+
+func TestHandleDeleteVault_NotFound_NoAuthConfig(t *testing.T) {
+	// Vault exists in neither engine nor auth config — should return 404.
+	store := newTestAuthStore(t)
+	eng := &vaultErrEngine{deleteErr: fmt.Errorf("vault %q: %w", "ghost", engine.ErrVaultNotFound)}
+	srv := NewServer("localhost:0", eng, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+	w := serveVault(srv, "DELETE", "/api/admin/vaults/ghost", nil, nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for truly missing vault, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/transport/rest/coverage_boost_test.go
+++ b/internal/transport/rest/coverage_boost_test.go
@@ -382,6 +382,29 @@ func (e *linkGenericErrorEngine) Link(_ context.Context, _ *mbp.LinkRequest) (*L
 	return nil, errors.New("generic link error")
 }
 
+type linkInvalidIDEngine struct{ MockEngine }
+
+func (e *linkInvalidIDEngine) Link(_ context.Context, _ *mbp.LinkRequest) (*LinkResponse, error) {
+	return nil, fmt.Errorf("%w: source_id %q: parse ulid: bad", engine.ErrInvalidID, "nonexistent-1")
+}
+
+func TestHandleLink_InvalidID_Returns400(t *testing.T) {
+	// Regression test for #395: invalid (non-ULID) source_id or target_id must
+	// return 400 Bad Request, not 500 Internal Server Error.
+	eng := &linkInvalidIDEngine{}
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+
+	body := `{"source_id":"nonexistent-1","target_id":"nonexistent-2","rel_type":1}`
+	req := httptest.NewRequest("POST", "/api/link", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // handleStats — error path (60% → better coverage)
 // ---------------------------------------------------------------------------

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -837,6 +837,10 @@ func (s *Server) handleLink(w http.ResponseWriter, r *http.Request) {
 	}
 	resp, err := s.engine.Link(r.Context(), mbpReq)
 	if err != nil {
+		if errors.Is(err, engine.ErrInvalidID) {
+			s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, err.Error())
+			return
+		}
 		if errors.Is(err, engine.ErrEngramNotFound) {
 			s.sendError(r, w, http.StatusNotFound, ErrEngramNotFound, err.Error())
 			return


### PR DESCRIPTION
Fixes both bugs from #377 reported by @schurabot.

---

## Bug 1: Cluster join fails with "peer not connected"

**Root cause:** `HandleJoinRequest` called `h.mgr.AddPeer(nodeID, addr)` which:
1. Found the `PeerConn` that `coordinator.HandleIncomingJoin` had just registered via `RegisterConn` (with the live inbound TCP connection)
2. Called `.Close()` on it — marking it `closed=true`, `conn=nil`
3. Replaced it with a new `PeerConn{conn: nil}` (disconnected)

The coordinator then called `peer.Send(TypeJoinResponse, ...)` → `ErrNotConnected` → every join attempt failed with `cluster: send JoinResponse to <lobe>: peer not connected`.

**Fix:** Remove the stale `AddPeer` call from `HandleJoinRequest`. The coordinator already calls `mgr.RegisterConn` with the live conn **before** invoking `HandleJoinRequest`. The `AddPeer` call was a leftover from before `RegisterConn` existed.

**Regression test:** `TestJoinHandler_HandleJoinRequest_LiveConnPreserved` — registers via `RegisterConn`, calls `HandleJoinRequest`, asserts `peer.IsConnected()` is still true and `peer.Send()` succeeds.

---

## Bug 2: MUNINN_ADMIN_PASSWORD ignored on existing instances

**Root cause:** `Bootstrap` only read `MUNINN_ADMIN_PASSWORD` inside `if !store.AdminExists()`. Existing instances skipped the env var entirely.

**Fix:** After the first-run branch, if `MUNINN_ADMIN_PASSWORD` is set and an admin already exists, call `ChangeAdminPassword("root", envPassword)`. Operators can now rotate the password by setting the env var and restarting — no first-run wipe needed.

**Tests:**
- `TestBootstrap_EnvPasswordAppliedOnExistingInstance` — verifies env var is applied on a subsequent bootstrap
- `TestBootstrap_EnvPasswordNotSetIdempotent` — verifies a manually-changed password is preserved when env var is unset

Fixes #377