### PR TITLE
fix(cli): load muninn.env before dispatching any subcommand (#473)

### DIFF
--- a/cmd/muninn/envfile_test.go
+++ b/cmd/muninn/envfile_test.go
@@ -21,6 +21,24 @@ func TestLoadEnvFile_SetsVars(t *testing.T) {
 	}
 }
 
+// TestLoadEnvFile_SetsDataDirForCLI pins the intent of wiring loadEnvFile() into
+// main(): MUNINNDB_DATA set only in muninn.env must steer the CLI's data dir
+// (via defaultDataDir), so 'muninn status'/'stop' look where the daemon — which
+// loads the same file — actually wrote its PID/addrs sidecar.
+func TestLoadEnvFile_SetsDataDirForCLI(t *testing.T) {
+	dir := t.TempDir()
+	dataDir := filepath.Join(dir, "custom-data")
+	path := filepath.Join(dir, "muninn.env")
+	os.WriteFile(path, []byte("MUNINNDB_DATA="+dataDir+"\n"), 0600)
+
+	t.Setenv("MUNINNDB_DATA", "")
+	os.Unsetenv("MUNINNDB_DATA")
+	loadEnvFileFrom(path)
+	if got := defaultDataDir(); got != dataDir {
+		t.Errorf("defaultDataDir() = %q, want %q (muninn.env's MUNINNDB_DATA must steer the CLI)", got, dataDir)
+	}
+}
+
 func TestLoadEnvFile_ShellEnvWins(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "muninn.env")

--- a/cmd/muninn/main.go
+++ b/cmd/muninn/main.go
@@ -7,6 +7,14 @@ import (
 )
 
 func main() {
+	// Load ~/.muninn/muninn.env before dispatching any subcommand, so the
+	// lifecycle/status CLI sees the same config the daemon does. Without this,
+	// MUNINNDB_DATA (or MUNINNDB_*_URL) set only in muninn.env left 'muninn
+	// status'/'stop' looking at the default data dir while the daemon the same
+	// file configured ran elsewhere. Shell env still wins (loader is set-if-
+	// unset); runServer/runMCPStdio also call it, which is a harmless no-op.
+	loadEnvFile()
+
 	if len(os.Args) < 2 {
 		runDefault()
 		return


### PR DESCRIPTION
Closes #473.

## What

`loadEnvFile()` was called only by the daemon entry points — `runServer` and `runMCPStdio` — so the lifecycle/status CLI never read `~/.muninn/muninn.env`. When that file set `MUNINNDB_DATA` (or `MUNINNDB_*_URL`), the forked daemon honored it but `muninn status` / `stop` / `start` used the compiled-in default data dir:

- `muninn status` probes the default-dir sidecar → reports a live daemon as **down**;
- `muninn stop` can't find the PID;
- the parent `muninn start` does its "already running?" check against the wrong dir.

## Fix

Call `loadEnvFile()` once at the top of `main()`, before subcommand dispatch, so every command shares the daemon's config view. Shell env still wins (the loader is set-if-unset); `runServer`/`runMCPStdio` call it again as a harmless no-op.

## Testing

`go build`, `go vet`, `go test ./cmd/muninn/` pass; `gofmt` clean. Adds `TestLoadEnvFile_SetsDataDirForCLI` — `MUNINNDB_DATA` in `muninn.env` now steers `defaultDataDir()`, which the lifecycle/status commands use.

## Note

Independent of the rest of the #443 stack (touches only `main.go`). When #465 lands, its `loadEnvFile()` inside `runInit` becomes redundant with this one — a no-op, safe to drop in a later cleanup.
