### PR TITLE
fix(ui): add favicon to web UI (fixes #413)

### DIFF
--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -122,6 +122,9 @@ func NewServer(webFS fs.FS, engine rest.EngineAPI, apiHandler http.Handler, auth
 		mux.HandleFunc("/events", s.handleSSE)
 	}
 	mux.Handle("/api/", apiHandler)
+	mux.HandleFunc("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/static/logo.jpg", http.StatusMovedPermanently)
+	})
 	mux.HandleFunc("/", s.handleSPA)
 
 	s.mux = mux

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MuninnDB</title>
+  <link rel="icon" type="image/jpeg" href="/static/logo.jpg" />
 
   <!-- FOUC prevention: apply theme before paint -->
   <script>


### PR DESCRIPTION
Fixes #413

## Summary
- Added `<link rel="icon" type="image/jpeg" href="/static/logo.jpg" />` to `index.html` — uses the existing logo asset, no new file needed
- Added explicit `/favicon.ico` route with a 301 redirect to `/static/logo.jpg` — prevents the SPA catch-all from serving the full HTML page for every favicon request

## Test Plan
- [ ] Build passes, UI tests green
- [ ] Opening the app shows the MuninnDB logo in the browser tab
- [ ] `GET /favicon.ico` returns 301 → `/static/logo.jpg` (not the SPA HTML)