### PR TITLE
chore: polish isLoopbackURL and isTLSCertError

### DIFF
--- a/cmd/muninn/repl_client.go
+++ b/cmd/muninn/repl_client.go
@@ -53,8 +53,8 @@ func mcpCall(baseURL, toolName string, args map[string]any) (map[string]any, err
 
 // isTLSCertError reports whether err is a TLS certificate verification failure
 // (untrusted CA, hostname mismatch, expired cert) rather than a plain
-// connection failure such as a refused or timed-out dial. Since Go 1.20 the
-// handshake wraps every verification failure in tls.CertificateVerificationError.
+// connection failure such as a refused or timed-out dial. The handshake wraps
+// every verification failure in tls.CertificateVerificationError.
 func isTLSCertError(err error) bool {
 	var certErr *tls.CertificateVerificationError
 	return errors.As(err, &certErr)

--- a/cmd/muninn/status.go
+++ b/cmd/muninn/status.go
@@ -252,18 +252,19 @@ func hostIsRoutable(host string) bool {
 }
 
 // isLoopbackURL reports whether rawURL targets this machine — its host is
-// empty, "localhost", or a loopback IP. It is the URL-level guard for deciding
-// when skipping TLS certificate verification is safe: a loopback peer cannot
-// be impersonated, an off-host peer can. Unparseable input is treated as
-// non-loopback so callers fail closed (keep verification on).
+// "localhost", a loopback IP, or any address in the 127.0.0.0/8 range. It is
+// the URL-level guard for deciding when skipping TLS certificate verification
+// is safe: a loopback peer cannot be impersonated, an off-host peer can.
+// Unparseable input is treated as non-loopback so callers fail closed (keep
+// verification on).
 func isLoopbackURL(rawURL string) bool {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return false
 	}
-	host := u.Hostname()
+	host := strings.ToLower(u.Hostname())
 	switch host {
-	case "", "127.0.0.1", "::1", "localhost":
+	case "127.0.0.1", "::1", "localhost":
 		return true
 	}
 	if ip := net.ParseIP(host); ip != nil {

--- a/cmd/muninn/status_test.go
+++ b/cmd/muninn/status_test.go
@@ -444,11 +444,15 @@ func TestIsLoopbackURL(t *testing.T) {
 	}{
 		{"loopback ipv4", "https://127.0.0.1:8475/api/vaults", true},
 		{"loopback ipv4 range", "https://127.5.6.7:8475", true},
+		{"loopback ipv4 no port", "https://127.0.0.1", true},
 		{"localhost", "https://localhost:8475", true},
+		{"localhost uppercase", "https://LOCALHOST:8475", true},
 		{"loopback ipv6", "https://[::1]:8475", true},
+		{"loopback ipv4-mapped ipv6", "https://[::ffff:127.0.0.1]:8475", true},
 		{"http loopback", "http://127.0.0.1:8475", true},
 		{"lan ip", "https://172.20.50.63:8475", false},
 		{"public host", "https://muninn.example.com:8475", false},
+		{"empty string", "", false},
 		{"malformed", "https://%zz", false},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Minor polish items flagged during the #444 review, kept separate to avoid mixing cleanup into a security fix.

- `isLoopbackURL`: lowercase the hostname before the switch so `LOCALHOST` (and other mixed-case variants) correctly return `true`
- `isLoopbackURL`: drop `""` from the switch — empty host is not a loopback address; fails closed as intended
- `isLoopbackURL`: tighten the doc comment to reflect actual behaviour
- `isTLSCertError`: drop the stale "Since Go 1.20" version qualifier (module floor is 1.26)
- `TestIsLoopbackURL`: add `LOCALHOST` (case-insensitivity), `127.0.0.1` without port, `::ffff:127.0.0.1` (IPv4-mapped IPv6), and empty-string cases

## Test plan

- [ ] `go build ./cmd/muninn/...` clean
- [ ] `go vet ./cmd/muninn/...` clean
- [ ] `go test -race ./cmd/muninn/...` passes