### PR TITLE
fix(engine): reject WriteRequest.CreatedAt outside [2000-01-01, now+5min] (fixes #417)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -914,8 +914,12 @@ func (e *Engine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteRe
 		eng.Summary = callerSummary
 	}
 
-	// Set custom CreatedAt if provided
+	// Set custom CreatedAt if provided; validate bounds to prevent provenance
+	// falsification and ULID overflow.
 	if req.CreatedAt != nil {
+		if err := validateCreatedAt(*req.CreatedAt); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrInvalidRequest, err)
+		}
 		eng.CreatedAt = *req.CreatedAt
 	}
 
@@ -1325,6 +1329,10 @@ func (e *Engine) WriteBatch(ctx context.Context, reqs []*mbp.WriteRequest) ([]*m
 			eng.Summary = callerSummary
 		}
 		if req.CreatedAt != nil {
+			if validateErr := validateCreatedAt(*req.CreatedAt); validateErr != nil {
+				errs[i] = fmt.Errorf("%w: %v", ErrInvalidRequest, validateErr)
+				continue
+			}
 			eng.CreatedAt = *req.CreatedAt
 		}
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -2304,5 +2305,123 @@ func TestEngine_SetTrust(t *testing.T) {
 	fakeID := "01ARZ3NDEKTSV4RRFFQ69G5FAV" // valid ULID format but no such engram
 	if err := eng.SetTrust(context.Background(), "default", fakeID, "verified"); err == nil {
 		t.Error("expected error for nonexistent engram")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: WriteRequest.CreatedAt bounds validation
+// ---------------------------------------------------------------------------
+
+func TestEngineWrite_CreatedAtFuture(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	future := time.Now().Add(10 * time.Minute)
+	_, err := eng.Write(context.Background(), &mbp.WriteRequest{
+		Vault:     "test",
+		Concept:   "x",
+		Content:   "test",
+		CreatedAt: &future,
+	})
+	if err == nil {
+		t.Error("expected error for future CreatedAt, got nil")
+	}
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Errorf("expected ErrInvalidRequest, got: %v", err)
+	}
+}
+
+func TestEngineWrite_CreatedAtTooOld(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	ancient := time.Date(1999, 12, 31, 0, 0, 0, 0, time.UTC)
+	_, err := eng.Write(context.Background(), &mbp.WriteRequest{
+		Vault:     "test",
+		Concept:   "x",
+		Content:   "test",
+		CreatedAt: &ancient,
+	})
+	if err == nil {
+		t.Error("expected error for CreatedAt before 2000-01-01, got nil")
+	}
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Errorf("expected ErrInvalidRequest, got: %v", err)
+	}
+}
+
+func TestEngineWrite_CreatedAtValid(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	past := time.Now().Add(-24 * time.Hour)
+	_, err := eng.Write(context.Background(), &mbp.WriteRequest{
+		Vault:     "test",
+		Concept:   "x",
+		Content:   "test",
+		CreatedAt: &past,
+	})
+	if err != nil {
+		t.Errorf("expected no error for valid past CreatedAt, got: %v", err)
+	}
+}
+
+func TestEngineWriteBatch_CreatedAtFuture(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	future := time.Now().Add(10 * time.Minute)
+	_, errs := eng.WriteBatch(context.Background(), []*mbp.WriteRequest{
+		{
+			Vault:     "test",
+			Concept:   "x",
+			Content:   "test",
+			CreatedAt: &future,
+		},
+	})
+	if len(errs) == 0 || errs[0] == nil {
+		t.Error("expected error for future CreatedAt in batch, got nil")
+	}
+	if !errors.Is(errs[0], ErrInvalidRequest) {
+		t.Errorf("expected ErrInvalidRequest, got: %v", errs[0])
+	}
+}
+
+func TestEngineWriteBatch_CreatedAtTooOld(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	ancient := time.Date(1999, 12, 31, 0, 0, 0, 0, time.UTC)
+	_, errs := eng.WriteBatch(context.Background(), []*mbp.WriteRequest{
+		{
+			Vault:     "test",
+			Concept:   "x",
+			Content:   "test",
+			CreatedAt: &ancient,
+		},
+	})
+	if len(errs) == 0 || errs[0] == nil {
+		t.Error("expected error for CreatedAt before 2000-01-01 in batch, got nil")
+	}
+	if !errors.Is(errs[0], ErrInvalidRequest) {
+		t.Errorf("expected ErrInvalidRequest, got: %v", errs[0])
+	}
+}
+
+func TestEngineWriteBatch_CreatedAtValid(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	past := time.Now().Add(-24 * time.Hour)
+	_, errs := eng.WriteBatch(context.Background(), []*mbp.WriteRequest{
+		{
+			Vault:     "test",
+			Concept:   "x",
+			Content:   "test",
+			CreatedAt: &past,
+		},
+	})
+	if len(errs) > 0 && errs[0] != nil {
+		t.Errorf("expected no error for valid past CreatedAt in batch, got: %v", errs[0])
 	}
 }

--- a/internal/engine/engine_validate.go
+++ b/internal/engine/engine_validate.go
@@ -1,0 +1,27 @@
+package engine
+
+import (
+	"fmt"
+	"time"
+)
+
+// createdAtFloor is the earliest acceptable CreatedAt for a WriteRequest.
+// Values before this date are almost certainly bugs and risk ULID overflow.
+var createdAtFloor = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// createdAtSkew is the maximum amount of clock skew tolerated when a caller
+// supplies a future CreatedAt.
+const createdAtSkew = 5 * time.Minute
+
+// validateCreatedAt returns an error if t is outside acceptable bounds:
+//   - Lower bound: 2000-01-01T00:00:00Z  (protects against ULID overflow and nonsensical dates)
+//   - Upper bound: now + 5 minutes       (clock skew tolerance; rejects future backdating)
+func validateCreatedAt(t time.Time) error {
+	if t.Before(createdAtFloor) {
+		return fmt.Errorf("created_at must not be before 2000-01-01")
+	}
+	if t.After(time.Now().Add(createdAtSkew)) {
+		return fmt.Errorf("created_at must not be more than 5 minutes in the future")
+	}
+	return nil
+}

--- a/internal/engine/engine_vault.go
+++ b/internal/engine/engine_vault.go
@@ -33,6 +33,12 @@ var ErrVaultNameCollision = errors.New("vault name already exists")
 // map it to HTTP 400 Bad Request.
 var ErrInvalidID = errors.New("invalid engram id")
 
+// ErrInvalidRequest is returned when a caller passes a field value that is
+// syntactically valid but semantically out of range (e.g. a CreatedAt timestamp
+// that is before the project epoch or too far in the future). REST handlers map
+// it to HTTP 422 Unprocessable Entity.
+var ErrInvalidRequest = errors.New("invalid request")
+
 // ClearVault removes all memories from a vault. The vault name remains registered.
 // It evicts all in-memory state (HNSW, FTS IDF cache, novelty fingerprints, coherence
 // counters, activity tracking) and adjusts the global engramCount.

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -648,6 +648,10 @@ func (s *Server) handleCreateEngram(w http.ResponseWriter, r *http.Request) {
 			s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, err.Error())
 			return
 		}
+		if errors.Is(err, engine.ErrInvalidRequest) {
+			s.sendError(r, w, http.StatusUnprocessableEntity, ErrInvalidEngram, err.Error())
+			return
+		}
 		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
 		return
 	}


### PR DESCRIPTION
Fixes #417

## Summary
- **Root cause**: `engine.Write()` and `engine.WriteBatch()` accepted any caller-supplied `CreatedAt` without validation. Authenticated write-mode keys could backdate engrams (falsify audit provenance), future-date them (corrupt ULID-based time range queries), or supply extreme values that panic `ulid.MustNew` on 48-bit overflow.
- **Fix**: Added `validateCreatedAt` helper enforcing bounds `[2000-01-01, now+5min]`. Both write paths call it before applying the timestamp. Violations wrap `ErrInvalidRequest` and surface as HTTP 422.
- Validation fires at the engine layer, protecting all transports (REST, MCP/MBP, gRPC) in one place.

## Test Plan
- [ ] `TestEngineWrite_CreatedAtFuture` — future timestamps rejected with `ErrInvalidRequest`
- [ ] `TestEngineWrite_CreatedAtTooOld` — timestamps before 2000-01-01 rejected
- [ ] `TestEngineWrite_CreatedAtValid` — valid past timestamps accepted
- [ ] Equivalent batch tests for all three scenarios
- [ ] Existing `TestCustomCreatedAt_*` tests still pass
- [ ] Full suite green locally