### PR TITLE
test(cli): use an RFC5737 documentation IP in TestIsLoopbackURL

### DIFF
--- a/cmd/muninn/status_test.go
+++ b/cmd/muninn/status_test.go
@@ -450,7 +450,7 @@ func TestIsLoopbackURL(t *testing.T) {
 		{"loopback ipv6", "https://[::1]:8475", true},
 		{"loopback ipv4-mapped ipv6", "https://[::ffff:127.0.0.1]:8475", true},
 		{"http loopback", "http://127.0.0.1:8475", true},
-		{"lan ip", "https://172.20.50.63:8475", false},
+		{"non-loopback ip", "https://203.0.113.10:8475", false},
 		{"public host", "https://muninn.example.com:8475", false},
 		{"empty string", "", false},
 		{"malformed", "https://%zz", false},


### PR DESCRIPTION
`TestIsLoopbackURL`'s non-loopback case used a specific private LAN address as its sample value. Test/documentation code should use the reserved ranges from [RFC 5737](https://datatracker.ietf.org/doc/html/rfc5737) instead, so this swaps it to `203.0.113.10` (TEST-NET-3) and renames the case `"lan ip"` → `"non-loopback ip"` to match its intent (a non-loopback IP literal, as opposed to the adjacent hostname case).

Pure test-data change — no production code touched. `go test ./cmd/muninn/ -run TestIsLoopbackURL` passes.
