### PR TITLE
feat(trust): per-engram trust/taint labels (#387)

### DIFF
--- a/cmd/muninn/smoke_exhaustive_test.go
+++ b/cmd/muninn/smoke_exhaustive_test.go
@@ -52,6 +52,7 @@ var allMCPTools = []string{
 	"muninn_provenance",
 	"muninn_entity_timeline",
 	"muninn_feedback",
+	"muninn_trust",
 	"muninn_entity",
 	"muninn_entities",
 }
@@ -837,6 +838,17 @@ func TestSmoke_AllMCPTools(t *testing.T) {
 		})
 		if errVal, hasErr := result["error"]; hasErr {
 			t.Errorf("muninn_feedback returned error field: %v", errVal)
+		}
+	})
+
+	t.Run("muninn_trust", func(t *testing.T) {
+		result := mcpTool(t, tok, "muninn_trust", map[string]any{
+			"vault": vault,
+			"id":    idA,
+			"trust": "verified",
+		})
+		if errVal, hasErr := result["error"]; hasErr {
+			t.Errorf("muninn_trust returned error field: %v", errVal)
 		}
 	})
 

--- a/internal/auth/plasticity.go
+++ b/internal/auth/plasticity.go
@@ -64,6 +64,10 @@ type PlasticityConfig struct {
 	// All zero/nil = disabled (backward compatible).
 	LTPThreshold   *int     `json:"ltp_threshold,omitempty"`    // co-activation count to trigger LTP (0 = disabled)
 	LTPWeightFloor *float32 `json:"ltp_weight_floor,omitempty"` // minimum weight for potentiated edges (0–1; 0 = disabled)
+
+	// ExcludeUntrusted controls whether untrusted engrams are filtered from ACTIVATE results.
+	// nil = false (default: include all engrams regardless of trust).
+	ExcludeUntrusted *bool `json:"exclude_untrusted,omitempty"`
 }
 
 // ResolvedPlasticity is the fully-merged configuration after applying preset defaults
@@ -113,6 +117,8 @@ type ResolvedPlasticity struct {
 	// LTP (Long-Term Potentiation) resolved values. Zero = disabled.
 	LTPThreshold   int     `json:"ltp_threshold"`
 	LTPWeightFloor float32 `json:"ltp_weight_floor"`
+	// ExcludeUntrusted: when true, ACTIVATE silently skips engrams with TrustUntrusted.
+	ExcludeUntrusted bool `json:"exclude_untrusted"`
 }
 
 type plasticityPreset struct {
@@ -460,6 +466,9 @@ func ResolvePlasticity(cfg *PlasticityConfig) ResolvedPlasticity {
 		} else {
 			r.ScoringFusion = "" // invalid → default (ACT-R)
 		}
+	}
+	if cfg.ExcludeUntrusted != nil {
+		r.ExcludeUntrusted = *cfg.ExcludeUntrusted
 	}
 	// LTP overrides
 	if cfg.LTPThreshold != nil {

--- a/internal/auth/plasticity_test.go
+++ b/internal/auth/plasticity_test.go
@@ -498,3 +498,18 @@ func TestPlasticityConfig_ArchiveThreshold_Override(t *testing.T) {
 		t.Errorf("overridden ArchiveThreshold: got %v, want 0.10", r.ArchiveThreshold)
 	}
 }
+
+func TestResolvePlasticity_ExcludeUntrusted(t *testing.T) {
+	// Default: ExcludeUntrusted is false
+	r := ResolvePlasticity(nil)
+	if r.ExcludeUntrusted {
+		t.Error("default ExcludeUntrusted should be false")
+	}
+
+	// Explicit true
+	tr := true
+	r2 := ResolvePlasticity(&PlasticityConfig{ExcludeUntrusted: &tr})
+	if !r2.ExcludeUntrusted {
+		t.Error("ExcludeUntrusted should be true when config sets it")
+	}
+}

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -168,6 +168,9 @@ type ActivateRequest struct {
 	// PAS: Predictive Activation Signal — sequential transition tracking.
 	PASEnabled       bool // when true, inject transition candidates in Phase 2
 	PASMaxInjections int  // max transition candidates to inject (0 = default 5)
+	// ExcludeUntrusted: when true, engrams with TrustUntrusted (0x04) are silently
+	// excluded from activation results. Set by the engine from vault PlasticityConfig.
+	ExcludeUntrusted bool
 }
 
 // ActivateResult is what the transport layer serializes and returns.
@@ -1168,11 +1171,22 @@ func (e *ActivationEngine) phase6Score(
 	}
 
 	// Filter out soft-deleted engrams (defense-in-depth; HNSW has no delete method).
+	// Also filter untrusted engrams when ExcludeUntrusted is set in the request.
 	var active []*storage.Engram
 	for _, eng := range allEngrams {
-		if eng != nil && eng.State != storage.StateSoftDeleted && eng.State != storage.StateArchived {
-			active = append(active, eng)
+		if eng == nil {
+			continue
 		}
+		if eng.State == storage.StateSoftDeleted || eng.State == storage.StateArchived {
+			continue
+		}
+		// Hard trust filter: skip engrams with TrustUntrusted (0x04) when requested.
+		// TrustUnset (0x00) is intentionally passed through — it is the zero-value
+		// backward-compat alias for TrustInferred, not an "unknown" or untrusted value.
+		if req.ExcludeUntrusted && eng.Trust == storage.TrustUntrusted {
+			continue
+		}
+		active = append(active, eng)
 	}
 	allEngrams = active
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2533,6 +2533,28 @@ func (e *Engine) UpdateLifecycleState(ctx context.Context, vault, id, state stri
 	return e.store.UpdateMetadata(ctx, ws, ulid, meta)
 }
 
+// SetTrust changes the trust label of an engram identified by id (string ULID).
+// trust must be one of "verified", "inferred", "external", "untrusted".
+// Returns an error if the engram is not found or trust is invalid.
+func (e *Engine) SetTrust(ctx context.Context, vault, id, trust string) error {
+	level, err := storage.ParseTrustLevel(trust)
+	if err != nil {
+		return fmt.Errorf("parse trust: %w", err)
+	}
+	ws := e.store.ResolveVaultPrefix(vault)
+	ulid, err := storage.ParseULID(id)
+	if err != nil {
+		return fmt.Errorf("parse id: %w", err)
+	}
+	if err := e.store.UpdateTrust(ctx, ws, ulid, level); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return ErrEngramNotFound
+		}
+		return err
+	}
+	return nil
+}
+
 // ListDeleted returns soft-deleted engrams in the vault, up to limit.
 func (e *Engine) ListDeleted(ctx context.Context, vault string, limit int) ([]*storage.Engram, error) {
 	ws := e.store.ResolveVaultPrefix(vault)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -875,6 +875,7 @@ func (e *Engine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteRe
 		Embedding:  req.Embedding,
 		MemoryType: storage.MemoryType(req.MemoryType),
 		TypeLabel:  req.TypeLabel,
+		Trust:      storage.TrustInferred, // all new MCP writes default to inferred
 	}
 
 	// Apply caller-provided summary directly to the engram.
@@ -1285,6 +1286,7 @@ func (e *Engine) WriteBatch(ctx context.Context, reqs []*mbp.WriteRequest) ([]*m
 			Embedding:  req.Embedding,
 			MemoryType: storage.MemoryType(req.MemoryType),
 			TypeLabel:  req.TypeLabel,
+			Trust:      storage.TrustInferred, // all new MCP writes default to inferred
 		}
 
 		if callerSummary != "" {
@@ -1686,6 +1688,7 @@ func (e *Engine) Read(ctx context.Context, req *mbp.ReadRequest) (*mbp.ReadRespo
 		TypeLabel:           eng.TypeLabel,
 		Classification:      eng.Classification,
 		EmbedDim:            uint8(eng.EmbedDim),
+		Trust:               uint8(eng.Trust),
 		Entities:            entities,
 		EntityRelationships: entityRels,
 	}, nil
@@ -1923,6 +1926,7 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 			LastAccess:  scored.Engram.LastAccess.UnixNano(),
 			AccessCount: scored.Engram.AccessCount,
 			Relevance:   scored.Engram.Relevance,
+			Trust:       uint8(scored.Engram.Trust),
 		}
 
 		items[i].ScoreComponents = mbp.ScoreComponents{
@@ -2640,6 +2644,7 @@ func (e *Engine) Evolve(ctx context.Context, vault, oldID, newContent, reason st
 		UpdatedAt:  now,
 		LastAccess: now,
 		Embedding:  embedding,
+		Trust:      storage.TrustInferred, // all new MCP writes default to inferred
 	}
 
 	// Build the supersedes association (new → old).

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1752,6 +1752,7 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 	// PAS: Predictive Activation Signal config from vault Plasticity.
 	actReq.PASEnabled = resolved.PredictiveActivation
 	actReq.PASMaxInjections = resolved.PASMaxInjections
+	actReq.ExcludeUntrusted = resolved.ExcludeUntrusted
 
 	// Set defaults
 	if actReq.MaxResults == 0 {

--- a/internal/engine/engine_activation_softdelete_test.go
+++ b/internal/engine/engine_activation_softdelete_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/scrypster/muninndb/internal/auth"
 	"github.com/scrypster/muninndb/internal/transport/mbp"
 )
 
@@ -91,5 +92,87 @@ func TestActivation_Phase6_SkipsSoftDeletedEngrams(t *testing.T) {
 	}
 	if !anyActiveFound && len(resp.Activations) == 0 {
 		t.Log("note: 0 activations returned — FTS may not have indexed in time; soft-delete filter assertion still passes (no deleted IDs returned)")
+	}
+}
+
+// TestActivation_ExcludeUntrusted verifies that when the vault PlasticityConfig has
+// ExcludeUntrusted=true, engrams marked as TrustUntrusted are filtered from results.
+func TestActivation_ExcludeUntrusted(t *testing.T) {
+	eng, as, _, cleanup := testEnvWithAuth(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "act-trust-filter"
+
+	// Configure this vault with ExcludeUntrusted=true.
+	tr := true
+	if err := as.SetVaultConfig(auth.VaultConfig{
+		Name:   vault,
+		Public: true,
+		Plasticity: &auth.PlasticityConfig{
+			ExcludeUntrusted: &tr,
+		},
+	}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+
+	// Write two engrams with the same distinctive content to ensure FTS can recall them.
+	respUntrusted, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   vault,
+		Concept: "trust filter untrusted engram",
+		Content: "exclude untrusted trust filter test zeta",
+	})
+	if err != nil {
+		t.Fatalf("Write untrusted: %v", err)
+	}
+
+	respTrusted, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   vault,
+		Concept: "trust filter trusted engram",
+		Content: "exclude untrusted trust filter test eta",
+	})
+	if err != nil {
+		t.Fatalf("Write trusted: %v", err)
+	}
+
+	// Mark the first engram as untrusted.
+	if err := eng.SetTrust(ctx, vault, respUntrusted.ID, "untrusted"); err != nil {
+		t.Fatalf("SetTrust (untrusted): %v", err)
+	}
+
+	// Allow the async FTS worker to index the written engrams.
+	awaitFTS(t, eng)
+
+	// Activate: query broadly so both engrams would match without the filter.
+	resp, err := eng.Activate(ctx, &mbp.ActivateRequest{
+		Vault:      vault,
+		Context:    []string{"exclude untrusted trust filter test"},
+		MaxResults: 10,
+		Threshold:  0.0,
+	})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+
+	// Build a set of returned IDs for fast lookup.
+	returnedIDs := make(map[string]bool, len(resp.Activations))
+	for _, a := range resp.Activations {
+		returnedIDs[a.ID] = true
+	}
+
+	// Precondition: awaitFTS guarantees indexing; we must see at least one result.
+	// Zero results would mean the filter is broken in both directions (or awaitFTS failed).
+	if len(resp.Activations) == 0 {
+		t.Fatalf("Activate returned 0 results after awaitFTS — expected at least the trusted engram")
+	}
+
+	// Assert: untrusted engram must NOT appear.
+	if returnedIDs[respUntrusted.ID] {
+		t.Errorf("untrusted engram id=%s appeared in Activate results — ExcludeUntrusted filter failed", respUntrusted.ID)
+	}
+
+	// Assert: trusted engram must appear.
+	if !returnedIDs[respTrusted.ID] {
+		t.Errorf("trusted engram id=%s missing from Activate results — over-filtering?", respTrusted.ID)
 	}
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -2269,3 +2269,39 @@ func TestEvolve_AutoStampsTrustInferred(t *testing.T) {
 		t.Errorf("ReadResponse.Trust = %d, want %d (TrustInferred)", readResp.Trust, uint8(storage.TrustInferred))
 	}
 }
+
+func TestEngine_SetTrust(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	resp, err := eng.Write(context.Background(), &mbp.WriteRequest{
+		Vault:   "default",
+		Content: "content for set-trust test",
+		Concept: "set-trust concept",
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if err := eng.SetTrust(context.Background(), "default", resp.ID, "verified"); err != nil {
+		t.Fatalf("SetTrust: %v", err)
+	}
+
+	readResp, err := eng.Read(context.Background(), &mbp.ReadRequest{ID: resp.ID, Vault: "default"})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if readResp.Trust != uint8(storage.TrustVerified) {
+		t.Errorf("Trust = %d, want %d (TrustVerified)", readResp.Trust, storage.TrustVerified)
+	}
+
+	if err := eng.SetTrust(context.Background(), "default", resp.ID, "bogus"); err == nil {
+		t.Error("expected error for invalid trust string")
+	}
+
+	// SetTrust on a nonexistent engram returns an error
+	fakeID := "01ARZ3NDEKTSV4RRFFQ69G5FAV" // valid ULID format but no such engram
+	if err := eng.SetTrust(context.Background(), "default", fakeID, "verified"); err == nil {
+		t.Error("expected error for nonexistent engram")
+	}
+}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -2112,3 +2112,160 @@ func TestEngineTraverse_EdgeRelTypePopulated(t *testing.T) {
 		t.Errorf("edge RelType = %v (%d), want storage.RelSupports (%d)", edges[0].RelType, edges[0].RelType, storage.RelSupports)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// TestWrite_AutoStampsTrustInferred: Write should auto-stamp TrustInferred
+// ---------------------------------------------------------------------------
+
+// TestWrite_AutoStampsTrustInferred verifies that Write auto-stamps TrustInferred
+// on new engrams and that Trust is propagated through Read and Activate responses.
+func TestWrite_AutoStampsTrustInferred(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Write an engram without specifying Trust
+	writeResp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   "test",
+		Concept: "trust inference test",
+		Content: "This engram should get TrustInferred automatically.",
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if writeResp.ID == "" {
+		t.Fatal("expected non-empty ID from Write")
+	}
+
+	// Read it back and verify Trust == TrustInferred
+	readResp, err := eng.Read(ctx, &mbp.ReadRequest{
+		Vault: "test",
+		ID:    writeResp.ID,
+	})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if readResp.Trust != uint8(storage.TrustInferred) {
+		t.Errorf("ReadResponse.Trust = %d, want %d (TrustInferred)", readResp.Trust, uint8(storage.TrustInferred))
+	}
+}
+
+// TestWriteBatch_AutoStampsTrustInferred verifies that WriteBatch auto-stamps
+// TrustInferred on new engrams and that Trust is visible via Read.
+func TestWriteBatch_AutoStampsTrustInferred(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	reqs := []*mbp.WriteRequest{
+		{
+			Vault:   "test",
+			Concept: "batch trust test",
+			Content: "This batch engram should get TrustInferred automatically.",
+		},
+	}
+
+	responses, errs := eng.WriteBatch(ctx, reqs)
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(responses))
+	}
+	if errs[0] != nil {
+		t.Fatalf("WriteBatch: %v", errs[0])
+	}
+	if responses[0] == nil || responses[0].ID == "" {
+		t.Fatal("expected non-empty ID from WriteBatch")
+	}
+
+	readResp, err := eng.Read(ctx, &mbp.ReadRequest{
+		Vault: "test",
+		ID:    responses[0].ID,
+	})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if readResp.Trust != uint8(storage.TrustInferred) {
+		t.Errorf("ReadResponse.Trust = %d, want %d (TrustInferred)", readResp.Trust, uint8(storage.TrustInferred))
+	}
+}
+
+// TestActivate_TrustPropagation verifies that Trust is propagated into
+// ActivationItem results returned by Activate.
+func TestActivate_TrustPropagation(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   "test",
+		Concept: "trust activation test",
+		Content: "Trust propagation through activation results.",
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	awaitFTS(t, eng)
+
+	resp, err := eng.Activate(ctx, &mbp.ActivateRequest{
+		Vault:      "test",
+		Context:    []string{"trust propagation activation results"},
+		MaxResults: 10,
+		Threshold:  0.01,
+	})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if len(resp.Activations) == 0 {
+		t.Fatal("Activate returned 0 results, want >= 1")
+	}
+
+	found := false
+	for _, item := range resp.Activations {
+		if item.Concept == "trust activation test" {
+			found = true
+			if item.Trust != uint8(storage.TrustInferred) {
+				t.Errorf("ActivationItem.Trust = %d, want %d (TrustInferred)", item.Trust, uint8(storage.TrustInferred))
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("did not find 'trust activation test' engram in Activate results")
+	}
+}
+
+// TestEvolve_AutoStampsTrustInferred verifies that Evolve auto-stamps
+// TrustInferred on the new engram it creates.
+func TestEvolve_AutoStampsTrustInferred(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	writeResp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   "test",
+		Concept: "evolve trust test",
+		Content: "Original content before evolution.",
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	newULID, err := eng.Evolve(ctx, "test", writeResp.ID, "Evolved content after trust stamp.", "trust test evolution", nil)
+	if err != nil {
+		t.Fatalf("Evolve: %v", err)
+	}
+	if newULID == (storage.ULID{}) {
+		t.Fatal("Evolve returned zero ID")
+	}
+
+	readResp, err := eng.Read(ctx, &mbp.ReadRequest{
+		Vault: "test",
+		ID:    newULID.String(),
+	})
+	if err != nil {
+		t.Fatalf("Read new engram: %v", err)
+	}
+	if readResp.Trust != uint8(storage.TrustInferred) {
+		t.Errorf("ReadResponse.Trust = %d, want %d (TrustInferred)", readResp.Trust, uint8(storage.TrustInferred))
+	}
+}

--- a/internal/engine/tree.go
+++ b/internal/engine/tree.go
@@ -135,6 +135,7 @@ func (e *Engine) RememberTree(ctx context.Context, req *RememberTreeRequest) (*R
 			Concept: item.input.Concept,
 			Content: item.input.Content,
 			Tags:    item.input.Tags,
+			Trust:   storage.TrustInferred, // all new MCP writes default to inferred
 		}
 		if item.input.Type != "" {
 			if mt, ok := storage.ParseMemoryType(item.input.Type); ok {
@@ -246,6 +247,7 @@ func (e *Engine) AddChild(ctx context.Context, vault, parentID string, input *Ad
 		Content:   input.Content,
 		Tags:      input.Tags,
 		Embedding: input.Embedding,
+		Trust:     storage.TrustInferred, // all new MCP writes default to inferred
 	}
 	if input.Type != "" {
 		if mt, ok := storage.ParseMemoryType(input.Type); ok {

--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -163,7 +163,8 @@ func isMutatingTool(name string) bool {
 		"muninn_entity_state_batch",
 		"muninn_merge_entity",
 		"muninn_replay_enrichment",
-		"muninn_feedback":
+		"muninn_feedback",
+		"muninn_trust":
 		return true
 	}
 	return false

--- a/internal/mcp/convert.go
+++ b/internal/mcp/convert.go
@@ -35,6 +35,7 @@ func activationToMemory(item *mbp.ActivationItem) Memory {
 		AccessCount: item.AccessCount,
 		Relevance:   item.Relevance,
 		SourceType:  item.SourceType,
+		Trust:       storage.TrustLevel(item.Trust).String(),
 	}
 }
 
@@ -54,6 +55,7 @@ func readResponseToMemory(r *mbp.ReadResponse) Memory {
 		LastAccess:  time.Unix(0, r.LastAccess).UTC(),
 		AccessCount: r.AccessCount,
 		Relevance:   r.Relevance,
+		Trust:       storage.TrustLevel(r.Trust).String(),
 	}
 	for _, e := range r.Entities {
 		m.Entities = append(m.Entities, ReadEntity{Name: e.Name, Type: e.Type})

--- a/internal/mcp/engine.go
+++ b/internal/mcp/engine.go
@@ -166,4 +166,8 @@ type EngineInterface interface {
 	// Derived from the HNSW index — returns 0 if no embeddings have been stored yet
 	// (dimension not yet established; any client-provided dimension will be accepted).
 	GetVaultEmbedDim(ctx context.Context, vault string) int
+
+	// SetTrust sets the trust label of an engram.
+	// trust must be one of "verified", "inferred", "external", "untrusted".
+	SetTrust(ctx context.Context, vault, id, trust string) error
 }

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -596,6 +596,10 @@ func (a *mcpEngineAdapter) GetVaultEmbedDim(ctx context.Context, vault string) i
 	return a.eng.GetVaultEmbedDim(ctx, vault)
 }
 
+func (a *mcpEngineAdapter) SetTrust(ctx context.Context, vault, id, trust string) error {
+	return a.eng.SetTrust(ctx, vault, id, trust)
+}
+
 func (a *mcpEngineAdapter) ListEntities(ctx context.Context, vault string, limit int, state string) ([]EntitySummary, error) {
 	records, err := a.eng.ListEntities(ctx, vault, limit, state)
 	if err != nil {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1719,3 +1719,29 @@ func (s *MCPServer) handleEntityTimeline(ctx context.Context, w http.ResponseWri
 	}
 	sendResult(w, id, textContent(mustJSON(timeline)))
 }
+
+func (s *MCPServer) handleSetTrust(ctx context.Context, w http.ResponseWriter, id json.RawMessage, vault string, args map[string]any) {
+	engramID, ok := args["id"].(string)
+	if !ok || engramID == "" {
+		sendError(w, id, -32602, "invalid params: 'id' is required")
+		return
+	}
+	trustStr, ok := args["trust"].(string)
+	if !ok || trustStr == "" {
+		sendError(w, id, -32602, "invalid params: 'trust' is required (one of: verified, inferred, external, untrusted)")
+		return
+	}
+	if _, err := storage.ParseTrustLevel(trustStr); err != nil {
+		sendError(w, id, -32602, "invalid params: "+err.Error())
+		return
+	}
+	if err := s.engine.SetTrust(ctx, vault, engramID, trustStr); err != nil {
+		sendError(w, id, -32000, "tool error: "+err.Error())
+		return
+	}
+	sendResult(w, id, textContent(mustJSON(map[string]any{
+		"id":    engramID,
+		"trust": trustStr,
+		"ok":    true,
+	})))
+}

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -3415,3 +3415,51 @@ func TestHandleAddChild_EmbeddingOmittedIsAccepted(t *testing.T) {
 		t.Errorf("expected no embedding, got %d elements", len(eng.lastChild.Embedding))
 	}
 }
+
+// ── muninn_trust ─────────────────────────────────────────────────────────────
+
+func TestHandleSetTrust(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		srv := newTestServer()
+		body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_trust","arguments":{"vault":"default","id":"01ARZ3NDEKTSV4RRFFQ69G5FAV","trust":"verified"}}}`
+		w := postRPC(t, srv, body)
+		resp := decodeResp(t, w.Body.String())
+		if resp.Error != nil {
+			t.Fatalf("unexpected error: %v", resp.Error)
+		}
+		inner := extractInnerJSON(t, resp)
+		if ok, _ := inner["ok"].(bool); !ok {
+			t.Errorf("expected ok=true in response, got %v", inner["ok"])
+		}
+	})
+
+	t.Run("missing id", func(t *testing.T) {
+		srv := newTestServer()
+		body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_trust","arguments":{"vault":"default","trust":"verified"}}}`
+		w := postRPC(t, srv, body)
+		resp := decodeResp(t, w.Body.String())
+		if resp.Error == nil || resp.Error.Code != -32602 {
+			t.Errorf("expected -32602 for missing id, got %v", resp.Error)
+		}
+	})
+
+	t.Run("missing trust", func(t *testing.T) {
+		srv := newTestServer()
+		body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_trust","arguments":{"vault":"default","id":"01ARZ3NDEKTSV4RRFFQ69G5FAV"}}}`
+		w := postRPC(t, srv, body)
+		resp := decodeResp(t, w.Body.String())
+		if resp.Error == nil || resp.Error.Code != -32602 {
+			t.Errorf("expected -32602 for missing trust, got %v", resp.Error)
+		}
+	})
+
+	t.Run("invalid trust level", func(t *testing.T) {
+		srv := newTestServer()
+		body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_trust","arguments":{"vault":"default","id":"01ARZ3NDEKTSV4RRFFQ69G5FAV","trust":"bogus"}}}`
+		w := postRPC(t, srv, body)
+		resp := decodeResp(t, w.Body.String())
+		if resp.Error == nil || resp.Error.Code != -32602 {
+			t.Errorf("expected -32602 for invalid trust level, got %v", resp.Error)
+		}
+	})
+}

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -873,6 +873,48 @@ func TestHandleRecallEmptySourceTypeOmitted(t *testing.T) {
 	}
 }
 
+// recallWithTrustEngine returns an ActivateResponse with a single ActivationItem
+// where Trust is set to TrustVerified, so that activationToMemory propagation can be verified.
+type recallWithTrustEngine struct{ fakeEngine }
+
+func (e *recallWithTrustEngine) Activate(_ context.Context, req *mbp.ActivateRequest) (*mbp.ActivateResponse, error) {
+	return &mbp.ActivateResponse{
+		Activations: []mbp.ActivationItem{
+			{
+				ID:      "trust-001",
+				Concept: "trust concept",
+				Content: "trust content",
+				Score:   0.8,
+				Trust:   uint8(storage.TrustVerified),
+			},
+		},
+	}, nil
+}
+
+func TestHandleRecall_IncludesTrust(t *testing.T) {
+	srv := newTestServerWith(&recallWithTrustEngine{})
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_recall","arguments":{"vault":"default","context":["test"]}}}`
+	w := postRPC(t, srv, body)
+	outer := extractInnerJSON(t, decodeResp(t, w.Body.String()))
+
+	memories, ok := outer["memories"].([]any)
+	if !ok || len(memories) == 0 {
+		t.Fatalf("expected non-empty memories array, got %T %v", outer["memories"], outer["memories"])
+	}
+	mem, ok := memories[0].(map[string]any)
+	if !ok {
+		t.Fatalf("memories[0] should be an object, got %T", memories[0])
+	}
+
+	trust, ok := mem["trust"].(string)
+	if !ok {
+		t.Fatalf("expected trust field to be a string, got %T (%v)", mem["trust"], mem["trust"])
+	}
+	if trust != "verified" {
+		t.Errorf("trust = %q, want %q", trust, "verified")
+	}
+}
+
 // ── muninn_read ──────────────────────────────────────────────────────────────
 
 // readWithDataEngine returns a populated ReadResponse so shape assertions are meaningful.
@@ -976,6 +1018,33 @@ func TestHandleRead_NoEntitiesOmitsFields(t *testing.T) {
 	}
 	if _, ok := content["entity_relationships"]; ok {
 		t.Error("entity_relationships field should be omitted when empty")
+	}
+}
+
+// readWithTrustEngine returns a ReadResponse with Trust set to TrustInferred.
+type readWithTrustEngine struct{ fakeEngine }
+
+func (e *readWithTrustEngine) Read(_ context.Context, req *mbp.ReadRequest) (*mbp.ReadResponse, error) {
+	return &mbp.ReadResponse{
+		ID:      req.ID,
+		Concept: "test concept",
+		Content: "test content body",
+		Trust:   uint8(storage.TrustInferred),
+	}, nil
+}
+
+func TestHandleRead_IncludesTrust(t *testing.T) {
+	srv := newTestServerWith(&readWithTrustEngine{})
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_read","arguments":{"vault":"default","id":"abc-123"}}}`
+	w := postRPC(t, srv, body)
+	content := extractInnerJSON(t, decodeResp(t, w.Body.String()))
+
+	trust, ok := content["trust"].(string)
+	if !ok {
+		t.Fatalf("expected trust field to be a string, got %T (%v)", content["trust"], content["trust"])
+	}
+	if trust != "inferred" {
+		t.Errorf("trust = %q, want %q", trust, "inferred")
 	}
 }
 

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -1757,6 +1757,9 @@ func (e *slowIdempotentEngine) ListEntities(ctx context.Context, vault string, l
 func (e *slowIdempotentEngine) GetVaultEmbedDim(ctx context.Context, vault string) int {
 	return (&fakeEngine{}).GetVaultEmbedDim(ctx, vault)
 }
+func (e *slowIdempotentEngine) SetTrust(ctx context.Context, vault, id, trust string) error {
+	return (&fakeEngine{}).SetTrust(ctx, vault, id, trust)
+}
 
 // TestHandleRemember_ConcurrentSameOpID verifies that two concurrent
 // muninn_remember calls carrying the same op_id do not produce duplicate

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -276,6 +276,9 @@ func (s *MCPServer) dispatchToolCall(ctx context.Context, w http.ResponseWriter,
 		// Entity aggregate view
 		"muninn_entity":   s.handleEntity,
 		"muninn_entities": s.handleEntities,
+
+		// Trust label
+		"muninn_trust": s.handleSetTrust,
 	}
 
 	handler, found := handlers[req.Params.Name]
@@ -304,6 +307,7 @@ func registeredToolNames() []string {
 		"muninn_similar_entities", "muninn_merge_entity", "muninn_entity_timeline",
 		"muninn_replay_enrichment", "muninn_provenance", "muninn_feedback",
 		"muninn_entity", "muninn_entities",
+		"muninn_trust",
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -180,6 +180,7 @@ func (f *fakeEngine) ListEntities(_ context.Context, _ string, _ int, _ string) 
 func (f *fakeEngine) GetVaultEmbedDim(_ context.Context, _ string) int {
 	return 0
 }
+func (f *fakeEngine) SetTrust(_ context.Context, _, _, _ string) error { return nil }
 
 func newTestServer() *MCPServer {
 	return New(":0", &fakeEngine{}, "", nil, nil)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -279,8 +279,8 @@ func TestListTools(t *testing.T) {
 	var result map[string]any
 	json.NewDecoder(w.Body).Decode(&result)
 	tools, _ := result["tools"].([]any)
-	if len(tools) != 38 {
-		t.Errorf("expected 38 tools, got %d", len(tools))
+	if len(tools) != 39 {
+		t.Errorf("expected 39 tools, got %d", len(tools))
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -801,5 +801,29 @@ func allToolDefinitions() []ToolDefinition {
 				"required": []string{},
 			},
 		},
+		// Trust label
+		{
+			Name:        "muninn_trust",
+			Description: "Set the trust level of an engram. Trust levels control how much confidence to place in a memory. Use 'verified' for human-confirmed facts, 'inferred' for AI-generated memories (default), 'external' for imported data, and 'untrusted' to flag unreliable memories. Untrusted memories can be excluded from recall by enabling ExcludeUntrusted in vault config.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"id": map[string]any{
+						"type":        "string",
+						"description": "ULID of the engram to update",
+					},
+					"trust": map[string]any{
+						"type":        "string",
+						"enum":        []string{"verified", "inferred", "external", "untrusted"},
+						"description": "Trust level to assign",
+					},
+					"vault": map[string]any{
+						"type":        "string",
+						"description": "Vault containing the engram (default: \"default\")",
+					},
+				},
+				"required": []string{"id", "trust"},
+			},
+		},
 	}
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestAllToolDefinitionsCount(t *testing.T) {
 	tools := allToolDefinitions()
-	if len(tools) != 38 {
-		t.Errorf("expected 38 tools, got %d", len(tools))
+	if len(tools) != 39 {
+		t.Errorf("expected 39 tools, got %d", len(tools))
 	}
 }
 

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -74,6 +74,7 @@ type Memory struct {
 	AccessCount uint32    `json:"access_count,omitempty"`
 	Relevance   float32   `json:"relevance,omitempty"`
 	SourceType  string    `json:"source_type,omitempty"`
+	Trust       string    `json:"trust,omitempty"` // "verified", "inferred", "external", "untrusted"
 
 	// Populated only by muninn_read (omitted from recall responses).
 	Entities            []ReadEntity    `json:"entities,omitempty"`

--- a/internal/storage/engram.go
+++ b/internal/storage/engram.go
@@ -376,6 +376,48 @@ func (ps *PebbleStore) UpdateRelevance(ctx context.Context, wsPrefix [8]byte, id
 	return nil
 }
 
+// UpdateTrust updates the trust label of an engram in-place using PatchTrust.
+// Invalidates the L1 and metadata caches. Appends a provenance entry.
+func (ps *PebbleStore) UpdateTrust(ctx context.Context, wsPrefix [8]byte, id ULID, trust TrustLevel) error {
+	engramKey := keys.EngramKey(wsPrefix, [16]byte(id))
+	rawBytes, err := Get(ps.db, engramKey)
+	if err != nil {
+		return fmt.Errorf("get engram raw: %w", err)
+	}
+	if rawBytes == nil {
+		return fmt.Errorf("engram not found")
+	}
+
+	if err := erf.PatchTrust(rawBytes, uint8(trust)); err != nil {
+		return fmt.Errorf("patch trust: %w", err)
+	}
+
+	batch := ps.db.NewBatch()
+	defer batch.Close()
+
+	batch.Set(engramKey, rawBytes, nil)
+	metaKey := keys.MetaKey(wsPrefix, [16]byte(id))
+	batch.Set(metaKey, erf.MetaKeySlice(rawBytes), nil)
+
+	// Invalidate L1 and metadata caches before commit — cached structs are stale.
+	ps.cache.Delete(wsPrefix, id)
+	ps.metaCache.Remove([16]byte(id))
+
+	if err := batch.Commit(pebble.NoSync); err != nil {
+		return fmt.Errorf("commit batch: %w", err)
+	}
+
+	ps.provWork.Submit(wsPrefix, id, provenance.ProvenanceEntry{
+		Timestamp: time.Now(),
+		Source:    provenance.SourceHuman,
+		AgentID:   "system:set-trust",
+		Operation: "update-trust",
+		Note:      trust.String(),
+	})
+
+	return nil
+}
+
 // DeleteEngram performs a hard delete: removes the engram, all association keys,
 // and all secondary indexes. Reads the engram first to gather index data.
 func (ps *PebbleStore) DeleteEngram(ctx context.Context, wsPrefix [8]byte, id ULID) error {
@@ -790,6 +832,7 @@ func toERFEngram(eng *Engram) *erf.Engram {
 		MemoryType:     uint8(eng.MemoryType),
 		TypeLabel:      eng.TypeLabel,
 		Classification: eng.Classification,
+		Trust:          uint8(eng.Trust),
 	}
 }
 
@@ -829,6 +872,7 @@ func fromERFEngram(e *erf.Engram) *Engram {
 		MemoryType:     MemoryType(e.MemoryType),
 		TypeLabel:      e.TypeLabel,
 		Classification: e.Classification,
+		Trust:          TrustLevel(e.Trust),
 	}
 }
 

--- a/internal/storage/engram_metadata_test.go
+++ b/internal/storage/engram_metadata_test.go
@@ -192,3 +192,61 @@ func TestUpdateDigest_NotFound(t *testing.T) {
 	err := store.UpdateDigest(ctx, ghost, "summary", []string{"kp"}, "", "")
 	require.Error(t, err, "UpdateDigest must return an error for a non-existent engram ID")
 }
+
+// ---------------------------------------------------------------------------
+// UpdateTrust
+// ---------------------------------------------------------------------------
+
+// TestUpdateTrust_PersistsValue writes an engram with TrustInferred, calls
+// UpdateTrust to set TrustVerified, reads back, and asserts the change.
+func TestUpdateTrust_PersistsValue(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("update-trust-persist")
+
+	eng := &Engram{
+		Concept: "trust-concept",
+		Content: "trust-content",
+		Trust:   TrustInferred,
+	}
+	id, err := store.WriteEngram(ctx, ws, eng)
+	require.NoError(t, err)
+
+	// Verify initial trust level is preserved after write.
+	got, err := store.GetEngram(ctx, ws, id)
+	require.NoError(t, err)
+	require.Equal(t, TrustInferred, got.Trust, "initial Trust must be TrustInferred")
+
+	// Prime metaCache before update so we can verify invalidation below.
+	metas, err := store.GetMetadata(ctx, ws, []ULID{id})
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+	require.NotNil(t, metas[0])
+
+	// Update trust to Verified.
+	require.NoError(t, store.UpdateTrust(ctx, ws, id, TrustVerified))
+
+	// Verify metaCache was invalidated — GetMetadata must not return a stale cached entry.
+	metas2, err := store.GetMetadata(ctx, ws, []ULID{id})
+	require.NoError(t, err)
+	require.Len(t, metas2, 1)
+	require.NotNil(t, metas2[0])
+	require.Equal(t, id, metas2[0].ID, "GetMetadata must return the correct ID after UpdateTrust")
+
+	// Read back — cache was invalidated by UpdateTrust.
+	got2, err := store.GetEngram(ctx, ws, id)
+	require.NoError(t, err)
+	require.Equal(t, TrustVerified, got2.Trust, "Trust must reflect the updated value")
+}
+
+// TestUpdateTrust_NotFound verifies that UpdateTrust returns an error when the
+// engram does not exist.
+func TestUpdateTrust_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("update-trust-notfound")
+
+	ghost := NewULID()
+	err := store.UpdateTrust(ctx, ws, ghost, TrustVerified)
+	require.Error(t, err, "UpdateTrust must return an error for a non-existent engram")
+}

--- a/internal/storage/erf/decode.go
+++ b/internal/storage/erf/decode.go
@@ -144,6 +144,7 @@ func Decode(data []byte) (*Engram, error) {
 	eng.EmbedDim = data[OffsetEmbedDim]
 	eng.MemoryType = data[OffsetMemoryType]
 	eng.Classification = binary.BigEndian.Uint16(data[OffsetClassification : OffsetClassification+2])
+	// TODO(task-2): read eng.Trust = data[OffsetTrust]
 
 	// Parse tagged extension fields between the end of variable data and CRC32 trailer.
 	varEnd := maxVarEnd(conceptOff, uint32(conceptLen), createdByOff, uint32(createdByLen),

--- a/internal/storage/erf/decode.go
+++ b/internal/storage/erf/decode.go
@@ -144,7 +144,7 @@ func Decode(data []byte) (*Engram, error) {
 	eng.EmbedDim = data[OffsetEmbedDim]
 	eng.MemoryType = data[OffsetMemoryType]
 	eng.Classification = binary.BigEndian.Uint16(data[OffsetClassification : OffsetClassification+2])
-	// TODO(task-2): read eng.Trust = data[OffsetTrust]
+	eng.Trust = data[OffsetTrust]
 
 	// Parse tagged extension fields between the end of variable data and CRC32 trailer.
 	varEnd := maxVarEnd(conceptOff, uint32(conceptLen), createdByOff, uint32(createdByLen),

--- a/internal/storage/erf/encode.go
+++ b/internal/storage/erf/encode.go
@@ -57,7 +57,7 @@ func encodeInto(b *erfBuffer, eng *Engram) error {
 	b.buf[OffsetEmbedDim] = eng.EmbedDim
 	b.buf[OffsetMemoryType] = eng.MemoryType
 	binary.BigEndian.PutUint16(b.buf[OffsetClassification:OffsetClassification+2], eng.Classification)
-	// TODO(task-2): write eng.Trust at OffsetTrust (b.buf[OffsetTrust] = eng.Trust)
+	b.buf[OffsetTrust] = eng.Trust
 
 	conceptBytes := []byte(eng.Concept)
 	createdByBytes := []byte(eng.CreatedBy)
@@ -208,7 +208,7 @@ func encodeV2Into(b *erfBuffer, eng *Engram) error {
 	b.buf[OffsetEmbedDim] = eng.EmbedDim
 	b.buf[OffsetMemoryType] = eng.MemoryType
 	binary.BigEndian.PutUint16(b.buf[OffsetClassification:OffsetClassification+2], eng.Classification)
-	// TODO(task-2): write eng.Trust at OffsetTrust (b.buf[OffsetTrust] = eng.Trust)
+	b.buf[OffsetTrust] = eng.Trust
 
 	conceptBytes := []byte(eng.Concept)
 	createdByBytes := []byte(eng.CreatedBy)

--- a/internal/storage/erf/encode.go
+++ b/internal/storage/erf/encode.go
@@ -57,6 +57,7 @@ func encodeInto(b *erfBuffer, eng *Engram) error {
 	b.buf[OffsetEmbedDim] = eng.EmbedDim
 	b.buf[OffsetMemoryType] = eng.MemoryType
 	binary.BigEndian.PutUint16(b.buf[OffsetClassification:OffsetClassification+2], eng.Classification)
+	// TODO(task-2): write eng.Trust at OffsetTrust (b.buf[OffsetTrust] = eng.Trust)
 
 	conceptBytes := []byte(eng.Concept)
 	createdByBytes := []byte(eng.CreatedBy)
@@ -207,6 +208,7 @@ func encodeV2Into(b *erfBuffer, eng *Engram) error {
 	b.buf[OffsetEmbedDim] = eng.EmbedDim
 	b.buf[OffsetMemoryType] = eng.MemoryType
 	binary.BigEndian.PutUint16(b.buf[OffsetClassification:OffsetClassification+2], eng.Classification)
+	// TODO(task-2): write eng.Trust at OffsetTrust (b.buf[OffsetTrust] = eng.Trust)
 
 	conceptBytes := []byte(eng.Concept)
 	createdByBytes := []byte(eng.CreatedBy)

--- a/internal/storage/erf/format.go
+++ b/internal/storage/erf/format.go
@@ -30,7 +30,7 @@ const (
 	OffsetEmbedDim    = 67
 	OffsetMemoryType  = 68 // uint8, first byte of formerly-reserved area
 	OffsetClassification = 69 // uint16, big-endian
-	OffsetReserved    = 71 // 29 bytes reserved (was 32)
+	OffsetTrust       = 71 // uint8; first byte of the formerly-reserved area (bytes 72-99 remain reserved)
 
 	// Offset table field offsets (relative to record start)
 	OffsetConceptOff   = 108

--- a/internal/storage/erf/patch.go
+++ b/internal/storage/erf/patch.go
@@ -53,3 +53,25 @@ func PatchAllMeta(raw []byte, updatedAt, lastAccess time.Time, confidence, relev
 	binary.BigEndian.PutUint32(raw[len(raw)-TrailerSize:], crc32val)
 	return nil
 }
+
+// GetTrust reads the trust byte from a raw ERF record without a full decode.
+// Returns 0x00 (unset/inferred) if the record is too short.
+func GetTrust(raw []byte) uint8 {
+	if len(raw) < VariableDataStart+TrailerSize {
+		return 0x00
+	}
+	return raw[OffsetTrust]
+}
+
+// PatchTrust updates the trust byte in a raw ERF record in-place and
+// recomputes the CRC32 trailer. Does NOT touch the CRC16 (covers bytes 0-5 only).
+// raw must be a mutable copy of the 0x01 record (Get() already returns a copy).
+func PatchTrust(raw []byte, trust uint8) error {
+	if len(raw) < VariableDataStart+TrailerSize {
+		return errors.New("erf: record too short for PatchTrust")
+	}
+	raw[OffsetTrust] = trust
+	crc32val := ComputeCRC32(raw[:len(raw)-TrailerSize])
+	binary.BigEndian.PutUint32(raw[len(raw)-TrailerSize:], crc32val)
+	return nil
+}

--- a/internal/storage/erf/trust_test.go
+++ b/internal/storage/erf/trust_test.go
@@ -1,0 +1,83 @@
+package erf_test
+
+import (
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage/erf"
+)
+
+func TestPatchTrust(t *testing.T) {
+	eng := &erf.Engram{
+		Concept:   "test",
+		Content:   "hello world",
+		CreatedBy: "tester",
+	}
+	raw, err := erf.Encode(eng)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	// Default trust is 0 (unset)
+	if got := erf.GetTrust(raw); got != 0x00 {
+		t.Errorf("initial GetTrust = %d, want 0", got)
+	}
+
+	// Patch to verified (0x01)
+	if err := erf.PatchTrust(raw, 0x01); err != nil {
+		t.Fatalf("PatchTrust: %v", err)
+	}
+	if got := erf.GetTrust(raw); got != 0x01 {
+		t.Errorf("GetTrust after patch = %d, want 1", got)
+	}
+
+	// CRC32 must still verify
+	if !erf.VerifyCRC32(raw) {
+		t.Error("CRC32 invalid after PatchTrust")
+	}
+
+	// Decode must succeed and trust survives
+	decoded, err := erf.Decode(raw)
+	if err != nil {
+		t.Fatalf("Decode after PatchTrust: %v", err)
+	}
+	if decoded.Trust != 0x01 {
+		t.Errorf("decoded.Trust = %d, want 1", decoded.Trust)
+	}
+}
+
+func TestEncodeDecodeTrustRoundtrip(t *testing.T) {
+	tests := []struct{ trust uint8 }{
+		{0x00}, {0x01}, {0x02}, {0x03}, {0x04},
+	}
+	for _, tc := range tests {
+		eng := &erf.Engram{
+			Concept:   "trust-roundtrip",
+			Content:   "content",
+			CreatedBy: "test",
+			Trust:     tc.trust,
+		}
+		raw, err := erf.Encode(eng)
+		if err != nil {
+			t.Fatalf("trust=%d Encode: %v", tc.trust, err)
+		}
+		decoded, err := erf.Decode(raw)
+		if err != nil {
+			t.Fatalf("trust=%d Decode: %v", tc.trust, err)
+		}
+		if decoded.Trust != tc.trust {
+			t.Errorf("trust=%d: roundtrip got %d", tc.trust, decoded.Trust)
+		}
+	}
+}
+
+func TestPatchTrustTooShort(t *testing.T) {
+	if err := erf.PatchTrust(make([]byte, 10), 0x01); err == nil {
+		t.Error("expected error for too-short record")
+	}
+}
+
+func TestGetTrustTooShort(t *testing.T) {
+	if got := erf.GetTrust(make([]byte, 10)); got != 0x00 {
+		t.Errorf("GetTrust on short record = %d, want 0", got)
+	}
+}

--- a/internal/storage/erf/types.go
+++ b/internal/storage/erf/types.go
@@ -26,6 +26,7 @@ type Engram struct {
 	MemoryType     uint8
 	TypeLabel      string // free-form label, e.g. "architectural_decision"
 	Classification uint16
+	Trust          uint8  // TrustLevel; 0x00=unset(inferred), 0x01=verified, 0x02=inferred, 0x03=external, 0x04=untrusted
 }
 
 // EngramMeta is the erf-package local representation of the 100-byte fixed metadata section.

--- a/internal/storage/trust_level_test.go
+++ b/internal/storage/trust_level_test.go
@@ -1,0 +1,50 @@
+package storage_test
+
+import (
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+func TestParseTrustLevel(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    storage.TrustLevel
+		wantErr bool
+	}{
+		{"verified", storage.TrustVerified, false},
+		{"inferred", storage.TrustInferred, false},
+		{"external", storage.TrustExternal, false},
+		{"untrusted", storage.TrustUntrusted, false},
+		{"bogus", 0, true},
+		{"", 0, true},
+	}
+	for _, tc := range tests {
+		got, err := storage.ParseTrustLevel(tc.input)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("ParseTrustLevel(%q) error = %v, wantErr %v", tc.input, err, tc.wantErr)
+		}
+		if !tc.wantErr && got != tc.want {
+			t.Errorf("ParseTrustLevel(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestTrustLevelString(t *testing.T) {
+	tests := []struct {
+		level storage.TrustLevel
+		want  string
+	}{
+		{storage.TrustUnset, "inferred"},
+		{storage.TrustVerified, "verified"},
+		{storage.TrustInferred, "inferred"},
+		{storage.TrustExternal, "external"},
+		{storage.TrustUntrusted, "untrusted"},
+		{storage.TrustLevel(99), "inferred"}, // unknown → inferred
+	}
+	for _, tc := range tests {
+		if got := tc.level.String(); got != tc.want {
+			t.Errorf("TrustLevel(%d).String() = %q, want %q", tc.level, got, tc.want)
+		}
+	}
+}

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -77,6 +77,7 @@ type Engram struct {
 	MemoryType     MemoryType
 	TypeLabel      string // free-form label, e.g. "architectural_decision", "coding_pattern"
 	Classification uint16 // concept-cluster ID
+	Trust          TrustLevel // provenance confidence label (OffsetTrust in ERF)
 }
 
 // EngramMeta is the 100-byte fixed metadata section.
@@ -286,6 +287,56 @@ func ParseMemoryType(s string) (MemoryType, bool) {
 		return TypeReference, true
 	default:
 		return TypeFact, false
+	}
+}
+
+// TrustLevel encodes the provenance confidence of an engram's content (uint8 on disk, offset 71).
+// 0x00 (TrustUnset) is the zero value for backward compatibility — all existing engrams read as "inferred".
+type TrustLevel uint8
+
+const (
+	TrustUnset     TrustLevel = 0x00 // zero value; displays as "inferred" for existing records
+	TrustVerified  TrustLevel = 0x01 // human-confirmed or admin-certified
+	TrustInferred  TrustLevel = 0x02 // AI-generated or system-inferred (default on new writes)
+	TrustExternal  TrustLevel = 0x03 // imported from an external system
+	TrustUntrusted TrustLevel = 0x04 // flagged as unreliable
+)
+
+// String returns the canonical string label for a TrustLevel.
+// TrustUnset and unknown values return "inferred" for display purposes.
+func (t TrustLevel) String() string {
+	switch t {
+	case TrustVerified:
+		return "verified"
+	case TrustInferred:
+		return "inferred"
+	case TrustExternal:
+		return "external"
+	case TrustUntrusted:
+		return "untrusted"
+	default: // TrustUnset (0x00) and unknown values — display as "inferred" for backward compatibility
+		return "inferred"
+	}
+}
+
+// ParseTrustLevel parses a trust level string into a TrustLevel.
+// Returns an error for unrecognized strings.
+// Note: "inferred" maps to TrustInferred (0x02), not TrustUnset (0x00).
+// Existing engrams with TrustUnset (zero-initialized) display as "inferred" via String()
+// but ParseTrustLevel will produce TrustInferred when written back — both are semantically
+// equivalent and the distinction is invisible to clients.
+func ParseTrustLevel(s string) (TrustLevel, error) {
+	switch s {
+	case "verified":
+		return TrustVerified, nil
+	case "inferred":
+		return TrustInferred, nil
+	case "external":
+		return TrustExternal, nil
+	case "untrusted":
+		return TrustUntrusted, nil
+	default:
+		return 0, fmt.Errorf("unknown trust level %q: must be one of verified, inferred, external, untrusted", s)
 	}
 }
 

--- a/internal/transport/mbp/types.go
+++ b/internal/transport/mbp/types.go
@@ -131,6 +131,11 @@ type ReadResponse struct {
 	// EmbedDim is the stored embedding dimensionality code (0 = no embedding).
 	// 1 = 384-dim, 2 = 768-dim, 3 = 1536-dim.
 	EmbedDim uint8 `msgpack:"embed_dim,omitempty" json:"embed_dim,omitempty"`
+	// Trust is the TrustLevel uint8 (0=unset/inferred, 1=verified, 2=inferred, 3=external, 4=untrusted).
+	// omitempty is intentional: TrustUnset(0x00) and TrustInferred(0x02) both render as "inferred"
+	// in the MCP layer, and legacy records (pre-trust) written as 0x00 are treated as inferred.
+	// Clients should treat an absent trust field as equivalent to TrustUnset (0x00).
+	Trust uint8 `msgpack:"trust,omitempty" json:"trust,omitempty"`
 
 	// Entities and EntityRelationships are populated by muninn_read to expose what
 	// was stored via inline enrichment. Empty when no entities/relationships were linked.
@@ -218,7 +223,9 @@ type ActivationItem struct {
 	LastAccess      int64           `msgpack:"last_access,omitempty"       json:"last_access,omitempty"`
 	AccessCount     uint32          `msgpack:"access_count,omitempty"      json:"access_count,omitempty"`
 	Relevance       float32         `msgpack:"relevance,omitempty"         json:"relevance,omitempty"`
-	SourceType      string          `msgpack:"source_type,omitempty"       json:"source_type,omitempty"`
+	SourceType string `msgpack:"source_type,omitempty" json:"source_type,omitempty"`
+	// Trust is the TrustLevel uint8. omitempty intentional — see ReadResponse.Trust comment.
+	Trust uint8 `msgpack:"trust,omitempty" json:"trust,omitempty"`
 }
 
 // ScoreComponents breaks down the activation score.


### PR DESCRIPTION
## Summary

- Adds `TrustLevel` (`uint8`) stored at ERF byte offset 71 (first reserved byte) with values `verified`, `inferred`, `external`, `untrusted`
- All new writes auto-stamp `TrustInferred (0x02)` — zero-value old records decode as `"inferred"` with no migration needed
- New `muninn_trust` MCP tool for post-write trust mutation
- Trust exposed as a string field in all `muninn_read` and `muninn_recall` responses
- New `ExcludeUntrusted` vault plasticity config that hard-filters `untrusted` engrams from ACTIVATE results

## Changes by Layer

- **Storage** (`erf/`, `storage/`): `TrustLevel` type, `OffsetTrust=71`, `PatchTrust`/`GetTrust`, ERF encode/decode, `PebbleStore.UpdateTrust` with provenance
- **Transport** (`mbp/`): `Trust uint8` on `ReadResponse` and `ActivationItem`
- **Engine**: Trust stamp on all write paths (Write, WriteBatch, Evolve, RememberTree, AddChild); `Engine.SetTrust`; `ExcludeUntrusted` filter in activation
- **Auth** (`plasticity.go`): `ExcludeUntrusted *bool` in `PlasticityConfig`
- **MCP**: `Memory.Trust string`; `handleSetTrust`; `muninn_trust` registration + tool definition + `isMutatingTool`

## Backward Compatibility

No migration required. Pre-existing engrams have `0x00` at byte 71 which decodes as `TrustUnset` and displays as `"inferred"`. `ExcludeUntrusted` defaults to `false` — existing behaviour is unchanged.

## Test Plan

- [ ] `go test ./... -count=1` — full suite green
- [ ] `TestWrite_AutoStampsTrustInferred` / `TestWriteBatch_AutoStampsTrustInferred` / `TestEvolve_AutoStampsTrustInferred`
- [ ] `TestEngine_SetTrust` (happy path, invalid label, not-found)
- [ ] `TestActivation_ExcludeUntrusted` — integration test with vault config
- [ ] `TestHandleSetTrust` — MCP handler validation (missing id, missing trust, invalid trust)
- [ ] `TestHandleRead_IncludesTrust` / `TestHandleRecall_IncludesTrust`
- [ ] `TestResolvePlasticity_ExcludeUntrusted`
- [ ] `TestToolClassification_CoversAllRegisteredHandlers`

Closes #387