### PR TITLE
fix(import): fix vault import deadlock, orphaned vault cleanup, and upload progress UI

### DIFF
--- a/internal/engine/engine_export.go
+++ b/internal/engine/engine_export.go
@@ -99,7 +99,13 @@ func (e *Engine) StartImport(ctx context.Context, vaultName, embedderModel strin
 		ExpectedModel:     embedderModel,
 		ExpectedDimension: dimension,
 	}
-	if !e.spawnJob(func() { e.runImport(job, wsTarget, vaultName, r, opts) }) {
+	var rc io.ReadCloser
+	if c, ok := r.(io.ReadCloser); ok {
+		rc = c
+	} else {
+		rc = io.NopCloser(r)
+	}
+	if !e.spawnJob(func() { e.runImport(job, wsTarget, vaultName, rc, opts) }) {
 		e.jobManager.Fail(job, fmt.Errorf("engine is shutting down"))
 		// Do NOT call DeleteVaultNameOnly here: the engine is shutting down and
 		// Pebble may already be closed, which would panic. The orphaned vault name
@@ -110,7 +116,7 @@ func (e *Engine) StartImport(ctx context.Context, vaultName, embedderModel strin
 	return job, nil
 }
 
-func (e *Engine) runImport(job *vaultjob.Job, wsTarget [8]byte, vaultName string, r io.Reader, opts storage.ImportOpts) {
+func (e *Engine) runImport(job *vaultjob.Job, wsTarget [8]byte, vaultName string, r io.ReadCloser, opts storage.ImportOpts) {
 	// Use engine lifecycle context so the goroutine exits when Stop() is called.
 	ctx := e.stopCtx
 
@@ -127,6 +133,7 @@ func (e *Engine) runImport(job *vaultjob.Job, wsTarget [8]byte, vaultName string
 			slog.Error("import job panicked", "job_id", job.ID, "vault", vaultName, "panic", rec)
 		}
 	}()
+	defer r.Close()
 
 	// Phase 1: import data from archive.
 	result, err := e.store.ImportVaultData(ctx, wsTarget, vaultName, opts, r)

--- a/internal/engine/engine_export.go
+++ b/internal/engine/engine_export.go
@@ -140,6 +140,14 @@ func (e *Engine) runImport(job *vaultjob.Job, wsTarget [8]byte, vaultName string
 	if err != nil {
 		metrics.ImportJobsTotal.WithLabelValues("failed").Inc()
 		e.jobManager.Fail(job, fmt.Errorf("import phase: %w", err))
+		// Clean up the reserved vault name so it does not linger as a ghost entry.
+		// Skip if the engine is shutting down — Pebble may already be closed.
+		if ctx.Err() == nil {
+			if cleanupErr := e.store.DeleteVaultNameOnly(context.Background(), vaultName, wsTarget); cleanupErr != nil {
+				slog.Error("runImport: failed to clean up orphaned vault name after phase 1 failure",
+					"vault", vaultName, "err", cleanupErr)
+			}
+		}
 		return
 	}
 	job.CopyCurrent.Store(result.EngramCount)

--- a/internal/engine/engine_export_test.go
+++ b/internal/engine/engine_export_test.go
@@ -167,6 +167,46 @@ func TestEngineExportImportRoundTrip(t *testing.T) {
 	}
 }
 
+func TestStartImport_OrphanedVaultCleanup(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	badData := bytes.NewReader([]byte("this is not a muninn archive"))
+
+	job, err := eng.StartImport(ctx, "orphan-vault", "", 0, false, badData)
+	if err != nil {
+		t.Fatalf("StartImport: %v", err)
+	}
+
+	// Wait for job to fail.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		j, ok := eng.GetVaultJob(job.ID)
+		if !ok {
+			t.Fatalf("job %q not found", job.ID)
+		}
+		if j.GetStatus() == vaultjob.StatusError {
+			break
+		}
+		if j.GetStatus() == vaultjob.StatusDone {
+			t.Fatal("expected job to fail with bad data, but it succeeded")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Vault name must NOT appear in the listing.
+	names, err := eng.store.ListVaultNames()
+	if err != nil {
+		t.Fatalf("ListVaultNames: %v", err)
+	}
+	for _, n := range names {
+		if n == "orphan-vault" {
+			t.Error("orphaned vault name still registered after failed import")
+		}
+	}
+}
+
 func TestStartImport_DeadlockOnError(t *testing.T) {
 	eng, cleanup := testEnv(t)
 	defer cleanup()

--- a/internal/engine/engine_export_test.go
+++ b/internal/engine/engine_export_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"testing"
 	"time"
 
@@ -163,5 +164,39 @@ func TestEngineExportImportRoundTrip(t *testing.T) {
 	})
 	if dstCount != engramCount {
 		t.Errorf("dst vault engram count = %d, want %d", dstCount, engramCount)
+	}
+}
+
+func TestStartImport_DeadlockOnError(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	pr, pw := io.Pipe()
+
+	done := make(chan error, 1)
+	go func() {
+		// Write invalid archive header — runImport will fail and (with the fix) close pr.
+		pw.Write([]byte("not a valid muninn archive"))
+		// Do NOT close pw. Instead, attempt another write that will block
+		// until runImport closes pr (causing ErrClosedPipe).
+		_, err := pw.Write(make([]byte, 1))
+		done <- err
+	}()
+
+	_, err := eng.StartImport(context.Background(), "deadlock-test-vault", "", 0, false, pr)
+	if err != nil {
+		t.Fatalf("StartImport: %v", err)
+	}
+
+	// With the fix: runImport closes pr → second pw.Write returns ErrClosedPipe → done receives error.
+	// Without the fix: runImport never closes pr → second pw.Write blocks → timeout.
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("expected write to fail with ErrClosedPipe after runImport closed the reader")
+		}
+		// err == io.ErrClosedPipe (or io.EOF) — test passes
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock: runImport did not close the pipe reader — writer goroutine blocked forever")
 	}
 }

--- a/web/static/css/components.css
+++ b/web/static/css/components.css
@@ -462,6 +462,10 @@ html.light .app-sidebar { background: rgba(250,250,250,0.95); }
   animation: slideIn 0.2s ease;
 }
 @keyframes slideIn { from { transform: translateX(100%); opacity:0; } to { transform: translateX(0); opacity:1; } }
+@keyframes indeterminate {
+  0%   { transform: translateX(-150%); }
+  100% { transform: translateX(350%); }
+}
 .toast.success { border-color: var(--success); }
 .toast.error   { border-color: var(--danger); }
 .toast.info    { border-color: var(--info); }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -2863,7 +2863,7 @@ document.addEventListener('alpine:init', () => {
 
     // ── Vault import ───────────────────────────────────────────────────────
     openImportModal() {
-      this.importModal = { show: true, vaultName: '', file: null, resetMeta: false };
+      this.importModal = { show: true, vaultName: '', file: null, resetMeta: false, uploading: false };
     },
 
     async startImport() {
@@ -2872,6 +2872,7 @@ document.addEventListener('alpine:init', () => {
         vault: this.importModal.vaultName,
         reset_metadata: this.importModal.resetMeta ? 'true' : 'false',
       });
+      this.importModal.uploading = true;
       try {
         const res = await fetch('/api/admin/vaults/import?' + params.toString(), {
           method: 'POST',
@@ -2891,6 +2892,8 @@ document.addEventListener('alpine:init', () => {
         });
       } catch (e) {
         this.addNotification('error', 'Import failed: ' + (e?.message || 'unknown error'));
+      } finally {
+        this.importModal.uploading = false;
       }
     },
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -3049,6 +3049,12 @@ Authorization = "Bearer &lt;token from %USERPROFILE%\.muninn\mcp.token&gt;"</pre
         <input type="checkbox" x-model="importModal.resetMeta" />
         Reset metadata (timestamps, access counts)
       </label>
+      <div x-show="importModal.uploading" style="margin-bottom:1rem;">
+        <p style="font-size:0.75rem;color:var(--text-muted);margin:0 0 0.25rem;">Uploading…</p>
+        <div style="height:0.5rem;background:var(--border-color,#e5e7eb);border-radius:9999px;overflow:hidden;">
+          <div style="height:100%;width:40%;background:#f59e0b;border-radius:9999px;animation:indeterminate 1.5s ease-in-out infinite;"></div>
+        </div>
+      </div>
       <div x-show="activeJob" style="margin-bottom:1rem;">
         <p style="font-size:0.75rem;color:var(--text-muted);margin:0 0 0.25rem;"
            x-text="activeJob?.phase === 'indexing' ? 'Re-indexing...' : 'Importing...'"></p>
@@ -3062,10 +3068,11 @@ Authorization = "Bearer &lt;token from %USERPROFILE%\.muninn\mcp.token&gt;"</pre
       <div style="display:flex;justify-content:flex-end;gap:0.75rem;">
         <button class="btn-secondary" @click="importModal.show = false; clearActiveJob()">Cancel</button>
         <button @click="startImport()"
-                :disabled="!importModal.vaultName || !importModal.file || activeJob?.status === 'running'"
+                :disabled="!importModal.vaultName || !importModal.file || importModal.uploading || activeJob?.status === 'running'"
                 style="padding:0.5rem 1rem;font-size:0.875rem;font-weight:500;background:#f59e0b;color:#fff;border:none;border-radius:0.5rem;cursor:pointer;"
-                :style="(!importModal.vaultName || !importModal.file || activeJob?.status === 'running') ? 'opacity:0.45;cursor:not-allowed;' : 'opacity:1;cursor:pointer;'">
-          Import
+                :style="(!importModal.vaultName || !importModal.file || importModal.uploading || activeJob?.status === 'running') ? 'opacity:0.45;cursor:not-allowed;' : 'opacity:1;cursor:pointer;'">
+          <span x-show="!importModal.uploading">Import</span>
+          <span x-show="importModal.uploading">Uploading…</span>
         </button>
       </div>
     </div>


### PR DESCRIPTION
Fixes #412

## Summary
- **Deadlock fix**: `runImport` now takes `io.ReadCloser` and always calls `defer r.Close()` on exit, so the HTTP handler's `io.Copy(pw, r.Body)` never blocks indefinitely when the import fails
- **Orphaned vault cleanup**: When phase 1 import fails, `DeleteVaultNameOnly` is called (guarded by `ctx.Err() == nil`) to remove the reserved vault name so it doesn't appear as a ghost entry in vault listings
- **Upload progress UI**: Import modal now shows an indeterminate progress bar and disables the Import button while the file upload is in flight (before the server-side job begins)

## Test Plan
- [ ] `TestStartImport_DeadlockOnError` — verifies pipe reader is closed on import failure (writer unblocks within 5s)
- [ ] `TestStartImport_OrphanedVaultCleanup` — verifies vault name is removed from listings after failed import
- [ ] `TestEngineExportImportRoundTrip` — verifies happy path still works end-to-end
- [ ] All 43 packages pass locally