### PR TITLE
fix(engine): Evolve must not append " (evolved)" to concept

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2697,7 +2697,7 @@ func (e *Engine) Evolve(ctx context.Context, vault, oldID, newContent, reason st
 	now := time.Now()
 	newEng := &storage.Engram{
 		ID:         newULID,
-		Concept:    oldEng.Concept + " (evolved)",
+		Concept:    oldEng.Concept,
 		Content:    newContent,
 		Tags:       oldEng.Tags,
 		Confidence: 1.0,

--- a/internal/engine/engine_evolve_test.go
+++ b/internal/engine/engine_evolve_test.go
@@ -66,3 +66,43 @@ func TestEvolve_AtomicBatch_OldSoftDeletedNewReadable(t *testing.T) {
 	assert.Equal(t, oldULID, assocs[0].TargetID, "association must point to old engram")
 	assert.Equal(t, storage.RelSupersedes, assocs[0].RelType, "association type must be RelSupersedes")
 }
+
+// TestEvolve_ConceptStableAcrossRepeatedEvolution verifies that the concept field
+// is inherited verbatim from the predecessor on every Evolve call, with no suffix
+// added or accumulated. Lineage is recorded via the RelSupersedes association, not
+// by mutating the concept string. Without this guarantee, callers that use concept
+// names as stable references (canonical-engram patterns) see the reference drift
+// further on every update: "topic" → "topic (evolved)" → "topic (evolved) (evolved)".
+func TestEvolve_ConceptStableAcrossRepeatedEvolution(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const originalConcept = "fact: example service — canonical specs"
+
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "test", Concept: originalConcept, Content: "v1",
+	})
+	require.NoError(t, err)
+
+	// First evolution: concept must equal original (no suffix).
+	id1, err := eng.Evolve(ctx, "test", resp.ID, "v2", "first update", nil)
+	require.NoError(t, err)
+
+	ws := eng.store.ResolveVaultPrefix("test")
+	eng1, err := eng.store.GetEngram(ctx, ws, id1)
+	require.NoError(t, err)
+	require.NotNil(t, eng1)
+	assert.Equal(t, originalConcept, eng1.Concept,
+		"concept must be inherited verbatim from predecessor, no suffix")
+
+	// Second evolution: concept must still equal original (no accumulation).
+	id2, err := eng.Evolve(ctx, "test", id1.String(), "v3", "second update", nil)
+	require.NoError(t, err)
+
+	eng2, err := eng.store.GetEngram(ctx, ws, id2)
+	require.NoError(t, err)
+	require.NotNil(t, eng2)
+	assert.Equal(t, originalConcept, eng2.Concept,
+		"concept must remain stable across repeated evolutions, no accumulating suffix")
+}


### PR DESCRIPTION
## Bug

Every call to `Engine.Evolve` concatenates `" (evolved)"` onto the predecessor's concept field. On repeated evolutions the suffix accumulates:

```
fact: example service — canonical specs
fact: example service — canonical specs (evolved)
fact: example service — canonical specs (evolved) (evolved)
fact: example service — canonical specs (evolved) (evolved) (evolved)
```

This breaks any caller using concept names as stable references — for example, the canonical-engram pattern where external systems or documentation point at an engram by concept name and expect the name to stay constant as the engram is updated in place.

## Reproduction (v0.6.1, via MCP)

```
muninn_remember(
  concept="observation: evolve probe — initial",
  content="round 0",
  type="observation",
  tags=["observation","self","mdb"],
  entities=[{"name":"Bob","type":"agent"}],
  vault="default"
)
# → id A

muninn_evolve(id=A, new_content="round 1", reason="first evolve", vault="default")
# → id B
muninn_read(id=B)  →  concept ends in " (evolved)"

muninn_evolve(id=B, new_content="round 2", reason="second evolve", vault="default")
# → id C
muninn_read(id=C)  →  concept ends in " (evolved) (evolved)"
```

## Root cause

`internal/engine/engine.go` line 2700:

```go
newEng := &storage.Engram{
    ID:         newULID,
    Concept:    oldEng.Concept + " (evolved)",   // ← this
    Content:    newContent,
    ...
}
```

Lineage from successor to predecessor is already recorded via the `RelSupersedes` association written in the same atomic batch a few lines below (lines 2713–2721). The string suffix duplicates information that's already first-class in the graph model, and uniquely mutates a field that callers reasonably expect to be stable.

## Fix

Inherit the concept verbatim. The supersedes association remains the authoritative lineage record.

```go
Concept: oldEng.Concept,
```

## Test impact

No existing test in the repo asserts on the `" (evolved)"` suffix (verified via `grep -rn '(evolved)' --include='*_test.go'` — zero hits). The fix breaks no existing assertions.

A regression test, `TestEvolve_ConceptStableAcrossRepeatedEvolution`, is included in `internal/engine/engine_evolve_test.go`. It writes an engram, evolves twice, and asserts the concept is unchanged at each step. Full local results:

```
go test ./internal/engine/ ./internal/mcp/ ./internal/transport/rest/
ok      github.com/scrypster/muninndb/internal/engine          29.638s
ok      github.com/scrypster/muninndb/internal/mcp              2.340s
ok      github.com/scrypster/muninndb/internal/transport/rest   1.505s
```