### PR TITLE
cli: support https in admin subcommands via -h scheme + env vars

### DIFF
--- a/cmd/muninn/repl.go
+++ b/cmd/muninn/repl.go
@@ -286,7 +286,8 @@ func (r *replState) printRotatingTip() {
 }
 
 // shellValidateAdmin validates admin credentials against the running UI server's
-// login endpoint (POST http://127.0.0.1:8476/api/auth/login).
+// login endpoint (POST <vaultUIBase>/api/auth/login). The base URL respects
+// the MUNINN_UI_URL environment variable when set.
 // Returns nil on success, non-nil on auth failure or network error.
 func shellValidateAdmin(username, password string) error {
 	body, _ := json.Marshal(map[string]string{
@@ -294,7 +295,7 @@ func shellValidateAdmin(username, password string) error {
 		"password": password,
 	})
 	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Post("http://127.0.0.1:8476/api/auth/login", "application/json", bytes.NewReader(body))
+	resp, err := client.Post(vaultUIBase+"/api/auth/login", "application/json", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("connect to server: %w", err)
 	}

--- a/cmd/muninn/vault_auth.go
+++ b/cmd/muninn/vault_auth.go
@@ -14,10 +14,19 @@ import (
 // Package-level session state set by runVault before dispatching subcommands.
 // Tests don't touch these, so doVaultRequestForce and friends work unchanged.
 var (
-	vaultAdminBase = "http://127.0.0.1:8475" // REST API
-	vaultUIBase    = "http://127.0.0.1:8476" // login endpoint lives here
-	vaultCookie    string                   // muninn_session value
+	vaultAdminBase = envOrDefault("MUNINN_ADMIN_URL", "http://127.0.0.1:8475") // REST API
+	vaultUIBase    = envOrDefault("MUNINN_UI_URL", "http://127.0.0.1:8476")    // login endpoint lives here
+	vaultCookie    string                                                      // muninn_session value
 )
+
+// envOrDefault returns the value of envVar (with any trailing slash trimmed)
+// when set and non-empty, otherwise the supplied fallback.
+func envOrDefault(envVar, fallback string) string {
+	if v := strings.TrimRight(os.Getenv(envVar), "/"); v != "" {
+		return v
+	}
+	return fallback
+}
 
 // parseAdminFlags extracts MySQL-style auth flags (-u, -p, -h) from args and
 // returns the remaining (non-auth) args. Sets package-level vaultAdminBase,
@@ -66,23 +75,33 @@ func parseAdminFlags(args []string) (remaining []string, username, password stri
 	return
 }
 
-// setHostPorts updates vaultAdminBase and vaultUIBase from a host or host:port.
+// setHostPorts updates vaultAdminBase and vaultUIBase from an argument that
+// may be a bare host, host:port, or a full URL with explicit scheme. Without
+// a scheme the legacy default (http://) is preserved for backwards
+// compatibility; with a "https://" or "http://" prefix that scheme is honored
+// for both the admin and UI base URLs.
 // If only a host is given (no port), the defaults (:8475/:8476) are used.
 // If host:port is given, the UI port is assumed to be port+1.
-func setHostPorts(hostPort string) {
-	if !strings.Contains(hostPort, ":") {
-		vaultAdminBase = "http://" + hostPort + ":8475"
-		vaultUIBase = "http://" + hostPort + ":8476"
+func setHostPorts(arg string) {
+	scheme, rest := "http://", arg
+	if strings.HasPrefix(arg, "https://") {
+		scheme, rest = "https://", strings.TrimPrefix(arg, "https://")
+	} else if strings.HasPrefix(arg, "http://") {
+		rest = strings.TrimPrefix(arg, "http://")
+	}
+	if !strings.Contains(rest, ":") {
+		vaultAdminBase = scheme + rest + ":8475"
+		vaultUIBase = scheme + rest + ":8476"
 		return
 	}
-	parts := strings.SplitN(hostPort, ":", 2)
-	vaultAdminBase = "http://" + hostPort
+	parts := strings.SplitN(rest, ":", 2)
+	vaultAdminBase = scheme + rest
 	// Derive UI port: attempt port+1, fallback to same host with :8476.
 	var port int
 	if _, err := fmt.Sscanf(parts[1], "%d", &port); err == nil {
-		vaultUIBase = fmt.Sprintf("http://%s:%d", parts[0], port+1)
+		vaultUIBase = fmt.Sprintf("%s%s:%d", scheme, parts[0], port+1)
 	} else {
-		vaultUIBase = "http://" + parts[0] + ":8476"
+		vaultUIBase = scheme + parts[0] + ":8476"
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #410.

The admin CLI (`muninn vault …`, `muninn api-key …`, `muninn admin
change-password`, the `muninn shell` admin login) hardcodes `http://` for the
REST and UI base URLs. The `-h <host>` flag only swaps host, not scheme, so
muninn deployments using `--tls-cert` / `--tls-key` cannot be administered from
the CLI.

This change:

- Lets `setHostPorts` accept an optional scheme prefix on its argument
  (`http://host[:port]` or `https://host[:port]`). Without a scheme the legacy
  default (`http://`) is preserved, so existing users see no change.
- Adds two env-var overrides — `MUNINN_ADMIN_URL` and `MUNINN_UI_URL` — for
  persistent configuration. Trailing slashes are trimmed.
- Routes `shellValidateAdmin` in `repl.go` through the package-level
  `vaultUIBase` so it picks up both mechanisms.

No new TLS-config code is needed: Go's `http.DefaultTransport` already uses
the OS trust store, so internal CAs installed via `update-ca-certificates`
(Linux), `security add-trusted-cert` (macOS), or `certutil` (Windows) work
out of the box.

## Changes

- `cmd/muninn/vault_auth.go`: new `envOrDefault` helper; defaults read from
  `MUNINN_ADMIN_URL` / `MUNINN_UI_URL`; `setHostPorts` parses optional scheme.
- `cmd/muninn/repl.go`: `shellValidateAdmin` posts to `vaultUIBase` instead of
  the hardcoded `http://127.0.0.1:8476` literal.

### Backwards compatibility

| Invocation | Before | After |
|---|---|---|
| `muninn vault list` | `http://127.0.0.1:8475` | `http://127.0.0.1:8475` (unchanged) |
| `muninn vault list -h muninn.lan:8475` | `http://muninn.lan:8475` | `http://muninn.lan:8475` (unchanged) |
| `muninn vault list -h https://muninn.lan:8475` | (broken — http coercion) | `https://muninn.lan:8475` |
| `MUNINN_ADMIN_URL=https://… muninn …` | (no effect) | uses env var |

## Release Checklist

- [x] ~~`CHANGELOG.md`~~ — maintainers update at release time
- [x] N/A — no API routes changed (CLI behaviour only)
- [x] N/A — no SDK schemas changed
- [x] N/A — small CLI tweak, flag help unchanged
- [ ] `go build ./...` — **not run locally** (no Go toolchain on the deployment host where I authored this); CI should catch any build issues
- [ ] `go vet ./...` — same as above
- [ ] `go test ./...` — same as above; logic is small enough to inspect, but I can add unit tests for the new `setHostPorts` shapes if you want before merge

## Out of scope (potential follow-ups)

- `--cacert <path>` flag for non-OS-store CAs.
- Probe-then-fall-back auto-detect (try https first, fall back to http).
- Allowing different schemes for REST vs UI (today the patch ties them
  together).
