### PR TITLE
feat(cli): derive Web UI URL host from the cert DNS SAN (#443 gap 6)

### DIFF
--- a/cmd/muninn/pid.go
+++ b/cmd/muninn/pid.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -21,6 +23,12 @@ type daemonAddrs struct {
 	RestAddr string `json:"rest_addr"`
 	MCPAddr  string `json:"mcp_addr"`
 	UIAddr   string `json:"ui_addr"`
+	// CertHost is a routable DNS SAN from the client-facing TLS certificate, if
+	// any — so 'muninn status' can print a Web UI URL that passes TLS
+	// verification instead of an os.Hostname() that the cert may not cover.
+	// Empty for http, for an older daemon, or for a cert with no routable DNS SAN.
+	// Recorded at startup; a cert rotated in place without a restart leaves it stale.
+	CertHost string `json:"cert_host"`
 }
 
 const addrsFileName = "muninn.addrs"
@@ -32,6 +40,33 @@ func schemeFor(tlsCert, tlsKey string) string {
 		return "https"
 	}
 	return "http"
+}
+
+// certRoutableHost returns the first routable, non-wildcard DNS SAN of the
+// client-facing TLS certificate, or "" if TLS is off, the cert can't be read,
+// or it has no such name. Best-effort: any error yields "" (the authoritative
+// cert load + validation happens separately at server startup). Wildcards are
+// skipped (they pass hostIsRoutable but make no usable URL); single-label names
+// are kept (the cert certifies them, so the URL verifies — resolution is the
+// operator's concern, same as os.Hostname()).
+func certRoutableHost(tlsCert, tlsKey string) string {
+	if tlsCert == "" || tlsKey == "" {
+		return ""
+	}
+	cert, err := tls.LoadX509KeyPair(tlsCert, tlsKey)
+	if err != nil || len(cert.Certificate) == 0 {
+		return ""
+	}
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return ""
+	}
+	for _, name := range leaf.DNSNames {
+		if !strings.Contains(name, "*") && hostIsRoutable(name) {
+			return name
+		}
+	}
+	return ""
 }
 
 func writeAddrsFile(dataDir string, addrs daemonAddrs) error {

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -811,6 +811,9 @@ func runServer() {
 		RestAddr: *restAddr,
 		MCPAddr:  *mcpAddr,
 		UIAddr:   *uiAddr,
+		// Best-effort parse of the cert's routable DNS SAN for the Web UI URL.
+		// "" on any error; the authoritative cert load + validation is below.
+		CertHost: certRoutableHost(*tlsCert, *tlsKey),
 	})
 
 	// Backup env fallbacks — flags take priority; env vars are the fallback.

--- a/cmd/muninn/status.go
+++ b/cmd/muninn/status.go
@@ -209,8 +209,10 @@ func probeServicesWithAddrs(addrs daemonAddrs) []serviceStatus {
 // callers may safely index [0].
 //   - MUNINNDB_UI_URL set        → that URL, verbatim.
 //   - UI bound to loopback/empty → just the localhost URL.
-//   - UI bound to 0.0.0.0 / LAN  → the routable host first (os.Hostname), then
-//     the localhost URL as an always-works fallback.
+//   - UI bound to 0.0.0.0 / LAN  → a routable host first, then the localhost URL
+//     as an always-works fallback. Under TLS, the routable host is the cert's
+//     DNS SAN (addrs.CertHost) when available, so the printed URL passes TLS
+//     verification; otherwise it falls back to os.Hostname().
 func webUIDisplay(addrs daemonAddrs) []string {
 	if v := os.Getenv("MUNINNDB_UI_URL"); v != "" {
 		return []string{strings.TrimRight(v, "/")}
@@ -230,11 +232,24 @@ func webUIDisplay(addrs daemonAddrs) []string {
 	}
 	local := scheme + "://127.0.0.1:" + port
 	if hostIsRoutable(host) {
-		if hn, err := os.Hostname(); err == nil && hn != "" {
+		if hn := routableUIHost(scheme, addrs.CertHost); hn != "" {
 			return []string{scheme + "://" + hn + ":" + port, local}
 		}
 	}
 	return []string{local}
+}
+
+// routableUIHost picks the host for the routable Web UI URL: under TLS, the
+// cert's DNS SAN (so the URL passes verification) when the daemon recorded one,
+// otherwise os.Hostname(). Returns "" only if os.Hostname() fails and no SAN.
+func routableUIHost(scheme, certHost string) string {
+	if scheme == "https" && certHost != "" {
+		return certHost
+	}
+	if h, err := os.Hostname(); err == nil {
+		return h
+	}
+	return ""
 }
 
 // hostIsRoutable reports whether host is a non-loopback bind — i.e. the UI is

--- a/cmd/muninn/webui_san_test.go
+++ b/cmd/muninn/webui_san_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeSANCert generates a self-signed cert with the given DNS/IP SANs, writes
+// cert.pem + key.pem to a temp dir, and returns their paths. certRoutableHost
+// takes file paths, so the fixtures must be real files.
+func writeSANCert(t *testing.T, dnsNames []string, ips []net.IP) (certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     dnsNames,
+		IPAddresses:  ips,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("createcert: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshalkey: %v", err)
+	}
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return certPath, keyPath
+}
+
+func TestCertRoutableHost(t *testing.T) {
+	t.Run("routable DNS SAN is returned", func(t *testing.T) {
+		c, k := writeSANCert(t, []string{"muninn.example"}, nil)
+		if got := certRoutableHost(c, k); got != "muninn.example" {
+			t.Errorf("got %q, want muninn.example", got)
+		}
+	})
+	t.Run("localhost is skipped, next routable SAN wins", func(t *testing.T) {
+		c, k := writeSANCert(t, []string{"localhost", "muninn.example"}, nil)
+		if got := certRoutableHost(c, k); got != "muninn.example" {
+			t.Errorf("got %q, want muninn.example", got)
+		}
+	})
+	t.Run("wildcard SAN is skipped", func(t *testing.T) {
+		c, k := writeSANCert(t, []string{"*.example.com"}, nil)
+		if got := certRoutableHost(c, k); got != "" {
+			t.Errorf("wildcard must be skipped, got %q", got)
+		}
+	})
+	t.Run("wildcard skipped, next routable SAN wins", func(t *testing.T) {
+		c, k := writeSANCert(t, []string{"*.example.com", "muninn.example"}, nil)
+		if got := certRoutableHost(c, k); got != "muninn.example" {
+			t.Errorf("got %q, want muninn.example", got)
+		}
+	})
+	t.Run("only localhost yields empty", func(t *testing.T) {
+		c, k := writeSANCert(t, []string{"localhost"}, nil)
+		if got := certRoutableHost(c, k); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+	t.Run("IP-only cert (no DNS SAN) yields empty", func(t *testing.T) {
+		c, k := writeSANCert(t, nil, []net.IP{net.ParseIP("203.0.113.10")})
+		if got := certRoutableHost(c, k); got != "" {
+			t.Errorf("got %q, want empty (IP SANs are not DNS names)", got)
+		}
+	})
+	t.Run("empty paths yield empty", func(t *testing.T) {
+		if got := certRoutableHost("", ""); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+	t.Run("one of pair yields empty", func(t *testing.T) {
+		c, _ := writeSANCert(t, []string{"muninn.example"}, nil)
+		if got := certRoutableHost(c, ""); got != "" {
+			t.Errorf("got %q, want empty for cert without key", got)
+		}
+	})
+	t.Run("nonexistent paths yield empty", func(t *testing.T) {
+		if got := certRoutableHost("/nope/cert.pem", "/nope/key.pem"); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+func TestWriteReadAddrsFile_CertHost(t *testing.T) {
+	dir := t.TempDir()
+	want := daemonAddrs{Scheme: "https", RestAddr: "127.0.0.1:8475", UIAddr: "0.0.0.0:8476", CertHost: "muninn.example"}
+	if err := writeAddrsFile(dir, want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readAddrsFile(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("round-trip: got %+v, want %+v", got, want)
+	}
+	// An old-format sidecar (no cert_host key) reads with CertHost empty.
+	old := `{"scheme":"https","rest_addr":"127.0.0.1:8475","ui_addr":"0.0.0.0:8476"}`
+	if err := os.WriteFile(filepath.Join(dir, addrsFileName), []byte(old), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = readAddrsFile(dir)
+	if got.CertHost != "" {
+		t.Errorf("old sidecar CertHost = %q, want empty", got.CertHost)
+	}
+}
+
+func TestWebUIDisplay_CertHost(t *testing.T) {
+	t.Run("https routable bind uses the cert SAN", func(t *testing.T) {
+		t.Setenv("MUNINNDB_UI_URL", "")
+		lines := webUIDisplay(daemonAddrs{Scheme: "https", UIAddr: "0.0.0.0:8476", CertHost: "muninn.example"})
+		if lines[0] != "https://muninn.example:8476" {
+			t.Errorf("got %q, want https://muninn.example:8476", lines[0])
+		}
+		if lines[len(lines)-1] != "https://127.0.0.1:8476" {
+			t.Errorf("last line should be the localhost fallback, got %q", lines[len(lines)-1])
+		}
+	})
+	t.Run("no CertHost falls back to os.Hostname (hostname-agnostic)", func(t *testing.T) {
+		t.Setenv("MUNINNDB_UI_URL", "")
+		lines := webUIDisplay(daemonAddrs{Scheme: "https", UIAddr: "0.0.0.0:8476"})
+		if !strings.HasPrefix(lines[0], "https://") {
+			t.Errorf("routable line should be https, got %q", lines[0])
+		}
+		if strings.Contains(lines[0], "127.0.0.1") {
+			t.Errorf("routable line should be a hostname, not loopback: %q", lines[0])
+		}
+	})
+	t.Run("http ignores CertHost", func(t *testing.T) {
+		t.Setenv("MUNINNDB_UI_URL", "")
+		lines := webUIDisplay(daemonAddrs{Scheme: "http", UIAddr: "0.0.0.0:8476", CertHost: "muninn.example"})
+		if strings.Contains(lines[0], "muninn.example") {
+			t.Errorf("http path must not use CertHost, got %q", lines[0])
+		}
+	})
+	t.Run("loopback bind ignores CertHost", func(t *testing.T) {
+		t.Setenv("MUNINNDB_UI_URL", "")
+		lines := webUIDisplay(daemonAddrs{Scheme: "https", UIAddr: "127.0.0.1:8476", CertHost: "muninn.example"})
+		if len(lines) != 1 || lines[0] != "https://127.0.0.1:8476" {
+			t.Errorf("loopback bind must not advertise the cert SAN, got %v", lines)
+		}
+	})
+	t.Run("MUNINNDB_UI_URL wins over CertHost", func(t *testing.T) {
+		t.Setenv("MUNINNDB_UI_URL", "https://override.lan:8476")
+		lines := webUIDisplay(daemonAddrs{Scheme: "https", UIAddr: "0.0.0.0:8476", CertHost: "muninn.example"})
+		if len(lines) != 1 || lines[0] != "https://override.lan:8476" {
+			t.Errorf("env override must win over CertHost, got %v", lines)
+		}
+	})
+}


### PR DESCRIPTION
## What

Implements **gap 6 of #443**. When the Web UI is bound to a routable address (`0.0.0.0`/LAN) under TLS, `webUIDisplay` printed `https://<os.Hostname()>:8476` — a host the certificate is unlikely to certify, so the printed URL **fails TLS verification**. It now uses a name the cert actually covers.

## How

- The **daemon** (which has the cert) records the cert's **first routable, non-wildcard DNS SAN** into the `muninn.addrs` sidecar via a new `cert_host` field (`certRoutableHost` in pid.go, next to `schemeFor`). `muninn status` stays a cheap file read — no new TLS dial.
- `webUIDisplay` prefers `addrs.CertHost` in the routable branch under https, so the printed URL passes verification. Precedence is unchanged elsewhere: `MUNINNDB_UI_URL` env override still wins outright; loopback binds and http are unaffected; it falls back to `os.Hostname()` when there's no usable SAN.
- **Wildcards are skipped** (`*.example.com` would make a broken URL); single-label SANs are kept (the cert certifies them, so the URL verifies). `localhost` is skipped via the existing `hostIsRoutable`.
- `certRoutableHost` is **best-effort** — any error (no TLS, unreadable/parse failure, one-of-pair) yields `""` and the display falls back to `os.Hostname()`. The authoritative cert load + validation (`os.Exit(1)` on a bad cert) at startup is untouched; the sidecar write stays where it is (a deliberate best-effort second parse, commented).

## Notes

- The new `cert_host` field is JSON-additive and backward-compatible: old sidecars read with it empty (Go ignores unknown fields; no `DisallowUnknownFields` in the tree), so an old daemon simply falls back to today's `os.Hostname()` behavior.
- **Value-add framing:** operators could already force a verifying URL with `MUNINNDB_UI_URL`; this makes the **default** (no env var) print one automatically.
- **Trade-off:** the printed `https://<SAN>:port` is what *verifies* — the operator is responsible for making `<SAN>` resolve (DNS/hosts), vs today's resolvable-but-maybe-unverifiable hostname. That's the intended #443 behavior ("guarantee the printed URL passes TLS verification").
- **Staleness:** `cert_host` is recorded at startup; a cert rotated in place without a restart leaves it stale (documented on the field). Display-only; self-heals on `muninn restart`.

## Tests

`cmd/muninn/webui_san_test.go`: `certRoutableHost` over generated SAN certs (routable SAN; localhost-skip; wildcard-skip; wildcard-then-hit; only-localhost; IP-only; empty/one-of-pair/nonexistent paths); the `muninn.addrs` round-trip with `cert_host` + an old-format sidecar; and `webUIDisplay` (uses the SAN under https-routable; falls back to `os.Hostname()` without a SAN; ignores `CertHost` for http and for loopback binds; `MUNINNDB_UI_URL` wins). Verified end-to-end in a sandbox: a `0.0.0.0`-bound TLS daemon with a `DNS:muninn.example` cert → `Web UI → https://muninn.example:<port>`. `gofmt`/`vet` clean.

> The repo-wide **Vulnerability scan** CI is currently red on every branch (a go1.26.3 stdlib advisory); see #464. Unrelated to this change.
