### PR TITLE
Activity chart: timezone-aware day bucketing (fixes UTC off-by-one)

### DIFF
--- a/cmd/muninn/main.go
+++ b/cmd/muninn/main.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	// Embed the IANA timezone database so time.LoadLocation works even on
+	// minimal runtime images (e.g. debian-slim) that ship without system
+	// tzdata. Required for the Activity chart's timezone-aware day bucketing.
+	_ "time/tzdata"
 )
 
 func main() {

--- a/docs/feature-reference.md
+++ b/docs/feature-reference.md
@@ -206,7 +206,7 @@ The ACTIVATE pipeline has **6 phases**:
 | Retry enrichment | — | — | `muninn_retry_enrich` |
 | Get usage guide | — | — | `muninn_guide` |
 | Get session activity | `GET /api/session` | — | `muninn_session` |
-| Get activity counts | `GET /api/activity-counts?days=N&until=YYYY-MM-DD` | — | — |
+| Get activity counts | `GET /api/activity-counts?days=N&until=YYYY-MM-DD&tz=IANA` | — | — |
 | Get contradictions | — | — | `muninn_contradictions` |
 | Stats + coherence | `GET /api/stats` | `Stat()` | `muninn_status` |
 | List engrams | `GET /api/engrams` | — | — |

--- a/internal/engine/activity_counts_test.go
+++ b/internal/engine/activity_counts_test.go
@@ -100,3 +100,50 @@ func TestActivityCounts(t *testing.T) {
 		}
 	})
 }
+
+// TestActivityCounts_Timezone verifies that both the contiguous day list and
+// the engram counts honor the location carried by the since/until arguments,
+// so an engram created just after midnight UTC is attributed to the previous
+// local day in a zone behind UTC.
+func TestActivityCounts_Timezone(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	vault := "activity-tz-test"
+	ws := eng.store.VaultPrefix(vault)
+
+	// 02:00 UTC on 2025-06-12 is still 2025-06-11 in a UTC-8 zone.
+	instant := time.Date(2025, 6, 12, 2, 0, 0, 0, time.UTC)
+	if _, err := eng.store.WriteEngram(ctx, ws, &storage.Engram{
+		Concept:   "tz",
+		Content:   "content",
+		CreatedAt: instant,
+	}); err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+
+	// FixedZone keeps the test independent of the system tzdata.
+	west := time.FixedZone("UTC-8", -8*60*60)
+	since := time.Date(2025, 6, 10, 0, 0, 0, 0, west)
+	until := time.Date(2025, 6, 11, 23, 59, 59, 999000000, west)
+
+	result, err := eng.ActivityCounts(ctx, vault, since, until)
+	if err != nil {
+		t.Fatalf("ActivityCounts: %v", err)
+	}
+
+	// Day list must be expressed in the west zone: 06-10, 06-11.
+	expected := []DailyCount{
+		{Date: "2025-06-10", Count: 0},
+		{Date: "2025-06-11", Count: 1},
+	}
+	if len(result) != len(expected) {
+		t.Fatalf("expected %d days, got %d: %v", len(expected), len(result), result)
+	}
+	for i, want := range expected {
+		if result[i].Date != want.Date || result[i].Count != want.Count {
+			t.Errorf("result[%d] = {%s, %d}, want {%s, %d}", i, result[i].Date, result[i].Count, want.Date, want.Count)
+		}
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2856,7 +2856,10 @@ type DailyCount struct {
 	Count int64
 }
 
-// ActivityCounts returns per-day engram counts between since and until for a vault.
+// ActivityCounts returns per-day engram counts between since and until
+// (inclusive) for a vault. Days are bucketed in the timezone of the since
+// argument's Location, and until is assumed to share that location; pass
+// UTC-located times for UTC-day buckets.
 func (e *Engine) ActivityCounts(ctx context.Context, vault string, since, until time.Time) ([]DailyCount, error) {
 	ws := e.store.ResolveVaultPrefix(vault)
 	counts, err := e.store.CountEngramsByDay(ctx, ws, since, until)
@@ -2864,8 +2867,17 @@ func (e *Engine) ActivityCounts(ctx context.Context, vault string, since, until 
 		return nil, err
 	}
 	// Build a contiguous day list so the caller always gets every day in range.
+	// Iterate calendar days in the location of the since argument so the day
+	// boundaries match how CountEngramsByDay bucketed the engrams. until is
+	// taken to share that location (the REST handler builds both together), so
+	// its own Location is intentionally not consulted. AddDate advances by a
+	// calendar day (not a fixed 24h), keeping the list correct across
+	// daylight-saving transitions.
+	loc := since.Location()
+	first := time.Date(since.Year(), since.Month(), since.Day(), 0, 0, 0, 0, loc)
+	last := time.Date(until.Year(), until.Month(), until.Day(), 0, 0, 0, 0, loc)
 	var result []DailyCount
-	for d := since.UTC().Truncate(24 * time.Hour); !d.After(until.UTC().Truncate(24 * time.Hour)); d = d.Add(24 * time.Hour) {
+	for d := first; !d.After(last); d = d.AddDate(0, 0, 1) {
 		day := d.Format("2006-01-02")
 		result = append(result, DailyCount{Date: day, Count: counts[day]})
 	}

--- a/internal/storage/query.go
+++ b/internal/storage/query.go
@@ -258,11 +258,19 @@ func (ps *PebbleStore) CountEngrams(ctx context.Context) (int64, error) {
 	return count, nil
 }
 
-// CountEngramsByDay counts engrams per UTC day between since and until
-// (inclusive) for a single vault. It scans only the 0x01 key prefix and
-// extracts the millisecond timestamp from each ULID without reading values,
+// CountEngramsByDay counts engrams per calendar day between since and until
+// (inclusive) for a single vault. Days are bucketed in the timezone of the
+// since argument's Location (pass UTC-located times for UTC-day buckets), and
+// until is assumed to share that location. It scans only the 0x01 key prefix
+// and extracts the millisecond timestamp from each ULID without reading values,
 // making it efficient even for large date ranges.
 func (ps *PebbleStore) CountEngramsByDay(ctx context.Context, wsPrefix [8]byte, since, until time.Time) (map[string]int64, error) {
+	// Day buckets are keyed in the location of the since argument, so callers
+	// control whether counts are grouped by the UTC or a local-timezone
+	// calendar day. The [since, until] scan below is absolute-time based (ULID
+	// epoch ms) and is therefore unaffected by the bucketing location.
+	loc := since.Location()
+
 	minID := ulidMinFromTime(since)
 	maxID := ulidMaxFromTime(until)
 
@@ -292,7 +300,7 @@ func (ps *PebbleStore) CountEngramsByDay(ctx context.Context, wsPrefix [8]byte, 
 		}
 		// Extract 48-bit ms timestamp from the ULID portion (bytes 9-14).
 		ms := uint64(binary.BigEndian.Uint32(key[9:13]))<<16 | uint64(binary.BigEndian.Uint16(key[13:15]))
-		t := time.Unix(int64(ms/1000), int64(ms%1000)*1e6).UTC()
+		t := time.Unix(int64(ms/1000), int64(ms%1000)*1e6).In(loc)
 		day := t.Format("2006-01-02")
 		counts[day]++
 	}

--- a/internal/storage/query_activity_test.go
+++ b/internal/storage/query_activity_test.go
@@ -109,3 +109,56 @@ func TestCountEngramsByDay(t *testing.T) {
 		}
 	})
 }
+
+// TestCountEngramsByDay_Timezone verifies that the day buckets are keyed in the
+// location of the since argument: the same engram lands in different calendar
+// days depending on the requested timezone.
+func TestCountEngramsByDay_Timezone(t *testing.T) {
+	store := openTestStore(t)
+	ws := store.VaultPrefix("activity-tz-test")
+	ctx := context.Background()
+
+	// 02:00 UTC on 2025-03-15 is still the evening of 2025-03-14 in a UTC-8 zone.
+	instant := time.Date(2025, 3, 15, 2, 0, 0, 0, time.UTC)
+	if _, err := store.WriteEngram(ctx, ws, &Engram{
+		Concept:   "tz engram",
+		Content:   "content",
+		CreatedAt: instant,
+	}); err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+
+	// FixedZone keeps the test independent of the system tzdata.
+	west := time.FixedZone("UTC-8", -8*60*60)
+
+	t.Run("UTC buckets on 2025-03-15", func(t *testing.T) {
+		since := time.Date(2025, 3, 14, 0, 0, 0, 0, time.UTC)
+		until := time.Date(2025, 3, 15, 23, 59, 59, 999000000, time.UTC)
+		counts, err := store.CountEngramsByDay(ctx, ws, since, until)
+		if err != nil {
+			t.Fatalf("CountEngramsByDay: %v", err)
+		}
+		if got := counts["2025-03-15"]; got != 1 {
+			t.Errorf("UTC: 2025-03-15 = %d, want 1 (counts=%v)", got, counts)
+		}
+		if got := counts["2025-03-14"]; got != 0 {
+			t.Errorf("UTC: 2025-03-14 = %d, want 0", got)
+		}
+	})
+
+	t.Run("UTC-8 buckets on 2025-03-14", func(t *testing.T) {
+		// The same window expressed in the western zone.
+		since := time.Date(2025, 3, 13, 0, 0, 0, 0, west)
+		until := time.Date(2025, 3, 14, 23, 59, 59, 999000000, west)
+		counts, err := store.CountEngramsByDay(ctx, ws, since, until)
+		if err != nil {
+			t.Fatalf("CountEngramsByDay: %v", err)
+		}
+		if got := counts["2025-03-14"]; got != 1 {
+			t.Errorf("UTC-8: 2025-03-14 = %d, want 1 (counts=%v)", got, counts)
+		}
+		if got := counts["2025-03-15"]; got != 0 {
+			t.Errorf("UTC-8: 2025-03-15 = %d, want 0", got)
+		}
+	})
+}

--- a/internal/transport/rest/openapi.yaml
+++ b/internal/transport/rest/openapi.yaml
@@ -2165,11 +2165,12 @@ paths:
       tags: [vault]
       summary: "Per-day engram creation counts for a vault."
       description: >
-        Returns the last `days` UTC calendar days of engram creation counts
-        ending on `until` (inclusive). All returned dates are UTC calendar
-        dates. Uses an efficient ULID key-header scan that never
-        deserializes engram values. Days that have zero writes are included
-        with a count of 0 so clients always get a contiguous series.
+        Returns the last `days` calendar days of engram creation counts
+        ending on `until` (inclusive). Counts are bucketed by calendar day in
+        the timezone given by `tz` (UTC when `tz` is omitted or unrecognized).
+        Uses an efficient ULID key-header scan that never deserializes engram
+        values. Days that have zero writes are included with a count of 0 so
+        clients always get a contiguous series.
       security:
         - BearerAuth: []
       parameters:
@@ -2180,7 +2181,7 @@ paths:
             default: "default"
         - name: days
           in: query
-          description: "Number of UTC calendar days to include (1–180, default 7). Returns 400 if out of range or non-numeric."
+          description: "Number of calendar days to include (1–180, default 7). Returns 400 if out of range or non-numeric."
           schema:
             type: integer
             default: 7
@@ -2188,10 +2189,21 @@ paths:
             maximum: 180
         - name: until
           in: query
-          description: "End date in YYYY-MM-DD format (default: today UTC). Returns 400 if malformed."
+          description: "End date in YYYY-MM-DD format, interpreted in `tz` (default: today in `tz`). Returns 400 if malformed."
           schema:
             type: string
             format: date
+        - name: tz
+          in: query
+          description: >
+            IANA timezone name (e.g. `America/Los_Angeles`) used to bucket
+            counts into calendar days and to interpret `until`. Missing,
+            unrecognized, or overly long (>64 chars) values silently fall back
+            to UTC; this parameter never causes an error.
+          schema:
+            type: string
+            default: "UTC"
+            example: "America/Los_Angeles"
       responses:
         "200":
           description: "Daily activity counts."

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -1389,6 +1389,11 @@ func (s *Server) handleGetSession(w http.ResponseWriter, r *http.Request) {
 	s.sendJSON(w, http.StatusOK, resp)
 }
 
+// maxTimezoneNameLen bounds the accepted length of the tz query parameter.
+// IANA timezone names are well under this; the cap keeps untrusted input from
+// reaching time.LoadLocation with an unreasonably long string.
+const maxTimezoneNameLen = 64
+
 func (s *Server) handleGetActivityCounts(w http.ResponseWriter, r *http.Request) {
 	vault := ctxVault(r)
 
@@ -1408,7 +1413,19 @@ func (s *Server) handleGetActivityCounts(w http.ResponseWriter, r *http.Request)
 		days = d
 	}
 
-	// Validate until parameter — reject malformed input, normalize to UTC end-of-day.
+	// Resolve the timezone used for day bucketing. Clients send their IANA
+	// name (e.g. "America/Los_Angeles") so the chart groups activity by the
+	// viewer's local calendar day. A missing, overlong, or unrecognized value
+	// falls back to UTC rather than erroring, so a bad client value can never
+	// break the chart and the default behavior is unchanged.
+	loc := time.UTC
+	if tzStr := r.URL.Query().Get("tz"); tzStr != "" && len(tzStr) <= maxTimezoneNameLen {
+		if l, err := time.LoadLocation(tzStr); err == nil {
+			loc = l
+		}
+	}
+
+	// Validate until parameter — reject malformed input, normalize to end-of-day in loc.
 	untilStr := r.URL.Query().Get("until")
 	var until time.Time
 	if untilStr != "" {
@@ -1417,16 +1434,16 @@ func (s *Server) handleGetActivityCounts(w http.ResponseWriter, r *http.Request)
 			s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "invalid 'until' parameter: expected YYYY-MM-DD format")
 			return
 		}
-		// End of that UTC day (ms-precision to match ULID granularity).
-		until = time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 999000000, time.UTC)
+		// End of that day in loc (ms-precision to match ULID granularity).
+		until = time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 999000000, loc)
 	} else {
-		// Default: end of today in UTC.
-		now := time.Now().UTC()
-		until = time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 999000000, time.UTC)
+		// Default: end of today in loc.
+		now := time.Now().In(loc)
+		until = time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 999000000, loc)
 	}
 
-	// since = start of the first day in the window (UTC 00:00:00.000).
-	since := time.Date(until.Year(), until.Month(), until.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -(days - 1))
+	// since = start of the first day in the window (00:00:00.000 in loc).
+	since := time.Date(until.Year(), until.Month(), until.Day(), 0, 0, 0, 0, loc).AddDate(0, 0, -(days - 1))
 
 	resp, err := s.engine.GetActivityCounts(r.Context(), &ActivityCountsRequest{Vault: vault, Since: since, Until: until})
 	if err != nil {

--- a/internal/transport/rest/server_test.go
+++ b/internal/transport/rest/server_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	_ "time/tzdata" // embed IANA tz data so LoadLocation works in the test binary
 
 	"github.com/cockroachdb/pebble"
 	"github.com/scrypster/muninndb/internal/auth"
@@ -2314,6 +2315,71 @@ func TestHandleActivityCounts_WithUntilDate(t *testing.T) {
 	}
 	if resp.Counts[6].Date != "2026-03-15" {
 		t.Errorf("last date = %s, want 2026-03-15", resp.Counts[6].Date)
+	}
+}
+
+func TestHandleActivityCounts_Timezone(t *testing.T) {
+	eng := &MockEngine{}
+	server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+	req := httptest.NewRequest("GET", "/api/activity-counts?vault=default&days=7&until=2026-03-15&tz=America/Los_Angeles", nil)
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if eng.lastActivityReq == nil {
+		t.Fatal("expected engine to receive request")
+	}
+	// since/until must be expressed in the requested location, not UTC, so the
+	// downstream layers bucket by the viewer's local calendar day.
+	if got := eng.lastActivityReq.Since.Location().String(); got != "America/Los_Angeles" {
+		t.Errorf("Since location = %q, want America/Los_Angeles", got)
+	}
+	if got := eng.lastActivityReq.Until.Location().String(); got != "America/Los_Angeles" {
+		t.Errorf("Until location = %q, want America/Los_Angeles", got)
+	}
+	wantSince := time.Date(2026, 3, 9, 0, 0, 0, 0, eng.lastActivityReq.Since.Location())
+	if !eng.lastActivityReq.Since.Equal(wantSince) {
+		t.Errorf("Since = %v, want %v", eng.lastActivityReq.Since, wantSince)
+	}
+	var resp ActivityCountsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Counts) != 7 {
+		t.Fatalf("expected 7 counts, got %d", len(resp.Counts))
+	}
+	if resp.Counts[0].Date != "2026-03-09" || resp.Counts[6].Date != "2026-03-15" {
+		t.Errorf("date range = %s..%s, want 2026-03-09..2026-03-15", resp.Counts[0].Date, resp.Counts[6].Date)
+	}
+}
+
+func TestHandleActivityCounts_InvalidTimezoneFallsBackToUTC(t *testing.T) {
+	tests := []struct {
+		name string
+		tz   string
+	}{
+		{"unknown zone", "Not/AZone"},
+		{"overlong", strings.Repeat("a", maxTimezoneNameLen+1)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eng := &MockEngine{}
+			server := NewServer("localhost:8080", eng, nil, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", nil)
+			req := httptest.NewRequest("GET", "/api/activity-counts?vault=default&tz="+tt.tz, nil)
+			w := httptest.NewRecorder()
+			server.mux.ServeHTTP(w, req)
+			// An invalid tz must not error — it silently falls back to UTC.
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200 for invalid tz, got %d: %s", w.Code, w.Body.String())
+			}
+			if eng.lastActivityReq == nil {
+				t.Fatal("expected engine to receive request")
+			}
+			if eng.lastActivityReq.Since.Location() != time.UTC {
+				t.Errorf("expected UTC fallback, got %v", eng.lastActivityReq.Since.Location())
+			}
+		})
 	}
 }
 

--- a/internal/transport/rest/types.go
+++ b/internal/transport/rest/types.go
@@ -239,6 +239,9 @@ type GetSessionResponse struct {
 }
 
 // ActivityCountsRequest requests daily activity counts for a vault.
+// The Location of Since (which Until is expected to match) selects the timezone
+// used to bucket counts into calendar days; UTC-located times produce UTC-day
+// buckets.
 type ActivityCountsRequest struct {
 	Vault string    `json:"vault"`
 	Since time.Time `json:"since"`

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -787,6 +787,13 @@ document.addEventListener('alpine:init', () => {
 
       const days = Math.max(1, Math.min(180, this.activityDays || 7));
       let url = '/api/activity-counts?vault=' + encodeURIComponent(this.vault) + '&days=' + days;
+      // Send the viewer's IANA timezone so the server buckets activity by the
+      // local calendar day instead of UTC. The server falls back to UTC if the
+      // name is missing or unrecognized.
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      if (tz) {
+        url += '&tz=' + encodeURIComponent(tz);
+      }
       if (this.activityUntil) {
         url += '&until=' + encodeURIComponent(this.activityUntil);
       }
@@ -890,7 +897,11 @@ document.addEventListener('alpine:init', () => {
                   const label = this.getLabelForValue(value);
                   const parts = label.split('-');
                   if (parts.length === 3) {
-                    // Parse as UTC to avoid timezone-induced date shift.
+                    // The server returns each label as a YYYY-MM-DD calendar day
+                    // already bucketed in the requested timezone. Render it as a
+                    // date-only value (parse and format in UTC) so the displayed
+                    // month/day matches the bucket exactly and is not shifted
+                    // again by the browser's local offset.
                     const d = new Date(label + 'T00:00:00Z');
                     if (isNaN(d.getTime())) return label;
                     return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });


### PR DESCRIPTION
## Summary

Makes the Dashboard **Activity chart** bucket and label engram activity by the viewer's **local calendar day** instead of UTC. Previously, in timezones behind UTC the chart showed "tomorrow" for several hours each evening, and engrams written in the local evening were counted under the next UTC day.

Closes #457.

## Problem

The activity-counts stack hardcoded UTC at every layer, so "today" advanced at 00:00 UTC rather than local midnight. At, say, 19:50 PDT (02:50 UTC) the 7‑day window's last bucket was already the next calendar date, and a memory written then landed in that next-day bucket.

## Change

An optional `tz` query parameter (IANA name, e.g. `America/Los_Angeles`) is threaded through the stack. The bucketing timezone is carried via the `Location()` of the `since`/`until` arguments, so **no engine/storage signatures change** and UTC‑located callers are unaffected (default behavior is identical to today).

| Layer | File | Change |
|---|---|---|
| Client | `web/static/js/app.js` | Sends `&tz=` from `Intl.DateTimeFormat().resolvedOptions().timeZone`. The date-axis label callback **intentionally stays UTC** — the server now returns date-only strings already in the requested tz, so re-localizing them would shift the displayed day. |
| REST | `internal/transport/rest/server.go` | Parses `tz` via `time.LoadLocation` (capped at 64 chars; missing/invalid/overlong → silent UTC fallback, never errors) and computes the `since`/`until` day boundaries in that location. |
| Engine | `internal/engine/engine.go` | Iterates the contiguous day list in `since.Location()` using `AddDate(0,0,1)` (DST-correct calendar days). |
| Storage | `internal/storage/query.go` | Buckets each engram by its timestamp `.In(since.Location())`. The `[since, until]` scan stays absolute-time based, so the range is unaffected. |
| Binary | `cmd/muninn/main.go` | Embeds `time/tzdata` so `LoadLocation` works on the `debian-slim` runtime image (which ships without system tzdata). |

## Backward compatibility

- Omitting `tz` (or sending an unrecognized/overlong value) preserves the exact prior UTC behavior.
- Display/aggregation only — stored `created_at` values remain UTC; **no data migration**.

## Tests

Added unit tests at all three layers (using `time.FixedZone` so they don't depend on system tzdata):

- `internal/storage/query_activity_test.go` — same engram buckets into different calendar days under UTC vs UTC‑8.
- `internal/engine/activity_counts_test.go` — the contiguous day list and counts honor the argument's location.
- `internal/transport/rest/server_test.go` — `tz` param produces `since`/`until` in the requested location; invalid/overlong `tz` falls back to UTC without erroring.

All existing activity-counts tests still pass; full `internal/transport/rest` package is green.

## Reviews

Independently reviewed for **security**, **code clarity**, and **documentation** before submitting:

- **Security:** No vulnerabilities. `time.LoadLocation` is safe against path traversal — Go rejects names containing `..` or leading separators before any lookup, and the embedded tzdata lookup is a pure in-memory scan; the 64‑char cap is defense-in-depth. The silent UTC fallback is the correct fail-open choice for a parameter that governs no authorization or data scope.
- **Clarity / Documentation:** The `since.Location()` contract is documented on `CountEngramsByDay`, `ActivityCounts`, and `ActivityCountsRequest`; the OpenAPI spec (`openapi.yaml`) now documents the `tz` parameter and no longer claims UTC-only; `CHANGELOG.md` and `docs/feature-reference.md` updated.

## Note on embedded tzdata

`time/tzdata` adds ~450 KB to the binary but guarantees the feature works on minimal images. If you'd prefer to instead `apt-get install tzdata` in the Dockerfile and rely on system zoneinfo, I'm happy to switch — let me know.
