### PR TITLE
fix(fts): worker resilience, multi-field posting, cross-vault IDF cache (#430)

### DIFF
--- a/internal/index/fts/fts.go
+++ b/internal/index/fts/fts.go
@@ -57,12 +57,19 @@ type PostingValue struct {
 	DocLen uint16
 }
 
+// idfKey is the composite cache key for the IDF value of a term within a vault.
+// Keying by (ws, term) prevents cross-vault IDF contamination.
+type idfKey struct {
+	ws   [8]byte
+	term string
+}
+
 // Index is the FTS inverted index backed by Pebble.
 type Index struct {
 	db       *pebble.DB
 	mu       sync.RWMutex
-	// In-memory IDF cache: term → idf
-	idfCache map[string]float64
+	// In-memory IDF cache: (vault, term) → idf
+	idfCache map[idfKey]float64
 	// versionCache caches the FTS schema version per vault (0=legacy dual-path, 1=stemmed-only).
 	// Populated lazily on first Search() for each vault; FTSVersionKey is write-once.
 	versionCache sync.Map // key: [8]byte wsPrefix, value: byte
@@ -71,7 +78,7 @@ type Index struct {
 func New(db *pebble.DB) *Index {
 	return &Index{
 		db:       db,
-		idfCache: make(map[string]float64, 1024),
+		idfCache: make(map[idfKey]float64, 1024),
 	}
 }
 
@@ -80,7 +87,7 @@ func New(db *pebble.DB) *Index {
 // from influencing BM25 scoring.
 func (idx *Index) InvalidateIDFCache() {
 	idx.mu.Lock()
-	idx.idfCache = make(map[string]float64)
+	idx.idfCache = make(map[idfKey]float64)
 	idx.mu.Unlock()
 }
 
@@ -247,7 +254,7 @@ func (idx *Index) IndexEngram(ws [8]byte, id [16]byte, concept, createdBy, conte
 		batch.Set(tkey, dfBuf[:], nil)
 
 		// Invalidate IDF cache for this term so it's recalculated on next search.
-		delete(idx.idfCache, term)
+		delete(idx.idfCache, idfKey{ws, term})
 	}
 
 	// Commit single atomic batch: posting lists + DF updates land together.
@@ -303,7 +310,7 @@ func (idx *Index) DeleteEngram(ws [8]byte, id [16]byte, concept, createdBy, cont
 		}
 
 		// Invalidate IDF cache for this term — DF is now stale.
-		delete(idx.idfCache, term)
+		delete(idx.idfCache, idfKey{ws, term})
 	}
 
 	err := batch.Commit(pebble.Sync)
@@ -510,8 +517,9 @@ func (idx *Index) readStats(ws [8]byte) FTSStats {
 }
 
 func (idx *Index) getIDF(ws [8]byte, term string, N float64) float64 {
+	k := idfKey{ws, term}
 	idx.mu.RLock()
-	idf, ok := idx.idfCache[term]
+	idf, ok := idx.idfCache[k]
 	idx.mu.RUnlock()
 	if ok {
 		return idf
@@ -531,10 +539,10 @@ func (idx *Index) getIDF(ws [8]byte, term string, N float64) float64 {
 	defer idx.mu.Unlock()
 	// Double-check: another goroutine may have populated the cache while we
 	// held no lock (between RUnlock above and this Lock).
-	if cached, ok := idx.idfCache[term]; ok {
+	if cached, ok := idx.idfCache[k]; ok {
 		return cached
 	}
-	idx.idfCache[term] = idf
+	idx.idfCache[k] = idf
 	return idf
 }
 

--- a/internal/index/fts/fts.go
+++ b/internal/index/fts/fts.go
@@ -222,7 +222,7 @@ func (idx *Index) IndexEngram(ws [8]byte, id [16]byte, concept, createdBy, conte
 				Field:  field,
 				DocLen: docLen,
 			}
-			key := keys.FTSPostingKey(ws, term, id)
+			key := keys.FTSPostingKey(ws, term, field, id)
 			val := encodePosting(pv)
 			batch.Set(key, val, nil)
 		}
@@ -289,9 +289,12 @@ func (idx *Index) DeleteEngram(ws [8]byte, id [16]byte, concept, createdBy, cont
 	batch := idx.db.NewBatch()
 
 	for term := range termSet {
-		// Delete posting-list key for this (term, engram) pair.
-		key := keys.FTSPostingKey(ws, term, id)
-		batch.Delete(key, nil)
+		// Delete posting-list keys for this engram across all fields.
+		// Deleting a non-existent key is a no-op in Pebble.
+		for _, field := range []uint8{FieldConcept, FieldContent, FieldTags, FieldCreatedBy} {
+			key := keys.FTSPostingKey(ws, term, field, id)
+			batch.Delete(key, nil)
+		}
 
 		// Delete trigram keys for this term.
 		for _, tri := range Trigrams(term) {
@@ -403,14 +406,15 @@ func (idx *Index) Search(ctx context.Context, ws [8]byte, query string, topK int
 // than the Search() loop body, which would otherwise defer all closes until
 // Search() returns (and risk double-close on the last iterator).
 func (idx *Index) searchToken(ws [8]byte, term string, scores map[[16]byte]float64, idf, avgdl float64) error {
-	// Prefix scan for this term
-	lowerBound := keys.FTSPostingKey(ws, term, [16]byte{})
-	// Upper bound: increment the separator byte after the term prefix.
-	// Allocate one byte longer than lowerBound so sepPos is always in bounds
-	// even when the term extends to the last position of lowerBound.
-	upperBound := make([]byte, len(lowerBound)+1)
+	// Prefix scan for this term across all fields.
+	// Key format: 0x05 | ws[8] | term | 0x00 | field[1] | id[16]
+	// Use field=0x00 for lower bound; upper bound stops at the 0x00 separator + 0x01.
+	lowerBound := keys.FTSPostingKey(ws, term, 0x00, [16]byte{})
+	// Upper bound: increment the separator byte after the term so the scan covers
+	// all field values (0x00–0xFF) for this term.
+	upperBound := make([]byte, len(lowerBound))
 	copy(upperBound, lowerBound)
-	// Increment the separator byte position
+	// sepPos is the index of the 0x00 separator byte: prefix(1) + ws(8) + term.
 	sepPos := 1 + 8 + len(term)
 	upperBound[sepPos] = 0x01
 
@@ -423,13 +427,17 @@ func (idx *Index) searchToken(ws [8]byte, term string, scores map[[16]byte]float
 	}
 	defer iter.Close()
 
+	// Key layout: 0x05[1] | ws[8] | term[n] | 0x00[1] | field[1] | id[16]
+	minKeyLen := 1 + 8 + len(term) + 1 + 1 + 16
+	idOffset := 1 + 8 + len(term) + 1 + 1 // skip prefix, ws, term, separator, field
+
 	for iter.First(); iter.Valid(); iter.Next() {
 		key := iter.Key()
-		if len(key) < 1+8+len(term)+1+16 {
+		if len(key) < minKeyLen {
 			continue
 		}
 		var engramID [16]byte
-		copy(engramID[:], key[1+8+len(term)+1:])
+		copy(engramID[:], key[idOffset:])
 
 		val := iter.Value()
 		pv := decodePosting(val)

--- a/internal/index/fts/fts_test.go
+++ b/internal/index/fts/fts_test.go
@@ -465,3 +465,43 @@ func TestMultiFieldPostingNoOverwrite(t *testing.T) {
 		t.Errorf("id1 score %v <= id2 score %v; expected multi-field boost", results[0].Score, results[1].Score)
 	}
 }
+
+// TestIDFCacheVaultIsolation verifies that IDF values are cached per (vault, term)
+// pair, not globally by term. Before the fix, idfCache was keyed by term only:
+// vault A's cached IDF for "robot" would be returned for vault B's search,
+// producing incorrect BM25 scores in multi-vault setups.
+func TestIDFCacheVaultIsolation(t *testing.T) {
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+
+	idx := New(db)
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 100})
+	wsA := store.VaultPrefix("vault-a")
+	wsB := store.VaultPrefix("vault-b")
+	ctx := context.Background()
+
+	// vault-a: index 10 engrams, only 1 contains "robot" → high IDF (rare term)
+	for i := 0; i < 9; i++ {
+		id := [16]byte{byte(i + 1)}
+		_ = idx.IndexEngram(wsA, id, "unrelated topic", "", "cooking baking gardening", nil)
+	}
+	idRobotA := [16]byte{10}
+	_ = idx.IndexEngram(wsA, idRobotA, "robot", "", "robot automation", nil)
+
+	// vault-b: index 3 engrams, all contain "robot" → low IDF (common term)
+	for i := 0; i < 3; i++ {
+		id := [16]byte{byte(i + 20)}
+		_ = idx.IndexEngram(wsB, id, "robot", "", "robot", nil)
+	}
+
+	// Warm the IDF cache for vault-a by running a search.
+	_, _ = idx.Search(ctx, wsA, "robot", 10)
+
+	// vault-b IDF for "robot" must be lower than vault-a's (it's common in vault-b).
+	idfA := idx.getIDF(wsA, "robot", float64(10))
+	idfB := idx.getIDF(wsB, "robot", float64(3))
+
+	if idfA <= idfB {
+		t.Errorf("idfA (%v) should be > idfB (%v): robot is rare in vault-a but common in vault-b", idfA, idfB)
+	}
+}

--- a/internal/index/fts/fts_test.go
+++ b/internal/index/fts/fts_test.go
@@ -227,14 +227,16 @@ func TestFTS_DualPathSearch(t *testing.T) {
 	// We use Pebble directly to bypass IndexEngram's stemming.
 	{
 		// Construct key manually: same layout as keys.FTSPostingKey
+		// Format: 0x05 | ws[8] | term | 0x00 | field[1] | id[16]
 		term := "running"
 		termBytes := []byte(term)
-		key := make([]byte, 1+8+len(termBytes)+1+16)
+		key := make([]byte, 1+8+len(termBytes)+1+1+16)
 		key[0] = 0x05
 		copy(key[1:9], ws[:])
 		copy(key[9:9+len(termBytes)], termBytes)
 		key[9+len(termBytes)] = 0x00
-		copy(key[10+len(termBytes):], id2[:])
+		key[10+len(termBytes)] = 0x03 // FieldContent
+		copy(key[11+len(termBytes):], id2[:])
 
 		// Encode a minimal 7-byte PostingValue: TF=1, Field=0x03 (content), DocLen=5.
 		import_pv := make([]byte, 7)
@@ -391,7 +393,7 @@ func TestFTS_ReindexedVaultSkipsDualPath(t *testing.T) {
 
 	// Write a raw "running" posting for id2 ONLY — simulating legacy data.
 	// This bypasses IndexEngram intentionally so there's no stemmed posting for id2.
-	postingKey := keys.FTSPostingKey(ws, "running", id2)
+	postingKey := keys.FTSPostingKey(ws, "running", FieldContent, id2)
 	if err := db.Set(postingKey, []byte{}, pebble.NoSync); err != nil {
 		t.Fatalf("Set raw posting: %v", err)
 	}
@@ -423,5 +425,43 @@ func TestFTS_ReindexedVaultSkipsDualPath(t *testing.T) {
 	}
 	if foundID2 {
 		t.Errorf("expected id2 (raw 'running' only) to NOT be found after reindex, but it was. Raw fallback was not skipped.")
+	}
+}
+
+// TestMultiFieldPostingNoOverwrite verifies that a term appearing in multiple
+// fields (concept AND content) contributes scores from both fields, not just
+// the last one written. Before the fix, FTSPostingKey had no field byte and
+// the last field's batch.Set overwrote all earlier ones.
+func TestMultiFieldPostingNoOverwrite(t *testing.T) {
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+
+	idx := New(db)
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 100})
+	ws := store.VaultPrefix("multifield")
+	ctx := context.Background()
+
+	// "rocket" appears in both concept and content — both fields should contribute.
+	id1 := [16]byte{1}
+	_ = idx.IndexEngram(ws, id1, "rocket science", "", "the rocket launches at dawn", nil)
+
+	// id2 has "rocket" only in content.
+	id2 := [16]byte{2}
+	_ = idx.IndexEngram(ws, id2, "space travel", "", "the rocket propels us forward", nil)
+
+	results, err := idx.Search(ctx, ws, "rocket", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) < 2 {
+		t.Fatalf("Search returned %d results, want 2", len(results))
+	}
+	// id1 has "rocket" in concept (weight 3.0) + content (weight 1.0) → higher score.
+	// id2 has "rocket" only in content (weight 1.0) → lower score.
+	if results[0].ID != id1 {
+		t.Errorf("top result = %x, want id1 (%x); multi-field boost not applied", results[0].ID, id1)
+	}
+	if results[0].Score <= results[1].Score {
+		t.Errorf("id1 score %v <= id2 score %v; expected multi-field boost", results[0].Score, results[1].Score)
 	}
 }

--- a/internal/index/fts/worker.go
+++ b/internal/index/fts/worker.go
@@ -26,6 +26,12 @@ type IndexJob struct {
 	Tags      []string
 }
 
+// indexer is the interface Worker depends on for indexing engrams.
+// *Index satisfies this interface.
+type indexer interface {
+	IndexEngram(ws [8]byte, id [16]byte, concept, createdBy, content string, tags []string) error
+}
+
 // Worker processes FTS indexing jobs asynchronously off the write hot path.
 // Jobs are distributed across NumCPU goroutines reading from a shared buffered channel.
 // If the queue is full, the job is dropped and a warning is logged — the engram is
@@ -33,7 +39,7 @@ type IndexJob struct {
 // Stale FTS entries for deleted engrams are harmless: Phase 6 of activation filters
 // nil metadata results, so orphaned posting list entries never surface in results.
 type Worker struct {
-	idx            *Index
+	idx            indexer
 	input          chan IndexJob
 	stopCh         chan struct{}
 	stopped        atomic.Bool
@@ -59,6 +65,13 @@ func (w *Worker) SetClearing(ws [8]byte, clearing bool) {
 // Spawns NumCPU goroutines all reading from a shared 32768-entry channel.
 // Call Stop() to drain and shut down on engine shutdown.
 func NewWorker(idx *Index) *Worker {
+	return newWorkerWithIndex(idx)
+}
+
+// newWorkerWithIndex creates and starts an async FTS indexing worker pool using
+// the provided indexer. This is the real constructor logic, extracted to allow
+// injection of a stub indexer in tests.
+func newWorkerWithIndex(idx indexer) *Worker {
 	n := runtime.NumCPU()
 	w := &Worker{
 		idx:    idx,
@@ -66,24 +79,31 @@ func NewWorker(idx *Index) *Worker {
 		stopCh: make(chan struct{}),
 		done:   make(chan struct{}),
 	}
-	w.wg.Add(n)
 	for range n {
-		go func() {
-			defer w.wg.Done()
+		w.wg.Add(1)
+		go w.runLoop()
+	}
+	return w
+}
+
+// runLoop is the per-goroutine entry point. It wraps run() in a restart loop:
+// after a non-fatal panic, the goroutine re-enters run() instead of exiting.
+// wg.Done() only fires when the worker is cleanly stopped.
+func (w *Worker) runLoop() {
+	defer w.wg.Done()
+	for !w.stopped.Load() {
+		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					// Swallow closed-DB panics that surface as panics in the FTS
-					// indexing path when Pebble is torn down before all goroutines exit.
 					if ftsIsClosedPanic(r) || w.stopped.Load() {
 						return
 					}
-					slog.Error("fts: worker goroutine panicked", "panic", r)
+					slog.Error("fts: worker goroutine panicked, restarting", "panic", r)
 				}
 			}()
 			w.run()
 		}()
 	}
-	return w
 }
 
 // Submit enqueues an FTS index job. Non-blocking — drops and warns if queue is full.

--- a/internal/index/fts/worker_test.go
+++ b/internal/index/fts/worker_test.go
@@ -1,0 +1,50 @@
+package fts
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// panicIndex is a stub *Index whose IndexEngram panics on the first N calls.
+type panicIndex struct {
+	panicCount atomic.Int64
+	callCount  atomic.Int64
+}
+
+func (p *panicIndex) IndexEngram(ws [8]byte, id [16]byte, concept, createdBy, content string, tags []string) error {
+	p.callCount.Add(1)
+	if p.panicCount.Add(-1) >= 0 {
+		panic("synthetic fts panic")
+	}
+	return nil
+}
+
+// TestWorkerRestartsAfterPanic verifies that a goroutine that panics during
+// IndexEngram is automatically replaced so subsequent jobs are still processed.
+func TestWorkerRestartsAfterPanic(t *testing.T) {
+	stub := &panicIndex{}
+	stub.panicCount.Store(1) // first IndexEngram call will panic
+
+	w := newWorkerWithIndex(stub)
+
+	// Submit the first job, which will panic during indexing.
+	job := IndexJob{Concept: "test"}
+	w.Submit(job)
+
+	// Give the worker time to process the first job (and panic+restart).
+	time.Sleep(300 * time.Millisecond)
+
+	// Submit the second job after the worker has had time to restart.
+	// This verifies that the restarted worker goroutine still processes jobs.
+	w.Submit(job)
+
+	// Give the worker time to process the second job.
+	time.Sleep(300 * time.Millisecond)
+
+	w.Stop()
+
+	if calls := stub.callCount.Load(); calls < 2 {
+		t.Errorf("callCount = %d, want >= 2 (worker must restart after panic)", calls)
+	}
+}

--- a/internal/storage/keys/keys.go
+++ b/internal/storage/keys/keys.go
@@ -68,14 +68,18 @@ func AssocRevKey(ws [8]byte, dst [16]byte, weight float32, src [16]byte) []byte 
 }
 
 // FTSPostingKey constructs the FTS posting list entry key (0x05 prefix).
-func FTSPostingKey(ws [8]byte, term string, id [16]byte) []byte {
+// Format: 0x05 | ws[8] | term | 0x00 | field[1] | id[16]
+// The field byte ensures each (term, field, engram) triple has a unique key,
+// preventing multi-field postings from overwriting each other.
+func FTSPostingKey(ws [8]byte, term string, field uint8, id [16]byte) []byte {
 	termBytes := []byte(term)
-	key := make([]byte, 1+8+len(termBytes)+1+16)
+	key := make([]byte, 1+8+len(termBytes)+1+1+16)
 	key[0] = 0x05
 	copy(key[1:9], ws[:])
 	copy(key[9:9+len(termBytes)], termBytes)
-	key[9+len(termBytes)] = 0x00
-	copy(key[10+len(termBytes):], id[:])
+	key[9+len(termBytes)] = 0x00 // separator
+	key[10+len(termBytes)] = field
+	copy(key[11+len(termBytes):], id[:])
 	return key
 }
 

--- a/internal/storage/keys/keys_test.go
+++ b/internal/storage/keys/keys_test.go
@@ -24,7 +24,7 @@ func TestKeyPrefixesAreUnique(t *testing.T) {
 		{"MetaKey", MetaKey(ws, id)},
 		{"AssocFwdKey", AssocFwdKey(ws, id, 0.5, id)},
 		{"AssocRevKey", AssocRevKey(ws, id, 0.5, id)},
-		{"FTSPostingKey", FTSPostingKey(ws, "test", id)},
+		{"FTSPostingKey", FTSPostingKey(ws, "test", 0x01, id)},
 		{"TrigramKey", TrigramKey(ws, trigram, id)},
 		{"HNSWNodeKey", HNSWNodeKey(ws, id, 0)},
 		{"FTSStatsKey", FTSStatsKey(ws)},


### PR DESCRIPTION
## Summary
- **Worker auto-restart:** FTS worker goroutines silently died on panic with no replacement, eventually making all new writes unsearchable. Wrapped `run()` in a restart loop so goroutines recover and continue processing after non-fatal panics.
- **Multi-field posting fix:** `FTSPostingKey` lacked a field byte, so a term appearing in multiple fields (e.g. concept + content) had all but the last field's data overwritten. Added `field uint8` to the key format; `searchToken` now accumulates BM25 scores across all fields correctly.
- **IDF cache vault isolation:** `idfCache` was keyed by term only, causing cross-vault IDF contamination in multi-vault setups. Changed to composite `idfKey{ws [8]byte; term string}` key.

## Test Plan
- [ ] `TestWorkerRestartsAfterPanic` — goroutine survives a panic and processes subsequent jobs
- [ ] `TestMultiFieldPostingNoOverwrite` — multi-field terms produce correct field-weighted scores
- [ ] `TestIDFCacheVaultIsolation` — IDF values are independent per vault
- [ ] Full test suite passes (`go test ./...`)
- [ ] Race detector clean on FTS and keys packages

Closes #430