### PR TITLE
feat(annotations): structured retrieval annotations for muninn_recall (#388)

### DIFF
--- a/internal/engine/annotation.go
+++ b/internal/engine/annotation.go
@@ -33,13 +33,13 @@ func (e *Engine) GetAnnotations(ctx context.Context, vault, id string) (*Annotat
 	ws := e.store.ResolveVaultPrefix(vault)
 	rawID, err := storage.ParseULID(id)
 	if err != nil {
-		return nil, fmt.Errorf("GetAnnotations: parse id: %w", err)
+		return nil, fmt.Errorf("parse id: %w", err)
 	}
 
 	// Forward associations: engrams THIS one contradicts (RelContradicts).
 	forward, err := e.store.GetAssociations(ctx, ws, []storage.ULID{rawID}, 100)
 	if err != nil {
-		return nil, fmt.Errorf("GetAnnotations: get associations: %w", err)
+		return nil, fmt.Errorf("get associations: %w", err)
 	}
 	var conflictsWith []string
 	for _, a := range forward[rawID] {
@@ -51,7 +51,7 @@ func (e *Engine) GetAnnotations(ctx context.Context, vault, id string) (*Annotat
 	// Reverse associations: engrams that supersede THIS one (RelSupersedes pointing TO this engram).
 	reverse, err := e.store.GetReverseAssociations(ctx, ws, rawID, 10)
 	if err != nil {
-		return nil, fmt.Errorf("GetAnnotations: get reverse associations: %w", err)
+		return nil, fmt.Errorf("get reverse associations: %w", err)
 	}
 	var supersededBy string
 	for _, a := range reverse {

--- a/internal/engine/annotation.go
+++ b/internal/engine/annotation.go
@@ -1,0 +1,78 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// AnnotationData is the raw annotation result for a single engram.
+// Staleness is NOT included here — it is computed from ActivationItem.LastAccess
+// in the MCP handler (buildAnnotations in handlers.go).
+type AnnotationData struct {
+	// ConflictsWith holds ULIDs of engrams this one contradicts
+	// (forward RelContradicts associations from this engram).
+	ConflictsWith []string
+
+	// SupersededBy is the ULID of the engram that supersedes this one.
+	// Empty string means no supersession exists.
+	// Populated from reverse RelSupersedes edges (another engram points TO this one with RelSupersedes).
+	SupersededBy string
+
+	// LastVerified is the timestamp of the last provenance entry for this engram.
+	// nil when no provenance entries exist.
+	LastVerified *time.Time
+}
+
+// GetAnnotations returns annotation metadata for an engram by string ULID.
+// Returns a non-nil *AnnotationData with zero-value fields when the engram has
+// no associations or provenance (normal case). Returns error only on storage failure.
+func (e *Engine) GetAnnotations(ctx context.Context, vault, id string) (*AnnotationData, error) {
+	ws := e.store.ResolveVaultPrefix(vault)
+	rawID, err := storage.ParseULID(id)
+	if err != nil {
+		return nil, fmt.Errorf("GetAnnotations: parse id: %w", err)
+	}
+
+	// Forward associations: engrams THIS one contradicts (RelContradicts).
+	forward, err := e.store.GetAssociations(ctx, ws, []storage.ULID{rawID}, 100)
+	if err != nil {
+		return nil, fmt.Errorf("GetAnnotations: get associations: %w", err)
+	}
+	var conflictsWith []string
+	for _, a := range forward[rawID] {
+		if a.RelType == storage.RelContradicts {
+			conflictsWith = append(conflictsWith, a.TargetID.String())
+		}
+	}
+
+	// Reverse associations: engrams that supersede THIS one (RelSupersedes pointing TO this engram).
+	reverse, err := e.store.GetReverseAssociations(ctx, ws, rawID, 10)
+	if err != nil {
+		return nil, fmt.Errorf("GetAnnotations: get reverse associations: %w", err)
+	}
+	var supersededBy string
+	for _, a := range reverse {
+		if a.RelType == storage.RelSupersedes {
+			supersededBy = a.TargetID.String() // TargetID = the source of the reverse edge (the superseding engram)
+			break
+		}
+	}
+
+	// Last provenance timestamp.
+	entries, err := e.prov.Get(ctx, ws, [16]byte(rawID))
+	var lastVerified *time.Time
+	if err == nil && len(entries) > 0 {
+		t := entries[len(entries)-1].Timestamp
+		lastVerified = &t
+	}
+	// provenance errors are non-fatal: annotations are best-effort
+
+	return &AnnotationData{
+		ConflictsWith: conflictsWith,
+		SupersededBy:  supersededBy,
+		LastVerified:  lastVerified,
+	}, nil
+}

--- a/internal/engine/annotation_test.go
+++ b/internal/engine/annotation_test.go
@@ -1,0 +1,114 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+func TestEngine_GetAnnotations_Contradicts(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	respA, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "default", Concept: "claim A", Content: "the sky is green",
+	})
+	if err != nil {
+		t.Fatalf("Write A: %v", err)
+	}
+	respB, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "default", Concept: "claim B", Content: "the sky is blue",
+	})
+	if err != nil {
+		t.Fatalf("Write B: %v", err)
+	}
+
+	_, err = eng.Link(ctx, &mbp.LinkRequest{
+		Vault:    "default",
+		SourceID: respA.ID,
+		TargetID: respB.ID,
+		RelType:  uint16(storage.RelContradicts),
+		Weight:   1.0,
+	})
+	if err != nil {
+		t.Fatalf("Link: %v", err)
+	}
+
+	ann, err := eng.GetAnnotations(ctx, "default", respA.ID)
+	if err != nil {
+		t.Fatalf("GetAnnotations: %v", err)
+	}
+	if len(ann.ConflictsWith) != 1 || ann.ConflictsWith[0] != respB.ID {
+		t.Errorf("ConflictsWith = %v, want [%s]", ann.ConflictsWith, respB.ID)
+	}
+	if ann.SupersededBy != "" {
+		t.Errorf("SupersededBy should be empty, got %q", ann.SupersededBy)
+	}
+}
+
+func TestEngine_GetAnnotations_SupersededBy(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	respOld, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "default", Concept: "old version", Content: "old content",
+	})
+	if err != nil {
+		t.Fatalf("Write old: %v", err)
+	}
+	respNew, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "default", Concept: "new version", Content: "new content",
+	})
+	if err != nil {
+		t.Fatalf("Write new: %v", err)
+	}
+
+	// new supersedes old: respNew → respOld with RelSupersedes
+	_, err = eng.Link(ctx, &mbp.LinkRequest{
+		Vault:    "default",
+		SourceID: respNew.ID,
+		TargetID: respOld.ID,
+		RelType:  uint16(storage.RelSupersedes),
+		Weight:   1.0,
+	})
+	if err != nil {
+		t.Fatalf("Link: %v", err)
+	}
+
+	// GetAnnotations on the OLD engram — SupersededBy should be respNew.ID
+	ann, err := eng.GetAnnotations(ctx, "default", respOld.ID)
+	if err != nil {
+		t.Fatalf("GetAnnotations: %v", err)
+	}
+	if ann.SupersededBy != respNew.ID {
+		t.Errorf("SupersededBy = %q, want %q", ann.SupersededBy, respNew.ID)
+	}
+}
+
+func TestEngine_GetAnnotations_NoData(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "default", Concept: "plain", Content: "no associations",
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	ann, err := eng.GetAnnotations(ctx, "default", resp.ID)
+	if err != nil {
+		t.Fatalf("GetAnnotations: %v", err)
+	}
+	if len(ann.ConflictsWith) != 0 {
+		t.Errorf("ConflictsWith should be empty, got %v", ann.ConflictsWith)
+	}
+	if ann.SupersededBy != "" {
+		t.Errorf("SupersededBy should be empty, got %q", ann.SupersededBy)
+	}
+}

--- a/internal/mcp/engine.go
+++ b/internal/mcp/engine.go
@@ -170,4 +170,9 @@ type EngineInterface interface {
 	// SetTrust sets the trust label of an engram.
 	// trust must be one of "verified", "inferred", "external", "untrusted".
 	SetTrust(ctx context.Context, vault, id, trust string) error
+
+	// GetAnnotations returns annotation metadata for a single engram.
+	// Used to populate muninn_recall annotation objects when annotate=true.
+	// Returns a non-nil *engine.AnnotationData (possibly with empty fields) on success.
+	GetAnnotations(ctx context.Context, vault, id string) (*engine.AnnotationData, error)
 }

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -600,6 +600,10 @@ func (a *mcpEngineAdapter) SetTrust(ctx context.Context, vault, id, trust string
 	return a.eng.SetTrust(ctx, vault, id, trust)
 }
 
+func (a *mcpEngineAdapter) GetAnnotations(ctx context.Context, vault, id string) (*engine.AnnotationData, error) {
+	return a.eng.GetAnnotations(ctx, vault, id)
+}
+
 func (a *mcpEngineAdapter) ListEntities(ctx context.Context, vault string, limit int, state string) ([]EntitySummary, error) {
 	records, err := a.eng.ListEntities(ctx, vault, limit, state)
 	if err != nil {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -16,6 +17,10 @@ import (
 	"github.com/scrypster/muninndb/internal/transport/mbp"
 	"golang.org/x/text/unicode/norm"
 )
+
+// annotationStaleDays is the threshold for marking a recalled memory as stale.
+// Memories not accessed in more than this many days are flagged stale=true.
+const annotationStaleDays = 30.0
 
 // parseEmbedding extracts and validates an optional "embedding" field from args.
 // Returns (nil, "") when the field is absent. Returns (nil, errMsg) on validation
@@ -368,6 +373,8 @@ func (s *MCPServer) handleRecall(ctx context.Context, w http.ResponseWriter, id 
 		req.Embedding = emb
 	}
 
+	annotate, _ := args["annotate"].(bool)
+
 	resp, err := s.engine.Activate(ctx, req)
 	if err != nil {
 		sendError(w, id, -32000, "tool error: "+err.Error())
@@ -378,6 +385,19 @@ func (s *MCPServer) handleRecall(ctx context.Context, w http.ResponseWriter, id 
 	for i := range resp.Activations {
 		memories = append(memories, activationToMemory(&resp.Activations[i]))
 	}
+
+	if annotate {
+		for i, item := range resp.Activations {
+			ann, err := s.engine.GetAnnotations(ctx, vault, item.ID)
+			if err != nil || ann == nil {
+				// Non-fatal: log and skip annotations for this result.
+				slog.Warn("handleRecall: GetAnnotations failed", "id", item.ID, "err", err)
+				continue
+			}
+			memories[i].Annotations = buildAnnotations(&item, ann)
+		}
+	}
+
 	result := map[string]any{
 		"memories": memories,
 		"total":    resp.TotalFound,
@@ -1718,6 +1738,23 @@ func (s *MCPServer) handleEntityTimeline(ctx context.Context, w http.ResponseWri
 		return
 	}
 	sendResult(w, id, textContent(mustJSON(timeline)))
+}
+
+// buildAnnotations constructs a MemoryAnnotations from engine annotation data
+// and the activation item. Staleness is derived from item.LastAccess (nanoseconds
+// Unix timestamp).
+func buildAnnotations(item *mbp.ActivationItem, data *engine.AnnotationData) *MemoryAnnotations {
+	staleDays := math.Round(time.Since(time.Unix(0, item.LastAccess)).Hours()/24.0*10) / 10
+	ann := &MemoryAnnotations{
+		Stale:         staleDays > annotationStaleDays,
+		StaleDays:     staleDays,
+		ConflictsWith: data.ConflictsWith,
+		SupersededBy:  data.SupersededBy,
+	}
+	if data.LastVerified != nil {
+		ann.LastVerified = data.LastVerified.UTC().Format(time.RFC3339)
+	}
+	return ann
 }
 
 func (s *MCPServer) handleSetTrust(ctx context.Context, w http.ResponseWriter, id json.RawMessage, vault string, args map[string]any) {

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -3463,3 +3463,95 @@ func TestHandleSetTrust(t *testing.T) {
 		}
 	})
 }
+
+// ── muninn_recall annotate ───────────────────────────────────────────────────
+
+// recallAnnotateEngine is a test double for annotation tests.
+type recallAnnotateEngine struct {
+	fakeEngine
+	annData *engine.AnnotationData
+}
+
+func (e *recallAnnotateEngine) Activate(_ context.Context, _ *mbp.ActivateRequest) (*mbp.ActivateResponse, error) {
+	return &mbp.ActivateResponse{
+		Activations: []mbp.ActivationItem{{
+			ID:         "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			Concept:    "test",
+			Content:    "content",
+			Score:      0.9,
+			LastAccess: time.Now().Add(-45 * 24 * time.Hour).UnixNano(), // 45 days ago → stale
+		}},
+	}, nil
+}
+
+func (e *recallAnnotateEngine) GetAnnotations(_ context.Context, _, _ string) (*engine.AnnotationData, error) {
+	return e.annData, nil
+}
+
+func TestHandleRecall_Annotate(t *testing.T) {
+	conflictID := "01HHHHHHHHHHHHHHHHHHHHHHHA"
+	supersederID := "01HHHHHHHHHHHHHHHHHHHHHHHB"
+	lastVerified := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	eng := &recallAnnotateEngine{
+		annData: &engine.AnnotationData{
+			ConflictsWith: []string{conflictID},
+			SupersededBy:  supersederID,
+			LastVerified:  &lastVerified,
+		},
+	}
+	srv := newTestServerWith(eng)
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_recall","arguments":{"context":["test"],"annotate":true}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	outer := extractInnerJSON(t, resp)
+
+	mems, ok := outer["memories"].([]interface{})
+	if !ok || len(mems) == 0 {
+		t.Fatalf("expected memories array, got %v", outer["memories"])
+	}
+	mem0 := mems[0].(map[string]interface{})
+	ann, ok := mem0["annotations"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected annotations object, got %T: %v", mem0["annotations"], mem0["annotations"])
+	}
+
+	if stale, _ := ann["stale"].(bool); !stale {
+		t.Errorf("stale should be true for 45-day-old engram, got %v", ann["stale"])
+	}
+	staleDays, _ := ann["stale_days"].(float64)
+	if staleDays < 44 || staleDays > 46 {
+		t.Errorf("stale_days = %v, want ~45", staleDays)
+	}
+	conflicts, _ := ann["conflicts_with"].([]interface{})
+	if len(conflicts) != 1 || conflicts[0].(string) != conflictID {
+		t.Errorf("conflicts_with = %v, want [%s]", conflicts, conflictID)
+	}
+	if sup, _ := ann["superseded_by"].(string); sup != supersederID {
+		t.Errorf("superseded_by = %q, want %q", sup, supersederID)
+	}
+	if lv, _ := ann["last_verified"].(string); lv != "2026-01-15T10:30:00Z" {
+		t.Errorf("last_verified = %q, want 2026-01-15T10:30:00Z", lv)
+	}
+}
+
+func TestHandleRecall_AnnotateFalse_NoAnnotations(t *testing.T) {
+	// Without annotate=true, annotations must be absent even if GetAnnotations would return data.
+	eng := &recallAnnotateEngine{
+		annData: &engine.AnnotationData{ConflictsWith: []string{"01ARZ3NDEKTSV4RRFFQ69G5FAV"}},
+	}
+	srv := newTestServerWith(eng)
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_recall","arguments":{"context":["test"]}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	outer := extractInnerJSON(t, resp)
+
+	mems, ok := outer["memories"].([]interface{})
+	if !ok || len(mems) == 0 {
+		t.Fatalf("expected memories array, got %v", outer["memories"])
+	}
+	mem0 := mems[0].(map[string]interface{})
+	if _, hasAnn := mem0["annotations"]; hasAnn {
+		t.Error("annotations should be absent when annotate=false (or not set)")
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -182,6 +182,10 @@ func (f *fakeEngine) GetVaultEmbedDim(_ context.Context, _ string) int {
 }
 func (f *fakeEngine) SetTrust(_ context.Context, _, _, _ string) error { return nil }
 
+func (f *fakeEngine) GetAnnotations(_ context.Context, _, _ string) (*engine.AnnotationData, error) {
+	return nil, nil
+}
+
 func newTestServer() *MCPServer {
 	return New(":0", &fakeEngine{}, "", nil, nil)
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -178,6 +178,10 @@ func allToolDefinitions() []ToolDefinition {
 						"items":       map[string]any{"type": "number"},
 						"description": "Optional pre-computed query embedding vector (array of floats). When provided, the server uses this vector for semantic search instead of computing one from 'context'. The dimension must match the vault's existing embedding dimension, or the call will be rejected.",
 					},
+					"annotate": map[string]any{
+						"type":        "boolean",
+						"description": "When true, each result includes an annotations object with staleness, conflict, and supersession metadata. Default false.",
+					},
 				},
 				"required": []string{"context"},
 			},

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -79,6 +79,17 @@ type Memory struct {
 	// Populated only by muninn_read (omitted from recall responses).
 	Entities            []ReadEntity    `json:"entities,omitempty"`
 	EntityRelationships []ReadEntityRel `json:"entity_relationships,omitempty"`
+	Annotations         *MemoryAnnotations `json:"annotations,omitempty"`
+}
+
+// MemoryAnnotations contains contextual metadata about a recalled memory,
+// populated only when muninn_recall is called with annotate=true.
+type MemoryAnnotations struct {
+	Stale         bool     `json:"stale"`
+	StaleDays     float64  `json:"stale_days"`
+	ConflictsWith []string `json:"conflicts_with,omitempty"`
+	SupersededBy  string   `json:"superseded_by,omitempty"`
+	LastVerified  string   `json:"last_verified,omitempty"` // RFC3339
 }
 
 // ReadEntity is a named entity linked to a specific engram.

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -79,7 +79,9 @@ type Memory struct {
 	// Populated only by muninn_read (omitted from recall responses).
 	Entities            []ReadEntity    `json:"entities,omitempty"`
 	EntityRelationships []ReadEntityRel `json:"entity_relationships,omitempty"`
-	Annotations         *MemoryAnnotations `json:"annotations,omitempty"`
+
+	// Populated only by muninn_recall when annotate=true.
+	Annotations *MemoryAnnotations `json:"annotations,omitempty"`
 }
 
 // MemoryAnnotations contains contextual metadata about a recalled memory,

--- a/internal/mcp/types_test.go
+++ b/internal/mcp/types_test.go
@@ -1,0 +1,45 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestMemoryAnnotations_JSONOmitEmpty(t *testing.T) {
+	// MemoryAnnotations with only stale/stale_days set — omitempty fields absent
+	ann := MemoryAnnotations{Stale: false, StaleDays: 5.2}
+	b, err := json.Marshal(ann)
+	if err != nil {
+		t.Fatalf("marshal MemoryAnnotations: %v", err)
+	}
+	if bytes.Contains(b, []byte("conflicts_with")) {
+		t.Errorf("conflicts_with should be omitted when nil: %s", b)
+	}
+	if bytes.Contains(b, []byte("superseded_by")) {
+		t.Errorf("superseded_by should be omitted when empty: %s", b)
+	}
+	if bytes.Contains(b, []byte("last_verified")) {
+		t.Errorf("last_verified should be omitted when empty: %s", b)
+	}
+
+	// Memory with non-nil Annotations — annotations key present
+	m := Memory{Annotations: &ann}
+	b2, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal Memory with annotations: %v", err)
+	}
+	if !bytes.Contains(b2, []byte(`"annotations"`)) {
+		t.Errorf("annotations should be present when non-nil: %s", b2)
+	}
+
+	// Memory with nil Annotations — annotations key absent
+	m2 := Memory{}
+	b3, err := json.Marshal(m2)
+	if err != nil {
+		t.Fatalf("marshal Memory without annotations: %v", err)
+	}
+	if bytes.Contains(b3, []byte(`"annotations"`)) {
+		t.Errorf("annotations should be absent when nil: %s", b3)
+	}
+}

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -739,6 +739,51 @@ func (ps *PebbleStore) GetChildrenByParent(ctx context.Context, wsPrefix [8]byte
 	return children, nil
 }
 
+// GetReverseAssociations returns all associations that TARGET id by scanning
+// the 0x04 reverse index. The returned Association.TargetID is the SOURCE
+// engram (the engram that points TO id). Results are capped at maxPerNode entries.
+// Reverse key layout: 0x04 | ws(8) | dstID(16) | weightComplement(4) | srcID(16) = 45 bytes
+func (ps *PebbleStore) GetReverseAssociations(ctx context.Context, wsPrefix [8]byte, id ULID, maxPerNode int) ([]Association, error) {
+	prefix := keys.AssocRevPrefixForID(wsPrefix, [16]byte(id))
+	iter, err := PrefixIterator(ps.db, prefix)
+	if err != nil {
+		return nil, fmt.Errorf("GetReverseAssociations prefix iter: %w", err)
+	}
+	defer iter.Close()
+
+	var results []Association
+	for iter.First(); iter.Valid() && (maxPerNode <= 0 || len(results) < maxPerNode); iter.Next() {
+		k := iter.Key()
+		if len(k) < 45 {
+			continue
+		}
+		var srcID ULID
+		copy(srcID[:], k[29:45])
+
+		var wc [4]byte
+		copy(wc[:], k[25:29])
+		weight := keys.WeightFromComplement(wc)
+
+		relType, confidence, createdAt, lastActivated, peakWeight, coActivationCount, restoredAt := decodeAssocValue(iter.Value())
+
+		results = append(results, Association{
+			TargetID:          srcID,
+			Weight:            weight,
+			RelType:           relType,
+			Confidence:        confidence,
+			CreatedAt:         createdAt,
+			LastActivated:     lastActivated,
+			PeakWeight:        peakWeight,
+			CoActivationCount: coActivationCount,
+			RestoredAt:        restoredAt,
+		})
+	}
+	if err := iter.Error(); err != nil {
+		return nil, fmt.Errorf("GetReverseAssociations scan: %w", err)
+	}
+	return results, nil
+}
+
 // FlagContradiction writes the 0x0A contradiction key for pair (a,b).
 func (ps *PebbleStore) FlagContradiction(ctx context.Context, wsPrefix [8]byte, a, b ULID) error {
 	batch := ps.db.NewBatch()

--- a/internal/storage/association_test.go
+++ b/internal/storage/association_test.go
@@ -743,3 +743,47 @@ func TestDecayAssocWeights_ArchivesStrongEdge(t *testing.T) {
 		t.Fatalf("archive value should be 30 bytes, got %d", len(val))
 	}
 }
+
+func TestGetReverseAssociations(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("reverse-assoc-test")
+
+	idA := NewULID()
+	idB := NewULID()
+
+	assoc := &Association{
+		TargetID:   idB,
+		Weight:     0.9,
+		RelType:    RelSupersedes,
+		Confidence: 1.0,
+		CreatedAt:  time.Now(),
+	}
+	if err := store.WriteAssociation(ctx, ws, idA, idB, assoc); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	// GetReverseAssociations on B — should return A with RelSupersedes.
+	results, err := store.GetReverseAssociations(ctx, ws, idB, 10)
+	if err != nil {
+		t.Fatalf("GetReverseAssociations: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 reverse association, got %d", len(results))
+	}
+	if results[0].TargetID != idA {
+		t.Errorf("TargetID = %v, want idA", results[0].TargetID)
+	}
+	if results[0].RelType != RelSupersedes {
+		t.Errorf("RelType = %v, want RelSupersedes", results[0].RelType)
+	}
+
+	// GetReverseAssociations on A — should return nothing (A is the source).
+	resultsA, err := store.GetReverseAssociations(ctx, ws, idA, 10)
+	if err != nil {
+		t.Fatalf("GetReverseAssociations on A: %v", err)
+	}
+	if len(resultsA) != 0 {
+		t.Errorf("expected 0 reverse associations on A (it's the source), got %d", len(resultsA))
+	}
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -85,6 +85,12 @@ type EngineStore interface {
 	// weight-sorted descending, up to maxPerNode per source.
 	GetAssociations(ctx context.Context, wsPrefix [8]byte, ids []ULID, maxPerNode int) (map[ULID][]Association, error)
 
+	// GetReverseAssociations returns all associations that TARGET the given id,
+	// by scanning the 0x04 reverse index. The returned Association.TargetID
+	// is the SOURCE engram (the engram that points TO id). Results are capped
+	// at maxPerNode entries.
+	GetReverseAssociations(ctx context.Context, wsPrefix [8]byte, id ULID, maxPerNode int) ([]Association, error)
+
 	// RecentActive returns up to topK engram IDs with the highest relevance
 	// in the vault. Uses the 0x10 relevance bucket index for O(k) scanning.
 	RecentActive(ctx context.Context, wsPrefix [8]byte, topK int) ([]ULID, error)


### PR DESCRIPTION
## Summary
- Adds optional `annotations` object to each `muninn_recall` result, surfacing staleness, conflicts, supersession, and last-verified timestamp
- All opt-in via `annotate: bool` param (default false — zero overhead on hot path)
- All annotation data sourced from existing internal state: LastAccess, RelContradicts forward edges, RelSupersedes reverse edges, and provenance store

## Changes
- `MemoryAnnotations` struct added to MCP types with `stale`, `stale_days`, `conflicts_with`, `superseded_by`, `last_verified` fields
- `GetReverseAssociations` added to `storage.Store` interface + `PebbleStore` (scans 0x04 reverse index for reverse edge lookups)
- `engine.GetAnnotations` method fetches annotation data for a single engram
- `handleRecall` wires it all together: annotation pass is non-fatal (errors skip that result, never abort recall)
- `muninn_recall` tool schema updated with `annotate` boolean property

## Test Plan
- [ ] `go test ./internal/storage/... -run TestGetReverseAssociations` — reverse edge lookup
- [ ] `go test ./internal/engine -run TestEngine_GetAnnotations` — engine integration (contradicts, superseded_by, no-data)
- [ ] `go test ./internal/mcp/... -run TestHandleRecall_Annotate` — annotation fields in handler response
- [ ] `go test ./internal/mcp/... -run TestHandleRecall_AnnotateFalse_NoAnnotations` — opt-out behavior
- [ ] `go test ./... -count=1` — full suite (all pass)

## Opus Review
APPROVED — zero issues found. Verified: zero-overhead guarantee, non-fatal error handling, correct reverse edge semantics, no regressions.