### PR TITLE
chore(ui): promote gemini-2.5-flash as default Google enrichment model

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -179,7 +179,7 @@ export MUNINN_ANTHROPIC_KEY="sk-ant-..."
 muninn server
 
 # Google
-export MUNINN_ENRICH_URL="google://gemini-1.5-flash"
+export MUNINN_ENRICH_URL="google://gemini-2.5-flash"
 export MUNINN_GOOGLE_KEY="AIza..."  # or MUNINN_ENRICH_API_KEY
 muninn server
 ```

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1800,7 +1800,7 @@
                 <div class="tab-bar" style="margin-top:0;margin-bottom:1rem;">
                   <template x-for="opt in [{val:'none',label:'None'},{val:'ollama',label:'Ollama (local)'},{val:'openai',label:'OpenAI'},{val:'anthropic',label:'Anthropic'},{val:'google',label:'Google'}]" :key="opt.val">
                     <button
-                      @click="pluginCfg.enrichProvider=opt.val;pluginCfg.enrichCmd='';if(opt.val==='google')pluginCfg.enrichModel='gemini-1.5-flash';if(opt.val==='anthropic')pluginCfg.enrichModel='claude-haiku-4-5-20251001'"
+                      @click="pluginCfg.enrichProvider=opt.val;pluginCfg.enrichCmd='';if(opt.val==='google')pluginCfg.enrichModel='gemini-2.5-flash';if(opt.val==='anthropic')pluginCfg.enrichModel='claude-haiku-4-5-20251001'"
                       :class="pluginCfg.enrichProvider===opt.val ? 'tab-btn active' : 'tab-btn'"
                       x-text="opt.label">
                     </button>
@@ -1896,10 +1896,11 @@
                 <div class="form-group">
                   <label>Model</label>
                   <select class="input-field" x-model="pluginCfg.enrichModel">
-                    <option value="gemini-1.5-flash">gemini-1.5-flash (recommended)</option>
+                    <option value="gemini-1.5-flash">gemini-1.5-flash</option>
                     <option value="gemini-1.5-pro">gemini-1.5-pro</option>
                     <option value="gemini-2.0-flash">gemini-2.0-flash</option>
-                    <option value="gemini-2.5-flash">gemini-2.5-flash</option>
+                    <option value="gemini-2.5-flash">gemini-2.5-flash (recommended)</option>
+                    <option value="gemini-2.5-pro">gemini-2.5-pro</option>
                   </select>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Follow-up chore from review of #450.

- Promotes `gemini-2.5-flash` as the recommended model (was `gemini-1.5-flash`)
- Adds `gemini-2.5-pro` to the dropdown
- Updates the provider-switch default handler to select `gemini-2.5-flash` when switching to Google provider
- Updates `docs/plugins.md` example URL

## Why

Google has deprecation notices on 1.5-series models on the `v1beta` endpoint. `gemini-2.5-flash` is the current GA Flash-tier default per Google's model cards.

## Test plan

- [ ] Switch enrichment provider to Google in UI — model should default to `gemini-2.5-flash`
- [ ] All existing model options still present in dropdown
- [ ] `docs/plugins.md` example reflects new default