### PR TITLE
test(storage): de-flake WAL syncer timing waits (#482)

### DIFF
--- a/internal/storage/wal_syncer_adaptive_test.go
+++ b/internal/storage/wal_syncer_adaptive_test.go
@@ -41,8 +41,10 @@ func TestWALSyncer_SyncsAfterWrite(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	// Wait for at least one tick to pick up the WAL change.
-	deadline := time.Now().Add(10 * walSyncInterval)
+	// Wait for the syncer to pick up the WAL change. Generous fixed bound:
+	// time.Ticker guarantees a minimum tick interval, not a maximum, so a
+	// starved CI runner can tick late (see #482).
+	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if s.syncCount.Load() > 0 {
 			break
@@ -73,7 +75,8 @@ func TestWALSyncer_IdleThenWrite(t *testing.T) {
 	if err := db.Set([]byte("k1"), []byte("v1"), pebble.NoSync); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	deadline := time.Now().Add(10 * walSyncInterval)
+	// Generous fixed bound — see #482 (ticker can be starved on a loaded runner).
+	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if s.syncCount.Load() > 0 {
 			break
@@ -137,8 +140,9 @@ func TestWALSyncer_FinalSyncOnClose(t *testing.T) {
 
 	s := newWALSyncer(db)
 
-	// Wait for the syncer to observe the write and sync.
-	deadline := time.Now().Add(10 * walSyncInterval)
+	// Wait for the syncer to observe the write and sync. Generous fixed bound —
+	// see #482 (ticker can be starved on a loaded runner).
+	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if s.syncCount.Load() > 0 {
 			break

--- a/internal/storage/wal_syncer_adaptive_test.go
+++ b/internal/storage/wal_syncer_adaptive_test.go
@@ -174,8 +174,14 @@ func TestWALSyncer_SyncCountAccurate(t *testing.T) {
 		if err := db.Set(key, key, pebble.NoSync); err != nil {
 			t.Fatalf("cycle %d write: %v", cycle, err)
 		}
-		// Wait for the sync to fire.
-		deadline := time.Now().Add(10 * walSyncInterval)
+		// Wait for the sync to fire. The deadline is a generous fixed wall-clock
+		// bound (not a small multiple of walSyncInterval): time.Ticker guarantees
+		// a *minimum* tick interval, not a maximum, so on a contended CI runner
+		// the syncer goroutine can be starved well past a few intervals. A tight
+		// 10×interval (100ms) deadline made this flake ("cycle 2: got 2"); 2s
+		// gives a heavily loaded runner ample room while a healthy run still
+		// passes in a couple of intervals.
+		deadline := time.Now().Add(2 * time.Second)
 		want := int64(cycle + 1)
 		for time.Now().Before(deadline) {
 			if s.syncCount.Load() >= want {


### PR DESCRIPTION
## Problem

`TestWALSyncer_SyncCountAccurate` failed intermittently on CI — e.g. on the develop run for #465's merge: `cycle 2: expected syncCount ≥ 3, got 2`. The syncer is correct; the tests were timing-fragile.

Each per-cycle/per-write wait used a deadline of `10 * walSyncInterval` (100ms) for the syncer's tick to fire an fsync. `time.Ticker` guarantees a *minimum* interval, not a maximum, so on a contended runner the syncer goroutine can be starved past several intervals and the wait expires before the expected syncs occur.

## Fix

Replace the tight interval-multiple deadlines with a generous fixed **2s** wall-clock bound across all four affected waits:
- `TestWALSyncer_SyncCountAccurate` (the one that actually flaked — needs 3 syncs across 3 cycles, most exposed)
- `TestWALSyncer_SyncsAfterWrite`, `_IdleThenWrite`, `_FinalSyncOnClose` (same fragile pattern; need only 1 sync so flake far less, but hardened to avoid latent flakes)

A healthy run still completes in a couple of intervals. Idle-detection assertions (count must **not** grow over an idle window) are unchanged — they test a deterministic property and were never the flaky part. Test-only; no production code touched.

## Verification

Non-deterministic bug, verified by stress rather than single red/green:
- **50×** `SyncCountAccurate` under `-race` / `GOMAXPROCS=1`
- **40×** under genuine background CPU load / `GOMAXPROCS=2`
- **30×** all `TestWALSyncer*` under `-race` / `GOMAXPROCS=1`

All green; the old 100ms deadline flaked under the same conditions.

Closes #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)