### PR TITLE
fix(engine): use ResolveVaultPrefix in bulk vault operations

### DIFF
--- a/internal/engine/engine_clone.go
+++ b/internal/engine/engine_clone.go
@@ -64,7 +64,8 @@ func (e *Engine) StartClone(ctx context.Context, sourceVault, newName string) (*
 		return nil, fmt.Errorf("start clone: %w", err)
 	}
 
-	wsSource := e.store.VaultPrefix(sourceVault)
+	// ResolveVaultPrefix to handle renamed source vaults (ws ≠ siphash(currentName)).
+	wsSource := e.store.ResolveVaultPrefix(sourceVault)
 
 	// Count engrams in source to set CopyTotal/IndexTotal for progress tracking.
 	sourceCount := e.store.GetVaultCount(ctx, wsSource)
@@ -203,8 +204,10 @@ func (e *Engine) StartMerge(ctx context.Context, sourceVault, targetVault string
 		return nil, fmt.Errorf("start merge: %w", err)
 	}
 
-	wsSource := e.store.VaultPrefix(sourceVault)
-	wsTarget := e.store.VaultPrefix(targetVault)
+	// Both source and target are existing vaults — use ResolveVaultPrefix so
+	// renamed vaults (ws ≠ siphash(currentName)) merge correctly.
+	wsSource := e.store.ResolveVaultPrefix(sourceVault)
+	wsTarget := e.store.ResolveVaultPrefix(targetVault)
 
 	sourceCount := e.store.GetVaultCount(ctx, wsSource)
 	job.CopyTotal = sourceCount

--- a/internal/engine/engine_export.go
+++ b/internal/engine/engine_export.go
@@ -38,7 +38,9 @@ func (e *Engine) ExportVault(ctx context.Context, vaultName, embedderModel strin
 		return nil, fmt.Errorf("export vault %q: %w", vaultName, ErrVaultNotFound)
 	}
 
-	ws := e.store.VaultPrefix(vaultName)
+	// Use ResolveVaultPrefix so vaults whose name has been changed via RenameVault
+	// (ws ≠ siphash(currentName)) are exported via their actual stored workspace.
+	ws := e.store.ResolveVaultPrefix(vaultName)
 	opts := storage.ExportOpts{
 		EmbedderModel: embedderModel,
 		Dimension:     dimension,

--- a/internal/engine/engine_reembed.go
+++ b/internal/engine/engine_reembed.go
@@ -50,7 +50,9 @@ func (e *Engine) StartReembedVault(ctx context.Context, vaultName, modelName str
 		return nil, fmt.Errorf("vault %q: %w", vaultName, ErrVaultNotFound)
 	}
 
-	ws := e.store.VaultPrefix(vaultName)
+	// Use ResolveVaultPrefix so reembed targets the actual workspace of vaults
+	// that have been renamed (ws ≠ siphash(currentName)).
+	ws := e.store.ResolveVaultPrefix(vaultName)
 
 	// Count engrams to set progress totals.
 	engramCount := e.store.GetVaultCount(ctx, ws)

--- a/internal/engine/engine_vault.go
+++ b/internal/engine/engine_vault.go
@@ -75,7 +75,11 @@ func (e *Engine) clearVault(ctx context.Context, vaultName string) error {
 		return fmt.Errorf("vault %q: %w", vaultName, ErrVaultNotFound)
 	}
 
-	ws := e.store.VaultPrefix(vaultName)
+	// Use ResolveVaultPrefix so renamed vaults (ws ≠ siphash(currentName))
+	// are cleared at their actual workspace. With raw VaultPrefix(name) here,
+	// ClearVault on a renamed vault would silently range-delete an empty
+	// prefix and leave the real engrams orphaned.
+	ws := e.store.ResolveVaultPrefix(vaultName)
 
 	// NOTE: Jobs already mid-flush may write ghost FTS entries after the range
 	// tombstones land. This is harmless — activation filtering skips engrams
@@ -134,10 +138,11 @@ var ErrVaultJobActive = fmt.Errorf("vault has an active clone/merge job in progr
 // It calls ClearVault (which adjusts engramCount and in-memory state),
 // then deletes the vault name keys from storage.
 //
-// Note: ws must be captured BEFORE calling ClearVault, because ClearVault
-// evicts vaultPrefixCache for the vault name. After ClearVault,
-// store.VaultPrefix would still return the SipHash but the name is no longer
-// registered — DeleteVaultNameOnly needs the ws captured before eviction.
+// Note: ws is resolved via ResolveVaultPrefix BEFORE calling ClearVault,
+// because ClearVault evicts vaultPrefixCache for the vault name. After
+// eviction, a subsequent ResolveVaultPrefix call would still read the
+// persisted 0x0F index — but for renamed vaults we need the index lookup
+// (not raw SipHash) to find the real ws, so we capture it up front.
 func (e *Engine) DeleteVault(ctx context.Context, vaultName string) error {
 	if !e.beginVaultOp() {
 		return fmt.Errorf("engine is shutting down")
@@ -160,7 +165,9 @@ func (e *Engine) deleteVault(ctx context.Context, vaultName string) error {
 	}
 
 	// Capture ws BEFORE ClearVault evicts the in-memory name cache.
-	ws := e.store.VaultPrefix(vaultName)
+	// ResolveVaultPrefix so renamed vaults (ws ≠ siphash(currentName))
+	// have their actual workspace passed to DeleteVaultNameOnly.
+	ws := e.store.ResolveVaultPrefix(vaultName)
 
 	if err := e.clearVault(ctx, vaultName); err != nil {
 		return fmt.Errorf("delete vault (clear phase): %w", err)


### PR DESCRIPTION
## Summary
`ExportVault`, `StartReembedVault`, `StartClone`, `StartMerge`, `ClearVault`, and `DeleteVault` derive the workspace prefix via `store.VaultPrefix(name)` (raw SipHash). Every per-engram production path in `engine.go` uses `store.ResolveVaultPrefix(name)` (looks up `0x0F siphash(name) → ws`). For a vault renamed via `RenameVault`, the stored `ws ≠ siphash(currentName)` — the rename only flips the index keys; engram data stays put.

## Failure modes on a renamed vault
- `ExportVault` → archive with `engram_count: 0` despite data being intact.
- `StartReembedVault` → clears 0 flags; no re-embedding happens.
- `StartClone` / `StartMerge` → `sourceCount=0`, empty target.
- `ClearVault` → range-deletes an empty prefix, reports success while real engrams remain.
- `DeleteVault` → calls broken `ClearVault`, then `DeleteVaultNameOnly` removes the `0x0F` key for the current name. Engrams are orphaned. Subsequent `ResolveVaultPrefix(name)` falls through to `siphash(name)`, poisoning the LRU cache.

## Reproduction (real deployment)
1. Vault renamed `default → hai` at some prior point.
2. `muninn vault export --vault hai` → 353-byte archive, manifest `engram_count: 0`.
3. MCP `muninn_status` (uses `ResolveVaultPrefix` via `engine.Stat`) → `total_memories: 1040`.

Diagnosed via a small read-only Pebble inspector reading `0x0E ws→name` and `0x0F siphash(name)→ws` keys: the vault's engrams live at `ws = siphash("default") = 0d50ac9956300490`. `siphash("hai") = fa6e5a93845dcc6f` resolves to an empty namespace.

## After the patch
- Same export → 6.4 MB archive, manifest `engram_count: 1040`.
- `muninn vault reembed hai` re-embedded 792 engrams under a new model in 22 min, 0 errors.

## Sites changed
**Fixed** (look up the ws of an *existing* vault):
- `engine_export.go:41` — source export
- `engine_reembed.go:53` — reembed target
- `engine_clone.go:67` — clone source
- `engine_clone.go:206–207` — merge source + target
- `engine_vault.go:78` — clear (silent data-orphaning was worst)
- `engine_vault.go:163` — delete (silent data-orphaning + cache poisoning)

**Intentionally kept as `VaultPrefix`** (register a *new* vault — `ws == siphash(name)` by construction):
- `engine_export.go:79` — `StartImport` target
- `engine_clone.go:52` — `StartClone` target

## Test plan
- `go test ./internal/engine/...` passes locally.
- **Gap:** existing tests use vaults where `ws == siphash(name)`, so they exercise the new code path identically and do not regression-test the renamed-vault case. A follow-up PR should add rename-then-bulk-op coverage to `internal/engine`.