### PR TITLE
fix(transport): enforce vault isolation on MBP and gRPC

### DIFF
--- a/internal/transport/grpc/server.go
+++ b/internal/transport/grpc/server.go
@@ -52,6 +52,44 @@ func denyReadOnlyMutation(ctx context.Context) error {
 	return nil
 }
 
+// resolveRequestVault validates the vault named in an RPC request against the
+// authenticated context and returns the vault to hand to the engine. It mirrors
+// the REST layer's validateResolvedVault so gRPC enforces the same vault model:
+//
+//   - Keyed request: the key's vault is authoritative. An empty request vault
+//     resolves to it; any other value is PermissionDenied (a key scoped to
+//     vault A can never operate on vault B, even a public one). The auth
+//     interceptor validates the key but does not pin the vault — this is where
+//     the pin is enforced.
+//   - Unkeyed request: the request vault (default "default") must be a vault
+//     configured Public, else Unauthenticated. This re-check is essential for
+//     streaming RPCs (Activate, Subscribe), where the interceptor runs before
+//     the first message arrives and can only pre-authorize "default".
+//
+// Fails closed when no auth store is present.
+func (s *Server) resolveRequestVault(ctx context.Context, reqVault string) (string, error) {
+	reqVault = strings.TrimSpace(reqVault)
+	if key, ok := ctx.Value(auth.ContextAPIKey).(*auth.APIKey); ok && key != nil {
+		if reqVault != "" && reqVault != key.Vault {
+			return "", status.Errorf(codes.PermissionDenied, "api key is not authorized for vault %q", reqVault)
+		}
+		return key.Vault, nil
+	}
+
+	vault := reqVault
+	if vault == "" {
+		vault = "default"
+	}
+	if s.authStore == nil {
+		return "", status.Errorf(codes.Unauthenticated, "vault %q requires an API key", vault)
+	}
+	cfg, err := s.authStore.GetVaultConfig(vault)
+	if err != nil || !cfg.Public {
+		return "", status.Errorf(codes.Unauthenticated, "vault %q requires an API key", vault)
+	}
+	return vault, nil
+}
+
 // NewServer creates a new gRPC server.
 // authStore is required and used to validate API keys on every inbound RPC.
 // tlsConfig, if non-nil, enables TLS using gRPC transport credentials.
@@ -233,6 +271,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 // Hello implements the Hello RPC.
 func (s *Server) Hello(ctx context.Context, req *pb.HelloRequest) (*pb.HelloResponse, error) {
+	vault, err := s.resolveRequestVault(ctx, req.Vault)
+	if err != nil {
+		return nil, err
+	}
+	req.Vault = vault
 	resp, err := s.engine.Hello(ctx, req)
 	if err != nil {
 		slog.Error("hello failed", "error", err)
@@ -246,6 +289,11 @@ func (s *Server) Write(ctx context.Context, req *pb.WriteRequest) (*pb.WriteResp
 	if err := denyReadOnlyMutation(ctx); err != nil {
 		return nil, err
 	}
+	vault, err := s.resolveRequestVault(ctx, req.Vault)
+	if err != nil {
+		return nil, err
+	}
+	req.Vault = vault
 	resp, err := s.engine.Write(ctx, req)
 	if err != nil {
 		slog.Error("write failed", "error", err)
@@ -259,6 +307,13 @@ func (s *Server) BatchWrite(ctx context.Context, req *pb.BatchWriteRequest) (*pb
 	if err := denyReadOnlyMutation(ctx); err != nil {
 		return nil, err
 	}
+	for _, w := range req.Requests {
+		vault, err := s.resolveRequestVault(ctx, w.Vault)
+		if err != nil {
+			return nil, err
+		}
+		w.Vault = vault
+	}
 	resp, err := s.engine.BatchWrite(ctx, req)
 	if err != nil {
 		slog.Error("batch write failed", "error", err)
@@ -269,6 +324,11 @@ func (s *Server) BatchWrite(ctx context.Context, req *pb.BatchWriteRequest) (*pb
 
 // Read implements the Read RPC.
 func (s *Server) Read(ctx context.Context, req *pb.ReadRequest) (*pb.ReadResponse, error) {
+	vault, err := s.resolveRequestVault(ctx, req.Vault)
+	if err != nil {
+		return nil, err
+	}
+	req.Vault = vault
 	resp, err := s.engine.Read(ctx, req)
 	if err != nil {
 		slog.Error("read failed", "error", err)
@@ -282,6 +342,11 @@ func (s *Server) Forget(ctx context.Context, req *pb.ForgetRequest) (*pb.ForgetR
 	if err := denyReadOnlyMutation(ctx); err != nil {
 		return nil, err
 	}
+	vault, err := s.resolveRequestVault(ctx, req.Vault)
+	if err != nil {
+		return nil, err
+	}
+	req.Vault = vault
 	resp, err := s.engine.Forget(ctx, req)
 	if err != nil {
 		slog.Error("forget failed", "error", err)
@@ -292,6 +357,11 @@ func (s *Server) Forget(ctx context.Context, req *pb.ForgetRequest) (*pb.ForgetR
 
 // Stat implements the Stat RPC.
 func (s *Server) Stat(ctx context.Context, req *pb.StatRequest) (*pb.StatResponse, error) {
+	vault, err := s.resolveRequestVault(ctx, req.Vault)
+	if err != nil {
+		return nil, err
+	}
+	req.Vault = vault
 	resp, err := s.engine.Stat(ctx, req)
 	if err != nil {
 		slog.Error("stat failed", "error", err)
@@ -305,6 +375,11 @@ func (s *Server) Link(ctx context.Context, req *pb.LinkRequest) (*pb.LinkRespons
 	if err := denyReadOnlyMutation(ctx); err != nil {
 		return nil, err
 	}
+	vault, err := s.resolveRequestVault(ctx, req.Vault)
+	if err != nil {
+		return nil, err
+	}
+	req.Vault = vault
 	resp, err := s.engine.Link(ctx, req)
 	if err != nil {
 		slog.Error("link failed", "error", err)
@@ -316,6 +391,11 @@ func (s *Server) Link(ctx context.Context, req *pb.LinkRequest) (*pb.LinkRespons
 // Activate implements the Activate RPC (server-streaming).
 func (s *Server) Activate(req *pb.ActivateRequest, stream pb.MuninnDB_ActivateServer) error {
 	ctx := stream.Context()
+	vault, err := s.resolveRequestVault(ctx, req.Vault)
+	if err != nil {
+		return err
+	}
+	req.Vault = vault
 	resp, err := s.engine.Activate(ctx, req)
 	if err != nil {
 		slog.Error("activate failed", "error", err)
@@ -341,6 +421,15 @@ func (s *Server) Subscribe(stream pb.MuninnDB_SubscribeServer) error {
 	if err != nil {
 		return err
 	}
+
+	// Enforce vault scope on the subscription's vault. The stream interceptor
+	// runs before this first message, so for unkeyed sessions it could only
+	// pre-authorize "default"; re-resolve here against the actual vault.
+	vault, err := s.resolveRequestVault(ctx, req.Vault)
+	if err != nil {
+		return err
+	}
+	req.Vault = vault
 
 	// Buffered push channel. The deliver func is non-blocking: it drops the push
 	// if the channel is full so the trigger worker goroutine is never blocked.

--- a/internal/transport/grpc/vault_scope_test.go
+++ b/internal/transport/grpc/vault_scope_test.go
@@ -1,0 +1,354 @@
+package grpc_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/auth"
+	"github.com/scrypster/muninndb/internal/engine/trigger"
+	transportgrpc "github.com/scrypster/muninndb/internal/transport/grpc"
+	pb "github.com/scrypster/muninndb/proto/gen/go/muninn/v1"
+	googlegrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ---------------------------------------------------------------------------
+// Vault-isolation tests: the gRPC transport must enforce the same vault model
+// as REST (auth.VaultAuthMiddleware + validateResolvedVault):
+//
+//   - keyed requests: the key's vault is authoritative — an empty request
+//     vault resolves to it, a mismatched one is rejected with PermissionDenied.
+//   - unkeyed stream messages: the interceptor can only pre-authorize
+//     "default"; a message naming another vault must pass the same fail-closed
+//     public-vault check.
+// ---------------------------------------------------------------------------
+
+// vaultRecorder wraps mockEngine and records the vault of every request that
+// reaches the engine.
+type vaultRecorder struct {
+	mockEngine
+	mu     sync.Mutex
+	vaults []string
+}
+
+func (r *vaultRecorder) record(v string) {
+	r.mu.Lock()
+	r.vaults = append(r.vaults, v)
+	r.mu.Unlock()
+}
+
+func (r *vaultRecorder) seen() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.vaults...)
+}
+
+func newVaultRecorder() *vaultRecorder {
+	r := &vaultRecorder{}
+	r.mockEngine = mockEngine{
+		helloFn: func(ctx context.Context, req *pb.HelloRequest) (*pb.HelloResponse, error) {
+			r.record(req.Vault)
+			return &pb.HelloResponse{ServerVersion: "1.0.0"}, nil
+		},
+		writeFn: func(ctx context.Context, req *pb.WriteRequest) (*pb.WriteResponse, error) {
+			r.record(req.Vault)
+			return &pb.WriteResponse{ID: "e-1"}, nil
+		},
+		readFn: func(ctx context.Context, req *pb.ReadRequest) (*pb.ReadResponse, error) {
+			r.record(req.Vault)
+			return &pb.ReadResponse{ID: req.ID}, nil
+		},
+		statFn: func(ctx context.Context, req *pb.StatRequest) (*pb.StatResponse, error) {
+			r.record(req.Vault)
+			return &pb.StatResponse{}, nil
+		},
+		forgetFn: func(ctx context.Context, req *pb.ForgetRequest) (*pb.ForgetResponse, error) {
+			r.record(req.Vault)
+			return &pb.ForgetResponse{OK: true}, nil
+		},
+		linkFn: func(ctx context.Context, req *pb.LinkRequest) (*pb.LinkResponse, error) {
+			r.record(req.Vault)
+			return &pb.LinkResponse{OK: true}, nil
+		},
+		batchWriteFn: func(ctx context.Context, req *pb.BatchWriteRequest) (*pb.BatchWriteResponse, error) {
+			for _, w := range req.Requests {
+				r.record(w.Vault)
+			}
+			return &pb.BatchWriteResponse{}, nil
+		},
+	}
+	return r
+}
+
+// keyedCtx builds the context the auth interceptors create for a request
+// authenticated with an API key scoped to the given vault.
+func keyedCtx(vault string) context.Context {
+	key := &auth.APIKey{Vault: vault, Mode: auth.ModeFull}
+	ctx := context.WithValue(context.Background(), auth.ContextVault, vault)
+	ctx = context.WithValue(ctx, auth.ContextMode, auth.ModeFull)
+	ctx = context.WithValue(ctx, auth.ContextAPIKey, key)
+	return ctx
+}
+
+// unkeyedCtx builds the context the stream interceptor creates for a request
+// with no API key (it can only pre-authorize "default").
+func unkeyedCtx() context.Context {
+	ctx := context.WithValue(context.Background(), auth.ContextVault, "default")
+	ctx = context.WithValue(ctx, auth.ContextMode, auth.ModeFull)
+	return ctx
+}
+
+func wantCode(t *testing.T, err error, want codes.Code, context string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: expected %v error, got nil", context, want)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("%s: expected gRPC status error, got %v", context, err)
+	}
+	if st.Code() != want {
+		t.Fatalf("%s: expected code %v, got %v (%s)", context, want, st.Code(), st.Message())
+	}
+}
+
+// --- keyed unary requests ----------------------------------------------------
+
+func TestVaultScope_KeyedWrite_ForeignVault_Rejected(t *testing.T) {
+	rec := newVaultRecorder()
+	srv := transportgrpc.NewServer(":0", rec, newTestAuthStore(t), nil)
+
+	_, err := srv.Write(keyedCtx("vault-a"), &pb.WriteRequest{Concept: "c", Content: "x", Vault: "vault-b"})
+	wantCode(t, err, codes.PermissionDenied, "keyed write to foreign vault")
+	if seen := rec.seen(); len(seen) != 0 {
+		t.Fatalf("request reached the engine with vaults %v — must be rejected", seen)
+	}
+}
+
+func TestVaultScope_KeyedWrite_EmptyVault_PinnedToKeyVault(t *testing.T) {
+	rec := newVaultRecorder()
+	srv := transportgrpc.NewServer(":0", rec, newTestAuthStore(t), nil)
+
+	_, err := srv.Write(keyedCtx("vault-a"), &pb.WriteRequest{Concept: "c", Content: "x"})
+	if err != nil {
+		t.Fatalf("keyed write with empty vault: %v", err)
+	}
+	if seen := rec.seen(); len(seen) != 1 || seen[0] != "vault-a" {
+		t.Fatalf("engine saw vaults %v, want [vault-a]", seen)
+	}
+}
+
+func TestVaultScope_KeyedWrite_MatchingVault_Allowed(t *testing.T) {
+	rec := newVaultRecorder()
+	srv := transportgrpc.NewServer(":0", rec, newTestAuthStore(t), nil)
+
+	_, err := srv.Write(keyedCtx("vault-a"), &pb.WriteRequest{Concept: "c", Content: "x", Vault: "vault-a"})
+	if err != nil {
+		t.Fatalf("keyed write to own vault: %v", err)
+	}
+	if seen := rec.seen(); len(seen) != 1 || seen[0] != "vault-a" {
+		t.Fatalf("engine saw vaults %v, want [vault-a]", seen)
+	}
+}
+
+// TestVaultScope_KeyedAllUnaryOps_ForeignVault_Rejected sweeps every unary RPC
+// with a vault field.
+func TestVaultScope_KeyedAllUnaryOps_ForeignVault_Rejected(t *testing.T) {
+	rec := newVaultRecorder()
+	srv := transportgrpc.NewServer(":0", rec, newTestAuthStore(t), nil)
+	ctx := keyedCtx("vault-a")
+
+	ops := []struct {
+		name string
+		call func() error
+	}{
+		{"hello", func() error { _, err := srv.Hello(ctx, &pb.HelloRequest{Version: "1", Vault: "vault-b"}); return err }},
+		{"read", func() error { _, err := srv.Read(ctx, &pb.ReadRequest{ID: "x", Vault: "vault-b"}); return err }},
+		{"forget", func() error { _, err := srv.Forget(ctx, &pb.ForgetRequest{ID: "x", Vault: "vault-b"}); return err }},
+		{"link", func() error {
+			_, err := srv.Link(ctx, &pb.LinkRequest{SourceID: "a", TargetID: "b", Vault: "vault-b"})
+			return err
+		}},
+		{"stat", func() error { _, err := srv.Stat(ctx, &pb.StatRequest{Vault: "vault-b"}); return err }},
+		{"batchwrite", func() error {
+			_, err := srv.BatchWrite(ctx, &pb.BatchWriteRequest{Requests: []*pb.WriteRequest{
+				{Concept: "c", Content: "x", Vault: "vault-a"},
+				{Concept: "c", Content: "x", Vault: "vault-b"},
+			}})
+			return err
+		}},
+	}
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			wantCode(t, op.call(), codes.PermissionDenied, op.name+" naming foreign vault")
+		})
+	}
+	if seen := rec.seen(); len(seen) != 0 {
+		t.Fatalf("requests reached the engine with vaults %v — all must be rejected", seen)
+	}
+}
+
+// --- unkeyed unary requests --------------------------------------------------
+
+// TestVaultScope_UnkeyedWrite_LockedVault_Rejected covers the path where the
+// unary interceptor pre-authorizes "default" (it cannot read the vault of a
+// non-batch request) and the handler-level resolveRequestVault is the sole
+// enforcement against an unkeyed request naming a locked vault.
+func TestVaultScope_UnkeyedWrite_LockedVault_Rejected(t *testing.T) {
+	store := newTestAuthStore(t)
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "default", Public: true}); err != nil {
+		t.Fatalf("SetVaultConfig default: %v", err)
+	}
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "secret", Public: false}); err != nil {
+		t.Fatalf("SetVaultConfig secret: %v", err)
+	}
+	rec := newVaultRecorder()
+	srv := transportgrpc.NewServer(":0", rec, store, nil)
+
+	_, err := srv.Write(unkeyedCtx(), &pb.WriteRequest{Concept: "c", Content: "x", Vault: "secret"})
+	wantCode(t, err, codes.Unauthenticated, "unkeyed write to locked vault")
+	if seen := rec.seen(); len(seen) != 0 {
+		t.Fatalf("request reached the engine with vaults %v — must be rejected", seen)
+	}
+}
+
+func TestVaultScope_UnkeyedWrite_PublicVault_Allowed(t *testing.T) {
+	store := newTestAuthStore(t)
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "shared", Public: true}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+	rec := newVaultRecorder()
+	srv := transportgrpc.NewServer(":0", rec, store, nil)
+
+	if _, err := srv.Write(unkeyedCtx(), &pb.WriteRequest{Concept: "c", Content: "x", Vault: "shared"}); err != nil {
+		t.Fatalf("unkeyed write to public vault: %v", err)
+	}
+	if seen := rec.seen(); len(seen) != 1 || seen[0] != "shared" {
+		t.Fatalf("engine saw vaults %v, want [shared]", seen)
+	}
+}
+
+// TestVaultScope_NilAuthStore_FailsClosed verifies resolveRequestVault denies an
+// unkeyed request when the server has no auth store, rather than defaulting open.
+func TestVaultScope_NilAuthStore_FailsClosed(t *testing.T) {
+	rec := newVaultRecorder()
+	srv := transportgrpc.NewServer(":0", rec, nil, nil)
+
+	_, err := srv.Write(unkeyedCtx(), &pb.WriteRequest{Concept: "c", Content: "x", Vault: "default"})
+	wantCode(t, err, codes.Unauthenticated, "unkeyed write with nil auth store")
+	if seen := rec.seen(); len(seen) != 0 {
+		t.Fatalf("request reached the engine with vaults %v — must fail closed", seen)
+	}
+}
+
+// --- streaming RPCs -----------------------------------------------------------
+
+// stubActivateStream implements pb.MuninnDB_ActivateServer.
+type stubActivateStream struct {
+	googlegrpc.ServerStream
+	ctx  context.Context
+	sent []*pb.ActivateResponse
+}
+
+func (s *stubActivateStream) Context() context.Context { return s.ctx }
+func (s *stubActivateStream) Send(r *pb.ActivateResponse) error {
+	s.sent = append(s.sent, r)
+	return nil
+}
+
+func TestVaultScope_KeyedActivateStream_ForeignVault_Rejected(t *testing.T) {
+	rec := newVaultRecorder()
+	rec.activateFn = func(ctx context.Context, req *pb.ActivateRequest) (*pb.ActivateResponse, error) {
+		rec.record(req.Vault)
+		return &pb.ActivateResponse{}, nil
+	}
+	srv := transportgrpc.NewServer(":0", rec, newTestAuthStore(t), nil)
+
+	stream := &stubActivateStream{ctx: keyedCtx("vault-a")}
+	err := srv.Activate(&pb.ActivateRequest{Context: []string{"q"}, Vault: "vault-b"}, stream)
+	wantCode(t, err, codes.PermissionDenied, "keyed activate stream to foreign vault")
+	if seen := rec.seen(); len(seen) != 0 {
+		t.Fatalf("request reached the engine with vaults %v — must be rejected", seen)
+	}
+}
+
+func TestVaultScope_KeyedActivateStream_EmptyVault_Pinned(t *testing.T) {
+	rec := newVaultRecorder()
+	rec.activateFn = func(ctx context.Context, req *pb.ActivateRequest) (*pb.ActivateResponse, error) {
+		rec.record(req.Vault)
+		return &pb.ActivateResponse{}, nil
+	}
+	srv := transportgrpc.NewServer(":0", rec, newTestAuthStore(t), nil)
+
+	stream := &stubActivateStream{ctx: keyedCtx("vault-a")}
+	if err := srv.Activate(&pb.ActivateRequest{Context: []string{"q"}}, stream); err != nil {
+		t.Fatalf("keyed activate with empty vault: %v", err)
+	}
+	if seen := rec.seen(); len(seen) != 1 || seen[0] != "vault-a" {
+		t.Fatalf("engine saw vaults %v, want [vault-a]", seen)
+	}
+}
+
+// stubSubscribeStream implements pb.MuninnDB_SubscribeServer, delivering one
+// SubscribeRequest then blocking until the context is done.
+type stubSubscribeStream struct {
+	googlegrpc.ServerStream
+	ctx    context.Context
+	cancel context.CancelFunc
+	req    *pb.SubscribeRequest
+	once   sync.Once
+}
+
+func (s *stubSubscribeStream) Context() context.Context { return s.ctx }
+func (s *stubSubscribeStream) Send(p *pb.ActivationPush) error {
+	// First send confirms the subscription; cancel so the handler loop exits.
+	s.cancel()
+	return nil
+}
+func (s *stubSubscribeStream) Recv() (*pb.SubscribeRequest, error) {
+	var req *pb.SubscribeRequest
+	s.once.Do(func() { req = s.req })
+	if req != nil {
+		return req, nil
+	}
+	<-s.ctx.Done()
+	return nil, s.ctx.Err()
+}
+
+func TestVaultScope_UnkeyedSubscribeStream_LockedVault_Rejected(t *testing.T) {
+	store := newTestAuthStore(t)
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "default", Public: true}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "secret", Public: false}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+	rec := newVaultRecorder()
+	rec.subscribeWithDeliverFn = func(ctx context.Context, req *pb.SubscribeRequest, _ trigger.DeliverFunc) (string, error) {
+		rec.record(req.Vault)
+		return "sub-1", nil
+	}
+	srv := transportgrpc.NewServer(":0", rec, store, nil)
+
+	ctx, cancel := context.WithCancel(unkeyedCtx())
+	defer cancel()
+	stream := &stubSubscribeStream{ctx: ctx, cancel: cancel, req: &pb.SubscribeRequest{Vault: "secret"}}
+	err := srv.Subscribe(stream)
+	wantCode(t, err, codes.Unauthenticated, "unkeyed subscribe to locked vault")
+	if seen := rec.seen(); len(seen) != 0 {
+		t.Fatalf("request reached the engine with vaults %v — must be rejected", seen)
+	}
+}
+
+func TestVaultScope_KeyedSubscribeStream_ForeignVault_Rejected(t *testing.T) {
+	rec := newVaultRecorder()
+	srv := transportgrpc.NewServer(":0", rec, newTestAuthStore(t), nil)
+
+	ctx, cancel := context.WithCancel(keyedCtx("vault-a"))
+	defer cancel()
+	stream := &stubSubscribeStream{ctx: ctx, cancel: cancel, req: &pb.SubscribeRequest{Vault: "vault-b"}}
+	err := srv.Subscribe(stream)
+	wantCode(t, err, codes.PermissionDenied, "keyed subscribe to foreign vault")
+}

--- a/internal/transport/mbp/mbp_test.go
+++ b/internal/transport/mbp/mbp_test.go
@@ -10,6 +10,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/scrypster/muninndb/internal/auth"
 )
 
 // ---------------------------------------------------------------------------
@@ -61,8 +65,21 @@ func (e *stubEngine) Stat(_ context.Context, _ *StatRequest) (*StatResponse, err
 // Test helpers
 // ---------------------------------------------------------------------------
 
-func newTestServer(eng EngineAPI) *Server {
-	return &Server{engine: eng, shutdown: make(chan struct{})}
+// newTestServer builds a server whose default vault is public, so the existing
+// dispatch tests (which handshake with auth_method "none" and use the default
+// vault) operate without an API key. Vault-isolation behaviour is covered
+// separately in vault_scope_test.go.
+func newTestServer(t *testing.T, eng EngineAPI) *Server {
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		panic("open test auth db: " + err.Error())
+	}
+	t.Cleanup(func() { db.Close() })
+	store := auth.NewStore(db)
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "default", Public: true}); err != nil {
+		panic("set default vault config: " + err.Error())
+	}
+	return &Server{engine: eng, authStore: store, shutdown: make(chan struct{})}
 }
 
 func startTestConn(t *testing.T, s *Server) (client net.Conn, wait func()) {
@@ -623,7 +640,7 @@ func TestProtocolVersionConstants(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestServer_DispatchAllHandlers(t *testing.T) {
-	s := newTestServer(&stubEngine{})
+	s := newTestServer(t, &stubEngine{})
 	c, wait := startTestConn(t, s)
 	defer wait()
 	doHandshake(t, c)
@@ -659,7 +676,7 @@ func TestServer_DispatchAllHandlers(t *testing.T) {
 }
 
 func TestServer_PingEchoData(t *testing.T) {
-	s := newTestServer(&stubEngine{})
+	s := newTestServer(t, &stubEngine{})
 	c, wait := startTestConn(t, s)
 	defer wait()
 	doHandshake(t, c)
@@ -678,7 +695,7 @@ func TestServer_PingEchoData(t *testing.T) {
 }
 
 func TestServer_EngineError(t *testing.T) {
-	s := newTestServer(&stubEngine{writeErr: fmt.Errorf("disk full")})
+	s := newTestServer(t, &stubEngine{writeErr: fmt.Errorf("disk full")})
 	c, wait := startTestConn(t, s)
 	defer wait()
 	doHandshake(t, c)
@@ -700,7 +717,7 @@ func TestServer_EngineError(t *testing.T) {
 }
 
 func TestServer_InvalidPayload(t *testing.T) {
-	s := newTestServer(&stubEngine{})
+	s := newTestServer(t, &stubEngine{})
 	c, wait := startTestConn(t, s)
 	defer wait()
 	doHandshake(t, c)
@@ -720,7 +737,7 @@ func TestServer_InvalidPayload(t *testing.T) {
 }
 
 func TestServer_UnknownFrameType(t *testing.T) {
-	s := newTestServer(&stubEngine{})
+	s := newTestServer(t, &stubEngine{})
 	c, wait := startTestConn(t, s)
 	defer wait()
 	doHandshake(t, c)
@@ -747,7 +764,7 @@ func TestServer_UnknownFrameType(t *testing.T) {
 }
 
 func TestServer_NonHelloFirst(t *testing.T) {
-	s := newTestServer(&stubEngine{})
+	s := newTestServer(t, &stubEngine{})
 	c, wait := startTestConn(t, s)
 	defer wait()
 
@@ -774,7 +791,7 @@ func TestServer_NonHelloFirst(t *testing.T) {
 }
 
 func TestServer_InvalidHelloPayload(t *testing.T) {
-	s := newTestServer(&stubEngine{})
+	s := newTestServer(t, &stubEngine{})
 	c, wait := startTestConn(t, s)
 	defer wait()
 
@@ -793,7 +810,7 @@ func TestServer_InvalidHelloPayload(t *testing.T) {
 }
 
 func TestServer_HelloBadVersion(t *testing.T) {
-	s := newTestServer(&stubEngine{})
+	s := newTestServer(t, &stubEngine{})
 	c, wait := startTestConn(t, s)
 	defer wait()
 
@@ -821,7 +838,7 @@ func TestServer_HelloBadVersion(t *testing.T) {
 }
 
 func TestServer_WriteResponsePayload(t *testing.T) {
-	s := newTestServer(&stubEngine{})
+	s := newTestServer(t, &stubEngine{})
 	c, wait := startTestConn(t, s)
 	defer wait()
 	doHandshake(t, c)
@@ -843,7 +860,7 @@ func TestServer_WriteResponsePayload(t *testing.T) {
 }
 
 func TestServer_StatResponsePayload(t *testing.T) {
-	s := newTestServer(&stubEngine{})
+	s := newTestServer(t, &stubEngine{})
 	c, wait := startTestConn(t, s)
 	defer wait()
 	doHandshake(t, c)

--- a/internal/transport/mbp/server.go
+++ b/internal/transport/mbp/server.go
@@ -177,13 +177,34 @@ func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
 		return
 	}
 
-	// Authenticate (if needed)
+	// Authenticate and establish the connection's vault scope. The scope is
+	// enforced on every subsequent frame (see dispatchFrame handlers), closing
+	// the gap where a "none" session could read/write any vault and a keyed
+	// session could name a vault other than its key's.
+	if s.authStore == nil {
+		s.writeErrorFrame(conn, helloFrame.CorrelationID, ErrAuthFailed, "server misconfigured: vault auth unavailable")
+		return
+	}
+	scope := &vaultScope{}
 	if helloReq.AuthMethod == "token" {
-		if _, err := s.authStore.ValidateAPIKey(helloReq.Token); err != nil {
+		key, err := s.authStore.ValidateAPIKey(helloReq.Token)
+		if err != nil {
 			s.writeErrorFrame(conn, helloFrame.CorrelationID, ErrAuthFailed, "invalid token")
 			return
 		}
+		scope.key = &key
 	}
+	connCtx = withVaultScope(connCtx, scope)
+
+	// Resolve and validate the HELLO vault under the new scope, then pin the
+	// request to it so the engine registers (and the response advertises) the
+	// authorized vault rather than a client-supplied one.
+	resolvedVault, err := s.scopeVault(connCtx, helloReq.Vault)
+	if err != nil {
+		s.writeErrorFrame(conn, helloFrame.CorrelationID, ErrAuthFailed, err.Error())
+		return
+	}
+	helloReq.Vault = resolvedVault
 
 	// Call engine's Hello handler
 	helloResp, err := s.engine.Hello(connCtx, &helloReq)
@@ -322,6 +343,13 @@ func (s *Server) handleWrite(ctx context.Context, corrID uint64, payload []byte,
 		return
 	}
 
+	resolved, err := s.scopeVault(ctx, req.Vault)
+	if err != nil {
+		s.queueErrorFrame(writeCh, corrID, ErrAuthFailed, err.Error())
+		return
+	}
+	req.Vault = resolved
+
 	resp, err := s.engine.Write(ctx, &req)
 	if err != nil {
 		s.queueErrorFrame(writeCh, corrID, ErrStorageError, err.Error())
@@ -337,6 +365,13 @@ func (s *Server) handleRead(ctx context.Context, corrID uint64, payload []byte, 
 		s.queueErrorFrame(writeCh, corrID, ErrInvalidEngram, "invalid read request")
 		return
 	}
+
+	resolved, err := s.scopeVault(ctx, req.Vault)
+	if err != nil {
+		s.queueErrorFrame(writeCh, corrID, ErrAuthFailed, err.Error())
+		return
+	}
+	req.Vault = resolved
 
 	resp, err := s.engine.Read(ctx, &req)
 	if err != nil {
@@ -354,6 +389,13 @@ func (s *Server) handleActivate(ctx context.Context, corrID uint64, payload []by
 		return
 	}
 
+	resolved, err := s.scopeVault(ctx, req.Vault)
+	if err != nil {
+		s.queueErrorFrame(writeCh, corrID, ErrAuthFailed, err.Error())
+		return
+	}
+	req.Vault = resolved
+
 	resp, err := s.engine.Activate(ctx, &req)
 	if err != nil {
 		s.queueErrorFrame(writeCh, corrID, ErrIndexError, err.Error())
@@ -369,6 +411,13 @@ func (s *Server) handleSubscribe(ctx context.Context, corrID uint64, payload []b
 		s.queueErrorFrame(writeCh, corrID, ErrInvalidEngram, "invalid subscribe request")
 		return
 	}
+
+	resolved, err := s.scopeVault(ctx, req.Vault)
+	if err != nil {
+		s.queueErrorFrame(writeCh, corrID, ErrAuthFailed, err.Error())
+		return
+	}
+	req.Vault = resolved
 
 	resp, err := s.engine.Subscribe(ctx, &req)
 	if err != nil {
@@ -402,6 +451,13 @@ func (s *Server) handleLink(ctx context.Context, corrID uint64, payload []byte, 
 		return
 	}
 
+	resolved, err := s.scopeVault(ctx, req.Vault)
+	if err != nil {
+		s.queueErrorFrame(writeCh, corrID, ErrAuthFailed, err.Error())
+		return
+	}
+	req.Vault = resolved
+
 	resp, err := s.engine.Link(ctx, &req)
 	if err != nil {
 		s.queueErrorFrame(writeCh, corrID, ErrInvalidAssociation, err.Error())
@@ -418,6 +474,13 @@ func (s *Server) handleForget(ctx context.Context, corrID uint64, payload []byte
 		return
 	}
 
+	resolved, err := s.scopeVault(ctx, req.Vault)
+	if err != nil {
+		s.queueErrorFrame(writeCh, corrID, ErrAuthFailed, err.Error())
+		return
+	}
+	req.Vault = resolved
+
 	resp, err := s.engine.Forget(ctx, &req)
 	if err != nil {
 		s.queueErrorFrame(writeCh, corrID, ErrStorageError, err.Error())
@@ -433,6 +496,13 @@ func (s *Server) handleStat(ctx context.Context, corrID uint64, payload []byte, 
 		s.queueErrorFrame(writeCh, corrID, ErrInvalidEngram, "invalid stat request")
 		return
 	}
+
+	resolved, err := s.scopeVault(ctx, req.Vault)
+	if err != nil {
+		s.queueErrorFrame(writeCh, corrID, ErrAuthFailed, err.Error())
+		return
+	}
+	req.Vault = resolved
 
 	resp, err := s.engine.Stat(ctx, &req)
 	if err != nil {

--- a/internal/transport/mbp/vault_scope.go
+++ b/internal/transport/mbp/vault_scope.go
@@ -1,0 +1,66 @@
+package mbp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/scrypster/muninndb/internal/auth"
+)
+
+// vaultScope is the per-connection authorization established at HELLO time.
+// A non-nil key means the connection authenticated with an API key and is
+// pinned to that key's vault; a nil key means an unauthenticated ("none")
+// session that may only touch public vaults.
+type vaultScope struct {
+	key *auth.APIKey
+}
+
+type vaultScopeKeyType struct{}
+
+var vaultScopeKey = vaultScopeKeyType{}
+
+// withVaultScope returns a context carrying the connection's vault scope so
+// per-frame handlers can enforce it without threading extra parameters.
+func withVaultScope(ctx context.Context, sc *vaultScope) context.Context {
+	return context.WithValue(ctx, vaultScopeKey, sc)
+}
+
+// scopeVault validates the vault named in a single request frame against the
+// connection's vault scope and returns the resolved vault to hand to the
+// engine. It mirrors auth.VaultAuthMiddleware so MBP enforces the same
+// fail-closed model as REST and MCP:
+//
+//   - Keyed session: the key's vault is authoritative. An empty request vault
+//     resolves to it; any other value is rejected (a key scoped to vault A can
+//     never operate on vault B, even a public one).
+//   - Unauthenticated session: the request vault (default "default") must be a
+//     vault configured Public. Locked or unconfigured vaults are rejected.
+//
+// It fails closed if the context carries no scope or the server has no auth
+// store, so a misconfigured server denies access rather than exposing every
+// vault.
+func (s *Server) scopeVault(ctx context.Context, reqVault string) (string, error) {
+	reqVault = strings.TrimSpace(reqVault)
+	sc, _ := ctx.Value(vaultScopeKey).(*vaultScope)
+	if sc == nil || s.authStore == nil {
+		return "", fmt.Errorf("vault access denied: connection is not authorized")
+	}
+
+	if sc.key != nil {
+		if reqVault != "" && reqVault != sc.key.Vault {
+			return "", fmt.Errorf("api key is not authorized for vault %q", reqVault)
+		}
+		return sc.key.Vault, nil
+	}
+
+	vault := reqVault
+	if vault == "" {
+		vault = "default"
+	}
+	cfg, err := s.authStore.GetVaultConfig(vault)
+	if err != nil || !cfg.Public {
+		return "", fmt.Errorf("vault %q requires an API key", vault)
+	}
+	return vault, nil
+}

--- a/internal/transport/mbp/vault_scope_test.go
+++ b/internal/transport/mbp/vault_scope_test.go
@@ -1,0 +1,356 @@
+package mbp
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/scrypster/muninndb/internal/auth"
+)
+
+// ---------------------------------------------------------------------------
+// Vault-isolation tests: the MBP transport must enforce the same fail-closed
+// vault model as REST (auth.VaultAuthMiddleware) and MCP:
+//
+//   - token sessions: the key's vault is authoritative — an empty request
+//     vault resolves to it, a mismatched one is rejected.
+//   - auth_method "none" sessions: every requested vault (default "default")
+//     must be configured Public; locked or unconfigured vaults are rejected.
+// ---------------------------------------------------------------------------
+
+// recEngine records the vault of every request that reaches the engine, so
+// tests can assert both that rejected requests never reach it and that
+// accepted requests arrive with the resolved (pinned) vault.
+type recEngine struct {
+	stubEngine
+	mu     sync.Mutex
+	vaults []string
+}
+
+func (e *recEngine) record(v string) {
+	e.mu.Lock()
+	e.vaults = append(e.vaults, v)
+	e.mu.Unlock()
+}
+
+func (e *recEngine) seen() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.vaults...)
+}
+
+func (e *recEngine) Hello(ctx context.Context, req *HelloRequest) (*HelloResponse, error) {
+	return e.stubEngine.Hello(ctx, req)
+}
+
+func (e *recEngine) Write(ctx context.Context, req *WriteRequest) (*WriteResponse, error) {
+	e.record(req.Vault)
+	return e.stubEngine.Write(ctx, req)
+}
+
+func (e *recEngine) Read(ctx context.Context, req *ReadRequest) (*ReadResponse, error) {
+	e.record(req.Vault)
+	return e.stubEngine.Read(ctx, req)
+}
+
+func (e *recEngine) Activate(ctx context.Context, req *ActivateRequest) (*ActivateResponse, error) {
+	e.record(req.Vault)
+	return e.stubEngine.Activate(ctx, req)
+}
+
+func (e *recEngine) Link(ctx context.Context, req *LinkRequest) (*LinkResponse, error) {
+	e.record(req.Vault)
+	return e.stubEngine.Link(ctx, req)
+}
+
+func (e *recEngine) Forget(ctx context.Context, req *ForgetRequest) (*ForgetResponse, error) {
+	e.record(req.Vault)
+	return e.stubEngine.Forget(ctx, req)
+}
+
+func (e *recEngine) Stat(ctx context.Context, req *StatRequest) (*StatResponse, error) {
+	e.record(req.Vault)
+	return e.stubEngine.Stat(ctx, req)
+}
+
+func (e *recEngine) Subscribe(ctx context.Context, req *SubscribeRequest) (*SubscribeResponse, error) {
+	e.record(req.Vault)
+	return e.stubEngine.Subscribe(ctx, req)
+}
+
+// newVaultAuthStore returns an auth store backed by an in-memory pebble DB
+// with the "default" vault configured Public (matching first-run bootstrap)
+// and a "secret" vault configured locked.
+func newVaultAuthStore(t *testing.T) *auth.Store {
+	t.Helper()
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open test auth db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store := auth.NewStore(db)
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "default", Public: true}); err != nil {
+		t.Fatalf("SetVaultConfig default: %v", err)
+	}
+	if err := store.SetVaultConfig(auth.VaultConfig{Name: "secret", Public: false}); err != nil {
+		t.Fatalf("SetVaultConfig secret: %v", err)
+	}
+	return store
+}
+
+func newAuthedTestServer(eng EngineAPI, store *auth.Store) *Server {
+	return &Server{engine: eng, authStore: store, shutdown: make(chan struct{})}
+}
+
+// doHandshakeReq sends an arbitrary HELLO and returns the response frame.
+func doHandshakeReq(t *testing.T, c net.Conn, req HelloRequest) *Frame {
+	t.Helper()
+	p, err := EncodeMsgpack(&req)
+	if err != nil {
+		t.Fatalf("encode hello: %v", err)
+	}
+	if err := WriteFrame(c, &Frame{Version: 0x01, Type: TypeHello, Payload: p}); err != nil {
+		t.Fatalf("write hello: %v", err)
+	}
+	f, err := ReadFrame(c)
+	if err != nil {
+		t.Fatalf("read hello response: %v", err)
+	}
+	return f
+}
+
+func assertAuthError(t *testing.T, f *Frame, context string) {
+	t.Helper()
+	if f.Type != TypeError {
+		t.Fatalf("%s: expected TypeError frame, got 0x%02x", context, f.Type)
+	}
+	var ep ErrorPayload
+	if err := DecodeMsgpack(f.Payload, &ep); err != nil {
+		t.Fatalf("%s: decode error payload: %v", context, err)
+	}
+	if ep.Code != ErrAuthFailed {
+		t.Fatalf("%s: expected ErrAuthFailed (%d), got %d (%s)", context, ErrAuthFailed, ep.Code, ep.Message)
+	}
+}
+
+// --- HELLO-time enforcement ------------------------------------------------
+
+func TestHello_NoneAuth_LockedVault_Rejected(t *testing.T) {
+	eng := &recEngine{}
+	s := newAuthedTestServer(eng, newVaultAuthStore(t))
+	c, wait := startTestConn(t, s)
+	defer wait()
+
+	f := doHandshakeReq(t, c, HelloRequest{Version: "1", AuthMethod: "none", Vault: "secret"})
+	assertAuthError(t, f, "HELLO none/secret")
+}
+
+func TestHello_NoneAuth_UnconfiguredVault_Rejected(t *testing.T) {
+	eng := &recEngine{}
+	s := newAuthedTestServer(eng, newVaultAuthStore(t))
+	c, wait := startTestConn(t, s)
+	defer wait()
+
+	f := doHandshakeReq(t, c, HelloRequest{Version: "1", AuthMethod: "none", Vault: "never-configured"})
+	assertAuthError(t, f, "HELLO none/unconfigured")
+}
+
+func TestHello_NoneAuth_PublicVault_OK(t *testing.T) {
+	eng := &recEngine{}
+	s := newAuthedTestServer(eng, newVaultAuthStore(t))
+	c, wait := startTestConn(t, s)
+	defer wait()
+
+	f := doHandshakeReq(t, c, HelloRequest{Version: "1", AuthMethod: "none"})
+	if f.Type != TypeHelloOK {
+		t.Fatalf("HELLO none/default-public: expected HELLO_OK, got 0x%02x", f.Type)
+	}
+}
+
+func TestHello_Token_VaultMismatch_Rejected(t *testing.T) {
+	eng := &recEngine{}
+	store := newVaultAuthStore(t)
+	token, _, err := store.GenerateAPIKey("vault-a", "test", "full", nil)
+	if err != nil {
+		t.Fatalf("GenerateAPIKey: %v", err)
+	}
+	s := newAuthedTestServer(eng, store)
+	c, wait := startTestConn(t, s)
+	defer wait()
+
+	f := doHandshakeReq(t, c, HelloRequest{Version: "1", AuthMethod: "token", Token: token, Vault: "vault-b"})
+	assertAuthError(t, f, "HELLO token vault mismatch")
+}
+
+func TestHello_Token_MatchingVault_OK(t *testing.T) {
+	eng := &recEngine{}
+	store := newVaultAuthStore(t)
+	token, _, err := store.GenerateAPIKey("vault-a", "test", "full", nil)
+	if err != nil {
+		t.Fatalf("GenerateAPIKey: %v", err)
+	}
+	s := newAuthedTestServer(eng, store)
+	c, wait := startTestConn(t, s)
+	defer wait()
+
+	f := doHandshakeReq(t, c, HelloRequest{Version: "1", AuthMethod: "token", Token: token, Vault: "vault-a"})
+	if f.Type != TypeHelloOK {
+		t.Fatalf("HELLO token matching vault: expected HELLO_OK, got 0x%02x", f.Type)
+	}
+}
+
+// --- Per-request enforcement: auth_method "none" sessions -------------------
+
+// TestNoneSession_LockedVault_AllOpsRejected verifies that a "none" session
+// (established against the public default vault) cannot touch a locked vault
+// with any vault-scoped operation — the request must be rejected with
+// ErrAuthFailed and must never reach the engine.
+func TestNoneSession_LockedVault_AllOpsRejected(t *testing.T) {
+	ops := []struct {
+		name  string
+		ftype uint8
+		req   interface{}
+	}{
+		{"write", TypeWrite, &WriteRequest{Concept: "c", Content: "x", Vault: "secret"}},
+		{"read", TypeRead, &ReadRequest{ID: "01HZZZZZZZZZZZZZZZZZZZZZZZ", Vault: "secret"}},
+		{"activate", TypeActivate, &ActivateRequest{Context: []string{"q"}, Vault: "secret"}},
+		{"link", TypeLink, &LinkRequest{SourceID: "a", TargetID: "b", Vault: "secret"}},
+		{"forget", TypeForget, &ForgetRequest{ID: "01HZZZZZZZZZZZZZZZZZZZZZZZ", Vault: "secret"}},
+		{"stat", TypeStat, &StatRequest{Vault: "secret"}},
+		{"subscribe", TypeSubscribe, &SubscribeRequest{Context: []string{"q"}, Vault: "secret"}},
+	}
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			eng := &recEngine{}
+			s := newAuthedTestServer(eng, newVaultAuthStore(t))
+			c, wait := startTestConn(t, s)
+			defer wait()
+			doHandshake(t, c)
+
+			f := sendAndReceive(t, c, op.ftype, 42, op.req)
+			assertAuthError(t, f, op.name+" to locked vault")
+			if seen := eng.seen(); len(seen) != 0 {
+				t.Fatalf("%s: request reached the engine with vaults %v — must be rejected before dispatch", op.name, seen)
+			}
+		})
+	}
+}
+
+func TestNoneSession_PublicVault_Allowed(t *testing.T) {
+	eng := &recEngine{}
+	s := newAuthedTestServer(eng, newVaultAuthStore(t))
+	c, wait := startTestConn(t, s)
+	defer wait()
+	doHandshake(t, c)
+
+	f := sendAndReceive(t, c, TypeWrite, 7, &WriteRequest{Concept: "c", Content: "x", Vault: "default"})
+	if f.Type != TypeWriteOK {
+		t.Fatalf("write to public vault: expected TypeWriteOK, got 0x%02x", f.Type)
+	}
+	if seen := eng.seen(); len(seen) != 1 || seen[0] != "default" {
+		t.Fatalf("engine saw vaults %v, want [default]", seen)
+	}
+}
+
+func TestNoneSession_EmptyVault_ResolvesToDefault(t *testing.T) {
+	eng := &recEngine{}
+	s := newAuthedTestServer(eng, newVaultAuthStore(t))
+	c, wait := startTestConn(t, s)
+	defer wait()
+	doHandshake(t, c)
+
+	f := sendAndReceive(t, c, TypeWrite, 7, &WriteRequest{Concept: "c", Content: "x"})
+	if f.Type != TypeWriteOK {
+		t.Fatalf("write with empty vault: expected TypeWriteOK, got 0x%02x", f.Type)
+	}
+	if seen := eng.seen(); len(seen) != 1 || seen[0] != "default" {
+		t.Fatalf("engine saw vaults %v, want [default]", seen)
+	}
+}
+
+// --- Per-request enforcement: token sessions --------------------------------
+
+func tokenSession(t *testing.T, eng EngineAPI, store *auth.Store, vault string) (net.Conn, func()) {
+	t.Helper()
+	token, _, err := store.GenerateAPIKey(vault, "test", "full", nil)
+	if err != nil {
+		t.Fatalf("GenerateAPIKey: %v", err)
+	}
+	s := newAuthedTestServer(eng, store)
+	c, wait := startTestConn(t, s)
+	f := doHandshakeReq(t, c, HelloRequest{Version: "1", AuthMethod: "token", Token: token})
+	if f.Type != TypeHelloOK {
+		t.Fatalf("token handshake: expected HELLO_OK, got 0x%02x", f.Type)
+	}
+	return c, wait
+}
+
+func TestTokenSession_OtherVault_Rejected(t *testing.T) {
+	eng := &recEngine{}
+	c, wait := tokenSession(t, eng, newVaultAuthStore(t), "vault-a")
+	defer wait()
+
+	f := sendAndReceive(t, c, TypeWrite, 9, &WriteRequest{Concept: "c", Content: "x", Vault: "vault-b"})
+	assertAuthError(t, f, "keyed write to foreign vault")
+	if seen := eng.seen(); len(seen) != 0 {
+		t.Fatalf("request reached the engine with vaults %v — must be rejected", seen)
+	}
+}
+
+// TestTokenSession_PublicVaultStillPinned: a key scoped to vault-a must not be
+// usable against any other vault — not even a public one. The key pins the
+// session; public access is for unauthenticated clients (REST behaves the same).
+func TestTokenSession_PublicVaultStillPinned(t *testing.T) {
+	eng := &recEngine{}
+	c, wait := tokenSession(t, eng, newVaultAuthStore(t), "vault-a")
+	defer wait()
+
+	f := sendAndReceive(t, c, TypeWrite, 9, &WriteRequest{Concept: "c", Content: "x", Vault: "default"})
+	assertAuthError(t, f, "keyed write to public-but-foreign vault")
+}
+
+func TestTokenSession_EmptyVault_ResolvesToKeyVault(t *testing.T) {
+	eng := &recEngine{}
+	c, wait := tokenSession(t, eng, newVaultAuthStore(t), "vault-a")
+	defer wait()
+
+	f := sendAndReceive(t, c, TypeWrite, 9, &WriteRequest{Concept: "c", Content: "x"})
+	if f.Type != TypeWriteOK {
+		t.Fatalf("keyed write with empty vault: expected TypeWriteOK, got 0x%02x", f.Type)
+	}
+	if seen := eng.seen(); len(seen) != 1 || seen[0] != "vault-a" {
+		t.Fatalf("engine saw vaults %v, want [vault-a]", seen)
+	}
+}
+
+func TestTokenSession_MatchingVault_Allowed(t *testing.T) {
+	eng := &recEngine{}
+	c, wait := tokenSession(t, eng, newVaultAuthStore(t), "vault-a")
+	defer wait()
+
+	f := sendAndReceive(t, c, TypeRead, 9, &ReadRequest{ID: "01HZZZZZZZZZZZZZZZZZZZZZZZ", Vault: "vault-a"})
+	if f.Type != TypeReadResp {
+		t.Fatalf("keyed read of own vault: expected TypeReadResp, got 0x%02x", f.Type)
+	}
+	if seen := eng.seen(); len(seen) != 1 || seen[0] != "vault-a" {
+		t.Fatalf("engine saw vaults %v, want [vault-a]", seen)
+	}
+}
+
+// --- Fail-closed without an auth store ---------------------------------------
+
+// TestNilAuthStore_FailsClosed: a server constructed without an auth store
+// (misconfiguration) must reject sessions rather than silently allowing
+// unrestricted access to every vault.
+func TestNilAuthStore_FailsClosed(t *testing.T) {
+	eng := &recEngine{}
+	s := &Server{engine: eng, shutdown: make(chan struct{})} // nil authStore
+	c, wait := startTestConn(t, s)
+	defer wait()
+
+	f := doHandshakeReq(t, c, HelloRequest{Version: "1", AuthMethod: "none"})
+	assertAuthError(t, f, "HELLO with nil auth store")
+}


### PR DESCRIPTION
## Problem

REST and MCP enforce a fail-closed vault model (a key scoped to vault A cannot touch vault B; unauthenticated callers reach only **public** vaults). The two binary transports did not — and both are network-exposed in the shipped `docker-compose.yml` with `MUNINN_LISTEN_HOST=0.0.0.0`:

- **MBP (port 8474):** the default `auth_method:"none"` path performed **no auth and no vault pinning** (`hello.go`, `server.go`). Any client could read/write/forget in **any** vault, including locked ones.
- **gRPC (port 8477):** the interceptor validated the API key but **never compared `key.Vault` to the request's vault** (`engine_adapter.go` used the request-supplied vault). A key scoped to vault A could operate on vault B by naming it.

Net effect: a network peer could cross vault boundaries. This is the live remainder of #368 (fixed for REST/MCP, not for the binary transports).

## Fix

Both transports now enforce the **same model as REST** (`auth.VaultAuthMiddleware` + `validateResolvedVault`):

- **Keyed:** the key's vault is authoritative — empty request vault resolves to it; any other named vault is rejected (a vault-A key can never touch vault B, even a public one).
- **Unauthenticated/"none":** the request vault (default `default`) must be configured **Public**; locked or unconfigured vaults are rejected.
- **Fail closed** when no auth store / scope is present.

**MBP:** establish a per-connection `vaultScope` at HELLO, carried in the connection context, and resolve+pin `req.Vault` in every vault-bearing handler (write/read/activate/link/forget/stat/subscribe). Nil auth store now fails closed at HELLO.

**gRPC:** new `resolveRequestVault` (mirrors `validateResolvedVault`) called in every vault-bearing RPC, pinning `req.Vault` before the engine sees it. Streaming `Activate`/`Subscribe` re-resolve from the first message, since the interceptor runs before the message arrives and can only pre-authorize `default`.

## Scope

Transport-only — **no engine / scoring / storage / cognitive semantics changed**. The `req.Vault` pin is exactly what REST already does via `resolveHandlerVault`. Production wiring already passes a non-nil auth store, and `auth.Bootstrap` makes the default vault public, so the new nil-store rejection and default-vault checks never trip in normal operation.

## Tests

39 new vault-isolation tests across both transports (TDD — written failing first, verified RED, then GREEN):
- keyed cross-vault rejection (incl. keyed-to-public-but-foreign), empty-vault pinning, matching-vault allow
- none-session locked/unconfigured/public vaults, empty→default
- nil auth store fails closed
- gRPC batch with mixed vaults rejected; streaming Activate/Subscribe scope checks

All green under `-race`; `go vet` clean; full build OK; existing `auth`/`engine`/`cmd/muninn` suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)