### PR TITLE
fix(cli): honour MUNINNDB_{ADMIN,MCP,UI}_URL in status + start probes

### DIFF
--- a/cmd/muninn/lifecycle.go
+++ b/cmd/muninn/lifecycle.go
@@ -157,8 +157,9 @@ func runStart(webEnabled bool) error {
 
 	// Wait for health check (up to 5s).
 	// Use the actual MCP port from daemon args — may differ from defaultMCPPort
-	// when the user passed --mcp-addr.
-	mcpHealthURL := "http://127.0.0.1:" + mcpPortFromArgs(args) + "/mcp/health"
+	// when the user passed --mcp-addr. Honours MUNINNDB_MCP_URL for TLS
+	// deployments (see #410 / #424 for the admin-CLI equivalents).
+	mcpHealthURL := healthURL("MUNINNDB_MCP_URL", mcpPortFromArgs(args)) + "/mcp/health"
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		time.Sleep(200 * time.Millisecond)

--- a/cmd/muninn/status.go
+++ b/cmd/muninn/status.go
@@ -6,8 +6,24 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
+
+// healthURL builds a base URL for a service health probe.
+// If envVar is set, it's used verbatim as the base URL (trailing slash
+// trimmed), matching the MUNINNDB_ADMIN_URL / MUNINNDB_UI_URL convention
+// established in vault_auth.go (see #410 / #424). Otherwise falls back to
+// http://127.0.0.1:<port>, preserving the legacy default for non-TLS
+// deployments.
+//
+// Callers append the per-service path (e.g. "/api/health").
+func healthURL(envVar, port string) string {
+	if v := os.Getenv(envVar); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return "http://127.0.0.1:" + port
+}
 
 // checkVersionHint prints a one-liner if a newer version is available.
 // Returns immediately if the check takes more than 3 seconds.
@@ -115,9 +131,9 @@ func probeServicesWithAddrs(addrs daemonAddrs) []serviceStatus {
 	uiPortInt, _ := strconv.Atoi(uiPort)
 
 	return []serviceStatus{
-		{name: "database", port: restPortInt, up: probe("http://127.0.0.1:" + restPort + "/api/health")},
-		{name: "mcp", port: mcpPortInt, up: probe("http://127.0.0.1:" + mcpPort + "/mcp/health")},
-		{name: "web ui", port: uiPortInt, up: probe("http://127.0.0.1:" + uiPort + "/")},
+		{name: "database", port: restPortInt, up: probe(healthURL("MUNINNDB_ADMIN_URL", restPort) + "/api/health")},
+		{name: "mcp", port: mcpPortInt, up: probe(healthURL("MUNINNDB_MCP_URL", mcpPort) + "/mcp/health")},
+		{name: "web ui", port: uiPortInt, up: probe(healthURL("MUNINNDB_UI_URL", uiPort) + "/")},
 	}
 }
 

--- a/cmd/muninn/status_test.go
+++ b/cmd/muninn/status_test.go
@@ -165,3 +165,103 @@ func TestPrintStatusDisplayCompactVsNonCompact(t *testing.T) {
 		t.Errorf("compact output missing 'database': %s", outCompact)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// healthURL + MUNINNDB_{ADMIN,UI,MCP}_URL env-var overrides
+// ---------------------------------------------------------------------------
+
+func TestHealthURL_DefaultWhenEnvUnset(t *testing.T) {
+	t.Setenv("MUNINNDB_ADMIN_URL", "")
+	got := healthURL("MUNINNDB_ADMIN_URL", "8475")
+	want := "http://127.0.0.1:8475"
+	if got != want {
+		t.Errorf("default: got %q, want %q", got, want)
+	}
+}
+
+func TestHealthURL_EnvOverrideHTTPS(t *testing.T) {
+	t.Setenv("MUNINNDB_ADMIN_URL", "https://tls.example.lan:8475")
+	got := healthURL("MUNINNDB_ADMIN_URL", "8475")
+	want := "https://tls.example.lan:8475"
+	if got != want {
+		t.Errorf("env override: got %q, want %q", got, want)
+	}
+}
+
+func TestHealthURL_TrimsTrailingSlash(t *testing.T) {
+	t.Setenv("MUNINNDB_UI_URL", "https://tls.example.lan:8476/")
+	got := healthURL("MUNINNDB_UI_URL", "8476")
+	want := "https://tls.example.lan:8476"
+	if got != want {
+		t.Errorf("trim trailing slash: got %q, want %q", got, want)
+	}
+}
+
+func TestHealthURL_EnvTakesPrecedenceOverPortArg(t *testing.T) {
+	// When the env var is set, the port argument is ignored — the env value
+	// is the complete base URL.
+	t.Setenv("MUNINNDB_ADMIN_URL", "https://other.lan:9999")
+	got := healthURL("MUNINNDB_ADMIN_URL", "8475")
+	want := "https://other.lan:9999"
+	if got != want {
+		t.Errorf("env should override port arg: got %q, want %q", got, want)
+	}
+}
+
+func TestProbeServicesWithAddrs_EnvVarOverridesSingleService(t *testing.T) {
+	// Only MUNINNDB_ADMIN_URL is set. addrs point at an unreachable port, so
+	// "database" must succeed via the env override while "mcp" and "web ui"
+	// must fail (no override, addrs unreachable).
+	srv := newHealthServer()
+	defer srv.Close()
+	t.Setenv("MUNINNDB_ADMIN_URL", srv.URL)
+	t.Setenv("MUNINNDB_MCP_URL", "")
+	t.Setenv("MUNINNDB_UI_URL", "")
+
+	addrs := daemonAddrs{
+		RestAddr: "127.0.0.1:19999",
+		MCPAddr:  "127.0.0.1:19999",
+		UIAddr:   "127.0.0.1:19999",
+	}
+	svcs := probeServicesWithAddrs(addrs)
+
+	byName := map[string]serviceStatus{}
+	for _, s := range svcs {
+		byName[s.name] = s
+	}
+	if !byName["database"].up {
+		t.Error("database should be up via MUNINNDB_ADMIN_URL override")
+	}
+	if byName["mcp"].up {
+		t.Error("mcp should be down (no env override, addrs unreachable)")
+	}
+	if byName["web ui"].up {
+		t.Error("web ui should be down (no env override, addrs unreachable)")
+	}
+}
+
+func TestProbeServicesWithAddrs_AllThreeEnvVarsHonored(t *testing.T) {
+	srvAdmin := newHealthServer()
+	defer srvAdmin.Close()
+	srvMCP := newHealthServer()
+	defer srvMCP.Close()
+	srvUI := newHealthServer()
+	defer srvUI.Close()
+
+	t.Setenv("MUNINNDB_ADMIN_URL", srvAdmin.URL)
+	t.Setenv("MUNINNDB_MCP_URL", srvMCP.URL)
+	t.Setenv("MUNINNDB_UI_URL", srvUI.URL)
+
+	// addrs intentionally unreachable — env vars must drive the probes.
+	addrs := daemonAddrs{
+		RestAddr: "127.0.0.1:19999",
+		MCPAddr:  "127.0.0.1:19999",
+		UIAddr:   "127.0.0.1:19999",
+	}
+	svcs := probeServicesWithAddrs(addrs)
+	for _, s := range svcs {
+		if !s.up {
+			t.Errorf("service %q should be up via env-var override", s.name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #439.

Follow-up to #410 / #424. `muninn status` and `muninn start`'s post-spawn
readiness probe still hardcode `http://`, so against a TLS-enabled deployment
`muninn status` reports every service `[down]` and `muninn start` exits with
"health check timed out" (which under systemd triggers a restart loop) — even
when the daemon is healthy.

This change extends the `MUNINNDB_*_URL` convention introduced in #424 to those
two paths:

| Env var | Used by | Probe path |
|---|---|---|
| `MUNINNDB_ADMIN_URL` (existing) | `status` database probe | `/api/health` |
| `MUNINNDB_UI_URL`    (existing) | `status` web UI probe   | `/` |
| `MUNINNDB_MCP_URL`   (new)      | `status` MCP probe + `start` readiness | `/mcp/health` |

When the env var is set, its value is used verbatim as the base URL (trailing
slash trimmed). Otherwise the probe falls back to the current default
`http://127.0.0.1:<port>`, with `<port>` still coming from the daemon's
sidecar `addrs` file. **No CLI behaviour change for users who don't set the
env vars.**

As with #424, no extra TLS-configuration code is needed: Go's
`http.DefaultTransport` uses the OS trust store, so an internal CA installed
via `update-ca-certificates` (Linux), `security add-trusted-cert` (macOS), or
`certutil` (Windows) works out of the box.

## Changes

- `cmd/muninn/status.go`: new package-local `healthURL(envVar, port)` helper;
  the three `probeServicesWithAddrs` probes route through it
  (`MUNINNDB_ADMIN_URL`, `MUNINNDB_MCP_URL`, `MUNINNDB_UI_URL`).
- `cmd/muninn/lifecycle.go`: post-spawn readiness probe in `runStart` reuses
  the same `healthURL` helper with `MUNINNDB_MCP_URL`.
- `cmd/muninn/status_test.go`: new tests using `t.Setenv` + `httptest.Server`,
  same style as `vault_auth_test.go`. Covers:
  - default (env unset → `http://127.0.0.1:<port>`)
  - `https://` env override
  - trailing-slash trim
  - env value takes precedence over the port arg
  - single env var honored while others fall through
  - all three env vars honored simultaneously

### Backwards compatibility

| Setup | Before | After |
|---|---|---|
| No env vars (plain HTTP deployment) | probes `http://127.0.0.1:<port>` | unchanged |
| `MUNINNDB_*_URL` unset | probes `http://127.0.0.1:<port>` | unchanged |
| `MUNINNDB_ADMIN_URL=https://host:8475` | (no effect — bug) | probe uses that base |
| `MUNINNDB_MCP_URL=https://host:8750` for `muninn start` | (no effect — bug) | readiness probe uses that base |

## Release Checklist

- [x] ~~`CHANGELOG.md`~~ — maintainers update at release time
- [x] N/A — no API routes changed (CLI behaviour only)
- [x] N/A — no SDK schemas changed
- [x] N/A — small CLI tweak, flag help unchanged
- [x] `go build ./...` — clean (Go 1.26)
- [x] `go vet ./...` — clean
- [x] `go test -p 1 -count=1 ./cmd/muninn/...` — passes (13.6s, 6 new tests + all existing)

## Out of scope (potential follow-ups)

- Auto-detect — probe `https://` first and fall back to `http://`. Cleaner UX,
  larger design change. Same scope note as #410.
- `--cacert <path>` flag for environments where the internal CA isn't in the
  OS trust store. Same scope note as #410.
- Three vars vs one: keeping per-service vars matches #424's convention. If
  you'd prefer a single `MUNINNDB_BASE_URL` with `:port` swapped per service,
  happy to revise.
