### PR TITLE
feat(cli): add 'muninn doctor' to self-describe TLS state (#443 gap 3)

### DIFF
--- a/cmd/muninn/doctor.go
+++ b/cmd/muninn/doctor.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/tlsutil"
+)
+
+// doctorReport is the gathered, render-free view of the daemon's TLS and
+// connectivity state. Populated by gatherDoctor (the only I/O); rendered by the
+// pure formatDoctor.
+type doctorReport struct {
+	svcs       []serviceStatus
+	scheme     string              // "https" | "http" | "" (unknown / server stopped)
+	addrs      daemonAddrs         // real bound addresses — displayed verbatim
+	cert       *x509.Certificate   // leaf; nil when TLS off or cert unobtainable
+	chain      []*x509.Certificate // additional chain certs (cert-file path only)
+	certSource string              // "live socket" | "cert file" | ""
+	tlsVersion uint16              // negotiated version (live path only; 0 otherwise)
+	cipher     uint16              // negotiated cipher (live path only; 0 otherwise)
+	certErr    string              // why the cert could not be inspected, if applicable
+}
+
+// dialServedCert opens a TLS connection to hostport and returns the leaf
+// certificate the server presents, plus the negotiated version and cipher.
+// Verification is intentionally skipped: doctor inspects the served cert, it
+// does not trust it, and gatherDoctor only ever points this at loopback.
+func dialServedCert(hostport string) (*x509.Certificate, uint16, uint16, error) {
+	conn, err := tls.DialWithDialer(
+		&net.Dialer{Timeout: 3 * time.Second},
+		"tcp", hostport,
+		&tls.Config{InsecureSkipVerify: true}, //nolint:gosec // inspect-not-trust; loopback self-inspection
+	)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	defer conn.Close()
+	st := conn.ConnectionState()
+	if len(st.PeerCertificates) == 0 {
+		return nil, 0, 0, errors.New("server presented no certificate")
+	}
+	return st.PeerCertificates[0], st.Version, st.CipherSuite, nil
+}
+
+// dialServedCertFn indirects dialServedCert so tests can stub the live dial.
+var dialServedCertFn = dialServedCert
+
+// runDoctor implements `muninn doctor`: a TLS/connectivity self-describe.
+func runDoctor(args []string) {
+	fs := flag.NewFlagSet("doctor", flag.ExitOnError)
+	// stdlib flag does not alias short/long forms — register both.
+	v := fs.Bool("v", false, "Verbose: SANs, serial, signature algorithm, TLS version/cipher, chain")
+	verbose := fs.Bool("verbose", false, "Verbose: SANs, serial, signature algorithm, TLS version/cipher, chain")
+	fs.Usage = func() { subcommandHelp["doctor"]() }
+	_ = fs.Parse(args)
+
+	fmt.Print(formatDoctor(gatherDoctor(), *v || *verbose, isatty()))
+}
+
+// gatherDoctor collects the daemon's connectivity and TLS state. This is the
+// only function in the doctor path that performs I/O.
+func gatherDoctor() doctorReport {
+	r := doctorReport{}
+	// running/degraded/stopped is owned by the live probe (status.go), so a
+	// systemd-managed server with a stale or absent sidecar is still seen up.
+	r.svcs = probeServices()
+
+	if addrs, err := readAddrsFile(defaultDataDir()); err == nil {
+		r.addrs = addrs
+	}
+	// Resolve the scheme BEFORE deciding to dial — resolveScheme recovers it
+	// from the web-ui probe when the sidecar predates the Scheme field, else a
+	// running pre-scheme-field TLS daemon would be reported as "TLS disabled".
+	r.scheme = resolveScheme(r.addrs, r.svcs)
+
+	// (a) Live socket — ground truth, what clients actually receive. Dial
+	// loopback on the REST port; the recorded host may be 0.0.0.0 (not reliably
+	// dialable), and may be absent entirely when the daemon is systemd-managed
+	// with no sidecar — fall back to the default REST port in that case.
+	if r.scheme == "https" {
+		if cert, ver, suite, err := dialServedCertFn(loopbackHostPort(r.addrs.RestAddr, "8475")); err == nil {
+			r.cert, r.tlsVersion, r.cipher, r.certSource = cert, ver, suite, "live socket"
+		}
+	}
+	// (b) Cert-file fallback — env-only, certificate-only (never the key). Works
+	// whether the live dial failed or the server is stopped. Surface the failure
+	// reason when TLS is known-on, or when the operator explicitly pointed
+	// MUNINN_TLS_CERT at a file to inspect offline (the documented stopped-server
+	// case) — otherwise a corrupt/unreadable cert would render nothing at all.
+	if r.cert == nil {
+		if leaf, chain, err := certFromEnvFile(); err == nil {
+			r.cert, r.chain, r.certSource = leaf, chain, "cert file"
+		} else if r.scheme == "https" || os.Getenv("MUNINN_TLS_CERT") != "" {
+			r.certErr = "could not inspect certificate (" + err.Error() + ")"
+		}
+	}
+	return r
+}
+
+// loopbackHostPort keeps only addr's port and pins the host to loopback.
+func loopbackHostPort(addr, fallbackPort string) string {
+	return "127.0.0.1:" + portFromAddr(addr, fallbackPort)
+}
+
+// certFromEnvFile parses the certificate at $MUNINN_TLS_CERT. It reads only the
+// certificate, never the private key. The first CERTIFICATE block is the leaf
+// (PEM leaf-first convention, matching tls.LoadX509KeyPair); any further blocks
+// form the chain.
+func certFromEnvFile() (leaf *x509.Certificate, chain []*x509.Certificate, err error) {
+	path := os.Getenv("MUNINN_TLS_CERT")
+	if path == "" {
+		return nil, nil, errors.New("server not reachable and MUNINN_TLS_CERT unset")
+	}
+	pemBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	for rest := pemBytes; ; {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		c, perr := x509.ParseCertificate(block.Bytes)
+		if perr != nil {
+			return nil, nil, perr
+		}
+		if leaf == nil {
+			leaf = c
+		} else {
+			chain = append(chain, c)
+		}
+	}
+	if leaf == nil {
+		return nil, nil, fmt.Errorf("no certificate found in %s", path)
+	}
+	return leaf, chain, nil
+}
+
+// formatDoctor renders a doctorReport. Pure: no I/O, no global state beyond the
+// passed isTTY. verbose adds SANs, serial, signature algorithm, the negotiated
+// TLS version/cipher, and the cert chain.
+func formatDoctor(r doctorReport, verbose, isTTY bool) string {
+	color := func(code, s string) string {
+		if !isTTY {
+			return s
+		}
+		return code + s + "\033[0m"
+	}
+	yellow := func(s string) string { return color("\033[33m", s) }
+	red := func(s string) string { return color("\033[31m", s) }
+	dim := func(s string) string { return color("\033[2m", s) }
+
+	// mark renders a status glyph in a TTY, or a plain ASCII token otherwise, so
+	// piped/log output never carries a bare Unicode glyph.
+	mark := func(code, glyph, text string) string {
+		if !isTTY {
+			return text
+		}
+		return color(code, glyph)
+	}
+	dotGreen := mark("\033[32m", "●", "[up]")
+	dotRed := mark("\033[31m", "○", "[down]")
+	dotOff := mark("\033[2m", "○", "[off]")
+	warnMark := mark("\033[33m", "⚠", "[warn]")
+
+	label := func(s string) string { return fmt.Sprintf("  %-10s ", s) }
+	indent := strings.Repeat(" ", len(label(""))) // align continuation rows under the value column
+
+	var b strings.Builder
+	b.WriteString("\n  muninn doctor\n\n")
+
+	// server
+	switch overallState(r.svcs) {
+	case stateRunning:
+		fmt.Fprintf(&b, "%s%s  running\n", label("server"), dotGreen)
+	case stateDegraded:
+		fmt.Fprintf(&b, "%s%s  %s\n", label("server"), warnMark, yellow("degraded"))
+	case stateStopped:
+		fmt.Fprintf(&b, "%s%s  stopped\n", label("server"), dotRed)
+	}
+
+	// TLS mode
+	switch r.scheme {
+	case "https":
+		fmt.Fprintf(&b, "%s%s  enabled (https)\n", label("TLS"), dotGreen)
+	case "http":
+		fmt.Fprintf(&b, "%s%s  %s\n", label("TLS"), dotOff, dim("disabled (http)"))
+	default:
+		fmt.Fprintf(&b, "%s%s  %s\n", label("TLS"), dotOff, dim("unknown (server not running)"))
+	}
+
+	// bind addresses — show the real bound host (may be 0.0.0.0); fall back to
+	// the probed port when the sidecar is absent.
+	addrFor := func(name string) string {
+		switch name {
+		case "database":
+			return r.addrs.RestAddr
+		case "mcp":
+			return r.addrs.MCPAddr
+		case "web ui":
+			return r.addrs.UIAddr
+		}
+		return ""
+	}
+	for i, s := range r.svcs {
+		addr := addrFor(s.name)
+		if addr == "" {
+			addr = fmt.Sprintf("127.0.0.1:%d", s.port)
+		}
+		lead := indent
+		if i == 0 {
+			lead = label("bind")
+		}
+		fmt.Fprintf(&b, "%s%-9s %s\n", lead, s.name, addr)
+	}
+
+	// TLS disabled → no certificate section.
+	if r.scheme == "http" {
+		return b.String()
+	}
+
+	// certificate
+	if r.cert == nil {
+		if r.certErr != "" {
+			fmt.Fprintf(&b, "\n  certificate  %s\n", yellow(r.certErr))
+		}
+		return b.String()
+	}
+
+	b.WriteString("\n")
+	fmt.Fprintf(&b, "  certificate  %s\n", dim("(from "+r.certSource+")"))
+	fmt.Fprintf(&b, "    subject    %s\n", certName(r.cert.Subject))
+	fmt.Fprintf(&b, "    issuer     %s\n", certName(r.cert.Issuer))
+	if len(r.cert.DNSNames) > 0 {
+		fmt.Fprintf(&b, "    dns sans   %s\n", strings.Join(r.cert.DNSNames, ", "))
+	}
+	fmt.Fprintf(&b, "    valid      %s → %s (UTC)\n",
+		r.cert.NotBefore.UTC().Format("2006-01-02"),
+		r.cert.NotAfter.UTC().Format("2006-01-02"))
+
+	// expiry — classified inline (no tlsutil.CheckCertExpiry: it logs via slog,
+	// which would corrupt this formatted output).
+	remaining := time.Until(r.cert.NotAfter)
+	expMark, expMsg := dotGreen, fmt.Sprintf("%d days remaining", tlsutil.DaysRemaining(remaining))
+	switch {
+	case remaining <= 0:
+		expMark, expMsg = dotRed, red(fmt.Sprintf("EXPIRED %d days ago", tlsutil.DaysRemaining(-remaining)))
+	case remaining < tlsutil.ExpiryWarnWindow:
+		expMark, expMsg = warnMark, yellow(fmt.Sprintf("expires in %d days", tlsutil.DaysRemaining(remaining)))
+	}
+	fmt.Fprintf(&b, "    expiry     %s  %s\n", expMark, expMsg)
+
+	if verbose {
+		if len(r.cert.IPAddresses) > 0 {
+			ips := make([]string, len(r.cert.IPAddresses))
+			for i, ip := range r.cert.IPAddresses {
+				ips[i] = ip.String()
+			}
+			fmt.Fprintf(&b, "    ip sans    %s\n", strings.Join(ips, ", "))
+		}
+		fmt.Fprintf(&b, "    serial     %s\n", r.cert.SerialNumber)
+		fmt.Fprintf(&b, "    sig alg    %s\n", r.cert.SignatureAlgorithm)
+		if r.tlsVersion != 0 {
+			fmt.Fprintf(&b, "    tls        %s, %s\n", tls.VersionName(r.tlsVersion), tls.CipherSuiteName(r.cipher))
+		} else {
+			fmt.Fprintf(&b, "    tls        %s\n", dim("n/a (cert file)"))
+		}
+		for i, c := range r.chain {
+			fmt.Fprintf(&b, "    chain[%d]   %s\n", i, certName(c.Subject))
+		}
+	}
+
+	return b.String()
+}
+
+// certName renders a certificate Subject/Issuer compactly: the CommonName when
+// present, otherwise the full RFC2253 distinguished name.
+func certName(n pkix.Name) string {
+	if n.CommonName != "" {
+		return "CN=" + n.CommonName
+	}
+	if s := n.String(); s != "" {
+		return s
+	}
+	return "(none)"
+}

--- a/cmd/muninn/doctor_test.go
+++ b/cmd/muninn/doctor_test.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// makeCert builds a self-signed leaf for tests and returns both the parsed
+// certificate and its PEM encoding. Mirrors internal/tlsutil/expiry_test.go.
+func makeCert(t *testing.T, cn string, dns []string, notAfter time.Time) (*x509.Certificate, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    notAfter.Add(-24 * time.Hour),
+		NotAfter:     notAfter,
+		DNSNames:     dns,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	return cert, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func svcsAllUp() []serviceStatus {
+	return []serviceStatus{
+		{name: "database", port: 8475, up: true, scheme: "https"},
+		{name: "mcp", port: 8750, up: true, scheme: "https"},
+		{name: "web ui", port: 8476, up: true, scheme: "https"},
+	}
+}
+
+func TestFormatDoctor(t *testing.T) {
+	addrs := daemonAddrs{Scheme: "https", RestAddr: "0.0.0.0:8475", MCPAddr: "127.0.0.1:8750", UIAddr: "127.0.0.1:8476"}
+
+	healthy, _ := makeCert(t, "vm-muninndb", []string{"vm-muninndb", "localhost"}, time.Now().Add(300*24*time.Hour))
+	expiring, _ := makeCert(t, "soon", nil, time.Now().Add(10*24*time.Hour))
+	expired, _ := makeCert(t, "old", nil, time.Now().Add(-1*time.Hour))
+
+	cases := []struct {
+		name      string
+		report    doctorReport
+		verbose   bool
+		isTTY     bool
+		want      []string // substrings that must appear
+		notWant   []string // substrings that must NOT appear
+		wantNoESC bool     // assert no ANSI escape leaks
+	}{
+		{
+			name:    "tls disabled, no cert section",
+			report:  doctorReport{svcs: svcsAllUp(), scheme: "http", addrs: daemonAddrs{Scheme: "http", RestAddr: "127.0.0.1:8475"}},
+			want:    []string{"disabled (http)", "running"},
+			notWant: []string{"certificate", "expiry"},
+		},
+		{
+			name:   "https healthy, live socket",
+			report: doctorReport{svcs: svcsAllUp(), scheme: "https", addrs: addrs, cert: healthy, certSource: "live socket", tlsVersion: tls.VersionTLS13, cipher: tls.TLS_AES_128_GCM_SHA256},
+			want:   []string{"enabled (https)", "CN=vm-muninndb", "dns sans", "days remaining", "(from live socket)", "0.0.0.0:8475"},
+		},
+		{
+			name:   "expiring soon",
+			report: doctorReport{svcs: svcsAllUp(), scheme: "https", addrs: addrs, cert: expiring, certSource: "live socket"},
+			want:   []string{"expires in", "days"},
+		},
+		{
+			name:   "expired",
+			report: doctorReport{svcs: svcsAllUp(), scheme: "https", addrs: addrs, cert: expired, certSource: "cert file"},
+			want:   []string{"EXPIRED", "days ago"},
+		},
+		{
+			name:   "https but cert unobtainable",
+			report: doctorReport{svcs: svcsAllUp(), scheme: "https", addrs: addrs, certErr: "could not inspect certificate (boom)"},
+			want:   []string{"could not inspect certificate"},
+		},
+		{
+			name:    "verbose adds detail",
+			report:  doctorReport{svcs: svcsAllUp(), scheme: "https", addrs: addrs, cert: healthy, certSource: "cert file"},
+			verbose: true,
+			want:    []string{"serial", "sig alg", "n/a (cert file)"},
+		},
+		{
+			name:      "non-tty has no ansi or unicode glyphs",
+			report:    doctorReport{svcs: svcsAllUp(), scheme: "https", addrs: addrs, cert: healthy, certSource: "live socket"},
+			isTTY:     false,
+			want:      []string{"[up]"},
+			notWant:   []string{"●", "○", "⚠"},
+			wantNoESC: true,
+		},
+		{
+			name:      "non-tty tls-disabled uses ascii off-marker, not a raw glyph",
+			report:    doctorReport{svcs: svcsAllUp(), scheme: "http", addrs: daemonAddrs{Scheme: "http", RestAddr: "127.0.0.1:8475"}},
+			isTTY:     false,
+			want:      []string{"[off]", "disabled (http)"},
+			notWant:   []string{"○"},
+			wantNoESC: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := formatDoctor(tc.report, tc.verbose, tc.isTTY)
+			for _, w := range tc.want {
+				if !strings.Contains(out, w) {
+					t.Errorf("output missing %q\n--- got ---\n%s", w, out)
+				}
+			}
+			for _, nw := range tc.notWant {
+				if strings.Contains(out, nw) {
+					t.Errorf("output unexpectedly contains %q\n--- got ---\n%s", nw, out)
+				}
+			}
+			if tc.wantNoESC && strings.Contains(out, "\033") {
+				t.Errorf("non-tty output leaked ANSI escape:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestFormatDoctor_NoCertPanic guards the formatter invariant: scheme=="https"
+// with a nil cert (failed dial) must render, not panic.
+func TestFormatDoctor_NoCertPanic(t *testing.T) {
+	r := doctorReport{svcs: svcsAllUp(), scheme: "https", addrs: daemonAddrs{Scheme: "https"}, cert: nil, certErr: "boom"}
+	_ = formatDoctor(r, true, true)
+}
+
+func TestGatherDoctor_LiveCertRewritesToLoopback(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MUNINNDB_DATA", tmp)
+	if err := writeAddrsFile(tmp, daemonAddrs{Scheme: "https", RestAddr: "0.0.0.0:8475", MCPAddr: "127.0.0.1:8750", UIAddr: "127.0.0.1:8476"}); err != nil {
+		t.Fatal(err)
+	}
+
+	origProbe := probeServicesFn
+	t.Cleanup(func() { probeServicesFn = origProbe })
+	probeServicesFn = svcsAllUp
+
+	cert, _ := makeCert(t, "live", []string{"live"}, time.Now().Add(300*24*time.Hour))
+	origDial := dialServedCertFn
+	t.Cleanup(func() { dialServedCertFn = origDial })
+	var dialed string
+	dialServedCertFn = func(hostport string) (*x509.Certificate, uint16, uint16, error) {
+		dialed = hostport
+		return cert, tls.VersionTLS13, tls.TLS_AES_128_GCM_SHA256, nil
+	}
+
+	r := gatherDoctor()
+	if dialed != "127.0.0.1:8475" {
+		t.Errorf("dial must target loopback (recorded host was 0.0.0.0), got %q", dialed)
+	}
+	if r.certSource != "live socket" || r.cert == nil {
+		t.Errorf("expected live-socket cert, got source=%q cert=%v", r.certSource, r.cert)
+	}
+}
+
+func TestGatherDoctor_FileFallbackWhenDialFails(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MUNINNDB_DATA", tmp)
+	if err := writeAddrsFile(tmp, daemonAddrs{Scheme: "https", RestAddr: "127.0.0.1:8475"}); err != nil {
+		t.Fatal(err)
+	}
+	origProbe := probeServicesFn
+	t.Cleanup(func() { probeServicesFn = origProbe })
+	probeServicesFn = svcsAllUp
+
+	origDial := dialServedCertFn
+	t.Cleanup(func() { dialServedCertFn = origDial })
+	dialServedCertFn = func(string) (*x509.Certificate, uint16, uint16, error) {
+		return nil, 0, 0, errors.New("connection refused")
+	}
+
+	cert, pemBytes := makeCert(t, "from-file", []string{"from-file"}, time.Now().Add(200*24*time.Hour))
+	certPath := filepath.Join(tmp, "cert.pem")
+	if err := os.WriteFile(certPath, pemBytes, 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MUNINN_TLS_CERT", certPath)
+
+	r := gatherDoctor()
+	if r.certSource != "cert file" {
+		t.Fatalf("expected cert-file fallback, got source=%q certErr=%q", r.certSource, r.certErr)
+	}
+	if r.cert == nil || r.cert.Subject.CommonName != cert.Subject.CommonName {
+		t.Errorf("wrong cert from file: %v", r.cert)
+	}
+	if r.tlsVersion != 0 {
+		t.Errorf("cert-file path must not report a negotiated TLS version, got %d", r.tlsVersion)
+	}
+}
+
+func TestGatherDoctor_CertErrWhenNothingAvailable(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MUNINNDB_DATA", tmp)
+	if err := writeAddrsFile(tmp, daemonAddrs{Scheme: "https", RestAddr: "127.0.0.1:8475"}); err != nil {
+		t.Fatal(err)
+	}
+	origProbe := probeServicesFn
+	t.Cleanup(func() { probeServicesFn = origProbe })
+	probeServicesFn = svcsAllUp
+
+	origDial := dialServedCertFn
+	t.Cleanup(func() { dialServedCertFn = origDial })
+	dialServedCertFn = func(string) (*x509.Certificate, uint16, uint16, error) {
+		return nil, 0, 0, errors.New("refused")
+	}
+	t.Setenv("MUNINN_TLS_CERT", "")
+
+	r := gatherDoctor()
+	if r.certErr == "" {
+		t.Error("expected certErr when neither live socket nor cert file is available")
+	}
+}
+
+// TestGatherDoctor_CertErrWhenEnvFileBadAndServerStopped covers the documented
+// offline-inspection path: server stopped (scheme unknown) but the operator set
+// MUNINN_TLS_CERT to an unreadable file — the failure must be surfaced, not
+// swallowed.
+func TestGatherDoctor_CertErrWhenEnvFileBadAndServerStopped(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MUNINNDB_DATA", tmp) // no addrs file → server stopped, scheme ""
+	origProbe := probeServicesFn
+	t.Cleanup(func() { probeServicesFn = origProbe })
+	probeServicesFn = func() []serviceStatus {
+		return []serviceStatus{{name: "database"}, {name: "mcp"}, {name: "web ui"}}
+	}
+
+	bad := filepath.Join(tmp, "bad.pem")
+	if err := os.WriteFile(bad, []byte("not a pem"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MUNINN_TLS_CERT", bad)
+
+	r := gatherDoctor()
+	if r.scheme != "" {
+		t.Fatalf("expected unknown scheme for a stopped server, got %q", r.scheme)
+	}
+	if r.certErr == "" {
+		t.Error("expected certErr when MUNINN_TLS_CERT points at an unreadable cert, even with the server stopped")
+	}
+}
+
+// TestGatherDoctor_LiveDialUsesDefaultPortWhenSidecarAbsent covers the
+// systemd-managed daemon with no muninn.addrs sidecar: scheme is recovered from
+// the probe, RestAddr is empty, and the live dial must still target the default
+// REST port on loopback.
+func TestGatherDoctor_LiveDialUsesDefaultPortWhenSidecarAbsent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MUNINNDB_DATA", tmp) // no addrs file → RestAddr ""
+	origProbe := probeServicesFn
+	t.Cleanup(func() { probeServicesFn = origProbe })
+	probeServicesFn = svcsAllUp // web-ui probe reports https → scheme recovered
+
+	cert, _ := makeCert(t, "sys", []string{"sys"}, time.Now().Add(100*24*time.Hour))
+	origDial := dialServedCertFn
+	t.Cleanup(func() { dialServedCertFn = origDial })
+	var dialed string
+	dialServedCertFn = func(hostport string) (*x509.Certificate, uint16, uint16, error) {
+		dialed = hostport
+		return cert, tls.VersionTLS13, tls.TLS_AES_128_GCM_SHA256, nil
+	}
+
+	r := gatherDoctor()
+	if dialed != "127.0.0.1:8475" {
+		t.Errorf("expected dial to default REST port when sidecar absent, got %q", dialed)
+	}
+	if r.certSource != "live socket" {
+		t.Errorf("expected live-socket cert via default port, got %q", r.certSource)
+	}
+}
+
+func TestCertFromEnvFile_LeafFirstWithChain(t *testing.T) {
+	tmp := t.TempDir()
+	_, leafPEM := makeCert(t, "leaf", []string{"leaf"}, time.Now().Add(100*24*time.Hour))
+	_, interPEM := makeCert(t, "intermediate", nil, time.Now().Add(3650*24*time.Hour))
+	bundle := append(append([]byte{}, leafPEM...), interPEM...)
+	path := filepath.Join(tmp, "fullchain.pem")
+	if err := os.WriteFile(path, bundle, 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MUNINN_TLS_CERT", path)
+
+	leaf, chain, err := certFromEnvFile()
+	if err != nil {
+		t.Fatalf("certFromEnvFile: %v", err)
+	}
+	if leaf.Subject.CommonName != "leaf" {
+		t.Errorf("first CERTIFICATE block must be the leaf, got CN=%q", leaf.Subject.CommonName)
+	}
+	if len(chain) != 1 || chain[0].Subject.CommonName != "intermediate" {
+		t.Errorf("expected one intermediate in chain, got %v", chain)
+	}
+}
+
+// TestDialServedCert_Live exercises the real production dialer end-to-end
+// against a live TLS listener.
+func TestDialServedCert_Live(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer srv.Close()
+
+	cert, ver, suite, err := dialServedCert(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dialServedCert: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("expected a served certificate")
+	}
+	if ver == 0 || suite == 0 {
+		t.Errorf("expected negotiated version+cipher, got ver=%d suite=%d", ver, suite)
+	}
+}

--- a/cmd/muninn/doctor_test.go
+++ b/cmd/muninn/doctor_test.go
@@ -56,7 +56,7 @@ func svcsAllUp() []serviceStatus {
 func TestFormatDoctor(t *testing.T) {
 	addrs := daemonAddrs{Scheme: "https", RestAddr: "0.0.0.0:8475", MCPAddr: "127.0.0.1:8750", UIAddr: "127.0.0.1:8476"}
 
-	healthy, _ := makeCert(t, "vm-muninndb", []string{"vm-muninndb", "localhost"}, time.Now().Add(300*24*time.Hour))
+	healthy, _ := makeCert(t, "muninn.example", []string{"muninn.example", "localhost"}, time.Now().Add(300*24*time.Hour))
 	expiring, _ := makeCert(t, "soon", nil, time.Now().Add(10*24*time.Hour))
 	expired, _ := makeCert(t, "old", nil, time.Now().Add(-1*time.Hour))
 
@@ -78,7 +78,7 @@ func TestFormatDoctor(t *testing.T) {
 		{
 			name:   "https healthy, live socket",
 			report: doctorReport{svcs: svcsAllUp(), scheme: "https", addrs: addrs, cert: healthy, certSource: "live socket", tlsVersion: tls.VersionTLS13, cipher: tls.TLS_AES_128_GCM_SHA256},
-			want:   []string{"enabled (https)", "CN=vm-muninndb", "dns sans", "days remaining", "(from live socket)", "0.0.0.0:8475"},
+			want:   []string{"enabled (https)", "CN=muninn.example", "dns sans", "days remaining", "(from live socket)", "0.0.0.0:8475"},
 		},
 		{
 			name:   "expiring soon",

--- a/cmd/muninn/help.go
+++ b/cmd/muninn/help.go
@@ -98,6 +98,18 @@ var subcommandHelp = map[string]func(){
 				"MUNINNDB_ADMIN_URL=https://host:8475 muninn status   # TLS: override probe URLs",
 			})
 	},
+	"doctor": func() {
+		printSubcommandUsage("doctor", "diagnose TLS state, bind addresses, and certificate",
+			"muninn doctor [-v]",
+			[][2]string{
+				{"-v, --verbose", "Show SANs, serial, signature algorithm, TLS version/cipher, chain"},
+			},
+			[]string{
+				"muninn doctor",
+				"muninn doctor -v",
+				"MUNINN_TLS_CERT=/path/cert.pem muninn doctor   # inspect cert while server is stopped",
+			})
+	},
 	"shell": func() {
 		printSubcommandUsage("shell", "interactive memory shell", "muninn shell", nil,
 			[]string{
@@ -312,6 +324,7 @@ func printHelp() {
 	fmt.Printf("  %-32s %s\n", cyan("muninn stop"), "Stop the running server")
 	fmt.Printf("  %-32s %s\n", cyan("muninn restart"), "Stop and restart")
 	fmt.Printf("  %-32s %s\n", cyan("muninn status"), "Show which services are running")
+	fmt.Printf("  %-32s %s\n", cyan("muninn doctor"), "Diagnose TLS state, bind addresses, and cert")
 	fmt.Printf("  %-32s %s\n", cyan("muninn"), "Status check / drop into interactive shell")
 	fmt.Printf("  %-32s %s\n", cyan("muninn shell"), "Interactive shell (alias: bare muninn when running)")
 	fmt.Printf("  %-32s %s\n", cyan("muninn logs"), "Show last 25 lines + tail")

--- a/cmd/muninn/main.go
+++ b/cmd/muninn/main.go
@@ -57,6 +57,8 @@ func main() {
 		runStopService("web")
 	case "status":
 		runStatus()
+	case "doctor":
+		runDoctor(rest)
 	case "exec":
 		runExec(rest)
 	case "dream":

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -42,6 +43,7 @@ import (
 	"github.com/scrypster/muninndb/internal/replication"
 	"github.com/scrypster/muninndb/internal/storage"
 	"github.com/scrypster/muninndb/internal/storage/migrate"
+	"github.com/scrypster/muninndb/internal/tlsutil"
 	grpcpkg "github.com/scrypster/muninndb/internal/transport/grpc"
 	"github.com/scrypster/muninndb/internal/transport/mbp"
 	"github.com/scrypster/muninndb/internal/transport/rest"
@@ -857,11 +859,24 @@ func runServer() {
 			slog.Error("tls: failed to load certificate", "cert", *tlsCert, "err", err)
 			os.Exit(1)
 		}
+
+		logAttrs := []any{"cert", *tlsCert}
+		if leaf, perr := x509.ParseCertificate(cert.Certificate[0]); perr == nil {
+			remaining := tlsutil.CheckCertExpiry(slog.Default(), leaf, "client-facing")
+			logAttrs = append(logAttrs,
+				"subject", leaf.Subject.CommonName,
+				"not_after", leaf.NotAfter.UTC().Format(time.RFC3339),
+				"days_remaining", tlsutil.DaysRemaining(remaining))
+		} else {
+			slog.Warn("tls: failed to parse certificate leaf for expiry check",
+				"cert", *tlsCert, "err", perr)
+		}
+
 		clientTLS = &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			MinVersion:   tls.VersionTLS12,
 		}
-		slog.Info("tls: client-facing TLS enabled", "cert", *tlsCert)
+		slog.Info("tls: client-facing TLS enabled", logAttrs...)
 	}
 
 	// Validate address flags early so misconfigurations are caught before any

--- a/cmd/muninn/status.go
+++ b/cmd/muninn/status.go
@@ -73,6 +73,32 @@ type serviceStatus struct {
 	note   string // optional: "not responding"
 }
 
+// portFromAddr extracts the port from a "host:port" address, returning fallback
+// when addr is empty or unparseable.
+func portFromAddr(addr, fallback string) string {
+	if addr != "" {
+		if _, p, err := net.SplitHostPort(addr); err == nil && p != "" {
+			return p
+		}
+	}
+	return fallback
+}
+
+// resolveScheme returns the daemon's client-facing scheme. When the sidecar
+// predates the Scheme field (empty), it recovers the scheme the web-ui health
+// probe actually reached, so a legacy TLS daemon is not misreported as http.
+func resolveScheme(addrs daemonAddrs, svcs []serviceStatus) string {
+	if addrs.Scheme != "" {
+		return addrs.Scheme
+	}
+	for _, s := range svcs {
+		if s.name == "web ui" && s.scheme != "" {
+			return s.scheme
+		}
+	}
+	return ""
+}
+
 // overallState computes the aggregate state from individual service statuses.
 func overallState(svcs []serviceStatus) runState {
 	up, down := 0, 0
@@ -160,20 +186,9 @@ func probeOnce(url string, insecure bool) bool {
 // actual addresses (and scheme) the daemon bound to; empty fields fall back to
 // the default ports and an "http" scheme.
 func probeServicesWithAddrs(addrs daemonAddrs) []serviceStatus {
-	// portFrom extracts the port from an "host:port" address string.
-	// Returns fallback when addr is empty or unparseable.
-	portFrom := func(addr, fallback string) string {
-		if addr != "" {
-			if _, p, err := net.SplitHostPort(addr); err == nil && p != "" {
-				return p
-			}
-		}
-		return fallback
-	}
-
-	restPort := portFrom(addrs.RestAddr, "8475")
-	mcpPort := portFrom(addrs.MCPAddr, "8750")
-	uiPort := portFrom(addrs.UIAddr, "8476")
+	restPort := portFromAddr(addrs.RestAddr, "8475")
+	mcpPort := portFromAddr(addrs.MCPAddr, "8750")
+	uiPort := portFromAddr(addrs.UIAddr, "8476")
 
 	restPortInt, _ := strconv.Atoi(restPort)
 	mcpPortInt, _ := strconv.Atoi(mcpPort)
@@ -344,15 +359,7 @@ func printStatusDisplay(compact bool) runState {
 		if state == stateRunning {
 			fmt.Println()
 			addrs, _ := readAddrsFile(defaultDataDir())
-			// If the daemon predates the muninn.addrs scheme field, fall back
-			// to the scheme the probe actually reached the Web UI on.
-			if addrs.Scheme == "" {
-				for _, s := range svcs {
-					if s.name == "web ui" && s.scheme != "" {
-						addrs.Scheme = s.scheme
-					}
-				}
-			}
+			addrs.Scheme = resolveScheme(addrs, svcs)
 			lines := webUIDisplay(addrs)
 			fmt.Printf("  Web UI → %s\n", lines[0])
 			for _, l := range lines[1:] {

--- a/internal/replication/tls.go
+++ b/internal/replication/tls.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"net"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/scrypster/muninndb/internal/config"
+	"github.com/scrypster/muninndb/internal/tlsutil"
 )
 
 // ClusterTLS manages TLS certificates for inter-node communication.
@@ -88,6 +90,12 @@ func (ct *ClusterTLS) Bootstrap(nodeID, dataDir string) error {
 		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 		if err != nil {
 			return fmt.Errorf("cluster-tls: load node cert: %w", err)
+		}
+		if leaf, perr := x509.ParseCertificate(cert.Certificate[0]); perr == nil {
+			tlsutil.CheckCertExpiry(slog.Default(), leaf, "cluster-node")
+		} else {
+			slog.Warn("cluster-tls: failed to parse node cert leaf for expiry check",
+				"cert", certFile, "err", perr)
 		}
 		ct.mu.Lock()
 		ct.nodeCert = &cert
@@ -260,6 +268,8 @@ func (ct *ClusterTLS) generateNodeCert(nodeID, certPath, keyPath string) error {
 	ct.mu.Lock()
 	ct.nodeCert = &tlsCert
 	ct.mu.Unlock()
+
+	tlsutil.CheckCertExpiry(slog.Default(), template, "cluster-node-generated")
 	return nil
 }
 

--- a/internal/tlsutil/expiry.go
+++ b/internal/tlsutil/expiry.go
@@ -1,0 +1,57 @@
+// Package tlsutil holds small TLS helpers shared between the main server and
+// the cluster-replication subsystem.
+package tlsutil
+
+import (
+	"crypto/x509"
+	"log/slog"
+	"time"
+)
+
+// ExpiryWarnWindow is the threshold below which a certificate is considered
+// "expiring soon". 30 days matches Let's Encrypt's renewal window and is the
+// de-facto standard across operational tooling.
+const ExpiryWarnWindow = 30 * 24 * time.Hour
+
+// DaysRemaining converts a positive duration to whole days, rounded up so a
+// duration of 23h59m reports 1 (not 0). Returns 0 for non-positive input. The
+// ceiling bias matches operator expectations: "you have N days to act."
+func DaysRemaining(d time.Duration) int {
+	if d <= 0 {
+		return 0
+	}
+	day := 24 * time.Hour
+	return int((d + day - 1) / day)
+}
+
+// CheckCertExpiry inspects cert.NotAfter and logs at the appropriate severity:
+//
+//   - Error when the certificate is already expired. The caller decides whether
+//     to abort; existing TLS connections may still function until the cert is
+//     actually rejected by a peer, so failing loud (not shut) is intentional.
+//   - Warn  when expiry is within ExpiryWarnWindow.
+//   - Silent otherwise; the caller may attach expiry fields to its own Info
+//     line so an operator can always see them at startup.
+//
+// The duration until NotAfter is returned (negative if already expired) so the
+// caller can include it in its own logging without re-computing.
+func CheckCertExpiry(logger *slog.Logger, cert *x509.Certificate, label string) time.Duration {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	remaining := time.Until(cert.NotAfter)
+	attrs := []any{
+		"label", label,
+		"subject", cert.Subject.CommonName,
+		"not_after", cert.NotAfter.UTC().Format(time.RFC3339),
+	}
+	switch {
+	case remaining <= 0:
+		logger.Error("tls: certificate is expired",
+			append(attrs, "expired_ago", (-remaining).Truncate(time.Hour).String())...)
+	case remaining < ExpiryWarnWindow:
+		logger.Warn("tls: certificate expires soon",
+			append(attrs, "days_remaining", DaysRemaining(remaining))...)
+	}
+	return remaining
+}

--- a/internal/tlsutil/expiry_test.go
+++ b/internal/tlsutil/expiry_test.go
@@ -1,0 +1,144 @@
+package tlsutil
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"log/slog"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestCert(t *testing.T, notAfter time.Time) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-cert"},
+		NotBefore:    notAfter.Add(-24 * time.Hour),
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	return cert
+}
+
+// recordHandler is a minimal slog.Handler that captures the highest severity
+// and the rendered messages. Avoids depending on slogtest or a JSON parser.
+type recordHandler struct {
+	buf      *bytes.Buffer
+	maxLevel slog.Level
+}
+
+func (h *recordHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *recordHandler) Handle(_ context.Context, r slog.Record) error {
+	if r.Level > h.maxLevel {
+		h.maxLevel = r.Level
+	}
+	h.buf.WriteString(r.Message)
+	h.buf.WriteByte('\n')
+	return nil
+}
+func (h *recordHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *recordHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func newRecorder() (*slog.Logger, *recordHandler) {
+	h := &recordHandler{buf: &bytes.Buffer{}, maxLevel: slog.LevelDebug - 1}
+	return slog.New(h), h
+}
+
+func TestCheckCertExpiry_Healthy(t *testing.T) {
+	cert := newTestCert(t, time.Now().Add(365*24*time.Hour))
+	logger, rec := newRecorder()
+
+	remaining := CheckCertExpiry(logger, cert, "test")
+
+	if remaining <= 0 {
+		t.Fatalf("expected positive remaining, got %v", remaining)
+	}
+	if rec.maxLevel >= slog.LevelWarn {
+		t.Fatalf("expected silent for healthy cert, got level %v with output: %q",
+			rec.maxLevel, rec.buf.String())
+	}
+}
+
+func TestCheckCertExpiry_Warn(t *testing.T) {
+	cert := newTestCert(t, time.Now().Add(10*24*time.Hour))
+	logger, rec := newRecorder()
+
+	remaining := CheckCertExpiry(logger, cert, "test")
+
+	if remaining <= 0 || remaining >= ExpiryWarnWindow {
+		t.Fatalf("expected 0 < remaining < ExpiryWarnWindow, got %v", remaining)
+	}
+	if rec.maxLevel != slog.LevelWarn {
+		t.Fatalf("expected Warn level, got %v with output: %q", rec.maxLevel, rec.buf.String())
+	}
+	if !strings.Contains(rec.buf.String(), "expires soon") {
+		t.Fatalf("expected 'expires soon' in log output, got: %q", rec.buf.String())
+	}
+}
+
+func TestCheckCertExpiry_Expired(t *testing.T) {
+	cert := newTestCert(t, time.Now().Add(-1*time.Hour))
+	logger, rec := newRecorder()
+
+	remaining := CheckCertExpiry(logger, cert, "test")
+
+	if remaining > 0 {
+		t.Fatalf("expected non-positive remaining for expired cert, got %v", remaining)
+	}
+	if rec.maxLevel != slog.LevelError {
+		t.Fatalf("expected Error level, got %v with output: %q", rec.maxLevel, rec.buf.String())
+	}
+	if !strings.Contains(rec.buf.String(), "expired") {
+		t.Fatalf("expected 'expired' in log output, got: %q", rec.buf.String())
+	}
+}
+
+func TestCheckCertExpiry_NilLogger(t *testing.T) {
+	// Must not panic — falls back to slog.Default(). We only assert no panic
+	// and a sensible return value; output goes to the global default handler.
+	cert := newTestCert(t, time.Now().Add(365*24*time.Hour))
+	remaining := CheckCertExpiry(nil, cert, "test")
+	if remaining <= 0 {
+		t.Fatalf("expected positive remaining, got %v", remaining)
+	}
+}
+
+func TestDaysRemaining(t *testing.T) {
+	cases := []struct {
+		name string
+		in   time.Duration
+		want int
+	}{
+		{"zero", 0, 0},
+		{"negative", -5 * time.Hour, 0},
+		{"sub-day rounds up to 1", 23*time.Hour + 59*time.Minute, 1},
+		{"exactly one day", 24 * time.Hour, 1},
+		{"one day plus a second rounds up to 2", 24*time.Hour + time.Second, 2},
+		{"ten days", 10 * 24 * time.Hour, 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DaysRemaining(tc.in); got != tc.want {
+				t.Errorf("DaysRemaining(%v) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds **`muninn doctor`** — a TLS/connectivity self-describe command implementing **gap 3 of #443** ("the server cannot self-describe its TLS state"). Operators currently reverse-engineer "is TLS on? which cert? bound where? when does it expire?" from env vars and unit files.

```
  muninn doctor

  server     ●  running
  TLS        ●  enabled (https)
  bind       database  0.0.0.0:8475
             mcp       0.0.0.0:8750
             web ui    0.0.0.0:8476

  certificate  (from live socket)
    subject    CN=muninn.example
    issuer     CN=Example Root CA
    dns sans   muninn.example, muninn
    valid      2026-05-01 → 2027-05-01 (UTC)
    expiry     ●  326 days remaining
```

`-v` adds IP SANs, serial, signature algorithm, the negotiated TLS version/cipher, and the certificate chain.

## How

- **Cert source priority:** (a) the **live TLS socket** — ground truth, what clients actually receive, dialed on loopback since the recorded bind host may be `0.0.0.0` (or absent under systemd, in which case it falls back to the default REST port); (b) the **`MUNINN_TLS_CERT` file** — cert-only PEM parse (never the private key), so a *stopped* server's configured cert can still be inspected offline.
- **Reuses `internal/tlsutil`** (`DaysRemaining`, `ExpiryWarnWindow`) for expiry classification — deliberately **not** `CheckCertExpiry`, which logs via slog and would corrupt the formatted stdout.
- Factors two shared helpers out of `status.go` (`resolveScheme`, `portFromAddr`) now used by **both** `status` and `doctor`, removing a verbatim scheme-recovery duplication.
- Pure gather/format split (`gatherDoctor` does the only I/O; `formatDoctor` is pure) with an injectable dial seam — see tests.

## Tests

`cmd/muninn/doctor_test.go`: formatter matrix (TLS off / healthy / expiring / expired / unobtainable / verbose / non-TTY ASCII degradation), `gatherDoctor` with stubbed probe+dial (asserts the `0.0.0.0`→loopback rewrite, the default-port fallback when the sidecar is absent, and that `MUNINN_TLS_CERT` errors surface even with the server stopped), PEM leaf-first chain selection, and a live smoke test against `httptest.NewTLSServer`. `gofmt`/`vet` clean; verified manually against a live TLS server.

## ⚠️ Stacked on #456

This branches off `feat/443-cert-expiry-warn` for the `internal/tlsutil` dependency, so this PR's diff currently **includes #456's commit** (`feat(tls): warn at startup when cert nears expiry`). **Review only the doctor commits**; rebase onto `develop` once #456 merges.
