### PR TITLE
consolidation: phase-2 dedup absorbs AccessCount of merged duplicates into the representative

### DIFF
--- a/internal/consolidation/dedup.go
+++ b/internal/consolidation/dedup.go
@@ -144,7 +144,14 @@ func (w *Worker) runPhase2Dedup(ctx context.Context, store *storage.PebbleStore,
 			mergedTags = append(mergedTags, tag)
 		}
 
-		// Archive non-representative members
+		// Archive non-representative members and count archived duplicates so
+		// the representative can absorb their frequency signal. Without this
+		// bump, semantic-duplicate write-only engrams (e.g. daily auto-ingest
+		// captures from agent harnesses) would never reach the recall path
+		// that auto-increments AccessCount in storage/cache/domain.go — losing
+		// the "this content recurred N times" signal that downstream skills
+		// currently emulate via per-vault feedback cron jobs.
+		archivedCount := uint32(0)
 		for _, member := range clust.members {
 			if member.ID == representative.ID {
 				continue
@@ -158,11 +165,17 @@ func (w *Worker) runPhase2Dedup(ctx context.Context, store *storage.PebbleStore,
 				}
 			}
 
+			archivedCount++
 			report.MergedEngrams++
 		}
 
-		// Update representative with merged tags (best-effort)
-		if !w.DryRun && len(mergedTags) != len(representative.Tags) {
+		// Persist representative updates when anything changed: tag-merge
+		// added tags, or frequency-absorption bumped AccessCount.
+		tagsChanged := len(mergedTags) != len(representative.Tags)
+		if !w.DryRun && archivedCount > 0 {
+			representative.AccessCount += archivedCount
+		}
+		if !w.DryRun && (tagsChanged || archivedCount > 0) {
 			if err := store.UpdateMetadata(ctx, wsPrefix, representative.ID, &storage.EngramMeta{
 				State:       representative.State,
 				Confidence:  representative.Confidence,
@@ -175,11 +188,13 @@ func (w *Worker) runPhase2Dedup(ctx context.Context, store *storage.PebbleStore,
 				slog.Warn("consolidation phase 2: failed to update representative metadata", "id", representative.ID, "error", err)
 				report.Errors = append(report.Errors, fmt.Sprintf("dedup: UpdateMetadata %s: %v", representative.ID, err))
 			}
-			// Persist the merged tags — UpdateMetadata patches only fixed-size metadata
-			// fields and does not touch the variable-length tag list.
-			if err := store.UpdateTags(ctx, wsPrefix, representative.ID, mergedTags); err != nil {
-				slog.Warn("consolidation phase 2: failed to update representative tags", "id", representative.ID, "error", err)
-				report.Errors = append(report.Errors, fmt.Sprintf("dedup: UpdateTags %s: %v", representative.ID, err))
+			if tagsChanged {
+				// Persist merged tags — UpdateMetadata patches only fixed-size
+				// metadata fields and does not touch the variable-length tag list.
+				if err := store.UpdateTags(ctx, wsPrefix, representative.ID, mergedTags); err != nil {
+					slog.Warn("consolidation phase 2: failed to update representative tags", "id", representative.ID, "error", err)
+					report.Errors = append(report.Errors, fmt.Sprintf("dedup: UpdateTags %s: %v", representative.ID, err))
+				}
 			}
 		}
 	}

--- a/internal/consolidation/dedup_test.go
+++ b/internal/consolidation/dedup_test.go
@@ -2,6 +2,7 @@ package consolidation
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/pebble"
@@ -106,6 +107,93 @@ func TestDedup_IdenticalEmbeddings_MergesCluster(t *testing.T) {
 	}
 	if archived.State != storage.StateArchived {
 		t.Errorf("duplicate engram state = %v, want archived", archived.State)
+	}
+}
+
+// TestDedup_AccessCountAbsorbsArchivedDuplicates verifies the representative
+// engram absorbs the AccessCount of each archived duplicate (+1 per archived
+// member). This preserves the frequency-of-occurrence signal for write-only
+// engrams (auto-ingest, daily captures) that never reach the recall path's
+// implicit AccessCount auto-bump. Without this, downstream skills must run
+// their own per-vault feedback cron jobs to compensate.
+func TestDedup_AccessCountAbsorbsArchivedDuplicates(t *testing.T) {
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	vault := "dedup_accesscount_bump"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	embed := []float32{1, 0, 0, 0}
+
+	// 1 representative + 3 duplicates → representative should end with AccessCount += 3.
+	repID := writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "rep", Content: "rep content", Confidence: 0.9, Relevance: 0.9,
+		Stability: 30, Embedding: embed, AccessCount: 5,
+	})
+	for i := 0; i < 3; i++ {
+		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+			Concept: fmt.Sprintf("dup-%d", i), Content: fmt.Sprintf("dup %d", i),
+			Confidence: 0.5, Relevance: 0.5,
+			Stability: 30, Embedding: embed, AccessCount: 0,
+		})
+	}
+
+	mock := &mockEngineInterface{store: store}
+	w := &Worker{Engine: mock, MaxDedup: 100, MaxTransitive: 100}
+	report := &ConsolidationReport{}
+
+	if err := w.runPhase2Dedup(ctx, store, wsPrefix, report, vault); err != nil {
+		t.Fatal(err)
+	}
+
+	rep, err := store.GetEngram(ctx, wsPrefix, repID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const wantAccess uint32 = 5 + 3
+	if rep.AccessCount != wantAccess {
+		t.Errorf("representative AccessCount = %d, want %d (5 starting + 3 absorbed from archived dupes)",
+			rep.AccessCount, wantAccess)
+	}
+}
+
+// TestDedup_DryRun_DoesNotBumpAccessCount verifies the frequency-absorption
+// bump only happens when mutations are enabled — DryRun must leave AccessCount
+// unchanged, matching the existing no-mutation contract for the archive step.
+func TestDedup_DryRun_DoesNotBumpAccessCount(t *testing.T) {
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	vault := "dedup_dryrun_accesscount"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	embed := []float32{1, 0, 0, 0}
+	repID := writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "rep", Content: "rep", Confidence: 0.9, Relevance: 0.9,
+		Stability: 30, Embedding: embed, AccessCount: 2,
+	})
+	writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "dup", Content: "dup", Confidence: 0.5, Relevance: 0.5,
+		Stability: 30, Embedding: embed, AccessCount: 0,
+	})
+
+	mock := &mockEngineInterface{store: store}
+	w := &Worker{Engine: mock, MaxDedup: 100, MaxTransitive: 100, DryRun: true}
+	report := &ConsolidationReport{}
+
+	if err := w.runPhase2Dedup(ctx, store, wsPrefix, report, vault); err != nil {
+		t.Fatal(err)
+	}
+
+	rep, err := store.GetEngram(ctx, wsPrefix, repID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.AccessCount != 2 {
+		t.Errorf("DryRun mutated AccessCount: got %d, want 2", rep.AccessCount)
 	}
 }
 


### PR DESCRIPTION
## Motivation


Phase-2 dedup (`internal/consolidation/dedup.go` `runPhase2Dedup`)
silently drops the frequency-of-occurrence signal carried by archived
duplicate engrams. Today the representative survives with its own
`AccessCount` unchanged; archived members move to `lifecycle=archived`
and their access counts are lost.

For **write-only engrams** — daily auto-ingest captures from agent
harnesses, batch imports, log-style memories — this matters. Those
engrams never reach the recall path that auto-increments `AccessCount`
in `internal/storage/cache/domain.go:99`. The only frequency signal
they carry is "how many semantic duplicates of me ended up in this
vault."

Downstream skills currently compensate by running per-vault cron jobs
that group engrams by exact-text fingerprint, keep the oldest, and call
`muninn_feedback(useful=true)` on it for each duplicate. This:

- Operates at SHA1-of-normalized-text granularity (misses near-duplicates
  that semantic dedup catches with cosine ≥ 0.95)
- Hits the `RecordFeedback` 30-min throttle (`internal/scoring/store.go:131`)
  so the bumps get coalesced anyway
- Lives outside the DB → must be re-implemented per harness

Folding the frequency-absorption into the existing dedup pass eliminates
the duplication, gets near-duplicate coverage for free, and keeps the
signal closer to where the merge decision is made.

## Change

```diff
- // Archive non-representative members
+ // Archive non-representative members and count archived duplicates so
+ // the representative can absorb their frequency signal.
+ archivedCount := uint32(0)
  for _, member := range clust.members {
      if member.ID == representative.ID {
          continue
      }
      if !w.DryRun {
          if err := w.Engine.UpdateLifecycleState(ctx, vault, member.ID.String(), "archived"); err != nil {
              slog.Warn("...", "id", member.ID, "error", err)
              continue
          }
      }
+     archivedCount++
      report.MergedEngrams++
  }

- // Update representative with merged tags (best-effort)
- if !w.DryRun && len(mergedTags) != len(representative.Tags) {
+ // Persist representative updates when anything changed: tag-merge added
+ // tags, or frequency-absorption bumped AccessCount.
+ tagsChanged := len(mergedTags) != len(representative.Tags)
+ if !w.DryRun && archivedCount > 0 {
+     representative.AccessCount += archivedCount
+ }
+ if !w.DryRun && (tagsChanged || archivedCount > 0) {
      _ = store.UpdateMetadata(ctx, wsPrefix, representative.ID, &storage.EngramMeta{
          State:       representative.State,
          ...
          AccessCount: representative.AccessCount,
          ...
      })
-     // Persist the merged tags — UpdateMetadata patches only fixed-size metadata
-     // fields and does not touch the variable-length tag list.
-     _ = store.UpdateTags(ctx, wsPrefix, representative.ID, mergedTags)
+     if tagsChanged {
+         _ = store.UpdateTags(ctx, wsPrefix, representative.ID, mergedTags)
+     }
  }
```

Side effect: `UpdateMetadata` is now called when only `AccessCount`
changed (not just on tag changes). That matches the documented semantic
("Update representative") and avoids losing the bump.

## Tests

Two new tests in `internal/consolidation/dedup_test.go`, both in the
existing test style (`testStoreWithDB` + `writeEngramWithEmbedding` +
`mockEngineInterface`):

- `TestDedup_AccessCountAbsorbsArchivedDuplicates`: 1 rep (start
  AccessCount=5) + 3 dupes (AccessCount=0) → rep ends at 8.
- `TestDedup_DryRun_DoesNotBumpAccessCount`: DryRun=true → AccessCount
  unchanged, matching the no-mutation contract on archive.

All 14 existing `TestDedup_*` tests continue to pass. `go test ./...`
green (~30s).

## Alternatives considered

- **`RecordFeedback(representative, useful=true)`** — would re-use the
  existing API but operates at vault-level weights (SGD), not engram
  AccessCount. Subject to a 30-min throttle that would coalesce batched
  dedup work. Loses the precise per-duplicate count.
- **Sum `AccessCount` rather than +N** — would over-credit when a
  duplicate had itself accumulated many accesses on the recall path.
  `+archivedCount` (one credit per absorbed engram) is the conservative
  choice; happy to discuss raising it to `+sum(member.AccessCount)+1` if
  that better matches the design intent.
- **Bump via an explicit storage API** (`IncrementAccessCount`) — bigger
  surface change. Re-using the already-present `UpdateMetadata` write
  keeps the diff inside one function.

## Migration / compatibility

- Pure server-side. No protocol change, no SDK change, no client change.
- Downstream skills can continue running their own dedup cron jobs;
  they'll just be partially redundant. After this lands they can be
  retired without losing the frequency signal.
- DryRun behavior preserved.

## Out of scope

- Inline dedup at `muninn_remember` time (suggested in our internal
  task tracker but rejected on latency grounds).
- Recency-decay per-vault tuning (already covered by ACT-R activation
  engine weights + offline Phase-4 decay accel; configurable in code
  but not as a runtime parameter — separate enhancement if desired).

## Artefacts

- Branch: `feat/dedup-bump-accesscount` (1 commit)
- Test run: `go test ./internal/consolidation/ -count=1 -timeout=60s`
  → ok ~1.0s; full suite green
