### PR TITLE
fix(lifecycle): prevent CLI/systemd lock conflict on runStart + friendlier errors (#391)

### DIFF
--- a/cmd/muninn/lifecycle.go
+++ b/cmd/muninn/lifecycle.go
@@ -88,6 +88,23 @@ func runStart(webEnabled bool) error {
 		os.Remove(pidPath)
 	}
 
+	// Guard against dual-ownership conflict with systemd (or any external
+	// process that already holds the Pebble flock). If we spawn a child that
+	// immediately exits due to lock contention, systemd's Restart=on-failure
+	// loop kicks in and both sides race forever.
+	if isPebbleLockHeld(dataDir) {
+		fmt.Fprintln(os.Stderr, "error: another process is already holding the MuninnDB database lock.")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "If MuninnDB is managed by systemd, use systemctl instead of the CLI:")
+		fmt.Fprintln(os.Stderr, "  systemctl status muninndb")
+		fmt.Fprintln(os.Stderr, "  systemctl start  muninndb")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "If no daemon should be running, find and stop the process holding the lock:")
+		fmt.Fprintf(os.Stderr, "  fuser %s/pebble/LOCK\n", dataDir)
+		fmt.Fprintf(os.Stderr, "  lsof  %s/pebble/LOCK\n", dataDir)
+		os.Exit(1)
+	}
+
 	// Ensure data directory exists
 	if err := os.MkdirAll(dataDir, 0700); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create data dir: %v\n", err)

--- a/cmd/muninn/pid.go
+++ b/cmd/muninn/pid.go
@@ -48,7 +48,10 @@ func writePID(path string, pid int) error {
 func readPID(path string) (int, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return 0, fmt.Errorf("no PID file at %s (is muninn running?): %w", path, err)
+		return 0, fmt.Errorf(
+			"no PID file at %s — muninn may not be running (try 'muninn start'),\n"+
+				"or it may be managed by systemd (try 'systemctl status muninndb'): %w",
+			path, err)
 	}
 	pid, err := strconv.Atoi(strings.TrimSpace(string(b)))
 	if err != nil {

--- a/cmd/muninn/process_unix.go
+++ b/cmd/muninn/process_unix.go
@@ -5,7 +5,10 @@ package main
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // stopProcess sends SIGTERM for graceful shutdown on Unix.
@@ -31,3 +34,43 @@ func daemonSysProcAttr() *syscall.SysProcAttr {
 
 // daemonExtraSetup applies platform-specific settings to the daemon command.
 func daemonExtraSetup(cmd *exec.Cmd) {}
+
+// isPebbleLockHeld returns true if the Pebble LOCK file inside dataDir is
+// currently held by another process.
+//
+// Pebble uses POSIX fcntl record locks (F_SETLK / F_WRLCK), not BSD flock.
+// On Linux these two locking mechanisms are independent — a flock check would
+// always succeed even while Pebble holds the database. We therefore probe with
+// the same F_SETLK / F_WRLCK approach that Pebble uses.
+//
+// Returns false on any error (file absent, no pebble/ dir yet, permission
+// denied) so that callers proceed and let Pebble itself produce a clear error.
+// There is an inherent TOCTOU race between this check and spawning the child
+// process; that is acceptable — this is a best-effort guard, and Pebble's own
+// lock will cause the losing process to fail fast.
+func isPebbleLockHeld(dataDir string) bool {
+	lockPath := filepath.Join(dataDir, "pebble", "LOCK")
+	f, err := os.OpenFile(lockPath, os.O_RDWR, 0600)
+	if err != nil {
+		// File does not exist or is otherwise inaccessible — not held.
+		return false
+	}
+	defer f.Close()
+
+	spec := unix.Flock_t{
+		Type:   unix.F_WRLCK,
+		Whence: 0, // SEEK_SET
+		Start:  0,
+		Len:    0, // whole file
+	}
+	// F_SETLK is non-blocking: returns EACCES or EAGAIN if already locked.
+	err = unix.FcntlFlock(f.Fd(), unix.F_SETLK, &spec)
+	if err != nil {
+		// Could not acquire — another process holds the lock.
+		return true
+	}
+	// We acquired it; release immediately and report not held.
+	spec.Type = unix.F_UNLCK
+	_ = unix.FcntlFlock(f.Fd(), unix.F_SETLK, &spec)
+	return false
+}

--- a/cmd/muninn/process_windows.go
+++ b/cmd/muninn/process_windows.go
@@ -56,3 +56,6 @@ func daemonExtraSetup(cmd *exec.Cmd) {
 	}
 	cmd.SysProcAttr.HideWindow = true
 }
+
+// isPebbleLockHeld is not implemented on Windows; always returns false.
+func isPebbleLockHeld(_ string) bool { return false }

--- a/contrib/muninndb.service
+++ b/contrib/muninndb.service
@@ -14,6 +14,16 @@
 #
 # After updating credentials, reload with:
 #   systemctl daemon-reload && systemctl restart muninndb
+#
+# WARNING: lifecycle conflict — do NOT run 'muninn start', 'muninn stop',
+# or 'muninn restart' while this service is enabled. These CLI commands and
+# systemd both own the process; running them concurrently races on the
+# Pebble database lock and can put systemd into a permanent Restart=on-failure
+# loop. While this unit is active, use systemctl to control MuninnDB:
+#   systemctl start muninndb   (instead of: muninn start)
+#   systemctl stop muninndb    (instead of: muninn stop)
+#   systemctl restart muninndb (instead of: muninn restart)
+#   systemctl status muninndb  (instead of: muninn status)
 
 [Unit]
 Description=MuninnDB Memory Server


### PR DESCRIPTION
Implements suggestions 1–3 from #391 reported by @johanneshauer.

## Root Cause

When `contrib/muninndb.service` is enabled and a user also runs `muninn start`, both sides race on the Pebble database lock:
1. systemd's `ExecStart` forks a child that acquires the Pebble flock
2. User's `muninn start` forks another child that can't acquire the lock → exits immediately
3. systemd sees the child die → `Restart=on-failure` → repeat forever (restart counter >95 observed)

## Fixes

### 1. Service file warning (`contrib/muninndb.service`)
Added a prominent `WARNING` comment explaining that `muninn start/stop/restart` must not be used while the unit is active, with the equivalent `systemctl` commands to use instead.

### 2. Lock contention guard in `runStart` (`lifecycle.go`)
Before forking, `runStart` now calls `isPebbleLockHeld(dataDir)`. If the Pebble `LOCK` file is already held by another process, `runStart` refuses to spawn and prints a clear error:
```
error: another process is already holding the MuninnDB database lock.

If MuninnDB is managed by systemd, use systemctl instead of the CLI:
  systemctl status muninndb
  systemctl start  muninndb

If no daemon should be running, find and stop the process holding the lock:
  fuser <datadir>/pebble/LOCK
  lsof  <datadir>/pebble/LOCK
```

**Implementation note:** Pebble uses POSIX `fcntl` record locks (`F_SETLK`/`F_WRLCK`), not BSD `flock`. On Linux these are entirely independent mechanisms — a `flock` probe would always return "not held" even while Pebble holds the database. `isPebbleLockHeld` uses `unix.FcntlFlock` (from `golang.org/x/sys/unix`, already a dependency) to match Pebble's own locking. There is an inherent TOCTOU race between the check and `cmd.Start()` — this is acceptable; it's a best-effort guard and Pebble's own lock causes the losing process to fail fast.

Windows stub always returns false (no-op).

### 3. Friendlier `no PID file` error (`pid.go`)
Updated `readPID` to hint at systemd management as an alternative explanation when the PID file is absent, instead of only suggesting `muninn start`.

Fixes #391