### PR TITLE
fix(ui): normalize created_at unit so memory detail panel shows a valid date

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -616,7 +616,10 @@ document.addEventListener('alpine:init', () => {
         // ends of the array confuse Alpine's DOM anchor tracking and produce the
         // "can't access property 'after', v is undefined" crash.
         if (!this.liveFeed.some(item => item.id === msg.data.id)) {
-          const next = [msg.data, ...this.liveFeed];
+          // The memory_added event carries createdAt in SECONDS (backend
+          // .Unix()) → normalize to ms so the frontend convention holds.
+          const item = { ...msg.data, createdAt: this.secondsToMillis(msg.data.createdAt) };
+          const next = [item, ...this.liveFeed];
           this.liveFeed = next.length > 20 ? next.slice(0, 20) : next;
         }
       }
@@ -634,6 +637,24 @@ document.addEventListener('alpine:init', () => {
         throw new Error(res.status + ': ' + text);
       }
       return res.json();
+    },
+
+    // ── created_at unit normalization ────────────────────────────────────────
+    // The REST API returns created_at in INCONSISTENT units depending on the
+    // endpoint (the backend types are shared with the MCP/gRPC transports, so
+    // they cannot be changed here):
+    //   • /api/engrams and /api/session use .Unix()      → SECONDS
+    //   • /api/activate and /api/engrams/{id} use UnixNano() → NANOSECONDS
+    // To keep the frontend consistent, every mapping site normalizes created_at
+    // to epoch MILLISECONDS via these helpers, and templates render the value
+    // directly with `new Date(createdAt)` (no `* 1000`). The pure converters
+    // live in time-utils.js (exposed as globalThis.MuninnTime) so they can be
+    // unit-tested under Vitest.
+    secondsToMillis(value) {
+      return MuninnTime.secondsToMillis(value);
+    },
+    nanosToMillis(value) {
+      return MuninnTime.nanosToMillis(value);
     },
 
     // ── Dashboard ──────────────────────────────────────────────────────────
@@ -976,7 +997,8 @@ document.addEventListener('alpine:init', () => {
         if (f.minConf > 0) url += '&min_confidence=' + f.minConf;
         if (f.maxConf > 0) url += '&max_confidence=' + f.maxConf;
         const data = await this.apiCall(url);
-        this.memories = (data.engrams || []).map(e => ({ ...e, createdAt: e.created_at }));
+        // /api/engrams returns created_at in SECONDS → normalize to ms.
+        this.memories = (data.engrams || []).map(e => ({ ...e, createdAt: this.secondsToMillis(e.created_at) }));
         this.totalMemories = data.total || 0;
       } catch (err) {
         this.addNotification('error', 'Load failed: ' + err.message);
@@ -1013,7 +1035,8 @@ document.addEventListener('alpine:init', () => {
           content: a.content,
           confidence: a.confidence || a.score || 0,
           vault: this.vault,
-          createdAt: a.created_at || 0,
+          // /api/activate returns created_at in NANOSECONDS → normalize to ms.
+          createdAt: this.nanosToMillis(a.created_at),
         }));
         this.totalMemories = this.memories.length;
         this.page = 0;
@@ -1092,7 +1115,9 @@ document.addEventListener('alpine:init', () => {
           const resp = await fetch('/api/engrams/' + encodeURIComponent(m.id) + '?vault=' + encodeURIComponent(this.vault));
           if (resp.ok) {
             const full = await resp.json();
-            m = { ...m, ...full, createdAt: full.created_at || m.createdAt };
+            // /api/engrams/{id} returns created_at in NANOSECONDS → normalize to
+            // ms; fall back to m.createdAt (already ms) when absent.
+            m = { ...m, ...full, createdAt: this.nanosToMillis(full.created_at) || m.createdAt };
           }
         } catch (e) { /* fall through with partial data */ }
       }
@@ -1776,7 +1801,8 @@ document.addEventListener('alpine:init', () => {
         );
         // GetSessionResponse has { entries: [] } or raw array
         const raw = data.entries || (Array.isArray(data) ? data : []);
-        this.sessionEntries = raw.map(e => ({ ...e, createdAt: e.created_at }));
+        // /api/session returns created_at in SECONDS → normalize to ms.
+        this.sessionEntries = raw.map(e => ({ ...e, createdAt: this.secondsToMillis(e.created_at) }));
       } catch (err) {
         this.addNotification('error', 'Session: ' + err.message);
       }

--- a/web/static/js/time-utils.js
+++ b/web/static/js/time-utils.js
@@ -1,0 +1,45 @@
+/**
+ * time-utils.js — pure created_at unit normalization helpers.
+ *
+ * The REST API returns created_at in INCONSISTENT units depending on the
+ * endpoint, because the backend response types are shared with the MCP and
+ * gRPC transports and cannot be changed for the Web UI alone:
+ *
+ *   • /api/engrams and /api/session      use .Unix()      → SECONDS
+ *   • /api/activate and /api/engrams/{id} use .UnixNano() → NANOSECONDS
+ *
+ * The Web UI normalizes every created_at to epoch MILLISECONDS at each mapping
+ * site so the rest of the frontend can treat the value uniformly and templates
+ * can render it with `new Date(createdAt)` (no `* 1000`). When the input is
+ * falsy (null / undefined / 0) the result stays 0 so the
+ * `createdAt ? … : 'unknown'` template branches still work.
+ *
+ * Loaded as a <script type="module"> so it can be imported by Vitest with ES
+ * module syntax. The globalThis assignment at the bottom exposes MuninnTime as a
+ * browser global so the non-module app.js can call it after Alpine init.
+ */
+
+/**
+ * Convert an epoch-seconds value to epoch-milliseconds.
+ * Falsy input (null / undefined / 0) is preserved as 0.
+ * @param {number|null|undefined} value
+ * @returns {number}
+ */
+export function secondsToMillis(value) {
+    return value ? value * 1000 : 0;
+}
+
+/**
+ * Convert an epoch-nanoseconds value to epoch-milliseconds.
+ * Falsy input (null / undefined / 0) is preserved as 0.
+ * @param {number|null|undefined} value
+ * @returns {number}
+ */
+export function nanosToMillis(value) {
+    return value ? Math.floor(value / 1e6) : 0;
+}
+
+// Expose as a browser global so the non-module app.js can access it after Alpine
+// initializes. Module scripts execute before Alpine's deferred init, so this is
+// always set by the time any component method runs.
+globalThis.MuninnTime = { secondsToMillis, nanosToMillis };

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -29,6 +29,8 @@
   <!-- plugin-config-utils: loaded as module after app.js sync execution,
        before Alpine's deferred init — sets globalThis.MuninnPluginCfg -->
   <script type="module" src="/static/js/plugin-config-utils.js"></script>
+  <!-- time-utils: created_at unit normalization helpers — sets globalThis.MuninnTime -->
+  <script type="module" src="/static/js/time-utils.js"></script>
 
   <!-- Alpine.js (deferred — initializes after DOM + app.js registers components) -->
   <script defer src="/static/vendor/alpine-3.14.9.min.js"></script>
@@ -315,7 +317,7 @@
               <div style="font-size:0.8125rem;padding:0.5rem;background:var(--bg-elevated);border-radius:0.375rem;">
                 <span class="badge-info" x-text="item.vault"></span>
                 <span style="color:var(--text-primary);margin-left:0.5rem;" x-text="item.concept"></span>
-                <div style="color:var(--text-muted);font-size:0.75rem;margin-top:0.25rem;" x-text="new Date(item.createdAt * 1000).toLocaleTimeString()"></div>
+                <div style="color:var(--text-muted);font-size:0.75rem;margin-top:0.25rem;" x-text="new Date(item.createdAt).toLocaleTimeString()"></div>
               </div>
             </template>
             <div x-show="liveFeed.length === 0" style="color:var(--text-muted);font-size:0.875rem;padding:0.5rem;">
@@ -498,7 +500,7 @@
               <!-- Embedding status dot -->
               <span :title="m.embed_dim && m.embed_dim > 0 ? 'Embedded' : 'No embedding'"
                 :style="'width:7px;height:7px;border-radius:50%;flex-shrink:0;background:' + (m.embed_dim && m.embed_dim > 0 ? '#22c55e' : '#9ca3af')"></span>
-              <span style="font-size:0.75rem;color:var(--text-muted);" x-text="m.createdAt ? new Date(m.createdAt * 1000).toLocaleDateString() : ''"></span>
+              <span style="font-size:0.75rem;color:var(--text-muted);" x-text="m.createdAt ? new Date(m.createdAt).toLocaleDateString() : ''"></span>
             </div>
           </div>
         </template>
@@ -705,7 +707,7 @@
             </div>
             <div class="form-group">
               <label>Created</label>
-              <span style="color:var(--text-secondary);font-size:0.875rem;" x-text="selectedMemory.createdAt ? new Date(selectedMemory.createdAt * 1000).toLocaleString() : 'unknown'"></span>
+              <span style="color:var(--text-secondary);font-size:0.875rem;" x-text="selectedMemory.createdAt ? new Date(selectedMemory.createdAt).toLocaleString() : 'unknown'"></span>
             </div>
             <div class="form-group" style="margin-top:1rem;">
               <label>Lifecycle State</label>
@@ -2200,7 +2202,7 @@ Authorization = "Bearer &lt;token from %USERPROFILE%\.muninn\mcp.token&gt;"</pre
             <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;">
               <span class="badge-info" x-text="entry.concept || entry.id.slice(0,8)"></span>
               <span style="color:var(--text-secondary);font-size:0.875rem;flex:1;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;" x-text="entry.content || ''"></span>
-              <span style="font-size:0.75rem;color:var(--text-muted);white-space:nowrap;" x-text="entry.createdAt ? new Date(entry.createdAt * 1000).toLocaleString() : ''"></span>
+              <span style="font-size:0.75rem;color:var(--text-muted);white-space:nowrap;" x-text="entry.createdAt ? new Date(entry.createdAt).toLocaleString() : ''"></span>
             </div>
           </div>
         </template>

--- a/web/time-utils.test.js
+++ b/web/time-utils.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { secondsToMillis, nanosToMillis } from './static/js/time-utils.js';
+
+describe('secondsToMillis', () => {
+    it('converts epoch seconds to milliseconds', () => {
+        // 2025-01-01T00:00:00Z = 1735689600 s
+        expect(secondsToMillis(1735689600)).toBe(1735689600000);
+    });
+
+    it('returns 0 for zero', () => {
+        expect(secondsToMillis(0)).toBe(0);
+    });
+
+    it('returns 0 for null', () => {
+        expect(secondsToMillis(null)).toBe(0);
+    });
+
+    it('returns 0 for undefined', () => {
+        expect(secondsToMillis(undefined)).toBe(0);
+    });
+
+    it('produces a valid Date (not NaN)', () => {
+        const d = new Date(secondsToMillis(1735689600));
+        expect(Number.isNaN(d.getTime())).toBe(false);
+        expect(d.toISOString()).toBe('2025-01-01T00:00:00.000Z');
+    });
+
+    it('swallows NaN input to 0 (not NaN)', () => {
+        expect(secondsToMillis(NaN)).toBe(0);
+    });
+
+    it('passes through negative input and produces a valid pre-epoch Date', () => {
+        const result = secondsToMillis(-1);
+        expect(result).toBe(-1000);
+        const d = new Date(result);
+        expect(Number.isNaN(d.getTime())).toBe(false);
+    });
+});
+
+describe('nanosToMillis', () => {
+    it('converts epoch nanoseconds to milliseconds (floored)', () => {
+        // 2025-01-01T00:00:00Z = 1735689600000000000 ns
+        expect(nanosToMillis(1735689600000000000)).toBe(1735689600000);
+    });
+
+    it('floors sub-millisecond precision', () => {
+        // 1_000_999_999 ns = 1000.999999 ms → floor → 1000
+        expect(nanosToMillis(1000999999)).toBe(1000);
+    });
+
+    it('returns 0 for zero', () => {
+        expect(nanosToMillis(0)).toBe(0);
+    });
+
+    it('returns 0 for null', () => {
+        expect(nanosToMillis(null)).toBe(0);
+    });
+
+    it('returns 0 for undefined', () => {
+        expect(nanosToMillis(undefined)).toBe(0);
+    });
+
+    it('produces a valid Date (not NaN)', () => {
+        const d = new Date(nanosToMillis(1735689600000000000));
+        expect(Number.isNaN(d.getTime())).toBe(false);
+        expect(d.toISOString()).toBe('2025-01-01T00:00:00.000Z');
+    });
+
+    it('is falsy for zero so the `nanosToMillis(...) || fallback` chain falls through', () => {
+        // Mirrors the /api/engrams/{id} mapping site:
+        //   nanosToMillis(full.created_at) || m.createdAt
+        // A zero nanos value must be falsy so the fallback (m.createdAt) wins.
+        expect(nanosToMillis(0)).toBe(0);
+        expect(nanosToMillis(0) || 1700000000000).toBe(1700000000000);
+    });
+
+    it('swallows NaN input to 0 (not NaN)', () => {
+        expect(nanosToMillis(NaN)).toBe(0);
+    });
+
+    it('passes through negative input and produces a valid pre-epoch Date', () => {
+        const result = nanosToMillis(-1000000);
+        expect(result).toBe(-1);
+        const d = new Date(result);
+        expect(Number.isNaN(d.getTime())).toBe(false);
+    });
+});


### PR DESCRIPTION
# fix(ui): normalize created_at unit so memory detail panel shows a valid date

Closes #460

## Problem

The dashboard memory detail panel showed `Created: Invalid Date` for memories
opened from search results (and for expanded session entries). Memories opened
from the plain browse list rendered correctly.

## Root cause

The REST API returns the `created_at` integer in **inconsistent units**, while
the frontend assumed a single unit everywhere:

| Endpoint | Used by | Serialized as | Unit |
|---|---|---|---|
| `GET /api/engrams` | browse list | `time.Time.Unix()` | seconds |
| `GET /api/session` | session timeline | `time.Time.Unix()` | seconds |
| `POST /api/activate` | search | `time.Time.UnixNano()` | nanoseconds |
| `GET /api/engrams/{id}` | open full engram | `time.Time.UnixNano()` | nanoseconds |

The frontend rendered every value as `new Date(createdAt * 1000)`:

- seconds × 1000 → milliseconds → correct
- nanoseconds × 1000 → ~10^21, outside JS `Date`'s valid range → `Invalid Date`

## Fix

Frontend-only, lowest blast radius (the activate/read response types are shared
with other transports, so the backend types are deliberately untouched):

- New `web/static/js/time-utils.js` with `secondsToMillis` / `nanosToMillis`,
  exposed via `globalThis.MuninnTime`, mirroring the existing
  `plugin-config-utils.js` pattern.
- Each `created_at` mapping site now normalizes to epoch **milliseconds** at
  ingest, choosing the converter that matches that endpoint's unit (browse +
  session = seconds; search + single-read = nanoseconds; the `memory_added`
  websocket feed = seconds).
- Every template render site drops the `* 1000` and renders `new Date(value)`.

The invariant is now "frontend `createdAt` is always epoch-milliseconds", applied
once at ingest and never re-scaled at render — no double-conversion.

## Tests

- New `web/time-utils.test.js` (vitest): seconds input, nanoseconds input
  (including sub-millisecond flooring), zero/null/undefined, NaN, negative
  inputs, the `|| fallback` chain semantics, and a valid-`Date` assertion for
  real inputs. 16 tests.
- Unit suite green: `npx vitest run plugin-config-utils.test.js time-utils.test.js`
  → 33 passed.

## Notes / out of scope

- The deeper asymmetry is in the backend (`.Unix()` vs `.UnixNano()` across
  endpoints). A follow-up could make the REST JSON contract emit a single unit
  so the frontend can drop the dual-converter logic; that touches response types
  shared with other transports and is tracked separately.
- `npm test` (bare `vitest run`) currently also tries to collect the Playwright
  `e2e/*.spec.ts` files and errors at collection — a pre-existing vite config
  gap unrelated to this change (run e2e via the Playwright script). Not modified
  here.
