### PR TITLE
refactor(auth): consolidate Bearer/static-token/vault-name validation into internal/auth (#381)

### DIFF
--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -1,0 +1,46 @@
+package auth
+
+import (
+	"crypto/subtle"
+	"strings"
+)
+
+// maxStaticTokenLen caps the token length accepted by ValidateStaticToken.
+// This prevents a DoS vector where an enormous Authorization header forces a
+// large heap allocation before subtle.ConstantTimeCompare can do its own
+// length-equality short-circuit. Real tokens are well under 100 bytes.
+const maxStaticTokenLen = 4096
+
+// ParseBearerToken extracts the token value from an Authorization header.
+// Returns ("", false) if the header is absent or does not begin with "Bearer ".
+func ParseBearerToken(header string) (string, bool) {
+	token, ok := strings.CutPrefix(header, "Bearer ")
+	if !ok || token == "" {
+		return "", false
+	}
+	return token, true
+}
+
+// ValidateStaticToken reports whether token matches required in constant time.
+// Returns false if required is empty (open-server mode must be handled by the
+// caller), if token exceeds maxStaticTokenLen, or if the values differ.
+func ValidateStaticToken(token, required string) bool {
+	if required == "" || len(token) > maxStaticTokenLen {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(token), []byte(required)) == 1
+}
+
+// IsValidVaultName reports whether name is a valid vault identifier:
+// 1–64 characters, containing only lowercase letters, digits, hyphens, and underscores.
+func IsValidVaultName(name string) bool {
+	if len(name) == 0 || len(name) > 64 {
+		return false
+	}
+	for _, r := range name {
+		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -1,0 +1,83 @@
+package auth_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/auth"
+)
+
+func TestParseBearerToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		header    string
+		wantToken string
+		wantOK    bool
+	}{
+		{"valid", "Bearer abc123", "abc123", true},
+		{"empty header", "", "", false},
+		{"no Bearer prefix", "Token abc123", "", false},
+		{"Bearer only no token", "Bearer ", "", false},
+		{"Basic auth", "Basic dXNlcjpwYXNz", "", false},
+		{"Bearer with spaces in token", "Bearer tok en", "tok en", true},
+		{"mk_ key", "Bearer mk_abc123", "mk_abc123", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := auth.ParseBearerToken(tc.header)
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.wantToken {
+				t.Errorf("token = %q, want %q", got, tc.wantToken)
+			}
+		})
+	}
+}
+
+func TestValidateStaticToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    string
+		required string
+		want     bool
+	}{
+		{"matching", "mdb_secret", "mdb_secret", true},
+		{"mismatch", "mdb_wrong", "mdb_secret", false},
+		{"empty required (open-server)", "anything", "", false},
+		{"empty token", "", "mdb_secret", false},
+		{"both empty", "", "", false},
+		{"oversized token", strings.Repeat("x", 4097), "mdb_secret", false},
+		{"exactly at limit", strings.Repeat("x", 4096), strings.Repeat("x", 4096), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := auth.ValidateStaticToken(tc.token, tc.required); got != tc.want {
+				t.Errorf("ValidateStaticToken(%q, %q) = %v, want %v", tc.token, tc.required, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsValidVaultName(t *testing.T) {
+	valid := []string{
+		"default", "my-vault", "vault_1", "a", "abc123",
+		strings.Repeat("a", 64), // exactly 64
+	}
+	invalid := []string{
+		"", "UPPER", "with space", "with/slash", "../etc/passwd",
+		"vault\u200b", // zero-width space
+		strings.Repeat("a", 65), // 65 chars
+		"vault!", "vault@name",
+	}
+	for _, name := range valid {
+		if !auth.IsValidVaultName(name) {
+			t.Errorf("IsValidVaultName(%q) = false, want true", name)
+		}
+	}
+	for _, name := range invalid {
+		if auth.IsValidVaultName(name) {
+			t.Errorf("IsValidVaultName(%q) = true, want false", name)
+		}
+	}
+}

--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -4,9 +4,7 @@ package mcp
 import (
 	"context"
 	"crypto/sha256"
-	"crypto/subtle"
 	"net/http"
-	"strings"
 
 	"github.com/scrypster/muninndb/internal/auth"
 )
@@ -34,10 +32,6 @@ func authFromContext(ctx context.Context) AuthContext {
 	return a
 }
 
-// maxTokenLen caps the bearer token length to prevent abuse of the constant-time
-// compare (e.g., a 100 MB token would waste CPU). Real tokens are ≤ 100 chars.
-const maxTokenLen = 4096
-
 // authFromRequest extracts the Bearer token from the Authorization header and
 // authenticates it in priority order:
 //
@@ -48,13 +42,12 @@ const maxTokenLen = 4096
 //
 // apiKeyStore may be nil to disable mk_ key auth (legacy mode).
 func authFromRequest(r *http.Request, requiredToken string, apiKeyStore apiKeyValidator) AuthContext {
-	header := r.Header.Get("Authorization")
-	token, found := strings.CutPrefix(header, "Bearer ")
+	token, found := auth.ParseBearerToken(r.Header.Get("Authorization"))
 
 	// 1. mk_ vault API key — always checked first, regardless of whether a static
 	// token is configured. Presenting a scoped key is an explicit opt-in to vault
 	// isolation; an invalid or revoked key must never fall through to open access.
-	if found && token != "" && strings.HasPrefix(token, "mk_") && apiKeyStore != nil {
+	if found && len(token) > 3 && token[:3] == "mk_" && apiKeyStore != nil {
 		if key, err := apiKeyStore.ValidateAPIKey(token); err == nil {
 			return AuthContext{
 				Token:      token,
@@ -73,15 +66,11 @@ func authFromRequest(r *http.Request, requiredToken string, apiKeyStore apiKeyVa
 		return AuthContext{Authorized: true}
 	}
 
-	// 3. Static token validation.
-	if !found || token == "" {
+	// 3. Static token validation — constant-time compare with length cap.
+	if !found {
 		return AuthContext{Authorized: false}
 	}
-	// Reject absurdly long tokens before any crypto work.
-	if len(token) > maxTokenLen {
-		return AuthContext{Authorized: false}
-	}
-	if subtle.ConstantTimeCompare([]byte(token), []byte(requiredToken)) == 1 {
+	if auth.ValidateStaticToken(token, requiredToken) {
 		return AuthContext{Token: token, Authorized: true}
 	}
 	return AuthContext{Authorized: false}
@@ -226,22 +215,9 @@ func vaultFromArgs(args map[string]any) (string, bool, bool) {
 	if !ok || s == "" {
 		return "", false, true
 	}
-	if !isValidVaultName(s) {
+	if !auth.IsValidVaultName(s) {
 		return "", false, true
 	}
 	return s, true, false
 }
 
-// isValidVaultName returns true if name is a valid vault name: 1–64 characters,
-// containing only lowercase letters, digits, hyphens, and underscores.
-func isValidVaultName(name string) bool {
-	if len(name) == 0 || len(name) > 64 {
-		return false
-	}
-	for _, r := range name {
-		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_') {
-			return false
-		}
-	}
-	return true
-}

--- a/internal/mcp/server_coverage_test.go
+++ b/internal/mcp/server_coverage_test.go
@@ -174,7 +174,7 @@ func TestHandleStreamablePost_Unauthorized(t *testing.T) {
 func TestIsValidVaultName_TooLong(t *testing.T) {
 	// 65-char lowercase vault name must be invalid.
 	name := strings.Repeat("a", 65)
-	if isValidVaultName(name) {
+	if auth.IsValidVaultName(name) {
 		t.Error("expected isValidVaultName to return false for 65-char name")
 	}
 }
@@ -182,19 +182,19 @@ func TestIsValidVaultName_TooLong(t *testing.T) {
 func TestIsValidVaultName_MaxLength(t *testing.T) {
 	// 64-char lowercase vault name must be valid.
 	name := strings.Repeat("a", 64)
-	if !isValidVaultName(name) {
+	if !auth.IsValidVaultName(name) {
 		t.Error("expected isValidVaultName to return true for 64-char name")
 	}
 }
 
 func TestIsValidVaultName_Empty(t *testing.T) {
-	if isValidVaultName("") {
+	if auth.IsValidVaultName("") {
 		t.Error("expected isValidVaultName to return false for empty string")
 	}
 }
 
 func TestIsValidVaultName_Uppercase(t *testing.T) {
-	if isValidVaultName("MyVault") {
+	if auth.IsValidVaultName("MyVault") {
 		t.Error("expected isValidVaultName to return false for uppercase chars")
 	}
 }
@@ -202,7 +202,7 @@ func TestIsValidVaultName_Uppercase(t *testing.T) {
 func TestIsValidVaultName_ValidChars(t *testing.T) {
 	cases := []string{"default", "my-vault", "vault_1", "a0-b_c"}
 	for _, name := range cases {
-		if !isValidVaultName(name) {
+		if !auth.IsValidVaultName(name) {
 			t.Errorf("expected isValidVaultName to return true for %q", name)
 		}
 	}

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -2,7 +2,6 @@ package rest
 
 import (
 	"context"
-	"crypto/subtle"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -1099,17 +1098,15 @@ func withClusterAuth(secret string, clusterActive bool) func(http.Handler) http.
 				return
 			}
 
-			// Extract Bearer token.
-			authHeader := r.Header.Get("Authorization")
-			const prefix = "Bearer "
-			if !strings.HasPrefix(authHeader, prefix) {
+			// Extract and validate Bearer token. auth.ValidateStaticToken enforces
+			// a length cap before the constant-time compare to prevent DoS via
+			// large Authorization header allocations.
+			token, found := auth.ParseBearerToken(r.Header.Get("Authorization"))
+			if !found {
 				writeError(w, http.StatusUnauthorized, "cluster_auth_required", "cluster authorization required")
 				return
 			}
-			token := authHeader[len(prefix):]
-
-			// Constant-time comparison to prevent timing attacks.
-			if subtle.ConstantTimeCompare([]byte(token), []byte(secret)) != 1 {
+			if !auth.ValidateStaticToken(token, secret) {
 				writeError(w, http.StatusUnauthorized, "cluster_auth_failed", "invalid cluster token")
 				return
 			}


### PR DESCRIPTION
Fixes #381.

## What changed

New `internal/auth/token.go` with three exported functions shared across transport layers:

- **`ParseBearerToken(header string) (string, bool)`** — parses the `Authorization: Bearer <token>` header, returns `("", false)` on absent or non-Bearer headers.
- **`ValidateStaticToken(token, required string) bool`** — constant-time comparison with a `maxStaticTokenLen=4096` cap to prevent DoS via large header allocations.
- **`IsValidVaultName(name string) bool`** — vault identifier validation (1–64 chars, lowercase alphanumeric + hyphen/underscore). Was previously unexported and only in `mcp/`.

## Security fix included

`withClusterAuth` in `rest/server.go` was performing `subtle.ConstantTimeCompare` directly without the token length cap. While Go's `ConstantTimeCompare` short-circuits on unequal lengths, it does not prevent allocating the full `[]byte` from the header first. A large Authorization header (e.g. 100 MB) would still force a heap allocation before the length check ran. The MCP layer already had the `maxTokenLen=4096` guard; `withClusterAuth` was missing it. Both paths now use `auth.ValidateStaticToken`.

## Scope

- `mcp/context.go` — uses `auth.ParseBearerToken`, `auth.ValidateStaticToken`, `auth.IsValidVaultName`; no longer imports `crypto/subtle` or `strings` directly
- `rest/server.go` — `withClusterAuth` uses shared helpers; `crypto/subtle` import removed
- `mcp/server_coverage_test.go` — `isValidVaultName` → `auth.IsValidVaultName`

Nothing moved between packages beyond what's described. `authFromRequest` and all MCP-specific logic stays in `mcp/`.