### PR TITLE
feat(cli): TLS setup in 'muninn init' + scheme-aware client URLs (#443 gaps 1 & 5)

### DIFF
--- a/cmd/muninn/coverage_hardening_test.go
+++ b/cmd/muninn/coverage_hardening_test.go
@@ -786,7 +786,7 @@ func TestRunNonInteractiveInit(t *testing.T) {
 	t.Setenv("MUNINNDB_DATA", filepath.Join(home, "data"))
 
 	out := captureStdout(func() {
-		runNonInteractiveInit("http://127.0.0.1:8750/mcp", "manual", "", false, true, true)
+		runNonInteractiveInit("manual", "", false, true, true, "", "")
 	})
 	if !strings.Contains(out, "Manual") && !strings.Contains(out, "manual") &&
 		!strings.Contains(out, "mcpServers") && !strings.Contains(out, "curl") {
@@ -1417,7 +1417,7 @@ func TestRunNonInteractiveInit_WithTools(t *testing.T) {
 	t.Setenv("MUNINNDB_DATA", filepath.Join(home, "data"))
 
 	out := captureStdout(func() {
-		runNonInteractiveInit("http://127.0.0.1:8750/mcp", "vscode,manual", "", true, true, true)
+		runNonInteractiveInit("vscode,manual", "", true, true, true, "", "")
 	})
 	_ = out
 }
@@ -1429,7 +1429,7 @@ func TestRunNonInteractiveInit_WithToken(t *testing.T) {
 	t.Setenv("MUNINNDB_DATA", filepath.Join(home, "data"))
 
 	out := captureStdout(func() {
-		runNonInteractiveInit("http://127.0.0.1:8750/mcp", "", "mdb_customtoken", false, true, true)
+		runNonInteractiveInit("", "mdb_customtoken", false, true, true, "", "")
 	})
 	if !strings.Contains(out, "Token") || !strings.Contains(out, "mcp.token") {
 		t.Logf("output: %s", out)
@@ -1444,7 +1444,7 @@ func TestRunNonInteractiveInit_GenerateToken(t *testing.T) {
 	t.Setenv("MUNINNDB_DATA", filepath.Join(home, ".muninn", "data"))
 
 	out := captureStdout(func() {
-		runNonInteractiveInit("http://127.0.0.1:8750/mcp", "", "", false, true, true)
+		runNonInteractiveInit("", "", false, true, true, "", "")
 	})
 	_ = out
 }
@@ -2199,7 +2199,7 @@ func TestRunStatus_Stopped(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// init.go: promptClaudeMD (stdin-based) 
+// init.go: promptClaudeMD (stdin-based)
 // ---------------------------------------------------------------------------
 
 func TestPromptClaudeMD_Yes(t *testing.T) {

--- a/cmd/muninn/envfile.go
+++ b/cmd/muninn/envfile.go
@@ -34,7 +34,7 @@ func buildEnvFileContent(embedProvider, enrichURL string) string {
 	allEmbed := []embedEntry{
 		{"ollama", "MUNINN_OLLAMA_URL", "ollama://localhost:11434/nomic-embed-text"},
 		{"openai", "MUNINN_OPENAI_KEY", "sk-..."},
-		{"openai", "MUNINN_OPENAI_URL", ""},  // optional, always commented
+		{"openai", "MUNINN_OPENAI_URL", ""}, // optional, always commented
 		{"voyage", "MUNINN_VOYAGE_KEY", "pa-..."},
 		{"cohere", "MUNINN_COHERE_KEY", "..."},
 		{"google", "MUNINN_GOOGLE_KEY", "..."},
@@ -125,35 +125,69 @@ func writeEnvFileTo(path, embedProvider, enrichURL string) (bool, error) {
 	if _, err := os.Lstat(path); err == nil {
 		return false, nil
 	}
-
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return false, err
-	}
-
-	content := buildEnvFileContent(embedProvider, enrichURL)
-
-	// Atomic write: temp file → chmod 0600 → rename.
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".muninn_env_*.tmp")
-	if err != nil {
-		return false, err
-	}
-	tmpName := tmp.Name()
-	defer os.Remove(tmpName) // clean up on failure
-
-	if _, err := tmp.WriteString(content); err != nil {
-		tmp.Close()
-		return false, err
-	}
-	if err := tmp.Close(); err != nil {
-		return false, err
-	}
-	if err := os.Chmod(tmpName, 0600); err != nil {
-		return false, err
-	}
-	if err := os.Rename(tmpName, path); err != nil {
+	if err := atomicWriteFile(path, buildEnvFileContent(embedProvider, enrichURL)); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+// atomicWriteFile writes content to path via a temp file → chmod 0600 → rename,
+// creating the parent directory if needed. The 0600 mode matches mcp.token and
+// the env file (both may hold secrets/paths).
+func atomicWriteFile(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".muninn_env_*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // clean up on failure
+	if _, err := tmp.WriteString(content); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// upsertEnvFileVar sets `key=value` as an active line in the env file at path,
+// replacing any existing line for key — commented or active, with or without an
+// "export " prefix (matching loadEnvFile's parsing) — and otherwise appending
+// it. All other lines are preserved. The file is created if absent; the write
+// is atomic at 0600. The literal "=" in the match guards against a key that is
+// a prefix of a longer one (MUNINN_TLS_CERT vs MUNINN_TLS_CERTIFICATE).
+func upsertEnvFileVar(path, key, value string) error {
+	content := ""
+	if b, err := os.ReadFile(path); err == nil {
+		content = string(b)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	newLine := key + "=" + value
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		t := strings.TrimSpace(line)
+		t = strings.TrimSpace(strings.TrimPrefix(t, "#"))
+		t = strings.TrimPrefix(t, "export ")
+		if strings.HasPrefix(t, key+"=") {
+			lines[i] = newLine
+			return atomicWriteFile(path, strings.Join(lines, "\n"))
+		}
+	}
+	// Not found — append, normalizing to exactly one trailing newline.
+	base := strings.TrimRight(content, "\n")
+	if base != "" {
+		base += "\n"
+	}
+	return atomicWriteFile(path, base+newLine+"\n")
 }
 
 const envFileName = ".muninn/muninn.env"

--- a/cmd/muninn/envfile.go
+++ b/cmd/muninn/envfile.go
@@ -79,7 +79,7 @@ func buildEnvFileContent(embedProvider, enrichURL string) string {
 	b.WriteString("# ── Network ──────────────────────────────────────────────\n")
 	b.WriteString("# MUNINN_LISTEN_HOST=127.0.0.1\n")
 	b.WriteString("# MUNINN_UI_ADDR=127.0.0.1:8476\n")
-	b.WriteString("# MUNINN_MCP_URL=http://127.0.0.1:8750/mcp\n")
+	fmt.Fprintf(&b, "# MUNINN_MCP_URL=%s://127.0.0.1:%s/mcp\n", tlsSchemeFromEnv(), defaultMCPPort)
 	b.WriteString("# MUNINN_CORS_ORIGINS=\n")
 	b.WriteString("\n")
 

--- a/cmd/muninn/envfile.go
+++ b/cmd/muninn/envfile.go
@@ -157,13 +157,56 @@ func atomicWriteFile(path, content string) error {
 	return os.Rename(tmpName, path)
 }
 
-// upsertEnvFileVar sets `key=value` as an active line in the env file at path,
-// replacing any existing line for key — commented or active, with or without an
-// "export " prefix (matching loadEnvFile's parsing) — and otherwise appending
-// it. All other lines are preserved. The file is created if absent; the write
-// is atomic at 0600. The literal "=" in the match guards against a key that is
-// a prefix of a longer one (MUNINN_TLS_CERT vs MUNINN_TLS_CERTIFICATE).
+// upsertEnvFileVar sets `key=value` as an active line in the env file at path.
+// See upsertEnvFileVars for the matching rules.
 func upsertEnvFileVar(path, key, value string) error {
+	return upsertEnvFileVars(path, [][2]string{{key, value}})
+}
+
+// envLineMatchesKey reports whether an env-file line is, or would activate to,
+// an assignment of key. It mirrors loadEnvFile's parsing exactly — optional
+// "export " prefix, whitespace around the key ("KEY = value") — plus one
+// leading "#" so a commented template line can be activated in place. Mirroring
+// the loader matters: any form the loader accepts that this misses would leave
+// a stale assignment behind that (first-active-line-wins) shadows the new one.
+func envLineMatchesKey(line, key string) bool {
+	t := strings.TrimSpace(line)
+	t = strings.TrimSpace(strings.TrimPrefix(t, "#"))
+	t = strings.TrimPrefix(t, "export ")
+	k, _, ok := strings.Cut(t, "=")
+	return ok && strings.TrimSpace(k) == key
+}
+
+// activeEnvLineMatchesKey is envLineMatchesKey restricted to active
+// (uncommented) assignments — the ones loadEnvFile would actually apply.
+func activeEnvLineMatchesKey(line, key string) bool {
+	t := strings.TrimSpace(line)
+	if strings.HasPrefix(t, "#") {
+		return false
+	}
+	t = strings.TrimPrefix(t, "export ")
+	k, _, ok := strings.Cut(t, "=")
+	return ok && strings.TrimSpace(k) == key
+}
+
+// upsertEnvFileVars applies the given key=value pairs to the env file at path
+// in ONE read + ONE atomic 0600 write, so related settings (a TLS cert/key
+// pair) can never be persisted half. For each key the first matching line —
+// commented or active, with or without an "export " prefix, with or without
+// spaces around the "=" — is replaced; keys with no match are appended. All
+// other lines are preserved (including their CRLF endings). The file is
+// created if absent. A symlinked or oversized file is refused: the loader
+// would reject both, so writing through them would persist settings the
+// daemon never sees (and destroy the symlink).
+func upsertEnvFileVars(path string, pairs [][2]string) error {
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s is a symlink — refusing to replace it (the daemon also refuses to load symlinked env files)", path)
+		}
+		if info.Size() > envFileMaxBytes {
+			return fmt.Errorf("%s exceeds the %d-byte limit the daemon will load — not writing", path, envFileMaxBytes)
+		}
+	}
 	content := ""
 	if b, err := os.ReadFile(path); err == nil {
 		content = string(b)
@@ -171,23 +214,48 @@ func upsertEnvFileVar(path, key, value string) error {
 		return err
 	}
 
-	newLine := key + "=" + value
 	lines := strings.Split(content, "\n")
-	for i, line := range lines {
-		t := strings.TrimSpace(line)
-		t = strings.TrimSpace(strings.TrimPrefix(t, "#"))
-		t = strings.TrimPrefix(t, "export ")
-		if strings.HasPrefix(t, key+"=") {
-			lines[i] = newLine
-			return atomicWriteFile(path, strings.Join(lines, "\n"))
+	var missing []string
+	for _, kv := range pairs {
+		key, value := kv[0], kv[1]
+		found := false
+		for i, line := range lines {
+			if !found && envLineMatchesKey(line, key) {
+				lines[i] = key + "=" + value
+				if strings.HasSuffix(line, "\r") {
+					lines[i] += "\r" // keep the file's CRLF endings intact
+				}
+				found = true
+				continue
+			}
+			// Neutralize any LATER active assignment of the same key: the loader
+			// is first-active-line-wins, so it would be dead anyway — but left
+			// active it reads as the effective config and traps future hand-edits.
+			if found && activeEnvLineMatchesKey(line, key) {
+				lines[i] = "# superseded by muninn init: " + line
+			}
+		}
+		if !found {
+			missing = append(missing, key+"="+kv[1])
 		}
 	}
-	// Not found — append, normalizing to exactly one trailing newline.
-	base := strings.TrimRight(content, "\n")
-	if base != "" {
-		base += "\n"
+
+	out := strings.Join(lines, "\n")
+	if len(missing) > 0 {
+		// Append the rest, normalizing to exactly one trailing newline.
+		out = strings.TrimRight(out, "\n")
+		if out != "" {
+			out += "\n"
+		}
+		out += strings.Join(missing, "\n") + "\n"
 	}
-	return atomicWriteFile(path, base+newLine+"\n")
+	// Guard the POST-write size too: the appended/neutralized lines could push a
+	// file that was just under the limit over it, after which the daemon would
+	// silently skip the whole file and the new setting would not survive a restart.
+	if int64(len(out)) > envFileMaxBytes {
+		return fmt.Errorf("%s would exceed the %d-byte limit the daemon will load — not writing", path, envFileMaxBytes)
+	}
+	return atomicWriteFile(path, out)
 }
 
 const envFileName = ".muninn/muninn.env"

--- a/cmd/muninn/help.go
+++ b/cmd/muninn/help.go
@@ -65,12 +65,15 @@ var subcommandHelp = map[string]func(){
 				{"--token <tok>", "Use a specific MCP token (skip generation)"},
 				{"--no-token", "Disable token auth (open MCP endpoint)"},
 				{"--no-start", "Configure tools but don't start the server"},
+				{"--tls-cert <p>", "TLS certificate (PEM) — serve clients over https"},
+				{"--tls-key <p>", "TLS private key (PEM)"},
 				{"--yes", "Accept all defaults (non-interactive)"},
 			},
 			[]string{
 				"muninn init",
 				"muninn init --tool claude,cursor --yes",
 				"muninn init --tool manual --no-token",
+				"muninn init --tool claude --tls-cert cert.pem --tls-key key.pem --yes",
 			})
 	},
 	"start": func() {

--- a/cmd/muninn/init.go
+++ b/cmd/muninn/init.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -81,6 +83,11 @@ func runInit() {
 	}
 	fs.Parse(args)
 
+	// Honor ~/.muninn/muninn.env like the daemon does (shell env still wins):
+	// a persisted MUNINN_TLS_CERT/KEY or MUNINN_MCP_URL must shape the configs
+	// this run generates, or a re-run on a TLS install would write http URLs.
+	loadEnvFile()
+
 	isInteractive := term.IsTerminal(int(os.Stdin.Fd()))
 
 	if !isInteractive && !*yes && *toolFlag == "" {
@@ -92,7 +99,7 @@ For non-interactive setup, use flags:
   muninn init --tool claude --tls-cert cert.pem --tls-key key.pem --yes
   muninn init --yes   (manual instructions only)
 
-  --tool <tools>   Comma-separated: claude, cursor, openclaw, windsurf, codex, vscode, manual
+  --tool <tools>   Comma-separated: claude, claude-code, cursor, openclaw, windsurf, codex, opencode, vscode, manual
   --token <tok>    Use specific token
   --no-token       Open MCP (no auth)
   --no-start       Skip starting server
@@ -130,54 +137,167 @@ func tlsSchemeFromEnv() string {
 	return schemeFor(os.Getenv("MUNINN_TLS_CERT"), os.Getenv("MUNINN_TLS_KEY"))
 }
 
+// daemonRunning reports whether a muninn daemon is currently running, going by
+// the PID file in the data directory.
+func daemonRunning() bool {
+	pid, err := readPID(filepath.Join(defaultDataDir(), "muninn.pid"))
+	return err == nil && isProcessRunning(pid)
+}
+
+// clientScheme is the scheme written into generated client configs and printed
+// URLs: https when this process's TLS env says so (a TLS setup happening right
+// now — runInit loads muninn.env, so persisted TLS counts too); otherwise the
+// scheme the RUNNING daemon recorded in the muninn.addrs sidecar, so re-running
+// init against an already-TLS daemon never downgrades configs to http. The
+// sidecar is consulted only while the daemon is alive — a stale file left by a
+// crash must not make a fresh plaintext daemon advertise https.
+func clientScheme() string {
+	if s := tlsSchemeFromEnv(); s == "https" {
+		return s
+	}
+	if daemonRunning() {
+		if addrs, err := readAddrsFile(defaultDataDir()); err == nil && addrs.Scheme != "" {
+			return addrs.Scheme
+		}
+	}
+	return "http"
+}
+
+// normalizeTLSPath expands a leading "~/" and makes the path absolute, so the
+// value survives being handed to the forked daemon and persisted into
+// muninn.env — a relative path would only resolve from init's cwd and would
+// break every later 'muninn start' from anywhere else. Best-effort: on any
+// resolution error the input is returned unchanged.
+func normalizeTLSPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			p = filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(p, "~"), "/"))
+		}
+	}
+	if abs, err := filepath.Abs(p); err == nil {
+		return abs
+	}
+	return p
+}
+
 // clientMCPURL is the MCP endpoint written into generated AI-tool configs.
 // MUNINN_MCP_URL (an operator-advertised, e.g. routable/remote, URL) wins;
-// otherwise the scheme follows the TLS env so a TLS deployment gets https.
+// otherwise the scheme follows clientScheme so a TLS deployment gets https.
 func clientMCPURL() string {
 	if v := os.Getenv("MUNINN_MCP_URL"); v != "" {
 		return strings.TrimRight(v, "/")
 	}
-	return tlsSchemeFromEnv() + "://127.0.0.1:" + defaultMCPPort + "/mcp"
+	return clientScheme() + "://127.0.0.1:" + defaultMCPPort + "/mcp"
 }
 
 // clientUIURL is the Web UI URL shown to the operator, scheme-aware.
 func clientUIURL() string {
-	return tlsSchemeFromEnv() + "://127.0.0.1:8476"
+	return clientScheme() + "://127.0.0.1:8476"
 }
 
 // clientRESTURL is the REST API base written into generated AI-tool guides
 // (e.g. the OpenClaw SKILL.md curl examples), scheme-aware.
 func clientRESTURL() string {
-	return tlsSchemeFromEnv() + "://127.0.0.1:8475"
+	return clientScheme() + "://127.0.0.1:8475"
+}
+
+// ambientTLSPair returns the env-configured TLS pair when it is set and valid,
+// else ("",""). Used so a pair inherited from the shell or muninn.env enables
+// the same persistence and messaging as explicit flags — without it, an
+// ambient-TLS init produced https configs and an https daemon but never
+// persisted the pair, so the next clean-shell start silently served http.
+// An invalid ambient pair is left alone: the daemon validates it fatally
+// itself, and init must not turn an operator's env into a hard error.
+func ambientTLSPair() (cert, key string) {
+	cert, key = os.Getenv("MUNINN_TLS_CERT"), os.Getenv("MUNINN_TLS_KEY")
+	if cert == "" || key == "" || validateTLSPair(cert, key) != nil {
+		return "", ""
+	}
+	return cert, key
 }
 
 // enableTLSFromFlagsOrPrompt resolves TLS for the interactive wizard. Explicit
 // flags are validated strictly — a bad --tls-cert/--tls-key pair is fatal,
 // matching the non-interactive path and the daemon, so an explicit TLS request
-// is never silently downgraded to plaintext http. With no flags it prompts
-// (which may be declined). On success it sets the TLS env so the upcoming
-// runStart's forked daemon serves https. Returns the resolved cert/key paths,
-// or ("","") when TLS is not enabled.
+// is never silently downgraded to plaintext http. With no flags, a valid
+// ambient env pair is adopted; otherwise it prompts (which may be declined).
+// On success it sets the TLS env (paths normalized to absolute) so the
+// upcoming runStart's forked daemon serves https. Returns the resolved
+// cert/key paths, or ("","") when TLS is not enabled.
 func enableTLSFromFlagsOrPrompt(certFlag, keyFlag string) (cert, key string) {
 	cert, key = certFlag, keyFlag
 	if cert == "" && key == "" {
-		cert, key = promptTLS()
-	} else if err := validateTLSPair(cert, key); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		if cert, key = ambientTLSPair(); cert != "" {
+			fmt.Println()
+			fmt.Println("  Using the TLS certificate from MUNINN_TLS_CERT / MUNINN_TLS_KEY.")
+		} else {
+			cert, key = promptTLS()
+		}
+	} else {
+		// Normalize before validating so "~/cert.pem" and relative flag paths
+		// resolve the same way the prompt path does, rather than fatally failing.
+		cert, key = normalizeTLSPath(cert), normalizeTLSPath(key)
+		if err := validateTLSPair(cert, key); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
 	}
 	if cert == "" {
 		return "", ""
 	}
+	cert, key = normalizeTLSPath(cert), normalizeTLSPath(key)
 	os.Setenv("MUNINN_TLS_CERT", cert)
 	os.Setenv("MUNINN_TLS_KEY", key)
 	fmt.Println("  ✓ TLS enabled — clients will connect over https")
+	warnIfCertNotLoopback(cert)
 	return cert, key
 }
 
+// warnIfCertNotLoopback notes when the certificate covers neither 127.0.0.1
+// nor localhost. This CLI skips verification on loopback, but the generated
+// tool configs point external MCP/REST clients at https://127.0.0.1 — and
+// those clients DO verify, so they would reject the connection.
+func warnIfCertNotLoopback(certPath string) {
+	b, err := os.ReadFile(certPath)
+	if err != nil {
+		return
+	}
+	// Find the leaf CERTIFICATE block: a combined PEM may put the private key
+	// first, and pem.Decode returns blocks in file order.
+	var c *x509.Certificate
+	for {
+		var block *pem.Block
+		block, b = pem.Decode(b)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		if parsed, err := x509.ParseCertificate(block.Bytes); err == nil {
+			c = parsed
+			break
+		}
+	}
+	if c == nil {
+		return
+	}
+	if c.VerifyHostname("127.0.0.1") == nil || c.VerifyHostname("localhost") == nil {
+		return
+	}
+	fmt.Println("  ⚠  The certificate covers neither 127.0.0.1 nor localhost.")
+	fmt.Println("     Generated client configs use https://127.0.0.1 — clients that verify")
+	fmt.Println("     certificates will reject it. Reissue the cert with an IP SAN for")
+	fmt.Println("     127.0.0.1, or set MUNINN_MCP_URL to a URL the cert does cover.")
+}
+
 // promptTLS asks whether to serve TLS and, if so, collects and validates a
-// cert/key pair (one retry). Returns ("","") when TLS is declined or the pair
-// can't be validated.
+// cert/key pair (one retry; "~/" is expanded). Returns ("","") when TLS is
+// declined or the pair can't be validated — always saying so, since the user
+// answered yes and would otherwise believe TLS is on.
 func promptTLS() (cert, key string) {
 	r := bufio.NewReader(os.Stdin)
 	fmt.Println()
@@ -193,8 +313,9 @@ func promptTLS() (cert, key string) {
 		k, _ := r.ReadString('\n')
 		c, k = strings.TrimSpace(c), strings.TrimSpace(k)
 		if c == "" && k == "" {
-			return "", ""
+			break // fall through to the explicit not-enabled warning
 		}
+		c, k = normalizeTLSPath(c), normalizeTLSPath(k)
 		if err := validateTLSPair(c, k); err != nil {
 			fmt.Printf("    ⚠  %v\n", err)
 			continue
@@ -206,10 +327,13 @@ func promptTLS() (cert, key string) {
 	return "", ""
 }
 
-// persistTLSEnv writes the TLS cert/key paths into muninn.env as active lines so
-// future restarts keep https. Best-effort: a failure leaves the current daemon's
-// TLS intact (it came from the inherited env). A no-op on empty input, so an
-// empty pair can never be written as active.
+// persistTLSEnv writes the TLS cert/key paths into muninn.env as active lines
+// so future restarts keep https. Both vars go in one atomic write — the pair
+// can never be persisted half, which would make every later daemon start fail
+// its exactly-one-of check. Best-effort: a failure leaves the current daemon's
+// TLS intact (it came from the inherited env), but is reported loudly because
+// it means TLS will not survive a restart. A no-op on empty input, so an empty
+// pair can never be written as active.
 func persistTLSEnv(cert, key string) {
 	if cert == "" || key == "" {
 		return
@@ -220,11 +344,13 @@ func persistTLSEnv(cert, key string) {
 		return
 	}
 	path := filepath.Join(home, envFileName)
-	for _, kv := range [][2]string{{"MUNINN_TLS_CERT", cert}, {"MUNINN_TLS_KEY", key}} {
-		if err := upsertEnvFileVar(path, kv[0], kv[1]); err != nil {
-			slog.Warn("init: could not persist TLS var to muninn.env", "key", kv[0], "error", err)
-			return
-		}
+	err = upsertEnvFileVars(path, [][2]string{
+		{"MUNINN_TLS_CERT", cert},
+		{"MUNINN_TLS_KEY", key},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  ⚠  could not persist TLS settings to %s: %v\n", path, err)
+		fmt.Fprintln(os.Stderr, "     TLS will NOT survive a restart — add MUNINN_TLS_CERT and MUNINN_TLS_KEY there manually.")
 	}
 }
 
@@ -328,6 +454,10 @@ func runInteractiveInit(tokenFlag *string, noToken *bool, noStart *bool, tlsCert
 		if err := runStart(true); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: daemon did not start cleanly: %v\n", err)
 		}
+		// runStart is a no-op on an already-running daemon — if that daemon's
+		// scheme doesn't match what we just configured, say so instead of
+		// printing a success summary for a TLS setup that isn't serving yet.
+		warnIfDaemonSchemeMismatch()
 		// Point our admin/UI base URLs at the daemon we just started (scheme + port
 		// from muninn.addrs) so the loopback login + plasticity calls below reach it
 		// under TLS or a non-default port instead of failing against http://:8475.
@@ -369,6 +499,8 @@ func runInteractiveInit(tokenFlag *string, noToken *bool, noStart *bool, tlsCert
 	if tlsEnabled {
 		fmt.Printf("  MCP endpoint    → %s\n", mcpURL)
 		fmt.Println("  Remote clients  → set MUNINN_MCP_URL to this server's routable https URL before 'muninn init'")
+		fmt.Println("  Client trust    → MCP/REST clients verify this certificate; distribute your CA")
+		fmt.Println("                    file to them (curl: --cacert <ca.crt>; GUI tools: OS trust store)")
 	}
 	fmt.Println()
 	fmt.Println("  ────────────────────────────────────────────────────")
@@ -727,14 +859,26 @@ func runNonInteractiveInit(toolStr, tokenStr string, noToken, noStart, yes bool,
 	printWelcomeBanner()
 
 	// TLS must be decided before runStart — the forked daemon inherits the env.
+	// Normalize before validating so "~/cert.pem" / relative flag paths resolve
+	// instead of fatally failing (and so the persisted path is absolute).
+	if tlsCert != "" || tlsKey != "" {
+		tlsCert, tlsKey = normalizeTLSPath(tlsCert), normalizeTLSPath(tlsKey)
+	}
 	if err := validateTLSPair(tlsCert, tlsKey); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
+	}
+	if tlsCert == "" {
+		// No flags: adopt a valid ambient env pair (shell or muninn.env) so it
+		// gets the same persistence and messaging as an explicit one.
+		tlsCert, tlsKey = ambientTLSPair()
+		tlsCert, tlsKey = normalizeTLSPath(tlsCert), normalizeTLSPath(tlsKey)
 	}
 	tlsEnabled := tlsCert != ""
 	if tlsEnabled {
 		os.Setenv("MUNINN_TLS_CERT", tlsCert)
 		os.Setenv("MUNINN_TLS_KEY", tlsKey)
+		warnIfCertNotLoopback(tlsCert)
 	}
 
 	var token string
@@ -755,6 +899,9 @@ func runNonInteractiveInit(toolStr, tokenStr string, noToken, noStart, yes bool,
 		if err := runStart(true); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: daemon did not start cleanly: %v\n", err)
 		}
+		// runStart is a no-op on an already-running daemon — flag a scheme
+		// mismatch instead of printing a success summary it doesn't serve yet.
+		warnIfDaemonSchemeMismatch()
 		fmt.Println()
 	}
 
@@ -801,6 +948,8 @@ func runNonInteractiveInit(toolStr, tokenStr string, noToken, noStart, yes bool,
 	fmt.Printf("  Web UI:         %s\n", clientUIURL())
 	if tlsEnabled {
 		fmt.Println("  Remote clients: set MUNINN_MCP_URL to this server's routable https URL before 'muninn init'")
+		fmt.Println("  Client trust:   MCP/REST clients verify this certificate; distribute your CA")
+		fmt.Println("                  file to them (curl: --cacert <ca.crt>; GUI tools: OS trust store)")
 	}
 	fmt.Println()
 }
@@ -961,6 +1110,36 @@ func printBehaviorNote(mode, customInstructions string) {
 	}
 }
 
+// warnIfDaemonSchemeMismatch tells the operator to restart when this run just
+// enabled TLS but the already-running daemon is still serving plaintext http.
+// runStart returns early on a live daemon, so enabling TLS on a running http
+// daemon (a flow promptTLS's own fallback hint recommends) would otherwise
+// print a success summary while the daemon keeps serving http.
+//
+// Only the https-wanted / http-served direction warrants a warning: the
+// reverse (a running https daemon we didn't reconfigure) is exactly what
+// clientScheme adopts from the sidecar, so the generated configs already match
+// the daemon — telling the operator to "restart" there would push them toward
+// the http the configs are NOT using.
+func warnIfDaemonSchemeMismatch() {
+	if tlsSchemeFromEnv() != "https" || !daemonRunning() {
+		return
+	}
+	addrs, err := readAddrsFile(defaultDataDir())
+	if err != nil {
+		return
+	}
+	have := addrs.Scheme
+	if have == "" {
+		have = "http"
+	}
+	if have != "https" {
+		fmt.Println()
+		fmt.Printf("  ⚠  The daemon is already running and serves %s, but TLS was just enabled.\n", have)
+		fmt.Println("     Restart it to serve https: muninn restart")
+	}
+}
+
 // alignLocalAdminBasesToDaemon points the package-level admin/UI base URLs at the
 // running daemon's actual scheme + port (from the muninn.addrs sidecar) so the
 // wizard's own loopback admin calls (loginAdmin, plasticity) reach a daemon it
@@ -1005,9 +1184,12 @@ func applyBehaviorToVault(mode, customInstructions string) {
 
 		plasticityURL := fmt.Sprintf("%s/api/admin/vault/default/plasticity", vaultAdminBase)
 		client := &http.Client{Timeout: 5 * time.Second}
-		if strings.HasPrefix(plasticityURL, "https://") && isLoopbackURL(plasticityURL) {
-			// Loopback https: skip cert verification (internal-CA self-talk can't be
-			// impersonated). Off-host stays verified. Unifies to httpClientForURL once #468 lands.
+		// ToLower: the scheme is case-insensitive; keep this consistent with
+		// isLoopbackURL (which lowercases via url.Parse).
+		if strings.HasPrefix(strings.ToLower(plasticityURL), "https://") && isLoopbackURL(plasticityURL) {
+			// Loopback https: skip cert verification — the connection never leaves
+			// this machine. Off-host stays verified. Unifies to httpClientForURL
+			// once #468 lands.
 			client.Transport = &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
 			}

--- a/cmd/muninn/init.go
+++ b/cmd/muninn/init.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -142,6 +143,12 @@ func clientMCPURL() string {
 // clientUIURL is the Web UI URL shown to the operator, scheme-aware.
 func clientUIURL() string {
 	return tlsSchemeFromEnv() + "://127.0.0.1:8476"
+}
+
+// clientRESTURL is the REST API base written into generated AI-tool guides
+// (e.g. the OpenClaw SKILL.md curl examples), scheme-aware.
+func clientRESTURL() string {
+	return tlsSchemeFromEnv() + "://127.0.0.1:8475"
 }
 
 // enableTLSFromFlagsOrPrompt resolves TLS for the interactive wizard. Explicit
@@ -321,6 +328,10 @@ func runInteractiveInit(tokenFlag *string, noToken *bool, noStart *bool, tlsCert
 		if err := runStart(true); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: daemon did not start cleanly: %v\n", err)
 		}
+		// Point our admin/UI base URLs at the daemon we just started (scheme + port
+		// from muninn.addrs) so the loopback login + plasticity calls below reach it
+		// under TLS or a non-default port instead of failing against http://:8475.
+		alignLocalAdminBasesToDaemon()
 		// Persist the behavior choice to the default vault now that the server is up.
 		// Retries once on failure; falls back to printing the manual command.
 		applyBehaviorToVault(behaviorMode, customInstructions)
@@ -950,6 +961,32 @@ func printBehaviorNote(mode, customInstructions string) {
 	}
 }
 
+// alignLocalAdminBasesToDaemon points the package-level admin/UI base URLs at the
+// running daemon's actual scheme + port (from the muninn.addrs sidecar) so the
+// wizard's own loopback admin calls (loginAdmin, plasticity) reach a daemon it
+// just started with TLS or on a non-default port. Operator overrides
+// (MUNINNDB_ADMIN_URL / MUNINNDB_UI_URL) are respected and left untouched.
+func alignLocalAdminBasesToDaemon() {
+	addrs, err := readAddrsFile(defaultDataDir())
+	if err != nil {
+		return // sidecar unreadable — keep the compiled-in http defaults
+	}
+	scheme := addrs.Scheme
+	if scheme == "" {
+		scheme = "http"
+	}
+	if os.Getenv("MUNINNDB_ADMIN_URL") == "" {
+		if _, port, err := net.SplitHostPort(addrs.RestAddr); err == nil && port != "" {
+			vaultAdminBase = scheme + "://127.0.0.1:" + port
+		}
+	}
+	if os.Getenv("MUNINNDB_UI_URL") == "" {
+		if _, port, err := net.SplitHostPort(addrs.UIAddr); err == nil && port != "" {
+			vaultUIBase = scheme + "://127.0.0.1:" + port
+		}
+	}
+}
+
 // applyBehaviorToVault persists the chosen behavior mode to the default vault's
 // plasticity config via the admin API. Called after runStart so the server is up.
 //
@@ -968,6 +1005,13 @@ func applyBehaviorToVault(mode, customInstructions string) {
 
 		plasticityURL := fmt.Sprintf("%s/api/admin/vault/default/plasticity", vaultAdminBase)
 		client := &http.Client{Timeout: 5 * time.Second}
+		if strings.HasPrefix(plasticityURL, "https://") && isLoopbackURL(plasticityURL) {
+			// Loopback https: skip cert verification (internal-CA self-talk can't be
+			// impersonated). Off-host stays verified. Unifies to httpClientForURL once #468 lands.
+			client.Transport = &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			}
+		}
 
 		// GET current config so we merge rather than overwrite.
 		getReq, err := http.NewRequest("GET", plasticityURL, nil)

--- a/cmd/muninn/init.go
+++ b/cmd/muninn/init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -69,6 +70,8 @@ func runInit() {
 	noToken := fs.Bool("no-token", false, "Disable token authentication (open MCP endpoint)")
 	noStart := fs.Bool("no-start", false, "Skip starting the server")
 	yes := fs.Bool("yes", false, "Accept all defaults non-interactively")
+	tlsCert := fs.String("tls-cert", "", "Path to TLS certificate (PEM) — serve clients over https")
+	tlsKey := fs.String("tls-key", "", "Path to TLS private key (PEM)")
 	fs.Usage = func() { subcommandHelp["init"]() }
 
 	var args []string
@@ -77,7 +80,6 @@ func runInit() {
 	}
 	fs.Parse(args)
 
-	mcpURL := "http://127.0.0.1:8750/mcp"
 	isInteractive := term.IsTerminal(int(os.Stdin.Fd()))
 
 	if !isInteractive && !*yes && *toolFlag == "" {
@@ -86,25 +88,140 @@ For non-interactive setup, use flags:
 
   muninn init --tool claude --yes
   muninn init --tool cursor,claude --no-token --yes
+  muninn init --tool claude --tls-cert cert.pem --tls-key key.pem --yes
   muninn init --yes   (manual instructions only)
 
   --tool <tools>   Comma-separated: claude, cursor, openclaw, windsurf, codex, vscode, manual
   --token <tok>    Use specific token
   --no-token       Open MCP (no auth)
   --no-start       Skip starting server
+  --tls-cert <p>   TLS certificate (PEM) — serve clients over https
+  --tls-key <p>    TLS private key (PEM)
   --yes            Accept defaults, non-interactive`)
 		os.Exit(1)
 	}
 
 	if isInteractive && *toolFlag == "" && !*yes {
-		runInteractiveInit(mcpURL, tokenFlag, noToken, noStart)
+		runInteractiveInit(tokenFlag, noToken, noStart, *tlsCert, *tlsKey)
 		return
 	}
 
-	runNonInteractiveInit(mcpURL, *toolFlag, *tokenFlag, *noToken, *noStart, *yes)
+	runNonInteractiveInit(*toolFlag, *tokenFlag, *noToken, *noStart, *yes, *tlsCert, *tlsKey)
 }
 
-func runInteractiveInit(mcpURL string, tokenFlag *string, noToken *bool, noStart *bool) {
+// validateTLSPair reports whether a cert/key pair is usable. Both empty is valid
+// (no TLS); exactly one set is an error; both set must load as a key pair.
+func validateTLSPair(cert, key string) error {
+	if (cert == "") != (key == "") {
+		return fmt.Errorf("--tls-cert and --tls-key must both be set (or neither)")
+	}
+	if cert == "" {
+		return nil
+	}
+	if _, err := tls.LoadX509KeyPair(cert, key); err != nil {
+		return fmt.Errorf("invalid TLS cert/key: %w", err)
+	}
+	return nil
+}
+
+// tlsSchemeFromEnv reports "https" when both TLS env vars are set, else "http".
+func tlsSchemeFromEnv() string {
+	return schemeFor(os.Getenv("MUNINN_TLS_CERT"), os.Getenv("MUNINN_TLS_KEY"))
+}
+
+// clientMCPURL is the MCP endpoint written into generated AI-tool configs.
+// MUNINN_MCP_URL (an operator-advertised, e.g. routable/remote, URL) wins;
+// otherwise the scheme follows the TLS env so a TLS deployment gets https.
+func clientMCPURL() string {
+	if v := os.Getenv("MUNINN_MCP_URL"); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return tlsSchemeFromEnv() + "://127.0.0.1:" + defaultMCPPort + "/mcp"
+}
+
+// clientUIURL is the Web UI URL shown to the operator, scheme-aware.
+func clientUIURL() string {
+	return tlsSchemeFromEnv() + "://127.0.0.1:8476"
+}
+
+// enableTLSFromFlagsOrPrompt resolves TLS for the interactive wizard. Explicit
+// flags are validated strictly — a bad --tls-cert/--tls-key pair is fatal,
+// matching the non-interactive path and the daemon, so an explicit TLS request
+// is never silently downgraded to plaintext http. With no flags it prompts
+// (which may be declined). On success it sets the TLS env so the upcoming
+// runStart's forked daemon serves https. Returns the resolved cert/key paths,
+// or ("","") when TLS is not enabled.
+func enableTLSFromFlagsOrPrompt(certFlag, keyFlag string) (cert, key string) {
+	cert, key = certFlag, keyFlag
+	if cert == "" && key == "" {
+		cert, key = promptTLS()
+	} else if err := validateTLSPair(cert, key); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if cert == "" {
+		return "", ""
+	}
+	os.Setenv("MUNINN_TLS_CERT", cert)
+	os.Setenv("MUNINN_TLS_KEY", key)
+	fmt.Println("  ✓ TLS enabled — clients will connect over https")
+	return cert, key
+}
+
+// promptTLS asks whether to serve TLS and, if so, collects and validates a
+// cert/key pair (one retry). Returns ("","") when TLS is declined or the pair
+// can't be validated.
+func promptTLS() (cert, key string) {
+	r := bufio.NewReader(os.Stdin)
+	fmt.Println()
+	fmt.Print("  Serve clients over TLS (https)? [y/N]: ")
+	ans, _ := r.ReadString('\n')
+	if a := strings.ToLower(strings.TrimSpace(ans)); a != "y" && a != "yes" {
+		return "", ""
+	}
+	for attempt := 0; attempt < 2; attempt++ {
+		fmt.Print("    TLS certificate path (PEM): ")
+		c, _ := r.ReadString('\n')
+		fmt.Print("    TLS private key path (PEM): ")
+		k, _ := r.ReadString('\n')
+		c, k = strings.TrimSpace(c), strings.TrimSpace(k)
+		if c == "" && k == "" {
+			return "", ""
+		}
+		if err := validateTLSPair(c, k); err != nil {
+			fmt.Printf("    ⚠  %v\n", err)
+			continue
+		}
+		return c, k
+	}
+	fmt.Println("    ⚠  TLS not enabled — the server will use plaintext http.")
+	fmt.Println("       Configure later: muninn init --tls-cert <cert> --tls-key <key>")
+	return "", ""
+}
+
+// persistTLSEnv writes the TLS cert/key paths into muninn.env as active lines so
+// future restarts keep https. Best-effort: a failure leaves the current daemon's
+// TLS intact (it came from the inherited env). A no-op on empty input, so an
+// empty pair can never be written as active.
+func persistTLSEnv(cert, key string) {
+	if cert == "" || key == "" {
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		slog.Warn("init: could not resolve home for muninn.env TLS persistence", "error", err)
+		return
+	}
+	path := filepath.Join(home, envFileName)
+	for _, kv := range [][2]string{{"MUNINN_TLS_CERT", cert}, {"MUNINN_TLS_KEY", key}} {
+		if err := upsertEnvFileVar(path, kv[0], kv[1]); err != nil {
+			slog.Warn("init: could not persist TLS var to muninn.env", "key", kv[0], "error", err)
+			return
+		}
+	}
+}
+
+func runInteractiveInit(tokenFlag *string, noToken *bool, noStart *bool, tlsCert, tlsKey string) {
 	printWelcomeBanner()
 
 	// Step 1: Tool detection + multi-select
@@ -157,6 +274,12 @@ func runInteractiveInit(mcpURL string, tokenFlag *string, noToken *bool, noStart
 	}
 	printBehaviorNote(behaviorMode, customInstructions)
 
+	// Step 4: TLS. Flags pre-fill (and skip) the prompt; otherwise ask. The env
+	// must be set here — before configuring tool URLs and before runStart, whose
+	// forked daemon inherits it.
+	tlsCertPath, tlsKeyPath := enableTLSFromFlagsOrPrompt(tlsCert, tlsKey)
+	tlsEnabled := tlsCertPath != ""
+
 	// Auto: generate token (no prompt)
 	var token string
 	if !*noToken {
@@ -176,7 +299,8 @@ func runInteractiveInit(mcpURL string, tokenFlag *string, noToken *bool, noStart
 		}
 	}
 
-	// Configure selected tools
+	// Configure selected tools. Derive the URL now that TLS env (if any) is set.
+	mcpURL := clientMCPURL()
 	if len(selectedTools) > 0 {
 		fmt.Println()
 		toolErrs := configureNamedTools(selectedTools, mcpURL, token, behaviorMode)
@@ -215,6 +339,11 @@ func runInteractiveInit(mcpURL string, tokenFlag *string, noToken *bool, noStart
 		fmt.Printf("  ✓ Config template written to %s\n", filepath.Join(home, ".muninn", "muninn.env"))
 		fmt.Println("  Edit this file to configure MuninnDB without shell exports.")
 	}
+	// Persist TLS into muninn.env (active) so future restarts keep https. After
+	// writeEnvFile so the template exists with the user's embedder, not clobbered.
+	if tlsEnabled {
+		persistTLSEnv(tlsCertPath, tlsKeyPath)
+	}
 
 	// Success message
 	fmt.Println()
@@ -225,7 +354,11 @@ func runInteractiveInit(mcpURL string, tokenFlag *string, noToken *bool, noStart
 	fmt.Println("  Try it → open Claude Code or Cursor and ask:")
 	fmt.Println(`    "What do you remember about me?"`)
 	fmt.Println()
-	fmt.Println("  Browse memories → http://127.0.0.1:8476")
+	fmt.Printf("  Browse memories → %s\n", clientUIURL())
+	if tlsEnabled {
+		fmt.Printf("  MCP endpoint    → %s\n", mcpURL)
+		fmt.Println("  Remote clients  → set MUNINN_MCP_URL to this server's routable https URL before 'muninn init'")
+	}
 	fmt.Println()
 	fmt.Println("  ────────────────────────────────────────────────────")
 	fmt.Println()
@@ -579,8 +712,19 @@ func printEmbedderNote(choice string) {
 	}
 }
 
-func runNonInteractiveInit(mcpURL, toolStr, tokenStr string, noToken, noStart, yes bool) {
+func runNonInteractiveInit(toolStr, tokenStr string, noToken, noStart, yes bool, tlsCert, tlsKey string) {
 	printWelcomeBanner()
+
+	// TLS must be decided before runStart — the forked daemon inherits the env.
+	if err := validateTLSPair(tlsCert, tlsKey); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	tlsEnabled := tlsCert != ""
+	if tlsEnabled {
+		os.Setenv("MUNINN_TLS_CERT", tlsCert)
+		os.Setenv("MUNINN_TLS_KEY", tlsKey)
+	}
 
 	var token string
 	if !noToken {
@@ -610,6 +754,7 @@ func runNonInteractiveInit(mcpURL, toolStr, tokenStr string, noToken, noStart, y
 		}
 	}
 
+	mcpURL := clientMCPURL()
 	if len(tools) > 0 {
 		fmt.Println("Configuring AI tools:")
 		toolErrs := configureNamedTools(tools, mcpURL, token, "")
@@ -632,14 +777,20 @@ func runNonInteractiveInit(mcpURL, toolStr, tokenStr string, noToken, noStart, y
 	if _, envErr := writeEnvFile("local", ""); envErr != nil {
 		slog.Warn("init: could not write muninn.env", "error", envErr)
 	}
+	if tlsEnabled {
+		persistTLSEnv(tlsCert, tlsKey)
+	}
 
 	fmt.Println()
 	fmt.Println("muninn is running.")
-	fmt.Println("  MCP endpoint:   http://127.0.0.1:8750/mcp")
+	fmt.Printf("  MCP endpoint:   %s\n", mcpURL)
 	if token != "" {
 		fmt.Println("  Token:          ~/.muninn/mcp.token")
 	}
-	fmt.Println("  Web UI:         http://127.0.0.1:8476")
+	fmt.Printf("  Web UI:         %s\n", clientUIURL())
+	if tlsEnabled {
+		fmt.Println("  Remote clients: set MUNINN_MCP_URL to this server's routable https URL before 'muninn init'")
+	}
 	fmt.Println()
 }
 

--- a/cmd/muninn/init_tls_test.go
+++ b/cmd/muninn/init_tls_test.go
@@ -8,8 +8,10 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -49,7 +51,92 @@ func writeCertKey(t *testing.T) (certPath, keyPath string) {
 	return certPath, keyPath
 }
 
+// writeLoopbackCertCombined writes a single PEM file with the private KEY block
+// FIRST and a cert (IP SAN 127.0.0.1) second — the order a naive first-block
+// reader would choke on. Returns the combined path.
+func writeLoopbackCertCombined(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	combined := append(
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})...,
+	)
+	path := filepath.Join(t.TempDir(), "combined.pem")
+	if err := os.WriteFile(path, combined, 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestWarnIfCertNotLoopback(t *testing.T) {
+	t.Run("key-first combined PEM with loopback SAN is silent", func(t *testing.T) {
+		path := writeLoopbackCertCombined(t)
+		if out := captureStdout(func() { warnIfCertNotLoopback(path) }); out != "" {
+			t.Errorf("a 127.0.0.1 cert must not warn even key-first, got:\n%s", out)
+		}
+	})
+	t.Run("non-loopback cert warns", func(t *testing.T) {
+		cert, _ := writeCertKey(t) // CN=test, no loopback SAN
+		out := captureStdout(func() { warnIfCertNotLoopback(cert) })
+		if !strings.Contains(out, "covers neither 127.0.0.1 nor localhost") {
+			t.Errorf("expected a non-loopback warning, got:\n%s", out)
+		}
+	})
+}
+
+func TestWarnIfDaemonSchemeMismatch(t *testing.T) {
+	setup := func(t *testing.T, daemonScheme string) {
+		dir := t.TempDir()
+		t.Setenv("MUNINNDB_DATA", dir)
+		if err := writeAddrsFile(dir, daemonAddrs{Scheme: daemonScheme, RestAddr: "127.0.0.1:8475", UIAddr: "127.0.0.1:8476"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := writePID(filepath.Join(dir, "muninn.pid"), os.Getpid()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("warns when TLS enabled but daemon serves http", func(t *testing.T) {
+		setup(t, "http")
+		t.Setenv("MUNINN_TLS_CERT", "/c.pem")
+		t.Setenv("MUNINN_TLS_KEY", "/k.pem")
+		out := captureStdout(warnIfDaemonSchemeMismatch)
+		if !strings.Contains(out, "Restart it to serve https") {
+			t.Errorf("expected a restart warning, got:\n%s", out)
+		}
+	})
+	t.Run("silent in the adopt direction (daemon https, no TLS env)", func(t *testing.T) {
+		setup(t, "https")
+		t.Setenv("MUNINN_TLS_CERT", "")
+		t.Setenv("MUNINN_TLS_KEY", "")
+		if out := captureStdout(warnIfDaemonSchemeMismatch); out != "" {
+			t.Errorf("must not advise a restart that breaks the https configs init wrote, got:\n%s", out)
+		}
+	})
+}
+
 func TestClientMCPURL(t *testing.T) {
+	// Pin the data dir: clientScheme consults a RUNNING daemon's muninn.addrs,
+	// and the host running these tests may have a live (possibly TLS) daemon.
+	t.Setenv("MUNINNDB_DATA", t.TempDir())
 	t.Run("default is http localhost", func(t *testing.T) {
 		t.Setenv("MUNINN_MCP_URL", "")
 		t.Setenv("MUNINN_TLS_CERT", "")
@@ -85,6 +172,7 @@ func TestClientMCPURL(t *testing.T) {
 }
 
 func TestClientUIURL(t *testing.T) {
+	t.Setenv("MUNINNDB_DATA", t.TempDir())
 	t.Setenv("MUNINN_TLS_CERT", "")
 	t.Setenv("MUNINN_TLS_KEY", "")
 	if got := clientUIURL(); got != "http://127.0.0.1:8476" {
@@ -94,6 +182,83 @@ func TestClientUIURL(t *testing.T) {
 	t.Setenv("MUNINN_TLS_KEY", "/k.pem")
 	if got := clientUIURL(); got != "https://127.0.0.1:8476" {
 		t.Errorf("got %q", got)
+	}
+}
+
+func TestClientScheme(t *testing.T) {
+	noTLSEnv := func(t *testing.T) {
+		t.Setenv("MUNINN_TLS_CERT", "")
+		t.Setenv("MUNINN_TLS_KEY", "")
+	}
+
+	t.Run("default is http", func(t *testing.T) {
+		t.Setenv("MUNINNDB_DATA", t.TempDir())
+		noTLSEnv(t)
+		if got := clientScheme(); got != "http" {
+			t.Errorf("got %q, want http", got)
+		}
+	})
+	t.Run("TLS env wins", func(t *testing.T) {
+		t.Setenv("MUNINNDB_DATA", t.TempDir())
+		t.Setenv("MUNINN_TLS_CERT", "/c.pem")
+		t.Setenv("MUNINN_TLS_KEY", "/k.pem")
+		if got := clientScheme(); got != "https" {
+			t.Errorf("got %q, want https", got)
+		}
+	})
+	t.Run("running daemon's sidecar scheme is adopted", func(t *testing.T) {
+		// Re-running init on a TLS deployment without flags or env must not
+		// downgrade generated configs to http (#443 review finding).
+		dir := t.TempDir()
+		t.Setenv("MUNINNDB_DATA", dir)
+		noTLSEnv(t)
+		if err := writeAddrsFile(dir, daemonAddrs{Scheme: "https", RestAddr: "127.0.0.1:8475", UIAddr: "127.0.0.1:8476"}); err != nil {
+			t.Fatal(err)
+		}
+		// Our own PID is alive — the sidecar counts as a running daemon's.
+		if err := writePID(filepath.Join(dir, "muninn.pid"), os.Getpid()); err != nil {
+			t.Fatal(err)
+		}
+		if got := clientScheme(); got != "https" {
+			t.Errorf("got %q, want https from the running daemon's sidecar", got)
+		}
+	})
+	t.Run("stale sidecar without a daemon is ignored", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("MUNINNDB_DATA", dir)
+		noTLSEnv(t)
+		if err := writeAddrsFile(dir, daemonAddrs{Scheme: "https"}); err != nil {
+			t.Fatal(err)
+		}
+		// No PID file: a crashed daemon's leftover sidecar must not make a
+		// fresh plaintext deployment advertise https.
+		if got := clientScheme(); got != "http" {
+			t.Errorf("got %q, want http (stale sidecar must be ignored)", got)
+		}
+	})
+}
+
+func TestNormalizeTLSPath(t *testing.T) {
+	if got := normalizeTLSPath(""); got != "" {
+		t.Errorf("empty must stay empty, got %q", got)
+	}
+	// Use a path that is absolute on the host OS (t.TempDir is absolute
+	// everywhere); a Unix-style "/abs/..." literal is NOT absolute on Windows,
+	// where filepath.Abs would prepend a drive letter.
+	abs := filepath.Join(t.TempDir(), "cert.pem")
+	if got := normalizeTLSPath(abs); got != abs {
+		t.Errorf("absolute must be unchanged, got %q want %q", got, abs)
+	}
+	got := normalizeTLSPath("cert.pem")
+	if !filepath.IsAbs(got) || filepath.Base(got) != "cert.pem" {
+		t.Errorf("relative must become absolute in cwd, got %q", got)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	if got := normalizeTLSPath("~/certs/c.pem"); got != filepath.Join(home, "certs", "c.pem") {
+		t.Errorf("~/ must expand to home, got %q", got)
 	}
 }
 
@@ -128,7 +293,9 @@ func TestUpsertEnvFileVar(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if fi.Mode().Perm() != 0600 {
+		// Windows doesn't honor Unix permission bits — os.Chmod(0600) surfaces as
+		// 0666 there — so only assert the mode on platforms that have them.
+		if runtime.GOOS != "windows" && fi.Mode().Perm() != 0600 {
 			t.Errorf("perm = %v, want 0600", fi.Mode().Perm())
 		}
 	})
@@ -205,4 +372,175 @@ func assertEnvLine(t *testing.T, path, want string) {
 		}
 	}
 	t.Errorf("missing active line %q in:\n%s", want, b)
+}
+
+// loadedEnvValue round-trips path through loadEnvFileFrom — the actual
+// consumer — and returns the value the daemon would see for key. The key is
+// guaranteed unset before the load and unset again afterwards.
+func loadedEnvValue(t *testing.T, path, key string) string {
+	t.Helper()
+	// loadEnvFileFrom mutates the global process env (set-if-unset) and a fixture
+	// may carry several keys — so snapshot every MUNINN* var and restore it on
+	// cleanup, unsetting any the load newly created. Without this the helper
+	// leaks (e.g. half a TLS pair) into later tests, including the integration
+	// tests that exec `muninn start` from this same process and would then see a
+	// daemon abort on a lone MUNINN_TLS_KEY.
+	snapshotMuninnEnv(t)
+	os.Unsetenv(key) // so set-if-unset actually applies the file's value
+	loadEnvFileFrom(path)
+	return os.Getenv(key)
+}
+
+// snapshotMuninnEnv records every MUNINN* env var now and registers a cleanup
+// that restores them exactly — re-setting changed ones and unsetting any the
+// test newly created.
+func snapshotMuninnEnv(t *testing.T) {
+	t.Helper()
+	saved := map[string]string{}
+	for _, kv := range os.Environ() {
+		if eq := strings.IndexByte(kv, '='); eq > 0 && strings.HasPrefix(kv, "MUNINN") {
+			saved[kv[:eq]] = kv[eq+1:]
+		}
+	}
+	t.Cleanup(func() {
+		for _, kv := range os.Environ() {
+			if eq := strings.IndexByte(kv, '='); eq > 0 && strings.HasPrefix(kv, "MUNINN") {
+				if _, ok := saved[kv[:eq]]; !ok {
+					os.Unsetenv(kv[:eq])
+				}
+			}
+		}
+		for k, v := range saved {
+			os.Setenv(k, v)
+		}
+	})
+}
+
+// TestUpsertEnvFileVars_LoaderRoundTrip pins the matcher to loadEnvFile's
+// parsing: every form the loader accepts as an assignment must be replaced,
+// not duplicated — a missed form would leave a stale first-active-line that
+// shadows the new value after restart.
+func TestUpsertEnvFileVars_LoaderRoundTrip(t *testing.T) {
+	t.Run("spaced assignment is replaced, not shadowed", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "muninn.env")
+		os.WriteFile(path, []byte("MUNINN_TLS_CERT = /old.pem\n"), 0600)
+		if err := upsertEnvFileVar(path, "MUNINN_TLS_CERT", "/new.pem"); err != nil {
+			t.Fatal(err)
+		}
+		if got := loadedEnvValue(t, path, "MUNINN_TLS_CERT"); got != "/new.pem" {
+			t.Errorf("daemon would load %q, want /new.pem", got)
+		}
+		b, _ := os.ReadFile(path)
+		if strings.Count(string(b), "MUNINN_TLS_CERT") != 1 {
+			t.Errorf("spaced assignment must be replaced, not duplicated:\n%s", b)
+		}
+	})
+
+	t.Run("later active duplicate is neutralized", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "muninn.env")
+		os.WriteFile(path, []byte("# MUNINN_TLS_CERT=/path/to/cert.pem\nMUNINN_TLS_CERT=/user.pem\n"), 0600)
+		if err := upsertEnvFileVar(path, "MUNINN_TLS_CERT", "/new.pem"); err != nil {
+			t.Fatal(err)
+		}
+		if got := loadedEnvValue(t, path, "MUNINN_TLS_CERT"); got != "/new.pem" {
+			t.Errorf("daemon would load %q, want /new.pem", got)
+		}
+		b, _ := os.ReadFile(path)
+		s := string(b)
+		assertEnvLine(t, path, "MUNINN_TLS_CERT=/new.pem")
+		if !strings.Contains(s, "# superseded by muninn init: MUNINN_TLS_CERT=/user.pem") {
+			t.Errorf("stale active line must be preserved as a comment:\n%s", s)
+		}
+		active := 0
+		for _, line := range strings.Split(s, "\n") {
+			if activeEnvLineMatchesKey(line, "MUNINN_TLS_CERT") {
+				active++
+			}
+		}
+		if active != 1 {
+			t.Errorf("exactly one active assignment expected, got %d:\n%s", active, s)
+		}
+	})
+
+	t.Run("CRLF endings are preserved", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "muninn.env")
+		os.WriteFile(path, []byte("# MUNINN_TLS_CERT=/x.pem\r\nMUNINN_TLS_KEY=/keep.pem\r\n"), 0600)
+		if err := upsertEnvFileVar(path, "MUNINN_TLS_CERT", "/new.pem"); err != nil {
+			t.Fatal(err)
+		}
+		b, _ := os.ReadFile(path)
+		if !strings.Contains(string(b), "MUNINN_TLS_CERT=/new.pem\r\n") {
+			t.Errorf("replaced line must keep its CRLF ending:\n%q", b)
+		}
+		if got := loadedEnvValue(t, path, "MUNINN_TLS_CERT"); got != "/new.pem" {
+			t.Errorf("daemon would load %q, want /new.pem", got)
+		}
+	})
+}
+
+// TestLoadedEnvValueNoLeak guards the test helper itself: a multi-key fixture
+// must not leak a stray var into the shared process env after the subtest, or
+// it would poison the integration tests that exec `muninn start` (a lone
+// MUNINN_TLS_KEY makes the daemon abort).
+func TestLoadedEnvValueNoLeak(t *testing.T) {
+	if _, ok := os.LookupEnv("MUNINN_TLS_KEY"); ok {
+		t.Skip("MUNINN_TLS_KEY already set in this environment")
+	}
+	t.Run("round-trip", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "muninn.env")
+		os.WriteFile(path, []byte("MUNINN_TLS_CERT=/c.pem\nMUNINN_TLS_KEY=/k.pem\n"), 0600)
+		_ = loadedEnvValue(t, path, "MUNINN_TLS_CERT")
+	})
+	// The subtest's cleanups have run by now.
+	if v, ok := os.LookupEnv("MUNINN_TLS_KEY"); ok {
+		t.Errorf("loadedEnvValue leaked MUNINN_TLS_KEY=%q into the process env", v)
+	}
+	if v, ok := os.LookupEnv("MUNINN_TLS_CERT"); ok {
+		t.Errorf("loadedEnvValue leaked MUNINN_TLS_CERT=%q into the process env", v)
+	}
+}
+
+func TestUpsertEnvFileVars_PairAndGuards(t *testing.T) {
+	t.Run("pair lands in one write", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "muninn.env")
+		err := upsertEnvFileVars(path, [][2]string{
+			{"MUNINN_TLS_CERT", "/c.pem"},
+			{"MUNINN_TLS_KEY", "/k.pem"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEnvLine(t, path, "MUNINN_TLS_CERT=/c.pem")
+		assertEnvLine(t, path, "MUNINN_TLS_KEY=/k.pem")
+	})
+
+	t.Run("symlinked env file is refused", func(t *testing.T) {
+		dir := t.TempDir()
+		real := filepath.Join(dir, "real.env")
+		link := filepath.Join(dir, "muninn.env")
+		os.WriteFile(real, []byte("MUNINN_TLS_KEY=/keep.pem\n"), 0600)
+		if err := os.Symlink(real, link); err != nil {
+			t.Skip("symlinks unavailable")
+		}
+		if err := upsertEnvFileVar(link, "MUNINN_TLS_CERT", "/c.pem"); err == nil {
+			t.Fatal("symlinked env file must be refused (the loader rejects symlinks)")
+		}
+		fi, err := os.Lstat(link)
+		if err != nil || fi.Mode()&os.ModeSymlink == 0 {
+			t.Error("the symlink must survive untouched")
+		}
+		b, _ := os.ReadFile(real)
+		if string(b) != "MUNINN_TLS_KEY=/keep.pem\n" {
+			t.Errorf("symlink target must be untouched, got:\n%s", b)
+		}
+	})
+
+	t.Run("oversized env file is refused", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "muninn.env")
+		big := strings.Repeat("# filler\n", envFileMaxBytes/9+1)
+		os.WriteFile(path, []byte(big), 0600)
+		if err := upsertEnvFileVar(path, "MUNINN_TLS_CERT", "/c.pem"); err == nil {
+			t.Fatal("oversized env file must be refused (the loader skips it entirely)")
+		}
+	})
 }

--- a/cmd/muninn/init_tls_test.go
+++ b/cmd/muninn/init_tls_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeCertKey generates a self-signed cert + matching key, writes them as PEM,
+// and returns their paths. The pair loads under tls.LoadX509KeyPair.
+func writeCertKey(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("createcert: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshalkey: %v", err)
+	}
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return certPath, keyPath
+}
+
+func TestClientMCPURL(t *testing.T) {
+	t.Run("default is http localhost", func(t *testing.T) {
+		t.Setenv("MUNINN_MCP_URL", "")
+		t.Setenv("MUNINN_TLS_CERT", "")
+		t.Setenv("MUNINN_TLS_KEY", "")
+		if got := clientMCPURL(); got != "http://127.0.0.1:8750/mcp" {
+			t.Errorf("got %q", got)
+		}
+	})
+	t.Run("https when both TLS vars set", func(t *testing.T) {
+		t.Setenv("MUNINN_MCP_URL", "")
+		t.Setenv("MUNINN_TLS_CERT", "/c.pem")
+		t.Setenv("MUNINN_TLS_KEY", "/k.pem")
+		if got := clientMCPURL(); got != "https://127.0.0.1:8750/mcp" {
+			t.Errorf("got %q", got)
+		}
+	})
+	t.Run("stays http when only cert set", func(t *testing.T) {
+		t.Setenv("MUNINN_MCP_URL", "")
+		t.Setenv("MUNINN_TLS_CERT", "/c.pem")
+		t.Setenv("MUNINN_TLS_KEY", "")
+		if got := clientMCPURL(); got != "http://127.0.0.1:8750/mcp" {
+			t.Errorf("got %q", got)
+		}
+	})
+	t.Run("MUNINN_MCP_URL override wins and is trimmed", func(t *testing.T) {
+		t.Setenv("MUNINN_TLS_CERT", "/c.pem")
+		t.Setenv("MUNINN_TLS_KEY", "/k.pem")
+		t.Setenv("MUNINN_MCP_URL", "https://muninn.example:8750/mcp/")
+		if got := clientMCPURL(); got != "https://muninn.example:8750/mcp" {
+			t.Errorf("got %q", got)
+		}
+	})
+}
+
+func TestClientUIURL(t *testing.T) {
+	t.Setenv("MUNINN_TLS_CERT", "")
+	t.Setenv("MUNINN_TLS_KEY", "")
+	if got := clientUIURL(); got != "http://127.0.0.1:8476" {
+		t.Errorf("got %q", got)
+	}
+	t.Setenv("MUNINN_TLS_CERT", "/c.pem")
+	t.Setenv("MUNINN_TLS_KEY", "/k.pem")
+	if got := clientUIURL(); got != "https://127.0.0.1:8476" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestValidateTLSPair(t *testing.T) {
+	cert, key := writeCertKey(t)
+
+	if err := validateTLSPair("", ""); err != nil {
+		t.Errorf("neither set should be valid (no TLS), got %v", err)
+	}
+	if err := validateTLSPair(cert, ""); err == nil {
+		t.Error("cert without key must error")
+	}
+	if err := validateTLSPair("", key); err == nil {
+		t.Error("key without cert must error")
+	}
+	if err := validateTLSPair(cert, key); err != nil {
+		t.Errorf("valid pair must pass, got %v", err)
+	}
+	if err := validateTLSPair("/nope/cert.pem", "/nope/key.pem"); err == nil {
+		t.Error("nonexistent pair must error")
+	}
+}
+
+func TestUpsertEnvFileVar(t *testing.T) {
+	t.Run("creates file when absent", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "muninn.env")
+		if err := upsertEnvFileVar(path, "MUNINN_TLS_CERT", "/c.pem"); err != nil {
+			t.Fatal(err)
+		}
+		assertEnvLine(t, path, "MUNINN_TLS_CERT=/c.pem")
+		fi, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Mode().Perm() != 0600 {
+			t.Errorf("perm = %v, want 0600", fi.Mode().Perm())
+		}
+	})
+
+	t.Run("activates a commented template line", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "muninn.env")
+		os.WriteFile(path, []byte("# ── TLS ──\n# MUNINN_TLS_CERT=/path/to/cert.pem\n# MUNINN_TLS_KEY=/path/to/key.pem\n"), 0600)
+		if err := upsertEnvFileVar(path, "MUNINN_TLS_CERT", "/real/cert.pem"); err != nil {
+			t.Fatal(err)
+		}
+		b, _ := os.ReadFile(path)
+		s := string(b)
+		assertEnvLine(t, path, "MUNINN_TLS_CERT=/real/cert.pem")
+		if strings.Contains(s, "# MUNINN_TLS_CERT=/path/to/cert.pem") {
+			t.Error("old commented cert line should be gone")
+		}
+		if !strings.Contains(s, "# MUNINN_TLS_KEY=/path/to/key.pem") {
+			t.Error("unrelated commented key line must be preserved")
+		}
+	})
+
+	t.Run("updates an existing active line", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "muninn.env")
+		os.WriteFile(path, []byte("MUNINN_TLS_CERT=/old.pem\nMUNINN_OTHER=keep\n"), 0600)
+		if err := upsertEnvFileVar(path, "MUNINN_TLS_CERT", "/new.pem"); err != nil {
+			t.Fatal(err)
+		}
+		assertEnvLine(t, path, "MUNINN_TLS_CERT=/new.pem")
+		b, _ := os.ReadFile(path)
+		if strings.Count(string(b), "MUNINN_TLS_CERT=") != 1 {
+			t.Errorf("expected exactly one cert line, got:\n%s", b)
+		}
+		if !strings.Contains(string(b), "MUNINN_OTHER=keep") {
+			t.Error("unrelated line must be preserved")
+		}
+	})
+
+	t.Run("recognizes a commented export line, no duplicate", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "muninn.env")
+		os.WriteFile(path, []byte("# export MUNINN_TLS_CERT=/old.pem\n"), 0600)
+		if err := upsertEnvFileVar(path, "MUNINN_TLS_CERT", "/new.pem"); err != nil {
+			t.Fatal(err)
+		}
+		b, _ := os.ReadFile(path)
+		if strings.Count(string(b), "MUNINN_TLS_CERT") != 1 {
+			t.Errorf("export line should be replaced, not duplicated:\n%s", b)
+		}
+		assertEnvLine(t, path, "MUNINN_TLS_CERT=/new.pem")
+	})
+
+	t.Run("prefix-collision: longer key untouched", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "muninn.env")
+		os.WriteFile(path, []byte("MUNINN_TLS_CERTIFICATE=keepme\n"), 0600)
+		if err := upsertEnvFileVar(path, "MUNINN_TLS_CERT", "/c.pem"); err != nil {
+			t.Fatal(err)
+		}
+		b, _ := os.ReadFile(path)
+		if !strings.Contains(string(b), "MUNINN_TLS_CERTIFICATE=keepme") {
+			t.Error("longer-named key must not be clobbered")
+		}
+		assertEnvLine(t, path, "MUNINN_TLS_CERT=/c.pem")
+	})
+}
+
+func assertEnvLine(t *testing.T, path, want string) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if line == want {
+			return
+		}
+	}
+	t.Errorf("missing active line %q in:\n%s", want, b)
+}

--- a/cmd/muninn/setup_ai.go
+++ b/cmd/muninn/setup_ai.go
@@ -467,7 +467,11 @@ func cleanupOpenClawBadConfig() {
 // The Usage pattern section varies based on the vault's behavior mode.
 func buildOpenClawSkillContent(mode string) string {
 	usagePattern := openClawUsagePattern(mode)
-	return openClawSkillHeader + usagePattern + openClawSkillFooter
+	// The header embeds the REST base URL twice (prose + MUNINN_URL); rewrite the
+	// compiled-in http default to the scheme-aware client URL so a TLS deployment
+	// gets https. A non-TLS deployment leaves it unchanged.
+	header := strings.ReplaceAll(openClawSkillHeader, "http://127.0.0.1:8475", clientRESTURL())
+	return header + usagePattern + openClawSkillFooter
 }
 
 // openClawUsagePattern returns the ## Usage pattern section for a given behavior mode.

--- a/cmd/muninn/setup_ai.go
+++ b/cmd/muninn/setup_ai.go
@@ -471,6 +471,13 @@ func buildOpenClawSkillContent(mode string) string {
 	// compiled-in http default to the scheme-aware client URL so a TLS deployment
 	// gets https. A non-TLS deployment leaves it unchanged.
 	header := strings.ReplaceAll(openClawSkillHeader, "http://127.0.0.1:8475", clientRESTURL())
+	if strings.HasPrefix(clientRESTURL(), "https://") {
+		// curl verifies certificates — under a self-signed/internal CA every
+		// example here fails with a trust error unless told where the CA lives.
+		header = strings.ReplaceAll(header,
+			"Use curl via the exec/bash tool for all memory\noperations.",
+			"Use curl via the exec/bash tool for all memory\noperations. The server uses TLS with a locally managed certificate — if curl\nreports a certificate error, ask the operator for the CA file and add\n`--cacert <path-to-ca.crt>` to every curl command below.")
+	}
 	return header + usagePattern + openClawSkillFooter
 }
 
@@ -808,7 +815,12 @@ func printManualInstructions(mcpURL, token string) {
 	if token != "" {
 		curlAuth = fmt.Sprintf(` -H "Authorization: Bearer %s"`, token)
 	}
-	fmt.Printf("    curl%s %s/mcp/health\n", curlAuth, mcpURL)
+	// mcpURL already ends in /mcp; the health endpoint lives at <base>/mcp/health.
+	// (Printing mcpURL+"/mcp/health" produced a doubled /mcp/mcp/health that 404s.)
+	fmt.Printf("    curl%s %s/health\n", curlAuth, mcpURL)
+	if strings.HasPrefix(strings.ToLower(mcpURL), "https://") {
+		fmt.Println("    (self-signed/internal CA: add --cacert <ca.crt>)")
+	}
 }
 
 // buildClaudeMDMemoryBlock returns the CLAUDE.md memory block parameterized by behavior mode.

--- a/cmd/muninn/vault_auth.go
+++ b/cmd/muninn/vault_auth.go
@@ -152,9 +152,12 @@ func loginAdmin(username, password string) error {
 	})
 	loginURL := vaultUIBase + "/api/auth/login"
 	client := &http.Client{Timeout: 5 * time.Second}
-	if strings.HasPrefix(loginURL, "https://") && isLoopbackURL(loginURL) {
-		// Loopback https: skip cert verification (internal-CA self-talk can't be
-		// impersonated). Off-host stays verified. Unifies to httpClientForURL once #468 lands.
+	// ToLower: the scheme is case-insensitive; keep this consistent with
+	// isLoopbackURL (which lowercases via url.Parse).
+	if strings.HasPrefix(strings.ToLower(loginURL), "https://") && isLoopbackURL(loginURL) {
+		// Loopback https: skip cert verification — the connection never leaves
+		// this machine. Off-host stays verified. Unifies to httpClientForURL
+		// once #468 lands.
 		client.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
 		}

--- a/cmd/muninn/vault_auth.go
+++ b/cmd/muninn/vault_auth.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -149,8 +150,16 @@ func loginAdmin(username, password string) error {
 		"username": username,
 		"password": password,
 	})
+	loginURL := vaultUIBase + "/api/auth/login"
 	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Post(vaultUIBase+"/api/auth/login", "application/json",
+	if strings.HasPrefix(loginURL, "https://") && isLoopbackURL(loginURL) {
+		// Loopback https: skip cert verification (internal-CA self-talk can't be
+		// impersonated). Off-host stays verified. Unifies to httpClientForURL once #468 lands.
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		}
+	}
+	resp, err := client.Post(loginURL, "application/json",
 		strings.NewReader(string(body)))
 	if err != nil {
 		return fmt.Errorf("connect to MuninnDB: %w", err)


### PR DESCRIPTION
## What

Implements **gaps 1 & 5 of #443** in the `muninn init` wizard:

- **Gap 1 — no TLS setup path.** `init` now has `--tls-cert`/`--tls-key` flags and an interactive *"Serve over TLS?"* prompt. Bring-your-own-cert — the wizard does **not** generate certificates (operator's job, per the issue).
- **Gap 5 — client onboarding over TLS is unowned.** `init` hardcoded `http://127.0.0.1:8750/mcp` into every generated AI-tool config, so a TLS deployment's clients got an unusable `http://` config. The URL is now scheme-aware.

## How

- **Validate up front:** the pair is checked with `tls.LoadX509KeyPair` before the daemon starts, so a bad cert gives a clear CLI error instead of a 5s health-probe-timeout hang (the daemon `os.Exit(1)`s on a bad cert). An explicit-but-invalid pair is **fatal** in both the flag and non-interactive paths — an explicit TLS request is never silently downgraded to plaintext.
- **Reach the daemon:** `init` sets `MUNINN_TLS_CERT/_KEY` in its env before `runStart` forks the daemon (which inherits the env and enables TLS via the existing fallback) — no `buildDaemonArgs` change, keeping cert paths out of `ps`, consistent with how the bearer token is handled.
- **Persist:** the cert/key are written into `~/.muninn/muninn.env` as **active** lines (new `upsertEnvFileVar`, which flips the commented template lines — handles commented/active/`export` forms, prefix-collision safe) so future `muninn start`/systemd restarts keep https.
- **Scheme-aware URLs:** `clientMCPURL()` returns `MUNINN_MCP_URL` (operator-advertised/routable) if set, else `<scheme>://127.0.0.1:8750/mcp` with the scheme following the TLS env. The success-banner MCP/UI URLs are scheme-aware too. **With no TLS the output is byte-identical to before** — no behaviour change for existing setups.

`envfile.go` also factors a shared `atomicWriteFile` primitive out of `writeEnvFileTo`.

## Follow-up in this PR (commit 54ee39c) — scheme-aware generated configs + admin calls under TLS

Closes the remaining init-under-TLS seams so the configs the wizard writes *and* the admin calls it makes are correct:

- **OpenClaw `SKILL.md` REST URL** is now scheme-aware (new `clientRESTURL()`), and the `muninn.env` `MUNINN_MCP_URL` template reflects the scheme + `defaultMCPPort`.
- **`alignLocalAdminBasesToDaemon()`** — after `runStart`, the wizard points its *own* admin/UI base URLs at the daemon's actual scheme + port read from the `muninn.addrs` sidecar (the ground truth `cmdShowVaults`/`doctor` already use), so `loginAdmin` and the plasticity `PUT` reach a daemon just started with TLS (or on a non-default port) instead of failing against `http://127.0.0.1:8475`. `MUNINNDB_ADMIN_URL`/`MUNINNDB_UI_URL` overrides are respected.
- **Loopback cert handling:** `loginAdmin` and the plasticity client skip verification *only* for a loopback `https` target (same gate as `cmdShowVaults`); off-host stays fully verified. These three sites unify onto `httpClientForURL` once #468 lands.

Without this, `muninn init --tls` set up TLS but then silently failed to persist the default vault's behaviour mode (login `http→https`) and emitted `http://` in the generated SKILL.md / env template. **No behaviour change for non-TLS setups** (the `http` output is byte-identical).

## Tests

`cmd/muninn/init_tls_test.go`: `clientMCPURL`/`clientUIURL` (default http, https from env, `MUNINN_MCP_URL` override + trim, cert-without-key stays http), `validateTLSPair` (both/one/neither + invalid), and `upsertEnvFileVar` (creates-when-absent, activates a commented template line, updates an active line, recognizes a commented `export` line without duplicating, prefix-collision leaves a longer-named key untouched). Verified end-to-end against a throwaway self-signed cert in a sandboxed `HOME`: TLS run writes `https://…` into the config + active `muninn.env` lines; no-TLS run writes `http://`. `gofmt`/`vet` clean.

## Scope / notes

- Independent of #456/#463 — reuses only phase-1 infra (the `muninn.addrs` scheme field, `schemeFor`).
- Out of scope (separate #443 gaps): the server-side `/api/admin/mcp-info` http construction and `docs/tls.md`. The OpenClaw `SKILL.md` REST URL and `muninn.env` `MUNINN_MCP_URL` template are now handled (commit 54ee39c). The wizard's *own* admin/UI calls now source scheme + port from `muninn.addrs`; the generated *client* config URLs (`clientMCPURL`/`clientUIURL`/`clientRESTURL`) still hardcode the default ports, so honouring a non-default `--rest-addr`/`--ui-addr` in those remains a small follow-up.
- The repo-wide **Vulnerability scan** CI job is currently red on every branch (a go1.26.3 stdlib advisory); see #464, which bumps the toolchain. Not related to this change.
