### PR TITLE
feat(tls): warn at startup when client-facing or cluster cert nears expiry (#443 gap 4)

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -42,6 +43,7 @@ import (
 	"github.com/scrypster/muninndb/internal/replication"
 	"github.com/scrypster/muninndb/internal/storage"
 	"github.com/scrypster/muninndb/internal/storage/migrate"
+	"github.com/scrypster/muninndb/internal/tlsutil"
 	grpcpkg "github.com/scrypster/muninndb/internal/transport/grpc"
 	"github.com/scrypster/muninndb/internal/transport/mbp"
 	"github.com/scrypster/muninndb/internal/transport/rest"
@@ -857,11 +859,24 @@ func runServer() {
 			slog.Error("tls: failed to load certificate", "cert", *tlsCert, "err", err)
 			os.Exit(1)
 		}
+
+		logAttrs := []any{"cert", *tlsCert}
+		if leaf, perr := x509.ParseCertificate(cert.Certificate[0]); perr == nil {
+			remaining := tlsutil.CheckCertExpiry(slog.Default(), leaf, "client-facing")
+			logAttrs = append(logAttrs,
+				"subject", leaf.Subject.CommonName,
+				"not_after", leaf.NotAfter.UTC().Format(time.RFC3339),
+				"days_remaining", tlsutil.DaysRemaining(remaining))
+		} else {
+			slog.Warn("tls: failed to parse certificate leaf for expiry check",
+				"cert", *tlsCert, "err", perr)
+		}
+
 		clientTLS = &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			MinVersion:   tls.VersionTLS12,
 		}
-		slog.Info("tls: client-facing TLS enabled", "cert", *tlsCert)
+		slog.Info("tls: client-facing TLS enabled", logAttrs...)
 	}
 
 	// Validate address flags early so misconfigurations are caught before any

--- a/internal/replication/tls.go
+++ b/internal/replication/tls.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"net"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/scrypster/muninndb/internal/config"
+	"github.com/scrypster/muninndb/internal/tlsutil"
 )
 
 // ClusterTLS manages TLS certificates for inter-node communication.
@@ -88,6 +90,12 @@ func (ct *ClusterTLS) Bootstrap(nodeID, dataDir string) error {
 		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 		if err != nil {
 			return fmt.Errorf("cluster-tls: load node cert: %w", err)
+		}
+		if leaf, perr := x509.ParseCertificate(cert.Certificate[0]); perr == nil {
+			tlsutil.CheckCertExpiry(slog.Default(), leaf, "cluster-node")
+		} else {
+			slog.Warn("cluster-tls: failed to parse node cert leaf for expiry check",
+				"cert", certFile, "err", perr)
 		}
 		ct.mu.Lock()
 		ct.nodeCert = &cert
@@ -260,6 +268,8 @@ func (ct *ClusterTLS) generateNodeCert(nodeID, certPath, keyPath string) error {
 	ct.mu.Lock()
 	ct.nodeCert = &tlsCert
 	ct.mu.Unlock()
+
+	tlsutil.CheckCertExpiry(slog.Default(), template, "cluster-node-generated")
 	return nil
 }
 

--- a/internal/tlsutil/expiry.go
+++ b/internal/tlsutil/expiry.go
@@ -1,0 +1,57 @@
+// Package tlsutil holds small TLS helpers shared between the main server and
+// the cluster-replication subsystem.
+package tlsutil
+
+import (
+	"crypto/x509"
+	"log/slog"
+	"time"
+)
+
+// ExpiryWarnWindow is the threshold below which a certificate is considered
+// "expiring soon". 30 days matches Let's Encrypt's renewal window and is the
+// de-facto standard across operational tooling.
+const ExpiryWarnWindow = 30 * 24 * time.Hour
+
+// DaysRemaining converts a positive duration to whole days, rounded up so a
+// duration of 23h59m reports 1 (not 0). Returns 0 for non-positive input. The
+// ceiling bias matches operator expectations: "you have N days to act."
+func DaysRemaining(d time.Duration) int {
+	if d <= 0 {
+		return 0
+	}
+	day := 24 * time.Hour
+	return int((d + day - 1) / day)
+}
+
+// CheckCertExpiry inspects cert.NotAfter and logs at the appropriate severity:
+//
+//   - Error when the certificate is already expired. The caller decides whether
+//     to abort; existing TLS connections may still function until the cert is
+//     actually rejected by a peer, so failing loud (not shut) is intentional.
+//   - Warn  when expiry is within ExpiryWarnWindow.
+//   - Silent otherwise; the caller may attach expiry fields to its own Info
+//     line so an operator can always see them at startup.
+//
+// The duration until NotAfter is returned (negative if already expired) so the
+// caller can include it in its own logging without re-computing.
+func CheckCertExpiry(logger *slog.Logger, cert *x509.Certificate, label string) time.Duration {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	remaining := time.Until(cert.NotAfter)
+	attrs := []any{
+		"label", label,
+		"subject", cert.Subject.CommonName,
+		"not_after", cert.NotAfter.UTC().Format(time.RFC3339),
+	}
+	switch {
+	case remaining <= 0:
+		logger.Error("tls: certificate is expired",
+			append(attrs, "expired_ago", (-remaining).Truncate(time.Hour).String())...)
+	case remaining < ExpiryWarnWindow:
+		logger.Warn("tls: certificate expires soon",
+			append(attrs, "days_remaining", DaysRemaining(remaining))...)
+	}
+	return remaining
+}

--- a/internal/tlsutil/expiry_test.go
+++ b/internal/tlsutil/expiry_test.go
@@ -1,0 +1,144 @@
+package tlsutil
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"log/slog"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestCert(t *testing.T, notAfter time.Time) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-cert"},
+		NotBefore:    notAfter.Add(-24 * time.Hour),
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	return cert
+}
+
+// recordHandler is a minimal slog.Handler that captures the highest severity
+// and the rendered messages. Avoids depending on slogtest or a JSON parser.
+type recordHandler struct {
+	buf      *bytes.Buffer
+	maxLevel slog.Level
+}
+
+func (h *recordHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *recordHandler) Handle(_ context.Context, r slog.Record) error {
+	if r.Level > h.maxLevel {
+		h.maxLevel = r.Level
+	}
+	h.buf.WriteString(r.Message)
+	h.buf.WriteByte('\n')
+	return nil
+}
+func (h *recordHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *recordHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func newRecorder() (*slog.Logger, *recordHandler) {
+	h := &recordHandler{buf: &bytes.Buffer{}, maxLevel: slog.LevelDebug - 1}
+	return slog.New(h), h
+}
+
+func TestCheckCertExpiry_Healthy(t *testing.T) {
+	cert := newTestCert(t, time.Now().Add(365*24*time.Hour))
+	logger, rec := newRecorder()
+
+	remaining := CheckCertExpiry(logger, cert, "test")
+
+	if remaining <= 0 {
+		t.Fatalf("expected positive remaining, got %v", remaining)
+	}
+	if rec.maxLevel >= slog.LevelWarn {
+		t.Fatalf("expected silent for healthy cert, got level %v with output: %q",
+			rec.maxLevel, rec.buf.String())
+	}
+}
+
+func TestCheckCertExpiry_Warn(t *testing.T) {
+	cert := newTestCert(t, time.Now().Add(10*24*time.Hour))
+	logger, rec := newRecorder()
+
+	remaining := CheckCertExpiry(logger, cert, "test")
+
+	if remaining <= 0 || remaining >= ExpiryWarnWindow {
+		t.Fatalf("expected 0 < remaining < ExpiryWarnWindow, got %v", remaining)
+	}
+	if rec.maxLevel != slog.LevelWarn {
+		t.Fatalf("expected Warn level, got %v with output: %q", rec.maxLevel, rec.buf.String())
+	}
+	if !strings.Contains(rec.buf.String(), "expires soon") {
+		t.Fatalf("expected 'expires soon' in log output, got: %q", rec.buf.String())
+	}
+}
+
+func TestCheckCertExpiry_Expired(t *testing.T) {
+	cert := newTestCert(t, time.Now().Add(-1*time.Hour))
+	logger, rec := newRecorder()
+
+	remaining := CheckCertExpiry(logger, cert, "test")
+
+	if remaining > 0 {
+		t.Fatalf("expected non-positive remaining for expired cert, got %v", remaining)
+	}
+	if rec.maxLevel != slog.LevelError {
+		t.Fatalf("expected Error level, got %v with output: %q", rec.maxLevel, rec.buf.String())
+	}
+	if !strings.Contains(rec.buf.String(), "expired") {
+		t.Fatalf("expected 'expired' in log output, got: %q", rec.buf.String())
+	}
+}
+
+func TestCheckCertExpiry_NilLogger(t *testing.T) {
+	// Must not panic — falls back to slog.Default(). We only assert no panic
+	// and a sensible return value; output goes to the global default handler.
+	cert := newTestCert(t, time.Now().Add(365*24*time.Hour))
+	remaining := CheckCertExpiry(nil, cert, "test")
+	if remaining <= 0 {
+		t.Fatalf("expected positive remaining, got %v", remaining)
+	}
+}
+
+func TestDaysRemaining(t *testing.T) {
+	cases := []struct {
+		name string
+		in   time.Duration
+		want int
+	}{
+		{"zero", 0, 0},
+		{"negative", -5 * time.Hour, 0},
+		{"sub-day rounds up to 1", 23*time.Hour + 59*time.Minute, 1},
+		{"exactly one day", 24 * time.Hour, 1},
+		{"one day plus a second rounds up to 2", 24*time.Hour + time.Second, 2},
+		{"ten days", 10 * 24 * time.Hour, 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DaysRemaining(tc.in); got != tc.want {
+				t.Errorf("DaysRemaining(%v) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Addresses [issue #443](https://github.com/scrypster/muninndb/issues/443) gap 8 — "Cert read at boot, expiry never surfaced."

Adds `internal/tlsutil.CheckCertExpiry` and wires it into the two TLS cert-load paths so operators see expiry at startup instead of discovering it via a failed handshake.

### Behavior

| Cert state            | Log level | Existing flow |
|-----------------------|-----------|---------------|
| Expired               | Error     | Server still starts — failing loud, not shut |
| < 30 days to expiry   | Warn      | Server starts normally |
| ≥ 30 days             | (silent)  | Server starts; expiry fields added to existing Info log |

Threshold of 30 days matches Let's Encrypt's renewal window.

### Wiring

- `cmd/muninn/server.go` — client-facing TLS, user-provided cert path. Existing `tls: client-facing TLS enabled` Info log now also carries `subject`, `not_after`, `days_remaining`.
- `internal/replication/tls.go` — cluster node TLS, both:
  - user-provided cert path (line ~91)
  - auto-generated 1-year cert path (`generateNodeCert`, line ~268), where the check uses the cert template directly (no re-parse)

### Notes

- Parse failure on a just-loaded cert is treated as best-effort: a Warn is logged and startup continues. The cert load itself succeeded; blocking startup because the expiry banner can't be drawn would be wrong.
- `tlsutil.DaysRemaining` uses ceiling-up so a cert with 23h59m left reports `days_remaining=1`, not `0` (which reads as expired).
- The pre-existing gofmt drift on `internal/replication/tls.go:126` (CA template literal alignment) is intentionally untouched — separate from this PR's logic change, per the convention from #445. Will be swept up either by the CI-gate cleanup (see the open question on #445) or by future PRs that touch those lines.

### Out of scope

This PR closes gap 8 only. The remaining #443 gaps (1–7, 9) will land as separate small PRs.

### Tests

- `internal/tlsutil/expiry_test.go` — 5 test functions, including table-driven coverage for `DaysRemaining` boundaries.
- Existing `cmd/muninn` and `internal/replication` test suites pass unchanged; the replication suite exercises the new auto-gen check path via `generateNodeCert`.

### Verification

- `go build ./...` ✓
- `go vet ./...` ✓
- `gofmt -l` clean on all changed regions
- Full test suite green on touched packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)