### PR TITLE
fix(replication): wire ReplicationLog.Append into all PebbleStore write paths (#409)

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -918,8 +918,9 @@ func runServer() {
 
 	// Wire ClusterCoordinator when cluster mode is enabled.
 	var coordinator *replication.ClusterCoordinator
+	var repLog *replication.ReplicationLog
 	if clusterCfg.Enabled {
-		repLog := replication.NewReplicationLog(db)
+		repLog = replication.NewReplicationLog(db)
 		applier := replication.NewApplier(db)
 		epochStore, err := replication.NewEpochStore(db)
 		if err != nil {
@@ -969,7 +970,14 @@ func runServer() {
 	}
 
 	// Build storage layer
-	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 10000})
+	storeCfg := storage.PebbleStoreConfig{CacheSize: 10000}
+	if clusterCfg.Enabled {
+		storeCfg.RepLogAppend = func(op uint8, key, value []byte) error {
+			_, err := repLog.Append(replication.WALOp(op), key, value)
+			return err
+		}
+	}
+	store := storage.NewPebbleStore(db, storeCfg)
 
 	// Run startup migrations before the engine is built.
 	runStartupMigrations(context.Background(), store)

--- a/internal/replication/applier.go
+++ b/internal/replication/applier.go
@@ -79,11 +79,12 @@ func (a *Applier) Apply(entry ReplicationEntry) (returnErr error) {
 		batch.Delete(entry.Key, nil)
 	case OpBatch:
 		// entry.Value is a Pebble batch repr (from batch.Repr() on the primary).
-		// Apply the repr atomically, then persist lastApplied in the outer batch.
+		// Apply the repr atomically, then persist lastApplied in a separate batch.
 		// SetRepr replaces the batch contents entirely; we must commit it as-is
 		// (adding ops after SetRepr causes a batch-count inconsistency in Pebble).
-		// The outer `batch` (empty, just created above) is used for the lastApplied
-		// marker and is closed by its own defer.
+		// The outer `batch` (created before the switch) is NOT used in this path —
+		// it is simply closed by its deferred Close(). A dedicated `reprBatch` applies
+		// the data, and a separate `markerBatch` writes the lastApplied sequence marker.
 		reprBatch := a.db.NewBatch()
 		defer reprBatch.Close()
 		if err := reprBatch.SetRepr(entry.Value); err != nil {

--- a/internal/replication/applier.go
+++ b/internal/replication/applier.go
@@ -78,8 +78,37 @@ func (a *Applier) Apply(entry ReplicationEntry) (returnErr error) {
 	case OpDelete:
 		batch.Delete(entry.Key, nil)
 	case OpBatch:
-		// OpBatch is reserved for future use (multi-op atomic writes)
-		batch.Set(entry.Key, entry.Value, nil)
+		// entry.Value is a Pebble batch repr (from batch.Repr() on the primary).
+		// Apply the repr atomically, then persist lastApplied in the outer batch.
+		// SetRepr replaces the batch contents entirely; we must commit it as-is
+		// (adding ops after SetRepr causes a batch-count inconsistency in Pebble).
+		// The outer `batch` (empty, just created above) is used for the lastApplied
+		// marker and is closed by its own defer.
+		reprBatch := a.db.NewBatch()
+		defer reprBatch.Close()
+		if err := reprBatch.SetRepr(entry.Value); err != nil {
+			return fmt.Errorf("apply batch repr at seq %d: %w", entry.Seq, err)
+		}
+		if err := reprBatch.Commit(pebble.NoSync); err != nil {
+			return err
+		}
+		seqBuf := make([]byte, 8)
+		binary.BigEndian.PutUint64(seqBuf, entry.Seq)
+		markerBatch := a.db.NewBatch()
+		defer markerBatch.Close()
+		markerBatch.Set(lastAppliedKey(), seqBuf, nil)
+		if err := markerBatch.Commit(pebble.NoSync); err != nil {
+			return err
+		}
+		a.lastApplied = entry.Seq
+		a.appliedSince++
+		if a.appliedSince >= applierSyncInterval {
+			if err := a.db.LogData(nil, pebble.Sync); err != nil {
+				return err
+			}
+			a.appliedSince = 0
+		}
+		return nil
 	case OpCognitive, OpIndex, OpMeta:
 		// All cognitive, index, and metadata operations are applied as key-value writes.
 		// The Op field is metadata for filtering; the persistence semantics are identical.

--- a/internal/replication/applier_test.go
+++ b/internal/replication/applier_test.go
@@ -356,3 +356,52 @@ func TestApplier_Apply_AllOpTypes_Idempotent(t *testing.T) {
 		t.Errorf("cognitive_key value = %q, want %q", string(val), "cognitive_value")
 	}
 }
+
+// TestApplier_OpBatch_PersistsLastApplied verifies that the lastApplied sequence
+// marker is persisted to disk after an OpBatch commit, so that a restarted Applier
+// resumes from the correct position without re-applying the batch.
+func TestApplier_OpBatch_PersistsLastApplied(t *testing.T) {
+	dir := t.TempDir()
+
+	// Phase 1: apply an OpBatch entry.
+	{
+		db, err := pebble.Open(dir, &pebble.Options{})
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		applier := NewApplier(db)
+
+		srcBatch := db.NewBatch()
+		srcBatch.Set([]byte{0x01, 0xCC}, []byte("persist-test"), nil)
+		repr := make([]byte, len(srcBatch.Repr()))
+		copy(repr, srcBatch.Repr())
+		srcBatch.Close()
+
+		if err := applier.Apply(ReplicationEntry{
+			Seq:   42,
+			Op:    OpBatch,
+			Key:   nil,
+			Value: repr,
+		}); err != nil {
+			db.Close()
+			t.Fatalf("Apply: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}
+
+	// Phase 2: reopen DB and verify lastApplied is 42.
+	{
+		db, err := pebble.Open(dir, &pebble.Options{})
+		if err != nil {
+			t.Fatalf("reopen: %v", err)
+		}
+		defer db.Close()
+
+		applier := NewApplier(db)
+		if got := applier.LastApplied(); got != 42 {
+			t.Errorf("LastApplied after restart = %d, want 42", got)
+		}
+	}
+}

--- a/internal/replication/applier_test.go
+++ b/internal/replication/applier_test.go
@@ -184,28 +184,43 @@ func TestApplier_Apply_AllOpTypes(t *testing.T) {
 
 	applier := NewApplier(db)
 
+	// Build a valid pebble batch repr for OpBatch.
+	// OpBatch.Value must be a pebble batch repr (not a raw key/value string).
+	batchSrc := db.NewBatch()
+	batchSrc.Set([]byte("batch_key"), []byte("batch_value"), nil)
+	rawRepr := batchSrc.Repr()
+	batchRepr := make([]byte, len(rawRepr))
+	copy(batchRepr, rawRepr)
+	batchSrc.Close()
+
 	tests := []struct {
-		name string
-		op   WALOp
-		seq  uint64
-		key  string
-		val  string
+		name    string
+		op      WALOp
+		seq     uint64
+		key     string
+		val     string
+		reprVal []byte // non-nil overrides val; used for OpBatch
 	}{
-		{"OpSet", OpSet, 1, "set_key", "set_value"},
-		{"OpDelete", OpDelete, 2, "delete_key", "delete_value"},
-		{"OpBatch", OpBatch, 3, "batch_key", "batch_value"},
-		{"OpCognitive", OpCognitive, 4, "cognitive_key", "cognitive_value"},
-		{"OpIndex", OpIndex, 5, "index_key", "index_value"},
-		{"OpMeta", OpMeta, 6, "meta_key", "meta_value"},
+		{"OpSet", OpSet, 1, "set_key", "set_value", nil},
+		{"OpDelete", OpDelete, 2, "delete_key", "delete_value", nil},
+		// OpBatch: Value is a pebble batch repr; the contained key is "batch_key".
+		{"OpBatch", OpBatch, 3, "batch_key", "batch_value", batchRepr},
+		{"OpCognitive", OpCognitive, 4, "cognitive_key", "cognitive_value", nil},
+		{"OpIndex", OpIndex, 5, "index_key", "index_value", nil},
+		{"OpMeta", OpMeta, 6, "meta_key", "meta_value", nil},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			entryVal := []byte(tt.val)
+			if tt.reprVal != nil {
+				entryVal = tt.reprVal
+			}
 			entry := ReplicationEntry{
 				Seq:   tt.seq,
 				Op:    tt.op,
 				Key:   []byte(tt.key),
-				Value: []byte(tt.val),
+				Value: entryVal,
 			}
 			if err := applier.Apply(entry); err != nil {
 				t.Fatalf("Apply failed: %v", err)
@@ -218,7 +233,7 @@ func TestApplier_Apply_AllOpTypes(t *testing.T) {
 					t.Errorf("expected key to be deleted, but found or got error: %v", err)
 				}
 			} else {
-				// For all other ops, verify key was set
+				// For all other ops, verify the key is readable with the expected value.
 				val, closer, err := db.Get([]byte(tt.key))
 				if err != nil {
 					t.Fatalf("key %q not found in Pebble: %v", tt.key, err)
@@ -236,6 +251,62 @@ func TestApplier_Apply_AllOpTypes(t *testing.T) {
 				t.Errorf("LastApplied = %d, want %d", applier.LastApplied(), tt.seq)
 			}
 		})
+	}
+}
+
+// TestApplier_OpBatch verifies that the Applier correctly applies a batch repr,
+// replicating all key-value pairs atomically. Regression test for issue #409.
+func TestApplier_OpBatch(t *testing.T) {
+	dir := t.TempDir()
+	db, err := pebble.Open(dir, &pebble.Options{})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	defer db.Close()
+
+	applier := NewApplier(db)
+
+	// Build a batch with two Set operations and capture its repr.
+	srcBatch := db.NewBatch()
+	key1 := []byte{0x01, 0xAA}
+	val1 := []byte("value-one")
+	key2 := []byte{0x01, 0xBB}
+	val2 := []byte("value-two")
+	srcBatch.Set(key1, val1, nil)
+	srcBatch.Set(key2, val2, nil)
+	// Copy the repr before closing: pebble's batch pool reuses the underlying
+	// slice, so Close() zeroes the count field in-place (Reset() truncates to
+	// batchHeaderLen and zeros all bytes). The copy is an independent buffer.
+	rawRepr := srcBatch.Repr()
+	repr := make([]byte, len(rawRepr))
+	copy(repr, rawRepr)
+	srcBatch.Close()
+
+	entry := ReplicationEntry{
+		Seq:   1,
+		Op:    OpBatch,
+		Key:   nil,
+		Value: repr,
+	}
+
+	if err := applier.Apply(entry); err != nil {
+		t.Fatalf("Apply OpBatch: %v", err)
+	}
+
+	for _, kv := range []struct{ k, v []byte }{{key1, val1}, {key2, val2}} {
+		got, closer, err := db.Get(kv.k)
+		if err != nil {
+			t.Errorf("Get %x: %v", kv.k, err)
+			continue
+		}
+		if string(got) != string(kv.v) {
+			t.Errorf("Get %x = %q, want %q", kv.k, got, kv.v)
+		}
+		closer.Close()
+	}
+
+	if got := applier.LastApplied(); got != 1 {
+		t.Errorf("LastApplied = %d, want 1", got)
 	}
 }
 

--- a/internal/storage/archive_restore.go
+++ b/internal/storage/archive_restore.go
@@ -145,6 +145,7 @@ func (ps *PebbleStore) RestoreArchivedEdges(ctx context.Context, ws [8]byte, src
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return nil, err
 	}
+	ps.replicateBatch(batch)
 
 	// Invalidate assocCache for src and all restored dst nodes.
 	ps.assocCache.Remove(assocCacheKey(ws, ULID(srcID)))

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -126,6 +126,7 @@ func (ps *PebbleStore) WriteAssociation(ctx context.Context, wsPrefix [8]byte, s
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("commit batch: %w", err)
 	}
+	ps.replicateBatch(batch)
 
 	// Invalidate source node's cached association list so BFS traversal
 	// sees the new edge immediately instead of waiting for TTL expiry.
@@ -412,6 +413,7 @@ func (ps *PebbleStore) UpdateAssocWeight(ctx context.Context, wsPrefix [8]byte, 
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("commit batch: %w", err)
 	}
+	ps.replicateBatch(batch)
 
 	ps.assocCache.Remove(assocCacheKey(wsPrefix, a))
 	return nil
@@ -482,6 +484,7 @@ func (ps *PebbleStore) UpdateAssocWeightBatch(ctx context.Context, updates []Ass
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("commit batch: %w", err)
 	}
+	ps.replicateBatch(batch)
 
 	// Invalidate assoc cache for all updated source nodes.
 	// Deduplicate to avoid redundant removals when a source appears multiple times.
@@ -586,6 +589,7 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 		if err := batch.Commit(pebble.NoSync); err != nil {
 			return fmt.Errorf("decay assoc chunk commit: %w", err)
 		}
+		ps.replicateBatch(batch)
 		chunk = chunk[:0]
 		return nil
 	}
@@ -811,6 +815,7 @@ func (ps *PebbleStore) FlagContradiction(ctx context.Context, wsPrefix [8]byte, 
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("commit batch: %w", err)
 	}
+	ps.replicateBatch(batch)
 
 	return nil
 }
@@ -834,6 +839,7 @@ func (ps *PebbleStore) ResolveContradiction(ctx context.Context, wsPrefix [8]byt
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("resolve contradiction: %w", err)
 	}
+	ps.replicateBatch(batch)
 	return nil
 }
 

--- a/internal/storage/engram.go
+++ b/internal/storage/engram.go
@@ -290,6 +290,7 @@ func (ps *PebbleStore) UpdateMetadata(ctx context.Context, wsPrefix [8]byte, id 
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("commit batch: %w", err)
 	}
+	ps.replicateBatch(batch)
 
 	// Update LastAccess index (best effort — index inconsistency is non-fatal).
 	if !meta.LastAccess.IsZero() {
@@ -363,6 +364,7 @@ func (ps *PebbleStore) UpdateRelevance(ctx context.Context, wsPrefix [8]byte, id
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("commit batch: %w", err)
 	}
+	ps.replicateBatch(batch)
 
 	// Append provenance entry via persistent worker (best effort — drops if full).
 	ps.provWork.Submit(wsPrefix, id, provenance.ProvenanceEntry{
@@ -406,6 +408,7 @@ func (ps *PebbleStore) UpdateTrust(ctx context.Context, wsPrefix [8]byte, id ULI
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("commit batch: %w", err)
 	}
+	ps.replicateBatch(batch)
 
 	ps.provWork.Submit(wsPrefix, id, provenance.ProvenanceEntry{
 		Timestamp: time.Now(),
@@ -430,7 +433,11 @@ func (ps *PebbleStore) DeleteEngram(ctx context.Context, wsPrefix [8]byte, id UL
 		batch.Delete(keys.EngramKey(wsPrefix, [16]byte(id)), nil)
 		batch.Delete(keys.MetaKey(wsPrefix, [16]byte(id)), nil)
 		ps.cache.Delete(wsPrefix, id)
-		return batch.Commit(pebble.NoSync)
+		if err := batch.Commit(pebble.NoSync); err != nil {
+			return err
+		}
+		ps.replicateBatch(batch)
+		return nil
 	}
 
 	batch := ps.db.NewBatch()
@@ -556,6 +563,7 @@ func (ps *PebbleStore) DeleteEngram(ctx context.Context, wsPrefix [8]byte, id UL
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("delete engram: %w", err)
 	}
+	ps.replicateBatch(batch)
 
 	ps.cache.Delete(wsPrefix, id)
 
@@ -652,6 +660,7 @@ func (ps *PebbleStore) SoftDelete(ctx context.Context, wsPrefix [8]byte, id ULID
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("commit batch: %w", err)
 	}
+	ps.replicateBatch(batch)
 
 	// Update cache (vault-scoped) and invalidate the metadata-only cache
 	// so subsequent GetMetadata calls see the updated StateSoftDeleted state.
@@ -708,6 +717,7 @@ func (ps *PebbleStore) UpdateTags(ctx context.Context, wsPrefix [8]byte, id ULID
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("commit batch: %w", err)
 	}
+	ps.replicateBatch(batch)
 
 	return nil
 }
@@ -787,6 +797,7 @@ func (ps *PebbleStore) UpdateConfidence(ctx context.Context, wsPrefix [8]byte, i
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("commit batch: %w", err)
 	}
+	ps.replicateBatch(batch)
 
 	// Update cache (vault-scoped).
 	ps.cache.Set(wsPrefix, id, eng)

--- a/internal/storage/entity.go
+++ b/internal/storage/entity.go
@@ -225,7 +225,11 @@ func (ps *PebbleStore) WriteEntityEngramLink(ctx context.Context, ws [8]byte, en
 	if err := batch.Set(revKey, nil, nil); err != nil {
 		return fmt.Errorf("write entity link rev: %w", err)
 	}
-	return batch.Commit(pebble.NoSync)
+	if err := batch.Commit(pebble.NoSync); err != nil {
+		return err
+	}
+	ps.replicateBatch(batch)
+	return nil
 }
 
 // RelinkEntityEngramLink atomically moves a vault-scoped engram link from fromEntity
@@ -258,7 +262,11 @@ func (ps *PebbleStore) RelinkEntityEngramLink(ctx context.Context, ws [8]byte, e
 	if err := batch.Delete(keys.EntityReverseIndexKey(fromHash, ws, id), nil); err != nil {
 		return fmt.Errorf("relink entity engram link: del rev: %w", err)
 	}
-	return batch.Commit(pebble.NoSync)
+	if err := batch.Commit(pebble.NoSync); err != nil {
+		return err
+	}
+	ps.replicateBatch(batch)
+	return nil
 }
 
 // DeleteEntityEngramLink deletes the 0x20 forward key and 0x23 reverse key for a
@@ -278,7 +286,11 @@ func (ps *PebbleStore) DeleteEntityEngramLink(ctx context.Context, ws [8]byte, e
 	if err := batch.Delete(revKey, nil); err != nil {
 		return fmt.Errorf("delete entity link rev: %w", err)
 	}
-	return batch.Commit(pebble.NoSync)
+	if err := batch.Commit(pebble.NoSync); err != nil {
+		return err
+	}
+	ps.replicateBatch(batch)
+	return nil
 }
 
 // ScanEntityEngrams scans the 0x23 reverse index for all vault-scoped engrams
@@ -713,6 +725,7 @@ func (ps *PebbleStore) RelinkRelationshipEntity(ctx context.Context, ws [8]byte,
 			batch.Close()
 			return fmt.Errorf("relink relationship entity: commit: %w", err)
 		}
+		ps.replicateBatch(batch)
 		batch.Close()
 	}
 	return nil
@@ -745,7 +758,11 @@ func (ps *PebbleStore) UpsertRelationshipRecord(ctx context.Context, ws [8]byte,
 	if err := batch.Set(idxToKey, nil, nil); err != nil {
 		return fmt.Errorf("upsert relationship record: set 0x26 to: %w", err)
 	}
-	return batch.Commit(pebble.NoSync)
+	if err := batch.Commit(pebble.NoSync); err != nil {
+		return err
+	}
+	ps.replicateBatch(batch)
+	return nil
 }
 
 const (
@@ -827,6 +844,7 @@ func (ps *PebbleStore) UpdateDigest(ctx context.Context, id ULID, summary string
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("UpdateDigest: commit: %w", err)
 	}
+	ps.replicateBatch(batch)
 
 	return nil
 }

--- a/internal/storage/impl.go
+++ b/internal/storage/impl.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -31,6 +32,11 @@ type PebbleStoreConfig struct {
 	// When true, the existing walSyncer provides durability within 10ms.
 	// Default false preserves the previous per-write fsync behavior.
 	NoSyncEngrams bool
+	// RepLogAppend, when non-nil, is called after every successful batch.Commit()
+	// on data-bearing write paths. op=3 (OpBatch) with value=batch.Repr() captures
+	// all keys atomically. Non-fatal: errors are logged, not returned.
+	// Only populated when cluster mode is enabled.
+	RepLogAppend func(op uint8, key, value []byte) error
 }
 
 // PebbleStore is the concrete Pebble-backed implementation of EngineStore.
@@ -81,6 +87,8 @@ type PebbleStore struct {
 	// during BFS traversal: if the filter says "no," skip the scan entirely.
 	// Rebuilt on startup and after GC runs via RebuildArchiveBloom.
 	archiveBloom *archiveBloom
+	// repLogAppend is the cluster replication callback. nil in non-cluster mode.
+	repLogAppend func(op uint8, key, value []byte) error
 }
 
 // assocCacheEntry holds a cached association list.
@@ -191,6 +199,7 @@ func NewPebbleStore(db *pebble.DB, cfg PebbleStoreConfig) *PebbleStore {
 	ps.provWork = newProvenanceWorker(prov)
 	ps.transCache = NewTransitionCache(ps)
 	ps.archiveBloom = ps.RebuildArchiveBloom()
+	ps.repLogAppend = cfg.RepLogAppend
 	return ps
 }
 
@@ -204,6 +213,23 @@ func (ps *PebbleStore) CacheLen() int {
 func (ps *PebbleStore) SetWAL(mol *wal.MOL, gc *wal.GroupCommitter) {
 	ps.mol = mol
 	ps.gc = gc
+}
+
+// replicateBatch appends the batch's complete key-value set to the replication
+// log as a single OpBatch entry (op=3). Captures batch.Repr() which remains
+// valid after Commit() and before Close(). Non-fatal: logs errors.
+// Must be called after a successful batch.Commit() and before batch.Close().
+func (ps *PebbleStore) replicateBatch(b *pebble.Batch) {
+	if ps.repLogAppend == nil {
+		return
+	}
+	repr := b.Repr()
+	if len(repr) == 0 {
+		return
+	}
+	if err := ps.repLogAppend(3, nil, repr); err != nil { // 3 = OpBatch
+		slog.Warn("replication log batch append failed", "err", err)
+	}
 }
 
 // VaultPrefix computes the 8-byte SipHash prefix for a vault name.
@@ -313,6 +339,8 @@ func (ps *PebbleStore) WriteEngram(ctx context.Context, wsPrefix [8]byte, eng *E
 	if err := batch.Commit(syncOption); err != nil {
 		return ULID{}, fmt.Errorf("commit batch: %w", err)
 	}
+
+	ps.replicateBatch(batch)
 
 	// NOTE: Intentionally NOT caching on write to avoid flooding L1 cache.
 
@@ -478,6 +506,8 @@ func (ps *PebbleStore) WriteEngramBatch(ctx context.Context, items []EngramBatch
 		}
 		return ids, errs
 	}
+
+	ps.replicateBatch(batch)
 
 	// Post-commit: vault counters, WAL/MOL, provenance — per item.
 	for i := range items {

--- a/internal/storage/impl.go
+++ b/internal/storage/impl.go
@@ -228,7 +228,7 @@ func (ps *PebbleStore) replicateBatch(b *pebble.Batch) {
 		return
 	}
 	if err := ps.repLogAppend(3, nil, repr); err != nil { // 3 = OpBatch
-		slog.Warn("replication log batch append failed", "err", err)
+		slog.Warn("storage: replication log batch append failed", "err", err)
 	}
 }
 

--- a/internal/storage/ordinal.go
+++ b/internal/storage/ordinal.go
@@ -24,6 +24,7 @@ func (ps *PebbleStore) WriteOrdinal(ctx context.Context, wsPrefix [8]byte, paren
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("WriteOrdinal commit: %w", err)
 	}
+	ps.replicateBatch(batch)
 	return nil
 }
 
@@ -47,6 +48,7 @@ func (ps *PebbleStore) DeleteOrdinal(ctx context.Context, wsPrefix [8]byte, pare
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("DeleteOrdinal commit: %w", err)
 	}
+	ps.replicateBatch(batch)
 	return nil
 }
 

--- a/internal/storage/plugin_store.go
+++ b/internal/storage/plugin_store.go
@@ -195,6 +195,7 @@ func (ps *PebbleStore) UpdateEmbedding(ctx context.Context, wsPrefix [8]byte, id
 	if err := batch.Commit(pebble.Sync); err != nil {
 		return fmt.Errorf("update embedding: commit: %w", err)
 	}
+	ps.replicateBatch(batch)
 	return nil
 }
 

--- a/internal/storage/replication_hook_test.go
+++ b/internal/storage/replication_hook_test.go
@@ -185,3 +185,37 @@ func TestRepLogHook_DeleteEngram(t *testing.T) {
 		t.Error("DeleteEngram: RepLogAppend not called")
 	}
 }
+
+// TestRepLogHook_WriteAssociation verifies callback fires on WriteAssociation.
+func TestRepLogHook_WriteAssociation(t *testing.T) {
+	db, cleanup := openRepHookDB(t)
+	defer cleanup()
+
+	var batchCount atomic.Int32
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{
+		RepLogAppend: func(op uint8, key, value []byte) error {
+			if op == 3 {
+				batchCount.Add(1)
+			}
+			return nil
+		},
+	})
+
+	ws := store.VaultPrefix("assoc-vault")
+	ctx := context.Background()
+
+	src, _ := store.WriteEngram(ctx, ws, &storage.Engram{Concept: "src", Content: "s"})
+	dst, _ := store.WriteEngram(ctx, ws, &storage.Engram{Concept: "dst", Content: "d"})
+	before := batchCount.Load()
+
+	if err := store.WriteAssociation(ctx, ws, src, dst, &storage.Association{
+		TargetID: dst,
+		Weight:   0.8,
+		RelType:  storage.RelRelatesTo,
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+	if batchCount.Load() <= before {
+		t.Error("WriteAssociation: RepLogAppend not called")
+	}
+}

--- a/internal/storage/replication_hook_test.go
+++ b/internal/storage/replication_hook_test.go
@@ -62,8 +62,8 @@ func TestRepLogHook_WriteEngram(t *testing.T) {
 		t.Fatalf("WriteEngram: %v", err)
 	}
 
-	if got := callCount.Load(); got == 0 {
-		t.Error("WriteEngram: RepLogAppend not called")
+	if got := callCount.Load(); got != 1 {
+		t.Errorf("WriteEngram: RepLogAppend called %d times, want 1", got)
 	}
 }
 

--- a/internal/storage/replication_hook_test.go
+++ b/internal/storage/replication_hook_test.go
@@ -19,6 +19,23 @@ func openRepHookDB(t *testing.T) (*pebble.DB, func()) {
 	return db, func() { _ = db.Close() }
 }
 
+// opBatchCounter returns a PebbleStoreConfig with RepLogAppend set to count
+// batch writes (op==3), and a function that returns the current count.
+func opBatchCounter(t *testing.T) (storage.PebbleStoreConfig, func() int32) {
+	t.Helper()
+	var count atomic.Int32
+	return storage.PebbleStoreConfig{
+		RepLogAppend: func(op uint8, key, value []byte) error {
+			if op == 3 {
+				count.Add(1)
+			}
+			return nil
+		},
+	}, func() int32 {
+		return count.Load()
+	}
+}
+
 // TestRepLogHook_NilCallback verifies WriteEngram does not panic when
 // RepLogAppend is nil (non-cluster deployments).
 func TestRepLogHook_NilCallback(t *testing.T) {
@@ -217,5 +234,26 @@ func TestRepLogHook_WriteAssociation(t *testing.T) {
 	}
 	if batchCount.Load() <= before {
 		t.Error("WriteAssociation: RepLogAppend not called")
+	}
+}
+
+// TestRepLogHook_WriteEntityEngramLink verifies callback fires on entity link write.
+func TestRepLogHook_WriteEntityEngramLink(t *testing.T) {
+	db, cleanup := openRepHookDB(t)
+	defer cleanup()
+
+	cfg, count := opBatchCounter(t)
+	store := storage.NewPebbleStore(db, cfg)
+	ws := store.VaultPrefix("entity-vault")
+	ctx := context.Background()
+
+	id, _ := store.WriteEngram(ctx, ws, &storage.Engram{Concept: "entity test", Content: "body"})
+	before := count()
+
+	if err := store.WriteEntityEngramLink(ctx, ws, id, "Alice"); err != nil {
+		t.Fatalf("WriteEntityEngramLink: %v", err)
+	}
+	if count() <= before {
+		t.Error("WriteEntityEngramLink: RepLogAppend not called")
 	}
 }

--- a/internal/storage/replication_hook_test.go
+++ b/internal/storage/replication_hook_test.go
@@ -129,3 +129,59 @@ func TestRepLogHook_EndToEnd(t *testing.T) {
 		t.Fatal("replica DB has no 0x01 engram keys after applying batch repr")
 	}
 }
+
+// TestRepLogHook_SoftDelete verifies callback fires on SoftDelete.
+func TestRepLogHook_SoftDelete(t *testing.T) {
+	db, cleanup := openRepHookDB(t)
+	defer cleanup()
+
+	var batchCount atomic.Int32
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{
+		RepLogAppend: func(op uint8, key, value []byte) error {
+			if op == 3 {
+				batchCount.Add(1)
+			}
+			return nil
+		},
+	})
+	ws := store.VaultPrefix("softdel-vault")
+	ctx := context.Background()
+
+	id, _ := store.WriteEngram(ctx, ws, &storage.Engram{Concept: "soft", Content: "body"})
+	before := batchCount.Load()
+
+	if err := store.SoftDelete(ctx, ws, id); err != nil {
+		t.Fatalf("SoftDelete: %v", err)
+	}
+	if batchCount.Load() <= before {
+		t.Error("SoftDelete: RepLogAppend not called")
+	}
+}
+
+// TestRepLogHook_DeleteEngram verifies callback fires on hard delete.
+func TestRepLogHook_DeleteEngram(t *testing.T) {
+	db, cleanup := openRepHookDB(t)
+	defer cleanup()
+
+	var batchCount atomic.Int32
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{
+		RepLogAppend: func(op uint8, key, value []byte) error {
+			if op == 3 {
+				batchCount.Add(1)
+			}
+			return nil
+		},
+	})
+	ws := store.VaultPrefix("del-vault")
+	ctx := context.Background()
+
+	id, _ := store.WriteEngram(ctx, ws, &storage.Engram{Concept: "del", Content: "body"})
+	before := batchCount.Load()
+
+	if err := store.DeleteEngram(ctx, ws, id); err != nil {
+		t.Fatalf("DeleteEngram: %v", err)
+	}
+	if batchCount.Load() <= before {
+		t.Error("DeleteEngram: RepLogAppend not called")
+	}
+}

--- a/internal/storage/replication_hook_test.go
+++ b/internal/storage/replication_hook_test.go
@@ -1,0 +1,131 @@
+package storage_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+func openRepHookDB(t *testing.T) (*pebble.DB, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := pebble.Open(dir, &pebble.Options{})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	return db, func() { _ = db.Close() }
+}
+
+// TestRepLogHook_NilCallback verifies WriteEngram does not panic when
+// RepLogAppend is nil (non-cluster deployments).
+func TestRepLogHook_NilCallback(t *testing.T) {
+	db, cleanup := openRepHookDB(t)
+	defer cleanup()
+
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{})
+	ws := store.VaultPrefix("nil-hook-vault")
+	ctx := context.Background()
+
+	if _, err := store.WriteEngram(ctx, ws, &storage.Engram{
+		Concept: "no callback",
+		Content: "should not panic",
+	}); err != nil {
+		t.Fatalf("WriteEngram with nil callback: %v", err)
+	}
+}
+
+// TestRepLogHook_WriteEngram fires once per WriteEngram call.
+func TestRepLogHook_WriteEngram(t *testing.T) {
+	db, cleanup := openRepHookDB(t)
+	defer cleanup()
+
+	var callCount atomic.Int32
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{
+		RepLogAppend: func(op uint8, key, value []byte) error {
+			if op == 3 {
+				callCount.Add(1)
+			}
+			return nil
+		},
+	})
+
+	ws := store.VaultPrefix("write-vault")
+	ctx := context.Background()
+
+	if _, err := store.WriteEngram(ctx, ws, &storage.Engram{
+		Concept: "test",
+		Content: "body",
+	}); err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+
+	if got := callCount.Load(); got == 0 {
+		t.Error("WriteEngram: RepLogAppend not called")
+	}
+}
+
+// TestRepLogHook_EndToEnd verifies that the batch repr captured via RepLogAppend
+// can be applied to a second Pebble instance (simulating what Applier.Apply does
+// for OpBatch). This is the direct regression test for issue #409.
+func TestRepLogHook_EndToEnd(t *testing.T) {
+	db, cleanup := openRepHookDB(t)
+	defer cleanup()
+
+	dir2 := t.TempDir()
+	db2, err := pebble.Open(dir2, &pebble.Options{})
+	if err != nil {
+		t.Fatalf("open replica pebble: %v", err)
+	}
+	defer db2.Close()
+
+	var capturedRepr []byte
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{
+		RepLogAppend: func(op uint8, key, value []byte) error {
+			if op == 3 && capturedRepr == nil {
+				capturedRepr = append([]byte(nil), value...)
+			}
+			return nil
+		},
+	})
+
+	ws := store.VaultPrefix("e2e-vault")
+	ctx := context.Background()
+
+	if _, err := store.WriteEngram(ctx, ws, &storage.Engram{
+		Concept: "end-to-end",
+		Content: "replica should receive this",
+	}); err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+
+	if len(capturedRepr) == 0 {
+		t.Fatal("no batch repr captured by RepLogAppend")
+	}
+
+	// Apply to replica DB — exactly what Applier.Apply does for OpBatch.
+	replicaBatch := db2.NewBatch()
+	defer replicaBatch.Close()
+	if err := replicaBatch.SetRepr(capturedRepr); err != nil {
+		t.Fatalf("SetRepr on replica: %v", err)
+	}
+	if err := replicaBatch.Commit(pebble.NoSync); err != nil {
+		t.Fatalf("replica batch commit: %v", err)
+	}
+
+	// Confirm replica has the 0x01-prefixed engram key.
+	iter, err := db2.NewIter(&pebble.IterOptions{
+		LowerBound: []byte{0x01},
+		UpperBound: []byte{0x02},
+	})
+	if err != nil {
+		t.Fatalf("NewIter: %v", err)
+	}
+	defer iter.Close()
+
+	if !iter.First() {
+		t.Fatal("replica DB has no 0x01 engram keys after applying batch repr")
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause of #409**: `ReplicationLog.Append` had 17 test-only call sites and zero production calls. `NetworkStreamer` polls a permanently empty log — replicas froze at snapshot time and never received ongoing writes.
- **Fix**: Added a `RepLogAppend func(op uint8, key, value []byte) error` callback to `PebbleStoreConfig`. After each successful `batch.Commit()`, `ps.replicateBatch(batch)` calls `repLogAppend(3, nil, batch.Repr())` — capturing all keys atomically (primary records, secondary indexes, associations, entity links, etc.) as a single `OpBatch` entry.
- **Applier**: Updated the `OpBatch` case from its "reserved for future use" placeholder to use `batch.SetRepr(entry.Value)`, applying the entire batch verbatim on the replica. A separate marker batch persists `lastApplied` sequence (required because `SetRepr` locks the op count, preventing appending to the same batch).
- **Server wiring**: `RepLogAppend` is set in `server.go` only when cluster mode is enabled — non-cluster deployments are unaffected (nil guard in `replicateBatch`).

## Write paths covered

`WriteEngram`, `WriteEngramBatch`, `UpdateMetadata`, `UpdateRelevance`, `UpdateTrust`, `UpdateTags`, `UpdateConfidence`, `SoftDelete`, `DeleteEngram`, `WriteAssociation`, `UpdateAssocWeight`, `UpdateAssocWeightBatch`, `DecayAssocWeights.flushChunk`, `FlagContradiction`, `ResolveContradiction`, `WriteEntityEngramLink`, `RelinkEntityEngramLink`, `DeleteEntityEngramLink`, `RelinkRelationshipEntity`, `UpsertRelationshipRecord`, `UpdateDigest`, `RestoreArchivedEdges`, `WriteOrdinal`, `DeleteOrdinal`, `UpdateEmbedding`

## Intentionally excluded

Vault metadata, idempotency receipts, last-access tracking, transition counters, coherence/dreamstate stats, archive GC, clone/export/migration bulk ops, entity aggregate records (0x1F), plugin stages, content hashes — all are local-only or rebuilt from scans on replicas.

## Test plan

- [x] `TestRepLogHook_NilCallback` — nil callback doesn't panic (non-cluster safe)
- [x] `TestRepLogHook_WriteEngram` — callback fires on write
- [x] `TestRepLogHook_EndToEnd` — batch repr applied to a second Pebble DB, `0x01` engram key present on replica (direct regression test for #409)
- [x] `TestRepLogHook_SoftDelete`, `TestRepLogHook_DeleteEngram` — engram mutations covered
- [x] `TestRepLogHook_WriteAssociation` — association writes covered
- [x] `TestRepLogHook_WriteEntityEngramLink` — entity link writes covered
- [x] `TestApplier_OpBatch` — Applier applies multi-key batch repr atomically
- [x] `TestApplier_OpBatch_PersistsLastApplied` — crash recovery: close/reopen DB, `LastApplied()` correct
- [x] Full suite: `go test -race ./... -count=1 -timeout 300s` — all pass, no data races