### PR TITLE
chore: bump go directive to 1.26.4 to clear govulncheck stdlib advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scrypster/muninndb
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/bits-and-blooms/bloom/v3 v3.7.1


### PR DESCRIPTION
## Problem

The **Vulnerability scan** CI job (`govulncheck ./...`) is failing on `develop` and on every open PR — `govulncheck@latest` now reports two Go **standard-library** advisories, both reachable from existing code:

| Advisory | Package | Fixed in | Reachable from |
|---|---|---|---|
| [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` (inefficient candidate hostname parsing) | go1.26.4 | `internal/mcp/server.go`, `internal/transport/grpc/engine_adapter.go` |
| [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` (arbitrary inputs unescaped in errors) | go1.26.4 | `internal/mcp/server.go` |

`go.mod` pins `go 1.26.3`, and CI's `setup-go` uses `go-version-file: go.mod`, so the scan builds against the vulnerable stdlib.

## Fix

Bump the `go` directive `1.26.3 → 1.26.4`. CI then builds against the patched standard library. No code changes; no new `toolchain` directive.

## Verification

```
$ govulncheck ./...   # before: go.mod @ 1.26.3
Your code is affected by 2 vulnerabilities from the Go standard library.  (exit 3)

$ govulncheck ./...   # after: go.mod @ 1.26.4
No vulnerabilities found.   (exit 0)
```

`go build ./...` succeeds under go1.26.4.