### PR TITLE
feat(mcp): cursor-based pagination for muninn_get_enrichment_candidates (#362)

### DIFF
--- a/internal/engine/engine_replay.go
+++ b/internal/engine/engine_replay.go
@@ -424,6 +424,9 @@ func (e *Engine) GetEnrichmentCandidates(ctx context.Context, vault string, stag
 			candidatesThisBatch++
 			lastCheckedID = id
 		}
+		// cursor advances to the last ID examined in this batch.
+		// When we break early (limit reached), lastCheckedID points to the
+		// limit-th candidate — the next call starts strictly after it.
 		cursor = lastCheckedID
 
 		// If we hit the limit early, there may be more engrams — return a non-zero cursor.

--- a/internal/engine/engine_replay.go
+++ b/internal/engine/engine_replay.go
@@ -342,10 +342,17 @@ func (e *Engine) ReplayEnrichment(ctx context.Context, vault string, stages []st
 
 // GetEnrichmentCandidates returns active engrams missing at least one requested
 // stage without invoking any enrichment plugin.
-func (e *Engine) GetEnrichmentCandidates(ctx context.Context, vault string, stages []string, limit int) ([]EnrichmentCandidate, []string, error) {
+//
+// afterID is an exclusive cursor — pass a zero ULID to start from the beginning.
+// The returned nextCursor is the last ULID examined; pass it as afterID on the
+// next call to continue. A zero nextCursor means all engrams have been scanned.
+//
+// Adaptive batch sizing: starts at limit*4, doubles (up to 2000) if a batch
+// yields 0 candidates — this converges quickly for highly-enriched vaults.
+func (e *Engine) GetEnrichmentCandidates(ctx context.Context, vault string, stages []string, afterID storage.ULID, limit int) ([]EnrichmentCandidate, []string, storage.ULID, error) {
 	stageMask, validStages, _, err := normalizeEnrichmentStages(stages)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, storage.ULID{}, err
 	}
 	if limit <= 0 {
 		limit = 50
@@ -355,43 +362,85 @@ func (e *Engine) GetEnrichmentCandidates(ctx context.Context, vault string, stag
 	}
 
 	ws := e.store.ResolveVaultPrefix(vault)
-	ids, err := e.store.ListByState(ctx, ws, storage.StateActive, limit)
-	if err != nil {
-		return nil, nil, fmt.Errorf("get enrichment candidates: list active engrams: %w", err)
-	}
-	if len(ids) == 0 {
-		return nil, validStages, nil
-	}
-
-	engrams, err := e.store.GetEngrams(ctx, ws, ids)
-	if err != nil {
-		return nil, nil, fmt.Errorf("get enrichment candidates: get engrams: %w", err)
+	cursor := afterID
+	candidates := make([]EnrichmentCandidate, 0, limit)
+	batchSize := limit * 4
+	if batchSize < 50 {
+		batchSize = 50
 	}
 
-	candidates := make([]EnrichmentCandidate, 0, len(engrams))
-	for _, eng := range engrams {
-		if eng == nil {
-			continue
+	for len(candidates) < limit {
+		ids, err := e.store.ListByStateFrom(ctx, ws, storage.StateActive, cursor, batchSize)
+		if err != nil {
+			return nil, nil, storage.ULID{}, fmt.Errorf("get enrichment candidates: list active engrams: %w", err)
 		}
-		flags, _ := e.store.GetDigestFlags(ctx, plugin.ULID(eng.ID))
-		if flags&stageMask == stageMask {
-			continue
+		if len(ids) == 0 {
+			// Exhausted — signal with zero cursor.
+			return candidates, validStages, storage.ULID{}, nil
 		}
-		candidates = append(candidates, EnrichmentCandidate{
-			ID:            eng.ID,
-			Concept:       eng.Concept,
-			Content:       eng.Content,
-			Summary:       eng.Summary,
-			MemoryType:    eng.MemoryType.String(),
-			TypeLabel:     eng.TypeLabel,
-			CreatedAt:     eng.CreatedAt,
-			UpdatedAt:     eng.UpdatedAt,
-			MissingStages: missingStagesForFlags(flags, validStages),
-			DigestFlags:   flags,
-		})
+
+		engramSlice, err := e.store.GetEngrams(ctx, ws, ids)
+		if err != nil {
+			return nil, nil, storage.ULID{}, fmt.Errorf("get enrichment candidates: get engrams: %w", err)
+		}
+		// Build map for O(1) lookup by ID.
+		engramMap := make(map[storage.ULID]*storage.Engram, len(engramSlice))
+		for _, eng := range engramSlice {
+			if eng != nil {
+				engramMap[eng.ID] = eng
+			}
+		}
+
+		lastCheckedID := cursor
+		candidatesThisBatch := 0
+		hitLimit := false
+		for _, id := range ids {
+			if len(candidates) >= limit {
+				hitLimit = true
+				break
+			}
+			eng := engramMap[id]
+			if eng == nil {
+				lastCheckedID = id
+				continue
+			}
+			flags, _ := e.store.GetDigestFlags(ctx, plugin.ULID(eng.ID))
+			if flags&stageMask == stageMask {
+				lastCheckedID = id
+				continue
+			}
+			candidates = append(candidates, EnrichmentCandidate{
+				ID:            eng.ID,
+				Concept:       eng.Concept,
+				Content:       eng.Content,
+				Summary:       eng.Summary,
+				MemoryType:    eng.MemoryType.String(),
+				TypeLabel:     eng.TypeLabel,
+				CreatedAt:     eng.CreatedAt,
+				UpdatedAt:     eng.UpdatedAt,
+				MissingStages: missingStagesForFlags(flags, validStages),
+				DigestFlags:   flags,
+			})
+			candidatesThisBatch++
+			lastCheckedID = id
+		}
+		cursor = lastCheckedID
+
+		// If we hit the limit early, there may be more engrams — return a non-zero cursor.
+		if hitLimit {
+			break
+		}
+
+		// Adaptive sizing: double batch if no candidates found this round.
+		if candidatesThisBatch == 0 {
+			batchSize *= 2
+			if batchSize > 2000 {
+				batchSize = 2000
+			}
+		}
 	}
 
-	return candidates, validStages, nil
+	return candidates, validStages, cursor, nil
 }
 
 // ApplyEnrichment persists explicit agent-generated enrichment output.

--- a/internal/engine/engine_replay_test.go
+++ b/internal/engine/engine_replay_test.go
@@ -276,7 +276,7 @@ func TestGetEnrichmentCandidates_ReturnsOnlyMissingStages(t *testing.T) {
 		}
 	}
 
-	candidates, stages, err := eng.GetEnrichmentCandidates(ctx, vault, nil, 10)
+	candidates, stages, _, err := eng.GetEnrichmentCandidates(ctx, vault, nil, storage.ULID{}, 10)
 	if err != nil {
 		t.Fatalf("GetEnrichmentCandidates: %v", err)
 	}
@@ -292,6 +292,131 @@ func TestGetEnrichmentCandidates_ReturnsOnlyMissingStages(t *testing.T) {
 	wantMissing := []string{"relationships", "classification", "summary"}
 	if fmt.Sprint(candidates[0].MissingStages) != fmt.Sprint(wantMissing) {
 		t.Fatalf("missing stages: got %v, want %v", candidates[0].MissingStages, wantMissing)
+	}
+}
+
+func TestGetEnrichmentCandidates_CursorPaginates(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	const vault = "default"
+
+	// Write 6 engrams; mark the first 4 fully enriched, leave last 2 unenriched.
+	ids := make([]storage.ULID, 6)
+	for i := 0; i < 6; i++ {
+		resp, err := eng.Write(ctx, &mbp.WriteRequest{
+			Vault:   vault,
+			Content: fmt.Sprintf("engram %d", i),
+			Concept: fmt.Sprintf("concept %d", i),
+		})
+		if err != nil {
+			t.Fatalf("Write %d: %v", i, err)
+		}
+		id, err := storage.ParseULID(resp.ID)
+		if err != nil {
+			t.Fatalf("ParseULID %d: %v", i, err)
+		}
+		ids[i] = id
+	}
+	allFlags := []uint8{plugin.DigestEntities, plugin.DigestRelationships, plugin.DigestClassified, plugin.DigestSummarized}
+	for i := 0; i < 4; i++ {
+		for _, flag := range allFlags {
+			if err := eng.store.SetDigestFlag(ctx, ids[i], flag); err != nil {
+				t.Fatalf("SetDigestFlag(%d, 0x%02x): %v", i, flag, err)
+			}
+		}
+	}
+
+	// Page 1: limit=1 should return engram at index 4 (first unenriched).
+	candidates1, _, cursor1, err := eng.GetEnrichmentCandidates(ctx, vault, nil, storage.ULID{}, 1)
+	if err != nil {
+		t.Fatalf("page1: %v", err)
+	}
+	if len(candidates1) != 1 {
+		t.Fatalf("page1 count: got %d, want 1", len(candidates1))
+	}
+	if candidates1[0].ID != ids[4] {
+		t.Errorf("page1 candidate: got %s, want %s", candidates1[0].ID, ids[4])
+	}
+	if cursor1 == (storage.ULID{}) {
+		t.Error("page1: expected non-zero cursor")
+	}
+
+	// Page 2: continue from cursor1, should return engram at index 5.
+	candidates2, _, cursor2, err := eng.GetEnrichmentCandidates(ctx, vault, nil, cursor1, 1)
+	if err != nil {
+		t.Fatalf("page2: %v", err)
+	}
+	if len(candidates2) != 1 {
+		t.Fatalf("page2 count: got %d, want 1", len(candidates2))
+	}
+	if candidates2[0].ID != ids[5] {
+		t.Errorf("page2 candidate: got %s, want %s", candidates2[0].ID, ids[5])
+	}
+
+	// Page 3: exhausted — cursor2 should be zero.
+	candidates3, _, cursor3, err := eng.GetEnrichmentCandidates(ctx, vault, nil, cursor2, 1)
+	if err != nil {
+		t.Fatalf("page3: %v", err)
+	}
+	if len(candidates3) != 0 {
+		t.Fatalf("page3 count: got %d, want 0", len(candidates3))
+	}
+	if cursor3 != (storage.ULID{}) {
+		t.Errorf("page3: expected zero cursor (exhausted), got %s", cursor3)
+	}
+}
+
+func TestGetEnrichmentCandidates_SkipsEnrichedAtStart(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	const vault = "default"
+
+	// Write 3 engrams. First 2 fully enriched, last one not.
+	ids := make([]storage.ULID, 3)
+	for i := 0; i < 3; i++ {
+		resp, err := eng.Write(ctx, &mbp.WriteRequest{
+			Vault:   vault,
+			Content: fmt.Sprintf("content %d", i),
+			Concept: fmt.Sprintf("concept %d", i),
+		})
+		if err != nil {
+			t.Fatalf("Write %d: %v", i, err)
+		}
+		id, err := storage.ParseULID(resp.ID)
+		if err != nil {
+			t.Fatalf("ParseULID %d: %v", i, err)
+		}
+		ids[i] = id
+	}
+	allFlags := []uint8{plugin.DigestEntities, plugin.DigestRelationships, plugin.DigestClassified, plugin.DigestSummarized}
+	for _, flag := range allFlags {
+		if err := eng.store.SetDigestFlag(ctx, ids[0], flag); err != nil {
+			t.Fatalf("SetDigestFlag(0): %v", err)
+		}
+		if err := eng.store.SetDigestFlag(ctx, ids[1], flag); err != nil {
+			t.Fatalf("SetDigestFlag(1): %v", err)
+		}
+	}
+
+	// Without cursor fix, a limit=2 call would scan only ids[0] and ids[1],
+	// both enriched, and return 0 candidates. With the fix it continues.
+	candidates, _, cursor, err := eng.GetEnrichmentCandidates(ctx, vault, nil, storage.ULID{}, 2)
+	if err != nil {
+		t.Fatalf("GetEnrichmentCandidates: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("candidates: got %d, want 1", len(candidates))
+	}
+	if candidates[0].ID != ids[2] {
+		t.Errorf("candidate id: got %s, want %s", candidates[0].ID, ids[2])
+	}
+	// ids[2] was the last engram — cursor should be zero (exhausted).
+	if cursor != (storage.ULID{}) {
+		t.Errorf("cursor should be zero (exhausted), got %s", cursor)
 	}
 }
 

--- a/internal/engine/engine_replay_test.go
+++ b/internal/engine/engine_replay_test.go
@@ -805,6 +805,59 @@ func TestReplayEnrichment_NothingToEnrich_CountedAsSkipped(t *testing.T) {
 	assertResultInvariant(t, result, 3)
 }
 
+// TestGetEnrichmentCandidates_AdaptiveBatch verifies that GetEnrichmentCandidates
+// finds unenriched engrams that appear after a run of fully-enriched ones,
+// exercising the "skip enriched, find unenriched at end" behavior of the
+// adaptive batch loop.
+func TestGetEnrichmentCandidates_AdaptiveBatch(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	const vault = "default"
+
+	// Write 25 fully enriched + 1 unenriched at the end.
+	enrichedCount := 25
+	ids := make([]storage.ULID, enrichedCount+1)
+	for i := 0; i <= enrichedCount; i++ {
+		resp, err := eng.Write(ctx, &mbp.WriteRequest{
+			Vault:   vault,
+			Content: fmt.Sprintf("content %d", i),
+			Concept: fmt.Sprintf("concept %d", i),
+		})
+		if err != nil {
+			t.Fatalf("Write %d: %v", i, err)
+		}
+		id, err := storage.ParseULID(resp.ID)
+		if err != nil {
+			t.Fatalf("ParseULID %d: %v", i, err)
+		}
+		ids[i] = id
+	}
+	allFlags := []uint8{plugin.DigestEntities, plugin.DigestRelationships, plugin.DigestClassified, plugin.DigestSummarized}
+	for i := 0; i < enrichedCount; i++ {
+		for _, flag := range allFlags {
+			if err := eng.store.SetDigestFlag(ctx, ids[i], flag); err != nil {
+				t.Fatalf("SetDigestFlag(%d): %v", i, err)
+			}
+		}
+	}
+
+	// The unenriched engram is ids[enrichedCount].
+	// With limit=5, batchSize starts at max(50, 20)=50, which covers all 26 engrams.
+	// All 25 enriched ones are skipped, and the 1 unenriched is found.
+	candidates, _, _, err := eng.GetEnrichmentCandidates(ctx, vault, nil, storage.ULID{}, 5)
+	if err != nil {
+		t.Fatalf("GetEnrichmentCandidates: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("candidates count: got %d, want 1", len(candidates))
+	}
+	if candidates[0].ID != ids[enrichedCount] {
+		t.Errorf("candidate: got %s, want %s", candidates[0].ID, ids[enrichedCount])
+	}
+}
+
 // TestReplayEnrichment_ContextAlreadyExpired verifies that when the context is
 // already cancelled before the loop starts, all engrams are counted as Remaining.
 func TestReplayEnrichment_ContextAlreadyExpired(t *testing.T) {

--- a/internal/mcp/engine.go
+++ b/internal/mcp/engine.go
@@ -137,7 +137,9 @@ type EngineInterface interface {
 
 	// GetEnrichmentCandidates returns active engrams missing one or more requested
 	// enrichment stages without invoking any enrichment plugin.
-	GetEnrichmentCandidates(ctx context.Context, vault string, stages []string, limit int) (*EnrichmentCandidatesResult, error)
+	// afterCursor is an opaque string cursor from a previous call's next_cursor field.
+	// Pass "" to start from the beginning. Returns next_cursor="" when exhausted.
+	GetEnrichmentCandidates(ctx context.Context, vault string, stages []string, afterCursor string, limit int) (*EnrichmentCandidatesResult, error)
 
 	// ApplyEnrichment persists explicit externally generated enrichment output.
 	ApplyEnrichment(ctx context.Context, vault string, req *ApplyEnrichmentRequest) (*ApplyEnrichmentResult, error)

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -414,11 +414,23 @@ func (a *mcpEngineAdapter) ReplayEnrichment(ctx context.Context, vault string, s
 	return a.eng.ReplayEnrichment(ctx, vault, stages, limit, dryRun)
 }
 
-func (a *mcpEngineAdapter) GetEnrichmentCandidates(ctx context.Context, vault string, stages []string, limit int) (*EnrichmentCandidatesResult, error) {
-	candidates, stagesRequested, _, err := a.eng.GetEnrichmentCandidates(ctx, vault, stages, storage.ULID{}, limit)
+func (a *mcpEngineAdapter) GetEnrichmentCandidates(ctx context.Context, vault string, stages []string, afterCursor string, limit int) (*EnrichmentCandidatesResult, error) {
+	// Parse the opaque cursor string to a storage.ULID.
+	// Empty string → zero ULID (start from beginning).
+	var afterID storage.ULID
+	if afterCursor != "" {
+		id, err := storage.ParseULID(afterCursor)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cursor: %w", err)
+		}
+		afterID = id
+	}
+
+	candidates, stagesRequested, nextID, err := a.eng.GetEnrichmentCandidates(ctx, vault, stages, afterID, limit)
 	if err != nil {
 		return nil, err
 	}
+
 	items := make([]EnrichmentCandidate, len(candidates))
 	for i, c := range candidates {
 		items[i] = EnrichmentCandidate{
@@ -439,10 +451,18 @@ func (a *mcpEngineAdapter) GetEnrichmentCandidates(ctx context.Context, vault st
 			},
 		}
 	}
+
+	// Encode next cursor. Zero ULID means exhausted → empty string (omitempty hides it).
+	var nextCursor string
+	if nextID != (storage.ULID{}) {
+		nextCursor = nextID.String()
+	}
+
 	return &EnrichmentCandidatesResult{
 		Items:           items,
 		StagesRequested: stagesRequested,
 		Count:           len(items),
+		NextCursor:      nextCursor,
 	}, nil
 }
 

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -415,7 +415,7 @@ func (a *mcpEngineAdapter) ReplayEnrichment(ctx context.Context, vault string, s
 }
 
 func (a *mcpEngineAdapter) GetEnrichmentCandidates(ctx context.Context, vault string, stages []string, limit int) (*EnrichmentCandidatesResult, error) {
-	candidates, stagesRequested, err := a.eng.GetEnrichmentCandidates(ctx, vault, stages, limit)
+	candidates, stagesRequested, _, err := a.eng.GetEnrichmentCandidates(ctx, vault, stages, storage.ULID{}, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1470,7 +1470,8 @@ func (s *MCPServer) handleGetEnrichmentCandidates(ctx context.Context, w http.Re
 	if limit > 200 {
 		limit = 200
 	}
-	result, err := s.engine.GetEnrichmentCandidates(ctx, vault, stages, limit)
+	cursor, _ := args["cursor"].(string) // optional; "" means start from beginning
+	result, err := s.engine.GetEnrichmentCandidates(ctx, vault, stages, cursor, limit)
 	if err != nil {
 		sendError(w, id, -32000, "tool error: "+err.Error())
 		return

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1471,6 +1471,12 @@ func (s *MCPServer) handleGetEnrichmentCandidates(ctx context.Context, w http.Re
 		limit = 200
 	}
 	cursor, _ := args["cursor"].(string) // optional; "" means start from beginning
+	if cursor != "" {
+		if _, err := storage.ParseULID(cursor); err != nil {
+			sendError(w, id, -32602, "invalid params: cursor is not a valid ULID")
+			return
+		}
+	}
 	result, err := s.engine.GetEnrichmentCandidates(ctx, vault, stages, cursor, limit)
 	if err != nil {
 		sendError(w, id, -32000, "tool error: "+err.Error())

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -2481,7 +2481,7 @@ type enrichmentCandidatesEngine struct {
 	err    error
 }
 
-func (e *enrichmentCandidatesEngine) GetEnrichmentCandidates(_ context.Context, _ string, _ []string, _ int) (*EnrichmentCandidatesResult, error) {
+func (e *enrichmentCandidatesEngine) GetEnrichmentCandidates(_ context.Context, _ string, _ []string, _ string, _ int) (*EnrichmentCandidatesResult, error) {
 	if e.err != nil {
 		return nil, e.err
 	}
@@ -2672,6 +2672,47 @@ func TestHandleGetEnrichmentCandidates_InvalidStages(t *testing.T) {
 	}
 	if resp.Error.Code != -32602 {
 		t.Fatalf("expected -32602, got %d", resp.Error.Code)
+	}
+}
+
+type enrichmentCandidatesCursorCapture struct {
+	fakeEngine
+	cursor *string
+}
+
+func (e *enrichmentCandidatesCursorCapture) GetEnrichmentCandidates(_ context.Context, _ string, _ []string, afterCursor string, _ int) (*EnrichmentCandidatesResult, error) {
+	*e.cursor = afterCursor
+	return &EnrichmentCandidatesResult{Items: []EnrichmentCandidate{}, StagesRequested: []string{}, Count: 0}, nil
+}
+
+func TestHandleGetEnrichmentCandidates_CursorPassedThrough(t *testing.T) {
+	capturedCursor := ""
+	eng := &enrichmentCandidatesCursorCapture{cursor: &capturedCursor}
+	srv := newTestServerWith(eng)
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_get_enrichment_candidates","arguments":{"vault":"default","cursor":"01HN5BQZ00000000000000000"}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: code=%d msg=%s", resp.Error.Code, resp.Error.Message)
+	}
+	if capturedCursor != "01HN5BQZ00000000000000000" {
+		t.Errorf("cursor: got %q, want %q", capturedCursor, "01HN5BQZ00000000000000000")
+	}
+}
+
+func TestHandleGetEnrichmentCandidates_NextCursorInResponse(t *testing.T) {
+	eng := &enrichmentCandidatesEngine{result: &EnrichmentCandidatesResult{
+		Items:           []EnrichmentCandidate{},
+		StagesRequested: []string{"entities"},
+		Count:           0,
+		NextCursor:      "01HN5BQZ00000000000000001",
+	}}
+	srv := newTestServerWith(eng)
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_get_enrichment_candidates","arguments":{"vault":"default"}}}`
+	w := postRPC(t, srv, body)
+	inner := extractInnerJSON(t, decodeResp(t, w.Body.String()))
+	if got, _ := inner["next_cursor"].(string); got != "01HN5BQZ00000000000000001" {
+		t.Errorf("next_cursor: got %q, want %q", got, "01HN5BQZ00000000000000001")
 	}
 }
 

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -2689,14 +2689,14 @@ func TestHandleGetEnrichmentCandidates_CursorPassedThrough(t *testing.T) {
 	capturedCursor := ""
 	eng := &enrichmentCandidatesCursorCapture{cursor: &capturedCursor}
 	srv := newTestServerWith(eng)
-	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_get_enrichment_candidates","arguments":{"vault":"default","cursor":"01HN5BQZ00000000000000000"}}}`
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_get_enrichment_candidates","arguments":{"vault":"default","cursor":"01ARZ3NDEKTSV4RRFFQ69G5FAV"}}}`
 	w := postRPC(t, srv, body)
 	resp := decodeResp(t, w.Body.String())
 	if resp.Error != nil {
 		t.Fatalf("unexpected error: code=%d msg=%s", resp.Error.Code, resp.Error.Message)
 	}
-	if capturedCursor != "01HN5BQZ00000000000000000" {
-		t.Errorf("cursor: got %q, want %q", capturedCursor, "01HN5BQZ00000000000000000")
+	if capturedCursor != "01ARZ3NDEKTSV4RRFFQ69G5FAV" {
+		t.Errorf("cursor: got %q, want %q", capturedCursor, "01ARZ3NDEKTSV4RRFFQ69G5FAV")
 	}
 }
 
@@ -2713,6 +2713,22 @@ func TestHandleGetEnrichmentCandidates_NextCursorInResponse(t *testing.T) {
 	inner := extractInnerJSON(t, decodeResp(t, w.Body.String()))
 	if got, _ := inner["next_cursor"].(string); got != "01HN5BQZ00000000000000001" {
 		t.Errorf("next_cursor: got %q, want %q", got, "01HN5BQZ00000000000000001")
+	}
+}
+
+func TestHandleGetEnrichmentCandidates_InvalidCursor(t *testing.T) {
+	srv := newTestServerWith(&enrichmentCandidatesEngine{})
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_get_enrichment_candidates","arguments":{"vault":"default","cursor":"not-a-valid-ulid"}}}`
+	w := postRPC(t, srv, body)
+	if w.Code != 200 {
+		t.Fatalf("status: %d", w.Code)
+	}
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error == nil {
+		t.Fatal("expected error response for invalid cursor")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("error code: got %d, want -32602", resp.Error.Code)
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -81,7 +81,7 @@ func (f *fakeEngine) ListDeleted(ctx context.Context, vault string, limit int) (
 func (f *fakeEngine) RetryEnrich(ctx context.Context, vault string, id string) (*RetryEnrichResult, error) {
 	return &RetryEnrichResult{EngramID: id, PluginsQueued: []string{}, AlreadyComplete: []string{}}, nil
 }
-func (f *fakeEngine) GetEnrichmentCandidates(_ context.Context, _ string, stages []string, _ int) (*EnrichmentCandidatesResult, error) {
+func (f *fakeEngine) GetEnrichmentCandidates(_ context.Context, _ string, stages []string, _ string, _ int) (*EnrichmentCandidatesResult, error) {
 	if len(stages) == 0 {
 		stages = []string{"entities", "relationships", "classification", "summary"}
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -406,6 +406,10 @@ func allToolDefinitions() []ToolDefinition {
 						"type":        "integer",
 						"description": "Maximum number of candidate memories to return in this call (default 50, max 200).",
 					},
+					"cursor": map[string]any{
+						"type":        "string",
+						"description": "Opaque pagination cursor returned by a previous call as next_cursor. Omit or pass an empty string to start from the beginning.",
+					},
 				},
 				"required": []string{},
 			},

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -245,6 +245,7 @@ type EnrichmentCandidatesResult struct {
 	Items           []EnrichmentCandidate `json:"items"`
 	StagesRequested []string              `json:"stages_requested"`
 	Count           int                   `json:"count"`
+	NextCursor      string                `json:"next_cursor,omitempty"`
 }
 
 // ApplyEnrichmentEntity is one externally generated entity.

--- a/internal/storage/query.go
+++ b/internal/storage/query.go
@@ -84,8 +84,32 @@ func (ps *PebbleStore) RecentActive(ctx context.Context, wsPrefix [8]byte, topK 
 // ListByState returns up to limit engram IDs whose state matches the given
 // lifecycle state, scanned from the 0x0B state secondary index.
 func (ps *PebbleStore) ListByState(ctx context.Context, wsPrefix [8]byte, state LifecycleState, limit int) ([]ULID, error) {
-	lower := keys.StateIndexKey(wsPrefix, uint8(state), [16]byte{})
+	return ps.ListByStateFrom(ctx, wsPrefix, state, ULID{}, limit)
+}
+
+// ListByStateFrom is the cursor-based variant of ListByState.
+// afterID is the exclusive lower-bound cursor — pass a zero ULID to start from the beginning.
+// The lower bound is computed as append(StateIndexKey(ws, state, afterID), 0x00), which
+// creates a 27-byte key strictly greater than the 26-byte cursor key, excluding afterID.
+// Returns at most limit IDs in state-index order (ULID / insertion order).
+func (ps *PebbleStore) ListByStateFrom(ctx context.Context, wsPrefix [8]byte, state LifecycleState, afterID ULID, limit int) ([]ULID, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	// Upper bound: the first key of the next state byte.
+	// StateActive = 0x01 which is well below 255, but guard explicitly.
+	if uint8(state) == 255 {
+		return nil, nil
+	}
 	upper := keys.StateIndexKey(wsPrefix, uint8(state)+1, [16]byte{})
+
+	// Lower bound: strictly after the cursor.
+	// If afterID is zero (all-zero bytes), append(afterKey, 0x00) is a 27-byte key
+	// greater than the all-zero 26-byte key — this correctly starts from the beginning
+	// of the state partition for this vault.
+	afterKey := keys.StateIndexKey(wsPrefix, uint8(state), afterID)
+	lower := append(afterKey, 0x00) // 27 bytes > any 26-byte key with same prefix
 
 	iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
 	if err != nil {
@@ -93,7 +117,6 @@ func (ps *PebbleStore) ListByState(ctx context.Context, wsPrefix [8]byte, state 
 	}
 	defer iter.Close()
 
-	// Key: 0x0B | ws(8) | state(1) | id(16) = 26 bytes; ULID starts at offset 10.
 	const idOffset = 10
 	const keyLen = 26
 
@@ -106,6 +129,9 @@ func (ps *PebbleStore) ListByState(ctx context.Context, wsPrefix [8]byte, state 
 		var id ULID
 		copy(id[:], k[idOffset:idOffset+16])
 		ids = append(ids, id)
+	}
+	if err := iter.Error(); err != nil {
+		return nil, err
 	}
 	return ids, nil
 }

--- a/internal/storage/query_test.go
+++ b/internal/storage/query_test.go
@@ -1,0 +1,73 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestListByStateFrom_CursorPagination(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	ws := store.ResolveVaultPrefix("default")
+
+	// Write 5 active engrams
+	ids := make([]ULID, 5)
+	for i := 0; i < 5; i++ {
+		id, err := store.WriteEngram(ctx, ws, &Engram{
+			Concept:    fmt.Sprintf("engram %d", i),
+			Content:    fmt.Sprintf("content %d", i),
+			State:      StateActive,
+			Confidence: 0.9,
+			Relevance:  0.8,
+		})
+		if err != nil {
+			t.Fatalf("WriteEngram %d: %v", i, err)
+		}
+		ids[i] = id
+	}
+
+	// Page 1: get first 2
+	page1, err := store.ListByStateFrom(ctx, ws, StateActive, ULID{}, 2)
+	if err != nil {
+		t.Fatalf("ListByStateFrom page1: %v", err)
+	}
+	if len(page1) != 2 {
+		t.Fatalf("page1 len: got %d, want 2", len(page1))
+	}
+
+	// Page 2: continue from last ID of page 1
+	cursor := page1[len(page1)-1]
+	page2, err := store.ListByStateFrom(ctx, ws, StateActive, cursor, 2)
+	if err != nil {
+		t.Fatalf("ListByStateFrom page2: %v", err)
+	}
+	if len(page2) != 2 {
+		t.Fatalf("page2 len: got %d, want 2", len(page2))
+	}
+	// Pages must not overlap
+	for _, id := range page2 {
+		if id == cursor {
+			t.Errorf("page2 contains cursor ID %s", cursor)
+		}
+	}
+
+	// Page 3: only 1 remaining
+	cursor2 := page2[len(page2)-1]
+	page3, err := store.ListByStateFrom(ctx, ws, StateActive, cursor2, 2)
+	if err != nil {
+		t.Fatalf("ListByStateFrom page3: %v", err)
+	}
+	if len(page3) != 1 {
+		t.Fatalf("page3 len: got %d, want 1", len(page3))
+	}
+
+	// Exhausted: empty cursor (all-zero) means start from beginning
+	fromZero, err := store.ListByStateFrom(ctx, ws, StateActive, ULID{}, 10)
+	if err != nil {
+		t.Fatalf("ListByStateFrom fromZero: %v", err)
+	}
+	if len(fromZero) != 5 {
+		t.Fatalf("fromZero len: got %d, want 5", len(fromZero))
+	}
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -132,6 +132,11 @@ type EngineStore interface {
 	// using the 0x0B state secondary index.
 	ListByState(ctx context.Context, wsPrefix [8]byte, state LifecycleState, limit int) ([]ULID, error)
 
+	// ListByStateFrom is the cursor-based variant of ListByState.
+	// afterID is the exclusive starting cursor — pass a zero ULID to start from the beginning.
+	// Returns at most limit IDs strictly after afterID in index order.
+	ListByStateFrom(ctx context.Context, wsPrefix [8]byte, state LifecycleState, afterID ULID, limit int) ([]ULID, error)
+
 	// VaultPrefix computes the 8-byte SipHash prefix for a vault name.
 	VaultPrefix(vault string) [8]byte
 


### PR DESCRIPTION
## Summary

- Adds `ListByStateFrom` to the storage layer — cursor-based iterator over the state index using `append(key, 0x00)` as a strict lower bound
- Rewrites `engine.GetEnrichmentCandidates` with an adaptive batch loop so it scans past fully-enriched engrams instead of returning 0 results
- Exposes `cursor` / `next_cursor` in the MCP tool so callers can page across calls

## Root cause

`ListByState` always scanned from the beginning and returned the first `limit` active IDs. In large vaults where those IDs were all fully enriched, the tool returned 0 candidates even though unenriched engrams existed further in the index.

## How to use

Pass `cursor` (from a previous response's `next_cursor`) to continue where you left off. Omit `cursor` (or pass `""`) to start from the beginning. An absent `next_cursor` in the response means the vault is exhausted.

## Test Plan

- [ ] `go test ./internal/storage/... ./internal/engine/... ./internal/mcp/...` — all pass
- [ ] `TestListByStateFrom_CursorPagination` — verifies 3-page cursor pagination with no overlap
- [ ] `TestGetEnrichmentCandidates_SkipsEnrichedAtStart` — regression test for original bug
- [ ] `TestGetEnrichmentCandidates_CursorPaginates` — end-to-end 3-page engine pagination
- [ ] `TestHandleGetEnrichmentCandidates_CursorPassedThrough` / `_NextCursorInResponse` / `_InvalidCursor` — MCP layer

Closes #362