### PR TITLE
style: gofmt-align literals in repl_client_test.go

### DIFF
--- a/cmd/muninn/repl_client_test.go
+++ b/cmd/muninn/repl_client_test.go
@@ -205,10 +205,10 @@ func TestCmdShowVaultsEmptyList(t *testing.T) {
 func TestFormatVaultTableMissingFields(t *testing.T) {
 	// Vaults with missing optional fields should not panic
 	vaults := []map[string]any{
-		{"name": "vault-no-count"},                    // no memory_count
-		{"name": "vault-no-time", "memory_count": float64(5)},  // no last_active
-		{"memory_count": float64(3)},                  // no name
-		{},                                             // completely empty
+		{"name": "vault-no-count"},                            // no memory_count
+		{"name": "vault-no-time", "memory_count": float64(5)}, // no last_active
+		{"memory_count": float64(3)},                          // no name
+		{},                                                    // completely empty
 	}
 	out := captureStdout(func() {
 		formatVaultTable(vaults)
@@ -229,14 +229,14 @@ func TestFormatVaultTableNormalVaults(t *testing.T) {
 	now := time.Now()
 	vaults := []map[string]any{
 		{
-			"name": "personal",
+			"name":         "personal",
 			"memory_count": float64(47),
-			"last_active": now.Format(time.RFC3339),
+			"last_active":  now.Format(time.RFC3339),
 		},
 		{
-			"name": "work",
+			"name":         "work",
 			"memory_count": float64(12),
-			"last_active": now.Add(-2*time.Hour).Format(time.RFC3339),
+			"last_active":  now.Add(-2 * time.Hour).Format(time.RFC3339),
 		},
 	}
 	out := captureStdout(func() {
@@ -266,9 +266,9 @@ func TestFormatVaultTableNormalVaults(t *testing.T) {
 func TestFormatVaultTableLongNames(t *testing.T) {
 	vaults := []map[string]any{
 		{
-			"name": "a-very-long-vault-name-for-testing",
+			"name":         "a-very-long-vault-name-for-testing",
 			"memory_count": float64(99),
-			"last_active": time.Now().Format(time.RFC3339),
+			"last_active":  time.Now().Format(time.RFC3339),
 		},
 	}
 	// Should not panic and should handle truncation gracefully
@@ -435,9 +435,9 @@ func TestLoadDefaultVaultInvalidJSON(t *testing.T) {
 func TestFormatVaultTableZeroMemories(t *testing.T) {
 	vaults := []map[string]any{
 		{
-			"name": "empty-vault",
+			"name":         "empty-vault",
 			"memory_count": float64(0),
-			"last_active": time.Now().Format(time.RFC3339),
+			"last_active":  time.Now().Format(time.RFC3339),
 		},
 	}
 	out := captureStdout(func() {


### PR DESCRIPTION
## What

`gofmt -w` on `cmd/muninn/repl_client_test.go`. The file has carried gofmt-misaligned composite literals since `1f1279a` (2026-02) — map keys and trailing comments in the `TestFormatVaultTable*` helpers were never column-aligned.

The change is **pure whitespace** — `git diff -w` produces an empty diff. No logic touched.

## Why it went unnoticed

CI currently has no `gofmt -l` / `golangci-lint` step, so formatting drift doesn't fail any check. The practical cost is diff noise: any contributor who runs `gofmt -w` (or whose editor formats on save) while editing this file drags these unrelated reformats into their PR.

Surfaced while working on #444 — kept out of that PR deliberately to avoid mixing a formatting cleanup into a security fix.

## Suggestion (optional)

Consider adding a `gofmt -l` gate to the CI workflow (fail if it lists any file) so this can't recur. Happy to open a separate PR for that if you'd like.

## Note

Touches the same file as #444, but in different regions (`TestFormatVaultTable*` here vs. a new test function there) — no overlap; whichever merges second needs no manual conflict resolution.
