### PR TITLE
feat(cli): reflect the TLS scheme in internal & printed URLs (#443 follow-ups)

### DIFF
--- a/cmd/muninn/backup.go
+++ b/cmd/muninn/backup.go
@@ -82,7 +82,7 @@ func runBackup(args []string) {
 		fmt.Fprintf(os.Stderr, "error: muninn is running (pid %d) — cannot perform offline backup\n", pid)
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Use the online backup endpoint instead:")
-		fmt.Fprintf(os.Stderr, "  curl -X POST http://127.0.0.1:8475/api/admin/backup -d '{\"output_dir\": \"%s\"}'\n", outputDir)
+		fmt.Fprintf(os.Stderr, "  curl -X POST %s://127.0.0.1:%s/api/admin/backup -d '{\"output_dir\": \"%s\"}'\n", localScheme(), defaultRESTPort, outputDir)
 		osExit(1)
 		return
 	}

--- a/cmd/muninn/cluster.go
+++ b/cmd/muninn/cluster.go
@@ -57,14 +57,14 @@ func printClusterHelp() {
 	fmt.Println("  disable       Disable cluster mode on the running node")
 	fmt.Println()
 	fmt.Println("Flags:")
-	fmt.Println("  --addr <url>   Server address (default: http://127.0.0.1:8475)")
+	fmt.Printf("  --addr <url>   Server address (default: %s)\n", clusterAddrDefault())
 	fmt.Println("  --json         Output raw JSON")
 }
 
 // runClusterInfo displays cluster topology and node status.
 func runClusterInfo(args []string) {
 	fs := flag.NewFlagSet("cluster info", flag.ContinueOnError)
-	addr := fs.String("addr", "http://127.0.0.1:8475", "Server address")
+	addr := fs.String("addr", clusterAddrDefault(), "Server address")
 	outputJSON := fs.Bool("json", false, "Output raw JSON")
 	fs.Parse(args)
 
@@ -124,7 +124,7 @@ func runClusterInfo(args []string) {
 // runClusterStatus shows cluster health and per-node replication lag.
 func runClusterStatus(args []string) {
 	fs := flag.NewFlagSet("cluster status", flag.ContinueOnError)
-	addr := fs.String("addr", "http://127.0.0.1:8475", "Server address")
+	addr := fs.String("addr", clusterAddrDefault(), "Server address")
 	outputJSON := fs.Bool("json", false, "Output raw JSON")
 	fs.Parse(args)
 
@@ -200,7 +200,7 @@ func runClusterStatus(args []string) {
 // runClusterFailover triggers a manual failover/election.
 func runClusterFailover(args []string) {
 	fs := flag.NewFlagSet("cluster failover", flag.ContinueOnError)
-	addr := fs.String("addr", "http://127.0.0.1:8475", "Server address")
+	addr := fs.String("addr", clusterAddrDefault(), "Server address")
 	yes := fs.Bool("yes", false, "Skip confirmation prompt")
 	fs.Parse(args)
 
@@ -303,7 +303,7 @@ func runClusterRemoveNode(args []string) {
 // runClusterEnable enables cluster mode on a running node via the admin API.
 func runClusterEnable(args []string) int {
 	fs := flag.NewFlagSet("cluster enable", flag.ContinueOnError)
-	addr := fs.String("addr", "http://127.0.0.1:8475", "MuninnDB admin address")
+	addr := fs.String("addr", clusterAddrDefault(), "MuninnDB admin address")
 	role := fs.String("role", "primary", "Node role: primary|replica|sentinel|observer")
 	bindAddr := fs.String("bind-addr", "", "Cluster bind address (IP:port)")
 	cortexAddr := fs.String("cortex-addr", "", "Cortex address (required for replica/sentinel/observer)")
@@ -365,7 +365,7 @@ func runClusterEnable(args []string) int {
 // runClusterDisable disables cluster mode on a running node via the admin API.
 func runClusterDisable(args []string) int {
 	fs := flag.NewFlagSet("cluster disable", flag.ContinueOnError)
-	addr := fs.String("addr", "http://127.0.0.1:8475", "MuninnDB admin address")
+	addr := fs.String("addr", clusterAddrDefault(), "MuninnDB admin address")
 	yes := fs.Bool("yes", false, "Skip confirmation prompt")
 
 	if err := fs.Parse(args); err != nil {
@@ -391,8 +391,15 @@ func runClusterDisable(args []string) int {
 
 // Helper functions for HTTP calls and JSON parsing
 
+// clusterAddrDefault is the default admin address for cluster commands: loopback
+// REST with the scheme the local daemon serves (so the default works against a
+// local TLS node). An explicit --addr (including a remote one) overrides it.
+func clusterAddrDefault() string {
+	return localScheme() + "://127.0.0.1:" + defaultRESTPort
+}
+
 func httpGet(url string) ([]byte, error) {
-	client := &http.Client{Timeout: 5 * time.Second}
+	client := httpClientForURL(url, 5*time.Second)
 	resp, err := client.Get(url)
 	if err != nil {
 		return nil, err
@@ -412,7 +419,7 @@ func httpGet(url string) ([]byte, error) {
 }
 
 func httpPost(url string) ([]byte, error) {
-	client := &http.Client{Timeout: 5 * time.Second}
+	client := httpClientForURL(url, 5*time.Second)
 	resp, err := client.Post(url, "application/json", nil)
 	if err != nil {
 		return nil, err
@@ -432,7 +439,7 @@ func httpPost(url string) ([]byte, error) {
 }
 
 func httpPostJSON(url string, body []byte) ([]byte, error) {
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := httpClientForURL(url, 10*time.Second)
 	var bodyReader *bytes.Reader
 	if body != nil {
 		bodyReader = bytes.NewReader(body)

--- a/cmd/muninn/help.go
+++ b/cmd/muninn/help.go
@@ -344,7 +344,7 @@ func printHelp() {
 	fmt.Println("  MuninnDB exposes an MCP server that AI tools connect to for memory.")
 	fmt.Println("  Run " + cyan("muninn init") + " to configure Claude Desktop, Cursor, or Windsurf automatically.")
 	fmt.Println()
-	fmt.Println("  MCP endpoint: http://127.0.0.1:8750/mcp")
+	fmt.Printf("  MCP endpoint: %s://127.0.0.1:%s/mcp\n", localScheme(), defaultMCPPort)
 	fmt.Printf("  %-28s %s\n", "MUNINN_MCP_URL", "Override MCP server URL (also used by 'muninn mcp' proxy)")
 	fmt.Printf("  %-28s %s\n", "MUNINNDB_DATA", "Override default data directory")
 	fmt.Printf("  %-28s %s\n", "MUNINNDB_ADMIN_URL", "TLS: base URL for 'muninn status'/admin REST probes")

--- a/cmd/muninn/mcp_stdio.go
+++ b/cmd/muninn/mcp_stdio.go
@@ -92,8 +92,17 @@ func runMCPStdio() {
 
 	if u := os.Getenv("MUNINN_MCP_URL"); u != "" {
 		mcpProxyURL = u
+	} else {
+		mcpProxyURL = defaultMCPProxyURL()
 	}
 	runMCPStdioWith(os.Stdin, os.Stdout)
+}
+
+// defaultMCPProxyURL is the proxy target when MUNINN_MCP_URL is unset: loopback
+// on the canonical MCP port, with the scheme the local daemon actually serves
+// (so the proxy uses https against a local TLS daemon).
+func defaultMCPProxyURL() string {
+	return localScheme() + "://127.0.0.1:" + defaultMCPPort + "/mcp"
 }
 
 // runMCPStdioWith is the testable implementation of the proxy loop.
@@ -103,7 +112,7 @@ func runMCPStdio() {
 // includes it in all subsequent requests. This keeps the daemon's per-session
 // state consistent across the lifetime of a single client session.
 func runMCPStdioWith(in io.Reader, out io.Writer) {
-	client := &http.Client{Timeout: 35 * time.Second}
+	client := httpClientForURL(mcpProxyURL, 35*time.Second)
 	scanner := bufio.NewScanner(in)
 	scanner.Buffer(make([]byte, 1<<20), 1<<20) // 1 MB max line
 

--- a/cmd/muninn/pid.go
+++ b/cmd/muninn/pid.go
@@ -34,6 +34,16 @@ func schemeFor(tlsCert, tlsKey string) string {
 	return "http"
 }
 
+// localScheme reports the scheme the local daemon is serving ("https"/"http"),
+// read from the muninn.addrs sidecar. Defaults to "http" when the sidecar is
+// absent (an older or stopped daemon) — matching the readers' empty-Scheme rule.
+func localScheme() string {
+	if addrs, err := readAddrsFile(defaultDataDir()); err == nil && addrs.Scheme != "" {
+		return addrs.Scheme
+	}
+	return "http"
+}
+
 func writeAddrsFile(dataDir string, addrs daemonAddrs) error {
 	b, err := json.Marshal(addrs)
 	if err != nil {

--- a/cmd/muninn/repl_client.go
+++ b/cmd/muninn/repl_client.go
@@ -70,16 +70,10 @@ func (r *replState) cmdShowVaults() {
 	}
 	apiURL := healthURL("MUNINNDB_ADMIN_URL", addrs.Scheme, restPort) + "/api/vaults"
 
-	client := &http.Client{Timeout: 5 * time.Second}
-	if strings.HasPrefix(apiURL, "https://") && isLoopbackURL(apiURL) {
-		// Skip cert verification only for a loopback target: an internal-CA
-		// TLS deployment talking to its own server can't be impersonated.
-		// For an off-host MUNINNDB_ADMIN_URL verification stays on — this
-		// request carries the admin session cookie.
-		client.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-		}
-	}
+	// Loopback https skips cert verification (internal-CA self-inspection); an
+	// off-host MUNINNDB_ADMIN_URL stays verified — this request carries the admin
+	// session cookie. See httpClientForURL.
+	client := httpClientForURL(apiURL, 5*time.Second)
 	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/muninn/scheme_urls_test.go
+++ b/cmd/muninn/scheme_urls_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -89,4 +92,106 @@ func TestHTTPClientForURL(t *testing.T) {
 			t.Error("http must not set an insecure transport")
 		}
 	})
+	t.Run("insecure clients share one transport", func(t *testing.T) {
+		a := httpClientForURL("https://127.0.0.1:8750/mcp", 5*time.Second)
+		b := httpClientForURL("https://127.0.0.1:8475/api", 10*time.Second)
+		if a.Transport != b.Transport {
+			t.Error("loopback https clients must reuse the shared transport (connection pooling)")
+		}
+	})
+}
+
+// TestHTTPClientForURL_RefusesOffLoopbackRedirect proves the insecure-for-loopback
+// client cannot be steered off-host: a redirect to a non-loopback target errors
+// instead of being followed with verification still skipped.
+func TestHTTPClientForURL_RefusesOffLoopbackRedirect(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://muninn.example.com/api/auth/login", http.StatusTemporaryRedirect)
+	}))
+	defer ts.Close()
+
+	c := httpClientForURL(ts.URL, 5*time.Second)
+	resp, err := c.Post(ts.URL+"/api/auth/login", "application/json", strings.NewReader(`{"password":"x"}`))
+	if err == nil {
+		resp.Body.Close()
+		t.Fatalf("redirect to non-loopback must fail, got status %d", resp.StatusCode)
+	}
+	if !strings.Contains(err.Error(), "refusing redirect") {
+		t.Errorf("error should come from the redirect guard, got: %v", err)
+	}
+
+	// A loopback-to-loopback redirect keeps working.
+	target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+	hop := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+	}))
+	defer hop.Close()
+	resp, err = httpClientForURL(hop.URL, 5*time.Second).Get(hop.URL)
+	if err != nil {
+		t.Fatalf("loopback-to-loopback redirect must succeed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestHTTPClientForURL_RedirectLoopBounded: a self-redirecting loopback server
+// must stop at the default hop cap, not loop forever — a custom CheckRedirect
+// replaces net/http's default 10-redirect limit, so the guard must re-impose it
+// (the timeout-0 clients in the REPL/vault paths have no other bound).
+func TestHTTPClientForURL_RedirectLoopBounded(t *testing.T) {
+	var hits int32
+	var ts *httptest.Server
+	ts = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		http.Redirect(w, r, ts.URL+"/again", http.StatusTemporaryRedirect)
+	}))
+	defer ts.Close()
+
+	// Timeout 0 (no deadline): only the hop cap can stop this.
+	resp, err := httpClientForURL(ts.URL, 0).Get(ts.URL)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("a redirect loop must error, not return a response")
+	}
+	if !strings.Contains(err.Error(), "stopped after") {
+		t.Errorf("expected the hop-cap error, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got > maxRedirects+1 {
+		t.Errorf("server hit %d times, want <= %d (hop cap not enforced)", got, maxRedirects+1)
+	}
+}
+
+// TestProbeOnce_VerifiesWhenSecure pins the off-host gating change: a self-signed
+// TLS server probed with insecure=false (the off-host case) must read as down —
+// i.e. verification actually happens. This fails on the pre-commit code, where
+// probeHealth probed every https URL insecurely.
+func TestProbeOnce_VerifiesWhenSecure(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	if probeOnce(ts.URL, false) {
+		t.Error("a self-signed server must read as down when verification is on")
+	}
+	if !probeOnce(ts.URL, true) {
+		t.Error("the same server must read as up when verification is skipped")
+	}
+}
+
+// TestProbeHealthLoopbackSelfSigned: a loopback https daemon with a self-signed
+// cert must still read as up (the probe skips verification on loopback only).
+func TestProbeHealthLoopbackSelfSigned(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	up, scheme := probeHealth(ts.URL)
+	if !up || scheme != "https" {
+		t.Errorf("probeHealth(%q) = (%v, %q), want (true, https)", ts.URL, up, scheme)
+	}
 }

--- a/cmd/muninn/scheme_urls_test.go
+++ b/cmd/muninn/scheme_urls_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// withSidecarScheme points MUNINNDB_DATA at a temp dir and writes a muninn.addrs
+// with the given scheme (empty scheme = no file written, i.e. absent sidecar).
+func withSidecarScheme(t *testing.T, scheme string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("MUNINNDB_DATA", dir)
+	if scheme != "" {
+		if err := writeAddrsFile(dir, daemonAddrs{Scheme: scheme, RestAddr: "127.0.0.1:8475", UIAddr: "127.0.0.1:8476"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestLocalScheme(t *testing.T) {
+	t.Run("https sidecar", func(t *testing.T) {
+		withSidecarScheme(t, "https")
+		if got := localScheme(); got != "https" {
+			t.Errorf("got %q, want https", got)
+		}
+	})
+	t.Run("http sidecar", func(t *testing.T) {
+		withSidecarScheme(t, "http")
+		if got := localScheme(); got != "http" {
+			t.Errorf("got %q, want http", got)
+		}
+	})
+	t.Run("absent sidecar defaults to http", func(t *testing.T) {
+		withSidecarScheme(t, "")
+		if got := localScheme(); got != "http" {
+			t.Errorf("got %q, want http", got)
+		}
+	})
+}
+
+func TestDefaultMCPProxyURL(t *testing.T) {
+	withSidecarScheme(t, "https")
+	if got := defaultMCPProxyURL(); got != "https://127.0.0.1:"+defaultMCPPort+"/mcp" {
+		t.Errorf("got %q", got)
+	}
+	withSidecarScheme(t, "")
+	if got := defaultMCPProxyURL(); got != "http://127.0.0.1:"+defaultMCPPort+"/mcp" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestClusterAddrDefault(t *testing.T) {
+	withSidecarScheme(t, "https")
+	if got := clusterAddrDefault(); got != "https://127.0.0.1:"+defaultRESTPort {
+		t.Errorf("got %q", got)
+	}
+	withSidecarScheme(t, "")
+	if got := clusterAddrDefault(); got != "http://127.0.0.1:"+defaultRESTPort {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHTTPClientForURL(t *testing.T) {
+	skipsVerify := func(c *http.Client) bool {
+		tr, ok := c.Transport.(*http.Transport)
+		return ok && tr.TLSClientConfig != nil && tr.TLSClientConfig.InsecureSkipVerify
+	}
+
+	t.Run("loopback https skips verification", func(t *testing.T) {
+		c := httpClientForURL("https://127.0.0.1:8750/mcp", 5*time.Second)
+		if !skipsVerify(c) {
+			t.Error("loopback https must skip verification")
+		}
+		if c.Timeout != 5*time.Second {
+			t.Errorf("timeout = %v, want 5s", c.Timeout)
+		}
+	})
+	t.Run("remote https keeps verification", func(t *testing.T) {
+		c := httpClientForURL("https://remote.example:8750/mcp", 5*time.Second)
+		if skipsVerify(c) {
+			t.Error("remote https must NOT skip verification")
+		}
+	})
+	t.Run("loopback http: no custom transport", func(t *testing.T) {
+		c := httpClientForURL("http://127.0.0.1:8750/mcp", 5*time.Second)
+		if skipsVerify(c) {
+			t.Error("http must not set an insecure transport")
+		}
+	})
+}

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -51,6 +51,7 @@ import (
 )
 
 const defaultMCPPort = "8750"
+const defaultRESTPort = "8475"
 const defaultOpenAIEmbedProviderURL = "openai://text-embedding-3-small"
 
 const vaultUpgradeWarning = `

--- a/cmd/muninn/status.go
+++ b/cmd/muninn/status.go
@@ -273,6 +273,23 @@ func isLoopbackURL(rawURL string) bool {
 	return false
 }
 
+// httpClientForURL returns an http.Client for rawURL. It skips TLS verification
+// only for a loopback https target — a self-signed/internal-CA daemon on the
+// same machine, where the cert can't be impersonated — matching probeOnce's
+// loopback rationale. A remote https endpoint keeps full verification.
+func httpClientForURL(rawURL string, timeout time.Duration) *http.Client {
+	c := &http.Client{Timeout: timeout}
+	// ToLower: the scheme is case-insensitive, and isLoopbackURL (via url.Parse)
+	// already is — keep this prefix check consistent with it.
+	if strings.HasPrefix(strings.ToLower(rawURL), "https://") && isLoopbackURL(rawURL) {
+		c.Transport = &http.Transport{
+			// loopback self-signed/internal-CA cert, not a security boundary
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		}
+	}
+	return c
+}
+
 // printStatusDisplay prints the unified status view.
 // compact=true omits the trailing hint lines (used before dropping into shell).
 // Returns the overall state so callers can act on it.

--- a/cmd/muninn/status.go
+++ b/cmd/muninn/status.go
@@ -113,13 +113,16 @@ func probeServicesDefault() []serviceStatus {
 // the returned scheme then lets callers correct a stale display URL. An
 // https:// URL (e.g. an env-var override) is probed directly.
 //
-// The https attempt skips certificate verification: this is a localhost
-// liveness check, not a security boundary, and an internal-CA or self-signed
-// cert must not make a healthy server look [down].
+// The https attempt skips certificate verification only for a loopback URL:
+// there it is a localhost liveness check, not a security boundary, and an
+// internal-CA or self-signed cert must not make a healthy server look [down].
+// An off-host https URL (e.g. a MUNINNDB_*_URL env override) keeps full
+// verification, consistent with httpClientForURL — so a remote server behind
+// an untrusted cert reads as [down] rather than silently probed insecurely.
 func probeHealth(url string) (up bool, scheme string) {
 	switch {
 	case strings.HasPrefix(url, "https://"):
-		if probeOnce(url, true) {
+		if probeOnce(url, isLoopbackURL(url)) {
 			return true, "https"
 		}
 		return false, ""
@@ -129,7 +132,8 @@ func probeHealth(url string) (up bool, scheme string) {
 		}
 		// The http probe failed — the server may actually speak TLS on this
 		// port. Retry once over https before concluding it is down.
-		if probeOnce("https://"+strings.TrimPrefix(url, "http://"), true) {
+		httpsURL := "https://" + strings.TrimPrefix(url, "http://")
+		if probeOnce(httpsURL, isLoopbackURL(httpsURL)) {
 			return true, "https"
 		}
 		return false, ""
@@ -143,10 +147,10 @@ func probeHealth(url string) (up bool, scheme string) {
 func probeOnce(url string, insecure bool) bool {
 	client := &http.Client{Timeout: 2 * time.Second}
 	if insecure {
-		client.Transport = &http.Transport{
-			// localhost liveness probe, not a security boundary
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-		}
+		client.Transport = insecureLoopbackTransport
+		// Same as httpClientForURL: an insecure (loopback) probe must not carry
+		// the verification skip off-host via a redirect.
+		client.CheckRedirect = loopbackOnlyRedirect
 	}
 	resp, err := client.Get(url)
 	if err != nil {
@@ -254,9 +258,12 @@ func hostIsRoutable(host string) bool {
 // isLoopbackURL reports whether rawURL targets this machine — its host is
 // "localhost", a loopback IP, or any address in the 127.0.0.0/8 range. It is
 // the URL-level guard for deciding when skipping TLS certificate verification
-// is safe: a loopback peer cannot be impersonated, an off-host peer can.
-// Unparseable input is treated as non-loopback so callers fail closed (keep
-// verification on).
+// is acceptable: a loopback connection never leaves the machine, an off-host
+// one can be intercepted in transit. (Loopback is a convenience boundary, not
+// a hard one — when the daemon is down, another local process could bind its
+// port. Verifying against the muninn-managed CA instead is a possible future
+// hardening.) Unparseable input is treated as non-loopback so callers fail
+// closed (keep verification on).
 func isLoopbackURL(rawURL string) bool {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -273,21 +280,52 @@ func isLoopbackURL(rawURL string) bool {
 	return false
 }
 
+// insecureLoopbackTransport is shared by every client httpClientForURL builds
+// for a loopback https target, so repeated calls (REPL commands, the job-status
+// poll) reuse TLS connections instead of handshaking — and abandoning idle
+// sockets — per request. Idle bounds match http.DefaultTransport's spirit.
+var insecureLoopbackTransport = &http.Transport{
+	// loopback self-signed/internal-CA cert; see isLoopbackURL for the rationale
+	TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+	MaxIdleConns:    10,
+	IdleConnTimeout: 90 * time.Second,
+}
+
 // httpClientForURL returns an http.Client for rawURL. It skips TLS verification
 // only for a loopback https target — a self-signed/internal-CA daemon on the
-// same machine, where the cert can't be impersonated — matching probeOnce's
-// loopback rationale. A remote https endpoint keeps full verification.
+// same machine — matching probeOnce's loopback rationale. A remote https
+// endpoint keeps full verification. The insecure client also refuses to follow
+// any redirect away from loopback: the verification skip (and a 307/308's
+// replayed request body) must never travel to an off-host peer.
 func httpClientForURL(rawURL string, timeout time.Duration) *http.Client {
 	c := &http.Client{Timeout: timeout}
 	// ToLower: the scheme is case-insensitive, and isLoopbackURL (via url.Parse)
 	// already is — keep this prefix check consistent with it.
 	if strings.HasPrefix(strings.ToLower(rawURL), "https://") && isLoopbackURL(rawURL) {
-		c.Transport = &http.Transport{
-			// loopback self-signed/internal-CA cert, not a security boundary
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-		}
+		c.Transport = insecureLoopbackTransport
+		c.CheckRedirect = loopbackOnlyRedirect
 	}
 	return c
+}
+
+// maxRedirects mirrors net/http's default cap. A custom CheckRedirect REPLACES
+// the default policy entirely, so any guard that sets one must re-impose the
+// hop limit itself — otherwise a loopback responder that redirects to itself in
+// a cycle is followed forever (bounded only by Client.Timeout, and not at all
+// for the timeout-0 clients in the REPL/vault paths).
+const maxRedirects = 10
+
+// loopbackOnlyRedirect refuses any redirect whose target leaves loopback (the
+// verification skip and a 307/308's replayed body must never reach an off-host
+// peer) and re-imposes net/http's default hop cap.
+func loopbackOnlyRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxRedirects)
+	}
+	if !isLoopbackURL(req.URL.String()) {
+		return fmt.Errorf("refusing redirect from loopback TLS endpoint to non-loopback %q", req.URL)
+	}
+	return nil
 }
 
 // printStatusDisplay prints the unified status view.

--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -470,7 +470,15 @@ func (s *Server) handleMCPInfo(w http.ResponseWriter, r *http.Request) {
 	if host == "" || host == "0.0.0.0" || host == "::" {
 		host = "127.0.0.1"
 	}
-	mcpURL := "http://" + host + ":" + port + "/mcp"
+	// Reflect the scheme the daemon actually serves. s.tlsConfig is non-nil iff
+	// client-facing TLS is enabled (it's what Serve wraps the listener with) and
+	// is more reliable than r.TLS here, which is nil when this endpoint is reached
+	// over loopback behind the UI reverse-proxy.
+	scheme := "http"
+	if s.tlsConfig != nil {
+		scheme = "https"
+	}
+	mcpURL := scheme + "://" + host + ":" + port + "/mcp"
 	s.sendJSON(w, http.StatusOK, MCPInfoResponse{
 		URL:             mcpURL,
 		TokenConfigured: s.mcpHasToken,

--- a/internal/transport/rest/admin_handlers_test.go
+++ b/internal/transport/rest/admin_handlers_test.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -326,6 +327,26 @@ func TestMCPInfo_CustomPort(t *testing.T) {
 	json.NewDecoder(w.Body).Decode(&resp)
 	if resp.URL != "http://127.0.0.1:9999/mcp" {
 		t.Errorf("unexpected URL for custom port: %q", resp.URL)
+	}
+}
+
+// TestMCPInfo_TLS verifies the returned URL uses https when the server is
+// configured with a TLS config (the condition under which Serve enables TLS).
+func TestMCPInfo_TLS(t *testing.T) {
+	store := newTestAuthStore(t)
+	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{}, EnrichInfo{}, nil, "", &tls.Config{}, MCPInfo{
+		Addr:     ":8750",
+		HasToken: true,
+	})
+
+	req := httptest.NewRequest("GET", "/api/admin/mcp-info", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	var resp MCPInfoResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.URL != "https://127.0.0.1:8750/mcp" {
+		t.Errorf("expected https URL under TLS, got %q", resp.URL)
 	}
 }
 
@@ -849,7 +870,7 @@ func TestHandleEmbedStatus_IncludesRateAndETA(t *testing.T) {
 			RatePerSec: 1.5,
 			ETASeconds: 120,
 		},
-		embeddedCount: 50,  // less than total → indexing=true
+		embeddedCount: 50, // less than total → indexing=true
 		totalCount:    100,
 	}
 	srv := NewServer("localhost:0", eng, nil, nil, nil, EmbedInfo{Provider: "ollama", Model: "nomic"}, EnrichInfo{}, nil, "", nil)
@@ -885,7 +906,7 @@ func TestHandleEmbedStatus_ZeroRateWhenIdle(t *testing.T) {
 			RatePerSec: 5.0,
 			ETASeconds: 999,
 		},
-		embeddedCount: 100,  // equal to total → indexing=false
+		embeddedCount: 100, // equal to total → indexing=false
 		totalCount:    100,
 	}
 	srv := NewServer("localhost:0", eng, nil, nil, nil, EmbedInfo{Provider: "ollama", Model: "nomic"}, EnrichInfo{}, nil, "", nil)


### PR DESCRIPTION
## What

Finishes the last *functional* rows of #443's gap-map — internal/printed URLs that hardcoded `http://` and broke or misled under TLS. (The numbered design gaps 1–6 are already shipped.)

- **Server-side MCP URL** — `/api/admin/mcp-info` now returns `https://…/mcp` when the daemon serves TLS.
- **`muninn mcp` stdio proxy** — defaulted to `http://`, so it spoke plaintext to a local **TLS** daemon (a real bug). Now scheme-aware.
- **`muninn cluster --addr` default** — defaulted to `http://127.0.0.1:8475`; now reflects the local daemon's scheme.
- Plus the `muninn help` MCP-endpoint line and the `muninn backup` curl hint.

## How

- **Server:** `handleMCPInfo` derives the scheme from `s.tlsConfig != nil` — the exact condition `Serve` wraps the listener with, and more reliable than `r.TLS` (which is `nil` when this endpoint is reached over loopback behind the UI reverse-proxy). The `MUNINN_MCP_URL` override is unchanged.
- **CLI:** a new `localScheme()` reads the scheme the daemon recorded in the `muninn.addrs` sidecar (the same source `muninn status` uses); `muninn mcp` and `muninn cluster` default to it.
- **The crux — a loopback-TLS-aware client.** Flipping a default to `https://` is wrong unless the client trusts a loopback self-signed/internal-CA cert. New `httpClientForURL(rawURL, timeout)` skips verification **only for loopback https** (`isLoopbackURL`), keeping remote https fully verified — generalizing the pattern already inline in `probeOnce`/`repl_client` (and `repl_client` is migrated to it). This also fixes a *pre-existing* latent bug: the cluster/mcp clients couldn't reach a loopback https daemon even with an explicit https URL.
- Adds the `defaultRESTPort` const (used at the touched sites; not a repo-wide literal sweep).

**Non-TLS behaviour is byte-identical**, and `MUNINN_MCP_URL` / an explicit `--addr` still override everything.

## Security

`InsecureSkipVerify` is scoped to **loopback only** (`isLoopbackURL`, which uses `u.Hostname()` — userinfo tricks like `https://127.0.0.1@evil.com/` resolve to `evil.com` and stay verified). The credential-bearing callers (MCP bearer token, admin session cookie) never send creds to a *remote* host with verification disabled — remote endpoints aren't loopback, so verification stays on.

## Tests

`cmd/muninn/scheme_urls_test.go`: `localScheme`/`defaultMCPProxyURL`/`clusterAddrDefault` (https sidecar ⇒ https, absent ⇒ http — each `t.Setenv(MUNINNDB_DATA)`), and `httpClientForURL` (loopback https ⇒ skip-verify transport; remote https ⇒ verified; http ⇒ verified). New `TestMCPInfo_TLS` (https when `tlsConfig != nil`; the 3 existing mcp-info tests stay http/green). Verified end-to-end in a sandbox: a TLS daemon makes `muninn cluster info -h` show an `https://` default and the `help` line `https://…/mcp`; a no-TLS sandbox stays `http://`. `gofmt`/`vet` clean.

## Scope

Out of scope (logged as follow-ups): `muninn init`-generated `SKILL.md`/`muninn.env` URLs (moot on `develop` — init has no TLS branch yet, that's the unmerged #465); the full `8475`/`8476` literal sweep; and ~30 other admin/vault CLI `http.Client`s (`vault.go`, `api-key.go`, `admin.go`) that have the same latent loopback-TLS gap `httpClientForURL` now solves — a clean follow-up.

> The repo-wide **Vulnerability scan** CI is currently red on every branch (a go1.26.3 stdlib advisory); see #464. Unrelated to this change.
