### PR TITLE
fix(cli): auto-detect TLS in muninn status/start (#442)

### DIFF
--- a/cmd/muninn/help.go
+++ b/cmd/muninn/help.go
@@ -93,7 +93,10 @@ var subcommandHelp = map[string]func(){
 	},
 	"status": func() {
 		printSubcommandUsage("status", "show service health and ports", "muninn status", nil,
-			[]string{"muninn status"})
+			[]string{
+				"muninn status",
+				"MUNINNDB_ADMIN_URL=https://host:8475 muninn status   # TLS: override probe URLs",
+			})
 	},
 	"shell": func() {
 		printSubcommandUsage("shell", "interactive memory shell", "muninn shell", nil,
@@ -344,6 +347,9 @@ func printHelp() {
 	fmt.Println("  MCP endpoint: http://127.0.0.1:8750/mcp")
 	fmt.Printf("  %-28s %s\n", "MUNINN_MCP_URL", "Override MCP server URL (also used by 'muninn mcp' proxy)")
 	fmt.Printf("  %-28s %s\n", "MUNINNDB_DATA", "Override default data directory")
+	fmt.Printf("  %-28s %s\n", "MUNINNDB_ADMIN_URL", "TLS: base URL for 'muninn status'/admin REST probes")
+	fmt.Printf("  %-28s %s\n", "MUNINNDB_UI_URL", "TLS: base URL for 'muninn status' Web UI probe")
+	fmt.Printf("  %-28s %s\n", "MUNINNDB_MCP_URL", "TLS: base URL for 'muninn status'/'start' MCP probe")
 	fmt.Println()
 
 	fmt.Println(bold("PORTS"))

--- a/cmd/muninn/lifecycle.go
+++ b/cmd/muninn/lifecycle.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"net"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -157,20 +155,14 @@ func runStart(webEnabled bool) error {
 
 	// Wait for health check (up to 5s).
 	// Use the actual MCP port from daemon args — may differ from defaultMCPPort
-	// when the user passed --mcp-addr. Honours MUNINNDB_MCP_URL for TLS
-	// deployments (see #410 / #424 for the admin-CLI equivalents).
-	mcpHealthURL := healthURL("MUNINNDB_MCP_URL", mcpPortFromArgs(args)) + "/mcp/health"
+	// when the user passed --mcp-addr. probeHealth's http→https retry makes the
+	// poll succeed against a TLS deployment with no MUNINNDB_MCP_URL set, so
+	// `muninn start` no longer times out (and boot-loops) under TLS.
+	mcpHealthURL := healthURL("MUNINNDB_MCP_URL", "http", mcpPortFromArgs(args)) + "/mcp/health"
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		time.Sleep(200 * time.Millisecond)
-		resp, err := http.Get(mcpHealthURL)
-		if err != nil {
-			continue
-		}
-		// Always drain and close body to allow connection reuse and prevent leaks.
-		io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-		if resp.StatusCode == 200 {
+		if up, _ := probeHealth(mcpHealthURL); up {
 			fmt.Printf("muninn started (pid %d)\n", cmd.Process.Pid)
 			fmt.Println()
 			printStatusDisplay(true)

--- a/cmd/muninn/pid.go
+++ b/cmd/muninn/pid.go
@@ -14,12 +14,25 @@ import (
 // the startup health poll can probe the correct ports when non-default
 // --*-addr flags are used.
 type daemonAddrs struct {
+	// Scheme is "http" or "https" — the scheme the daemon's client-facing
+	// listeners serve. An empty Scheme (e.g. a sidecar written by an older
+	// daemon that predates this field) is treated as "http" by readers.
+	Scheme   string `json:"scheme"`
 	RestAddr string `json:"rest_addr"`
 	MCPAddr  string `json:"mcp_addr"`
 	UIAddr   string `json:"ui_addr"`
 }
 
 const addrsFileName = "muninn.addrs"
+
+// schemeFor reports the scheme the daemon's client-facing listeners serve:
+// "https" when both a TLS cert and key are configured, "http" otherwise.
+func schemeFor(tlsCert, tlsKey string) string {
+	if tlsCert != "" && tlsKey != "" {
+		return "https"
+	}
+	return "http"
+}
 
 func writeAddrsFile(dataDir string, addrs daemonAddrs) error {
 	b, err := json.Marshal(addrs)

--- a/cmd/muninn/pid_test.go
+++ b/cmd/muninn/pid_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -70,5 +71,61 @@ func TestWriteAddrsFileOverwrites(t *testing.T) {
 	}
 	if got != second {
 		t.Errorf("got %+v, want %+v", got, second)
+	}
+}
+
+func TestWriteReadAddrsFile_Scheme(t *testing.T) {
+	dir := t.TempDir()
+	want := daemonAddrs{
+		Scheme:   "https",
+		RestAddr: "127.0.0.1:8475",
+		MCPAddr:  "127.0.0.1:8750",
+		UIAddr:   "127.0.0.1:8476",
+	}
+	if err := writeAddrsFile(dir, want); err != nil {
+		t.Fatalf("writeAddrsFile: %v", err)
+	}
+	got, err := readAddrsFile(dir)
+	if err != nil {
+		t.Fatalf("readAddrsFile: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestReadAddrsFile_OldFormatNoScheme(t *testing.T) {
+	// A sidecar written by an older daemon has no "scheme" key. readAddrsFile
+	// must tolerate it and leave Scheme empty (callers treat empty as "http").
+	dir := t.TempDir()
+	blob := `{"rest_addr":"127.0.0.1:8475","mcp_addr":"127.0.0.1:8750","ui_addr":"127.0.0.1:8476"}`
+	if err := os.WriteFile(filepath.Join(dir, addrsFileName), []byte(blob), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := readAddrsFile(dir)
+	if err != nil {
+		t.Fatalf("readAddrsFile: %v", err)
+	}
+	if got.Scheme != "" {
+		t.Errorf("Scheme = %q, want empty for an old-format sidecar", got.Scheme)
+	}
+	if got.RestAddr != "127.0.0.1:8475" {
+		t.Errorf("RestAddr = %q, want 127.0.0.1:8475", got.RestAddr)
+	}
+}
+
+func TestSchemeFor(t *testing.T) {
+	cases := []struct {
+		cert, key, want string
+	}{
+		{"", "", "http"},
+		{"cert.pem", "", "http"},
+		{"", "key.pem", "http"},
+		{"cert.pem", "key.pem", "https"},
+	}
+	for _, c := range cases {
+		if got := schemeFor(c.cert, c.key); got != c.want {
+			t.Errorf("schemeFor(%q, %q) = %q, want %q", c.cert, c.key, got, c.want)
+		}
 	}
 }

--- a/cmd/muninn/repl_client.go
+++ b/cmd/muninn/repl_client.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -49,8 +51,24 @@ func mcpCall(baseURL, toolName string, args map[string]any) (map[string]any, err
 }
 
 func (r *replState) cmdShowVaults() {
+	addrs, _ := readAddrsFile(defaultDataDir())
+	restPort := "8475"
+	if addrs.RestAddr != "" {
+		if _, p, err := net.SplitHostPort(addrs.RestAddr); err == nil && p != "" {
+			restPort = p
+		}
+	}
+	apiURL := healthURL("MUNINNDB_ADMIN_URL", addrs.Scheme, restPort) + "/api/vaults"
+
 	client := &http.Client{Timeout: 5 * time.Second}
-	req, err := http.NewRequest("GET", "http://127.0.0.1:8475/api/vaults", nil)
+	if strings.HasPrefix(apiURL, "https://") {
+		// localhost admin REPL talking to its own server — skip cert
+		// verification so an internal-CA TLS deployment still works.
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		}
+	}
+	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return
@@ -70,7 +88,7 @@ func (r *replState) cmdShowVaults() {
 		// Fallback: show static message
 		fmt.Println("  default   (built-in)")
 		fmt.Println()
-		fmt.Println("  For full vault list, open: http://127.0.0.1:8476")
+		fmt.Printf("  For full vault list, open: %s\n", webUIDisplay(addrs)[0])
 		return
 	}
 
@@ -346,11 +364,12 @@ func (r *replState) cmdShowStats() {
 		return
 	}
 	resp.Body.Close()
+	addrs, _ := readAddrsFile(defaultDataDir())
 	fmt.Println("Server: running")
 	fmt.Println("  MBP  :8474   binary protocol")
 	fmt.Println("  REST :8475   JSON API")
 	fmt.Println("  MCP  :8750   AI tool integration")
-	fmt.Println("  UI   :8476   http://127.0.0.1:8476")
+	fmt.Printf("  UI   :8476   %s\n", webUIDisplay(addrs)[0])
 	if r.vault != "" {
 		fmt.Println()
 		result, err := mcpCall(r.mcpURL, "muninn_status", map[string]any{"vault": r.vault})

--- a/cmd/muninn/repl_client.go
+++ b/cmd/muninn/repl_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -50,6 +51,15 @@ func mcpCall(baseURL, toolName string, args map[string]any) (map[string]any, err
 	return res, nil
 }
 
+// isTLSCertError reports whether err is a TLS certificate verification failure
+// (untrusted CA, hostname mismatch, expired cert) rather than a plain
+// connection failure such as a refused or timed-out dial. Since Go 1.20 the
+// handshake wraps every verification failure in tls.CertificateVerificationError.
+func isTLSCertError(err error) bool {
+	var certErr *tls.CertificateVerificationError
+	return errors.As(err, &certErr)
+}
+
 func (r *replState) cmdShowVaults() {
 	addrs, _ := readAddrsFile(defaultDataDir())
 	restPort := "8475"
@@ -61,9 +71,11 @@ func (r *replState) cmdShowVaults() {
 	apiURL := healthURL("MUNINNDB_ADMIN_URL", addrs.Scheme, restPort) + "/api/vaults"
 
 	client := &http.Client{Timeout: 5 * time.Second}
-	if strings.HasPrefix(apiURL, "https://") {
-		// localhost admin REPL talking to its own server — skip cert
-		// verification so an internal-CA TLS deployment still works.
+	if strings.HasPrefix(apiURL, "https://") && isLoopbackURL(apiURL) {
+		// Skip cert verification only for a loopback target: an internal-CA
+		// TLS deployment talking to its own server can't be impersonated.
+		// For an off-host MUNINNDB_ADMIN_URL verification stays on — this
+		// request carries the admin session cookie.
 		client.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
 		}
@@ -78,6 +90,12 @@ func (r *replState) cmdShowVaults() {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		if isTLSCertError(err) {
+			fmt.Fprintf(os.Stderr, "Error: TLS certificate verification failed for %s: %v\n", apiURL, err)
+			fmt.Println("The server's certificate is not trusted. Install its CA into the system")
+			fmt.Println("trust store, or point MUNINNDB_ADMIN_URL at a loopback address.")
+			return
+		}
 		fmt.Fprintf(os.Stderr, "Error connecting to server: %v\n", err)
 		fmt.Println("Is muninn running? Try: muninn start")
 		return

--- a/cmd/muninn/repl_client_test.go
+++ b/cmd/muninn/repl_client_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -203,6 +206,22 @@ func TestCmdShowVaults401FallbackMessage(t *testing.T) {
 	})
 	if !strings.Contains(out, "https://ui.example.lan:8476") {
 		t.Errorf("401 fallback should show the scheme-aware Web UI URL, got: %q", out)
+	}
+}
+
+// TestIsTLSCertError verifies a certificate-verification failure is told apart
+// from a plain connection error, so cmdShowVaults can give the right hint.
+func TestIsTLSCertError(t *testing.T) {
+	certErr := &url.Error{Op: "Get", URL: "https://x", Err: &tls.CertificateVerificationError{}}
+	if !isTLSCertError(certErr) {
+		t.Error("wrapped tls.CertificateVerificationError should be detected")
+	}
+	plain := &url.Error{Op: "Get", URL: "https://x", Err: errors.New("connection refused")}
+	if isTLSCertError(plain) {
+		t.Error("plain connection error must not be flagged as a cert error")
+	}
+	if isTLSCertError(nil) {
+		t.Error("nil error must not be flagged")
 	}
 }
 

--- a/cmd/muninn/repl_client_test.go
+++ b/cmd/muninn/repl_client_test.go
@@ -172,20 +172,37 @@ func TestLoadSaveDefaultVault(t *testing.T) {
 	}
 }
 
-// TestCmdShowVaults401Fallback tests cmdShowVaults with connection error.
-func TestCmdShowVaults401Fallback(t *testing.T) {
-	// When the server is unreachable, cmdShowVaults should handle gracefully
-	r := &replState{mcpURL: "http://localhost:9998"}
+// TestCmdShowVaultsConnectionError verifies cmdShowVaults degrades gracefully
+// when the server is unreachable.
+func TestCmdShowVaultsConnectionError(t *testing.T) {
+	t.Setenv("MUNINNDB_DATA", t.TempDir())
+	t.Setenv("MUNINNDB_ADMIN_URL", "http://127.0.0.1:19998") // nothing listening
+	r := &replState{}
 	errOut := captureStderr(func() {
 		captureStdout(func() {
 			r.cmdShowVaults()
 		})
 	})
-	// Should print error message to stderr or handle gracefully
-	// (error message is written to stderr, not stdout)
-	if !strings.Contains(errOut, "Error connecting to server") && !strings.Contains(errOut, "muninn start") {
-		// If not in stderr, the function should at least complete without panic
-		t.Logf("cmdShowVaults handled connection error gracefully")
+	if !strings.Contains(errOut, "Error connecting to server") {
+		t.Errorf("expected a connection-error message on stderr, got: %q", errOut)
+	}
+}
+
+// TestCmdShowVaults401FallbackMessage verifies the 401 fallback prints the
+// scheme-aware Web UI URL (from webUIDisplay), not a hardcoded http://localhost.
+func TestCmdShowVaults401FallbackMessage(t *testing.T) {
+	t.Setenv("MUNINNDB_DATA", t.TempDir())
+	srv := newJSONServer(http.StatusUnauthorized, `{"error":"unauthorized"}`)
+	defer srv.Close()
+	t.Setenv("MUNINNDB_ADMIN_URL", srv.URL)
+	t.Setenv("MUNINNDB_UI_URL", "https://ui.example.lan:8476")
+
+	r := &replState{}
+	out := captureStdout(func() {
+		r.cmdShowVaults()
+	})
+	if !strings.Contains(out, "https://ui.example.lan:8476") {
+		t.Errorf("401 fallback should show the scheme-aware Web UI URL, got: %q", out)
 	}
 }
 

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -783,14 +783,6 @@ func runServer() {
 	}
 	flag.Parse()
 
-	// Persist actual bound addresses so 'muninn status' and the startup health poll
-	// can probe the correct ports when non-default --*-addr flags are used.
-	_ = writeAddrsFile(*dataDir, daemonAddrs{
-		RestAddr: *restAddr,
-		MCPAddr:  *mcpAddr,
-		UIAddr:   *uiAddr,
-	})
-
 	// MCP token resolution order (highest to lowest priority):
 	//   1. --mcp-token flag  — explicit override for tests / container entrypoints
 	//   2. MUNINN_MCP_TOKEN env var — preferred for Docker / docker-compose deployments
@@ -809,6 +801,17 @@ func runServer() {
 	if *tlsKey == "" {
 		*tlsKey = os.Getenv("MUNINN_TLS_KEY")
 	}
+
+	// Persist actual bound addresses + scheme so 'muninn status' and the startup
+	// health poll can probe the correct ports and scheme when non-default
+	// --*-addr flags or TLS are in use. Written after the TLS env fallbacks so
+	// Scheme reflects both --tls-cert flags and MUNINN_TLS_CERT/_KEY env vars.
+	_ = writeAddrsFile(*dataDir, daemonAddrs{
+		Scheme:   schemeFor(*tlsCert, *tlsKey),
+		RestAddr: *restAddr,
+		MCPAddr:  *mcpAddr,
+		UIAddr:   *uiAddr,
+	})
 
 	// Backup env fallbacks — flags take priority; env vars are the fallback.
 	if *backupInterval == "" {

--- a/cmd/muninn/status.go
+++ b/cmd/muninn/status.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -248,6 +249,27 @@ func hostIsRoutable(host string) bool {
 		return !ip.IsLoopback()
 	}
 	return true
+}
+
+// isLoopbackURL reports whether rawURL targets this machine — its host is
+// empty, "localhost", or a loopback IP. It is the URL-level guard for deciding
+// when skipping TLS certificate verification is safe: a loopback peer cannot
+// be impersonated, an off-host peer can. Unparseable input is treated as
+// non-loopback so callers fail closed (keep verification on).
+func isLoopbackURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	switch host {
+	case "", "127.0.0.1", "::1", "localhost":
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // printStatusDisplay prints the unified status view.

--- a/cmd/muninn/status.go
+++ b/cmd/muninn/status.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -14,15 +16,18 @@ import (
 // If envVar is set, it's used verbatim as the base URL (trailing slash
 // trimmed), matching the MUNINNDB_ADMIN_URL / MUNINNDB_UI_URL convention
 // established in vault_auth.go (see #410 / #424). Otherwise falls back to
-// http://127.0.0.1:<port>, preserving the legacy default for non-TLS
-// deployments.
+// <scheme>://127.0.0.1:<port>; an empty scheme is treated as "http",
+// preserving the legacy default for non-TLS deployments.
 //
 // Callers append the per-service path (e.g. "/api/health").
-func healthURL(envVar, port string) string {
+func healthURL(envVar, scheme, port string) string {
 	if v := os.Getenv(envVar); v != "" {
 		return strings.TrimRight(v, "/")
 	}
-	return "http://127.0.0.1:" + port
+	if scheme == "" {
+		scheme = "http"
+	}
+	return scheme + "://127.0.0.1:" + port
 }
 
 // checkVersionHint prints a one-liner if a newer version is available.
@@ -60,10 +65,11 @@ const (
 )
 
 type serviceStatus struct {
-	name string
-	port int
-	up   bool
-	note string // optional: "not responding"
+	name   string
+	port   int
+	up     bool
+	scheme string // scheme the probe reached the service on ("http"/"https"/"")
+	note   string // optional: "not responding"
 }
 
 // overallState computes the aggregate state from individual service statuses.
@@ -99,18 +105,60 @@ func probeServicesDefault() []serviceStatus {
 	return probeServicesWithAddrs(addrs)
 }
 
-// probeServicesWithAddrs is the testable implementation. addrs contains the
-// actual addresses the daemon bound to; empty strings fall back to defaults.
-func probeServicesWithAddrs(addrs daemonAddrs) []serviceStatus {
-	client := &http.Client{Timeout: 2 * time.Second}
-	probe := func(url string) bool {
-		resp, err := client.Get(url)
-		if err != nil {
-			return false
+// probeHealth reports whether the service health endpoint at url is up (a 2xx
+// response) and the scheme that actually worked ("http" or "https"; "" when
+// down). If an http:// probe fails — transport error or non-2xx — it retries
+// once over https://, so a TLS deployment is detected with no configuration;
+// the returned scheme then lets callers correct a stale display URL. An
+// https:// URL (e.g. an env-var override) is probed directly.
+//
+// The https attempt skips certificate verification: this is a localhost
+// liveness check, not a security boundary, and an internal-CA or self-signed
+// cert must not make a healthy server look [down].
+func probeHealth(url string) (up bool, scheme string) {
+	switch {
+	case strings.HasPrefix(url, "https://"):
+		if probeOnce(url, true) {
+			return true, "https"
 		}
-		resp.Body.Close()
-		return resp.StatusCode >= 200 && resp.StatusCode < 300
+		return false, ""
+	case strings.HasPrefix(url, "http://"):
+		if probeOnce(url, false) {
+			return true, "http"
+		}
+		// The http probe failed — the server may actually speak TLS on this
+		// port. Retry once over https before concluding it is down.
+		if probeOnce("https://"+strings.TrimPrefix(url, "http://"), true) {
+			return true, "https"
+		}
+		return false, ""
+	default:
+		return probeOnce(url, false), ""
 	}
+}
+
+// probeOnce performs a single health-check GET. When insecure is set the TLS
+// client skips certificate verification (see probeHealth for the rationale).
+func probeOnce(url string, insecure bool) bool {
+	client := &http.Client{Timeout: 2 * time.Second}
+	if insecure {
+		client.Transport = &http.Transport{
+			// localhost liveness probe, not a security boundary
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		}
+	}
+	resp, err := client.Get(url)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// probeServicesWithAddrs is the testable implementation. addrs contains the
+// actual addresses (and scheme) the daemon bound to; empty fields fall back to
+// the default ports and an "http" scheme.
+func probeServicesWithAddrs(addrs daemonAddrs) []serviceStatus {
 	// portFrom extracts the port from an "host:port" address string.
 	// Returns fallback when addr is empty or unparseable.
 	portFrom := func(addr, fallback string) string {
@@ -130,11 +178,76 @@ func probeServicesWithAddrs(addrs daemonAddrs) []serviceStatus {
 	mcpPortInt, _ := strconv.Atoi(mcpPort)
 	uiPortInt, _ := strconv.Atoi(uiPort)
 
-	return []serviceStatus{
-		{name: "database", port: restPortInt, up: probe(healthURL("MUNINNDB_ADMIN_URL", restPort) + "/api/health")},
-		{name: "mcp", port: mcpPortInt, up: probe(healthURL("MUNINNDB_MCP_URL", mcpPort) + "/mcp/health")},
-		{name: "web ui", port: uiPortInt, up: probe(healthURL("MUNINNDB_UI_URL", uiPort) + "/")},
+	svcs := []serviceStatus{
+		{name: "database", port: restPortInt},
+		{name: "mcp", port: mcpPortInt},
+		{name: "web ui", port: uiPortInt},
 	}
+	urls := []string{
+		healthURL("MUNINNDB_ADMIN_URL", addrs.Scheme, restPort) + "/api/health",
+		healthURL("MUNINNDB_MCP_URL", addrs.Scheme, mcpPort) + "/mcp/health",
+		healthURL("MUNINNDB_UI_URL", addrs.Scheme, uiPort) + "/",
+	}
+	// Probe concurrently: with the http→https retry a serial sweep could take
+	// several seconds when services are unreachable. Each goroutine writes its
+	// own fixed index, so result order stays [database, mcp, web ui].
+	var wg sync.WaitGroup
+	for i := range svcs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			svcs[i].up, svcs[i].scheme = probeHealth(urls[i])
+		}(i)
+	}
+	wg.Wait()
+	return svcs
+}
+
+// webUIDisplay returns the Web UI URL(s) to show the operator, derived from the
+// daemon's recorded bind address. It always returns at least one element, so
+// callers may safely index [0].
+//   - MUNINNDB_UI_URL set        → that URL, verbatim.
+//   - UI bound to loopback/empty → just the localhost URL.
+//   - UI bound to 0.0.0.0 / LAN  → the routable host first (os.Hostname), then
+//     the localhost URL as an always-works fallback.
+func webUIDisplay(addrs daemonAddrs) []string {
+	if v := os.Getenv("MUNINNDB_UI_URL"); v != "" {
+		return []string{strings.TrimRight(v, "/")}
+	}
+	scheme := addrs.Scheme
+	if scheme == "" {
+		scheme = "http"
+	}
+	host, port := "", "8476"
+	if addrs.UIAddr != "" {
+		if h, p, err := net.SplitHostPort(addrs.UIAddr); err == nil {
+			host = h
+			if p != "" {
+				port = p
+			}
+		}
+	}
+	local := scheme + "://127.0.0.1:" + port
+	if hostIsRoutable(host) {
+		if hn, err := os.Hostname(); err == nil && hn != "" {
+			return []string{scheme + "://" + hn + ":" + port, local}
+		}
+	}
+	return []string{local}
+}
+
+// hostIsRoutable reports whether host is a non-loopback bind — i.e. the UI is
+// reachable beyond this machine, so a routable hostname is worth showing
+// alongside the localhost URL.
+func hostIsRoutable(host string) bool {
+	switch host {
+	case "", "127.0.0.1", "::1", "localhost":
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return !ip.IsLoopback()
+	}
+	return true
 }
 
 // printStatusDisplay prints the unified status view.
@@ -207,14 +320,21 @@ func printStatusDisplay(compact bool) runState {
 		}
 		if state == stateRunning {
 			fmt.Println()
-			uiPort := "8476"
-			for _, s := range svcs {
-				if s.name == "web ui" && s.port != 0 {
-					uiPort = strconv.Itoa(s.port)
-					break
+			addrs, _ := readAddrsFile(defaultDataDir())
+			// If the daemon predates the muninn.addrs scheme field, fall back
+			// to the scheme the probe actually reached the Web UI on.
+			if addrs.Scheme == "" {
+				for _, s := range svcs {
+					if s.name == "web ui" && s.scheme != "" {
+						addrs.Scheme = s.scheme
+					}
 				}
 			}
-			fmt.Printf("  Web UI → http://127.0.0.1:%s\n", uiPort)
+			lines := webUIDisplay(addrs)
+			fmt.Printf("  Web UI → %s\n", lines[0])
+			for _, l := range lines[1:] {
+				fmt.Printf("           %s\n", l)
+			}
 			checkVersionHint()
 		}
 	}

--- a/cmd/muninn/status_test.go
+++ b/cmd/muninn/status_test.go
@@ -172,7 +172,7 @@ func TestPrintStatusDisplayCompactVsNonCompact(t *testing.T) {
 
 func TestHealthURL_DefaultWhenEnvUnset(t *testing.T) {
 	t.Setenv("MUNINNDB_ADMIN_URL", "")
-	got := healthURL("MUNINNDB_ADMIN_URL", "8475")
+	got := healthURL("MUNINNDB_ADMIN_URL", "http", "8475")
 	want := "http://127.0.0.1:8475"
 	if got != want {
 		t.Errorf("default: got %q, want %q", got, want)
@@ -181,7 +181,7 @@ func TestHealthURL_DefaultWhenEnvUnset(t *testing.T) {
 
 func TestHealthURL_EnvOverrideHTTPS(t *testing.T) {
 	t.Setenv("MUNINNDB_ADMIN_URL", "https://tls.example.lan:8475")
-	got := healthURL("MUNINNDB_ADMIN_URL", "8475")
+	got := healthURL("MUNINNDB_ADMIN_URL", "http", "8475")
 	want := "https://tls.example.lan:8475"
 	if got != want {
 		t.Errorf("env override: got %q, want %q", got, want)
@@ -190,7 +190,7 @@ func TestHealthURL_EnvOverrideHTTPS(t *testing.T) {
 
 func TestHealthURL_TrimsTrailingSlash(t *testing.T) {
 	t.Setenv("MUNINNDB_UI_URL", "https://tls.example.lan:8476/")
-	got := healthURL("MUNINNDB_UI_URL", "8476")
+	got := healthURL("MUNINNDB_UI_URL", "http", "8476")
 	want := "https://tls.example.lan:8476"
 	if got != want {
 		t.Errorf("trim trailing slash: got %q, want %q", got, want)
@@ -201,7 +201,7 @@ func TestHealthURL_EnvTakesPrecedenceOverPortArg(t *testing.T) {
 	// When the env var is set, the port argument is ignored — the env value
 	// is the complete base URL.
 	t.Setenv("MUNINNDB_ADMIN_URL", "https://other.lan:9999")
-	got := healthURL("MUNINNDB_ADMIN_URL", "8475")
+	got := healthURL("MUNINNDB_ADMIN_URL", "http", "8475")
 	want := "https://other.lan:9999"
 	if got != want {
 		t.Errorf("env should override port arg: got %q, want %q", got, want)
@@ -263,5 +263,171 @@ func TestProbeServicesWithAddrs_AllThreeEnvVarsHonored(t *testing.T) {
 		if !s.up {
 			t.Errorf("service %q should be up via env-var override", s.name)
 		}
+	}
+}
+
+func TestHealthURL_SchemeApplied(t *testing.T) {
+	t.Setenv("MUNINNDB_ADMIN_URL", "")
+	if got := healthURL("MUNINNDB_ADMIN_URL", "https", "8475"); got != "https://127.0.0.1:8475" {
+		t.Errorf("https scheme: got %q", got)
+	}
+	if got := healthURL("MUNINNDB_ADMIN_URL", "http", "8475"); got != "http://127.0.0.1:8475" {
+		t.Errorf("http scheme: got %q", got)
+	}
+	if got := healthURL("MUNINNDB_ADMIN_URL", "", "8475"); got != "http://127.0.0.1:8475" {
+		t.Errorf("empty scheme should default to http: got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// probeHealth — http→https auto-retry
+// ---------------------------------------------------------------------------
+
+func TestProbeHealth_HTTPServer(t *testing.T) {
+	srv := newHealthServer()
+	defer srv.Close()
+	up, scheme := probeHealth(srv.URL + "/")
+	if !up {
+		t.Error("probeHealth should report a plain-HTTP server up")
+	}
+	if scheme != "http" {
+		t.Errorf("scheme = %q, want http", scheme)
+	}
+}
+
+func TestProbeHealth_RetriesHTTPS(t *testing.T) {
+	// A TLS-only server probed with an http:// URL: the http attempt fails,
+	// probeHealth must retry https:// and report the working scheme as https.
+	srv := newTLSHealthServer()
+	defer srv.Close()
+	httpURL := "http://" + strings.TrimPrefix(srv.URL, "https://")
+	up, scheme := probeHealth(httpURL)
+	if !up {
+		t.Error("probeHealth should detect a TLS server via http→https retry")
+	}
+	if scheme != "https" {
+		t.Errorf("retry scheme = %q, want https", scheme)
+	}
+	// A direct https:// URL (env-override style) is probed without retry.
+	if up, scheme := probeHealth(srv.URL); !up || scheme != "https" {
+		t.Errorf("direct https probe: up=%v scheme=%q, want true/https", up, scheme)
+	}
+}
+
+func TestProbeHealth_DownServer(t *testing.T) {
+	// Nothing listening — both the http attempt and the https retry must fail.
+	if up, scheme := probeHealth("http://127.0.0.1:19998/"); up || scheme != "" {
+		t.Errorf("unreachable server: up=%v scheme=%q, want false/empty", up, scheme)
+	}
+}
+
+func TestProbeServicesWithAddrs_HTTPSScheme(t *testing.T) {
+	// addrs.Scheme = "https" against a TLS server → all three services up with
+	// no env-var override needed.
+	srv := newTLSHealthServer()
+	defer srv.Close()
+	_, port, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "https://"))
+	t.Setenv("MUNINNDB_ADMIN_URL", "")
+	t.Setenv("MUNINNDB_MCP_URL", "")
+	t.Setenv("MUNINNDB_UI_URL", "")
+	addrs := daemonAddrs{
+		Scheme:   "https",
+		RestAddr: "127.0.0.1:" + port,
+		MCPAddr:  "127.0.0.1:" + port,
+		UIAddr:   "127.0.0.1:" + port,
+	}
+	for _, s := range probeServicesWithAddrs(addrs) {
+		if !s.up {
+			t.Errorf("service %q should be up against an https daemon", s.name)
+		}
+		if s.scheme != "https" {
+			t.Errorf("service %q: probe scheme = %q, want https", s.name, s.scheme)
+		}
+	}
+}
+
+func TestPrintStatusDisplay_WebUISchemeFromProbe(t *testing.T) {
+	// Daemon predates the muninn.addrs scheme field (schemeless sidecar) but the
+	// server is TLS — printStatusDisplay must show an https Web UI URL, using
+	// the scheme the probe discovered via the http→https retry.
+	srv := newTLSHealthServer()
+	defer srv.Close()
+	_, port, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "https://"))
+
+	dir := t.TempDir()
+	t.Setenv("MUNINNDB_DATA", dir)
+	t.Setenv("MUNINNDB_ADMIN_URL", "")
+	t.Setenv("MUNINNDB_MCP_URL", "")
+	t.Setenv("MUNINNDB_UI_URL", "")
+	if err := writeAddrsFile(dir, daemonAddrs{
+		RestAddr: "127.0.0.1:" + port,
+		MCPAddr:  "127.0.0.1:" + port,
+		UIAddr:   "127.0.0.1:" + port,
+	}); err != nil {
+		t.Fatalf("writeAddrsFile: %v", err)
+	}
+	out := captureStdout(func() { printStatusDisplay(false) })
+	if !strings.Contains(out, "Web UI → https://") {
+		t.Errorf("Web UI line should use https (probe-discovered), got:\n%s", out)
+	}
+}
+
+func TestProbeServicesWithAddrs_PreservesOrder(t *testing.T) {
+	// Concurrent probing must keep the result order [database, mcp, web ui].
+	svcs := probeServicesWithAddrs(daemonAddrs{})
+	want := []string{"database", "mcp", "web ui"}
+	if len(svcs) != len(want) {
+		t.Fatalf("got %d services, want %d", len(svcs), len(want))
+	}
+	for i, s := range svcs {
+		if s.name != want[i] {
+			t.Errorf("index %d: got %q, want %q", i, s.name, want[i])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// webUIDisplay
+// ---------------------------------------------------------------------------
+
+func TestWebUIDisplay_Loopback(t *testing.T) {
+	t.Setenv("MUNINNDB_UI_URL", "")
+	lines := webUIDisplay(daemonAddrs{Scheme: "http", UIAddr: "127.0.0.1:8476"})
+	if len(lines) != 1 || lines[0] != "http://127.0.0.1:8476" {
+		t.Errorf("loopback bind: got %v", lines)
+	}
+}
+
+func TestWebUIDisplay_EmptyAddrsDefault(t *testing.T) {
+	t.Setenv("MUNINNDB_UI_URL", "")
+	lines := webUIDisplay(daemonAddrs{})
+	if len(lines) != 1 || lines[0] != "http://127.0.0.1:8476" {
+		t.Errorf("empty addrs should yield the legacy localhost default: got %v", lines)
+	}
+}
+
+func TestWebUIDisplay_NonLoopbackBind(t *testing.T) {
+	t.Setenv("MUNINNDB_UI_URL", "")
+	lines := webUIDisplay(daemonAddrs{Scheme: "https", UIAddr: "0.0.0.0:8476"})
+	if len(lines) < 1 {
+		t.Fatal("webUIDisplay must return at least one line")
+	}
+	// The localhost fallback line is always last, and every line uses the
+	// recorded scheme.
+	if lines[len(lines)-1] != "https://127.0.0.1:8476" {
+		t.Errorf("expected https localhost fallback line last, got %q", lines[len(lines)-1])
+	}
+	for _, l := range lines {
+		if !strings.HasPrefix(l, "https://") {
+			t.Errorf("line %q should use the https scheme", l)
+		}
+	}
+}
+
+func TestWebUIDisplay_EnvOverride(t *testing.T) {
+	t.Setenv("MUNINNDB_UI_URL", "https://ui.example.lan:8476/")
+	lines := webUIDisplay(daemonAddrs{Scheme: "http", UIAddr: "0.0.0.0:8476"})
+	if len(lines) != 1 || lines[0] != "https://ui.example.lan:8476" {
+		t.Errorf("MUNINNDB_UI_URL override should win outright: got %v", lines)
 	}
 }

--- a/cmd/muninn/status_test.go
+++ b/cmd/muninn/status_test.go
@@ -431,3 +431,31 @@ func TestWebUIDisplay_EnvOverride(t *testing.T) {
 		t.Errorf("MUNINNDB_UI_URL override should win outright: got %v", lines)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// isLoopbackURL
+// ---------------------------------------------------------------------------
+
+func TestIsLoopbackURL(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"loopback ipv4", "https://127.0.0.1:8475/api/vaults", true},
+		{"loopback ipv4 range", "https://127.5.6.7:8475", true},
+		{"localhost", "https://localhost:8475", true},
+		{"loopback ipv6", "https://[::1]:8475", true},
+		{"http loopback", "http://127.0.0.1:8475", true},
+		{"lan ip", "https://172.20.50.63:8475", false},
+		{"public host", "https://muninn.example.com:8475", false},
+		{"malformed", "https://%zz", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isLoopbackURL(tc.url); got != tc.want {
+				t.Errorf("isLoopbackURL(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/muninn/testutil_test.go
+++ b/cmd/muninn/testutil_test.go
@@ -71,6 +71,14 @@ func newHealthServer() *httptest.Server {
 	}))
 }
 
+// newTLSHealthServer starts a TLS-only test server that returns 200 on any
+// request. Caller must call Close() when done.
+func newTLSHealthServer() *httptest.Server {
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
 // newJSONServer starts a test HTTP server that returns the given JSON body with status.
 func newJSONServer(status int, body string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/muninn/upgrade.go
+++ b/cmd/muninn/upgrade.go
@@ -260,7 +260,12 @@ func runUpgrade(args []string) {
 			}
 			fmt.Println(" ✓")
 			fmt.Println()
-			fmt.Printf("  Web UI → http://127.0.0.1:8476\n")
+			addrs, _ := readAddrsFile(defaultDataDir())
+			uiLines := webUIDisplay(addrs)
+			fmt.Printf("  Web UI → %s\n", uiLines[0])
+			for _, l := range uiLines[1:] {
+				fmt.Printf("           %s\n", l)
+			}
 			fmt.Println()
 		}
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -299,6 +299,9 @@ curl http://127.0.0.1:8750/mcp/health
 | `MUNINN_GC_PERCENT` | `200` | GOGC tuning |
 | `MUNINN_CORS_ORIGINS` | `""` | Comma-separated allowed CORS origins |
 | `MUNINN_MCP_URL` | `http://127.0.0.1:8750/mcp` | Override MCP endpoint used by `muninn mcp` proxy (OpenClaw) |
+| `MUNINNDB_ADMIN_URL` | auto-detected | Override the REST/admin base URL probed by `muninn status` & admin CLI (TLS deployments) |
+| `MUNINNDB_UI_URL` | auto-detected | Override the Web UI base URL probed by `muninn status` (TLS deployments) |
+| `MUNINNDB_MCP_URL` | auto-detected | Override the MCP base URL probed by `muninn status` / `muninn start` (TLS deployments) |
 
 ---
 


### PR DESCRIPTION
## Summary

`muninn status` reported a healthy TLS deployment as `[down]`, printed `http://`
Web UI links for an HTTPS-only UI, and `muninn start` boot-looped under the shipped
`contrib/muninndb.service` — all because the CLI assumed `http://127.0.0.1`. #424/#440
added the `MUNINNDB_*_URL` env vars, but a TLS deployment still had to configure them
by hand. This makes TLS auto-detected. Fixes #442.

## Changes

- The existing `muninn.addrs` sidecar (`daemonAddrs`) gains a `scheme` field; the
  daemon records `https` when a TLS cert + key are configured (`schemeFor`).
- `healthURL` is scheme-aware; a new `probeHealth` retries `https://` when an
  `http://` probe fails — a TLS server is detected with zero configuration.
- `muninn status` probes the three services concurrently.
- `webUIDisplay` renders the `Web UI →` line with the correct scheme and a routable
  host (localhost as a fallback line) — fixes the hardcoded prints in `status.go`
  and `upgrade.go`.
- `muninn start`'s readiness poll uses `probeHealth`, so it succeeds under TLS
  instead of timing out and boot-looping under the `Type=forking` contrib unit.
- `muninn shell`'s `cmdShowVaults` / `cmdShowStats` resolve URLs from `muninn.addrs`
  instead of hardcoding `http://127.0.0.1`.
- `MUNINNDB_{ADMIN,UI,MCP}_URL` are documented in `muninn help` and
  `muninn status --help`.

`muninn.addrs` stays backward-compatible — an absent `scheme` is treated as `http`,
so old/new daemon and CLI interoperate. The `MUNINNDB_*_URL` env vars remain as an
explicit override (e.g. for remote admin).

Against a daemon that predates this change (no `scheme` in `muninn.addrs`), `muninn
status` still gets it right: the probe's http→https retry discovers the scheme, and
that discovered scheme is used for the `Web UI →` line too.

Verified on a live internal-CA TLS deployment: `muninn status` reports `[up]` with no
env vars set and prints `Web UI → https://…`; `muninn start` under TLS exits 0 (no
boot-loop); a daemon from this branch writes `"scheme":"https"` to `muninn.addrs`.

The broader "make TLS a first-class mode" design is tracked in #443.

## Release Checklist

- [x] ~~`CHANGELOG.md`~~ — maintainers update this at release time, no action needed
- [x] OpenAPI spec — N/A (no REST API routes changed)
- [x] SDK types — N/A (no request/response schemas changed; `muninn.addrs` is internal)
- [x] `docs/` updated — `MUNINNDB_*_URL` added to `docs/self-hosting.md`
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./cmd/muninn/...` passes (full `./...` suite runs in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
