### PR TITLE
fix(cli): muninn status treats a cert failure as 'up' (#481)

### DIFF
--- a/cmd/muninn/status.go
+++ b/cmd/muninn/status.go
@@ -103,20 +103,30 @@ func resolveScheme(addrs daemonAddrs, svcs []serviceStatus) string {
 }
 
 // overallState computes the aggregate state from individual service statuses.
+//
+// A certErr service is treated as REACHABLE: a TLS verification failure means
+// the daemon answered the handshake and only trust failed, so the server is up.
+// This keeps an all-cert-fail deployment in stateDegraded (a fixable trust
+// problem) instead of stateStopped (which would wrongly tell the user to start
+// an already-running server). See #481.
 func overallState(svcs []serviceStatus) runState {
-	up, down := 0, 0
+	reachable, down, certErrs := 0, 0, 0
 	for _, s := range svcs {
-		if s.up {
-			up++
-		} else {
+		switch {
+		case s.up:
+			reachable++
+		case s.certErr:
+			reachable++
+			certErrs++
+		default:
 			down++
 		}
 	}
-	if down == 0 {
-		return stateRunning
-	}
-	if up == 0 {
+	if reachable == 0 && down > 0 {
 		return stateStopped
+	}
+	if down == 0 && certErrs == 0 {
+		return stateRunning
 	}
 	return stateDegraded
 }
@@ -436,6 +446,7 @@ func printStatusDisplay(compact bool) runState {
 	if state == stateDegraded {
 		fmt.Println()
 		certIssue := false
+		downIssue := false
 		for _, s := range svcs {
 			if s.up {
 				continue
@@ -444,6 +455,7 @@ func printStatusDisplay(compact bool) runState {
 				certIssue = true
 				fmt.Printf("  %s is reachable but its TLS certificate failed verification", s.name)
 			} else {
+				downIssue = true
 				fmt.Printf("  %s is not responding", s.name)
 			}
 			if s.name == "mcp" {
@@ -451,12 +463,16 @@ func printStatusDisplay(compact bool) runState {
 			}
 			fmt.Println(".")
 		}
+		// Cert failures and genuine outages can coexist; surface guidance for
+		// each kind that is present rather than letting a cert issue hide that
+		// another service genuinely needs a restart (#481).
 		if certIssue {
 			// A restart won't fix a trust problem — the server is up.
 			fmt.Println("  The server is up but its certificate isn't trusted. Check that the")
 			fmt.Println("  cert is valid for this host and that your CA is trusted (or, for a")
 			fmt.Println("  remote endpoint, that MUNINNDB_*_URL points at a host the cert covers).")
-		} else {
+		}
+		if downIssue {
 			fmt.Println("  Run: muninn restart")
 		}
 	}

--- a/cmd/muninn/status_certfail_test.go
+++ b/cmd/muninn/status_certfail_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #481: when a service is reachable but its TLS certificate fails
+// verification, the daemon is UP — only trust failed. The status output must
+// not report "stopped / muninn start" in that case, and a mix of cert-failed
+// and genuinely-dead services must surface BOTH the trust guidance and the
+// restart hint.
+
+// TestOverallState_AllCertFail_IsDegraded: a cert-verification failure means
+// the server answered the TLS handshake, so an all-cert-fail deployment is
+// degraded (trust problem), not stopped.
+func TestOverallState_AllCertFail_IsDegraded(t *testing.T) {
+	svcs := []serviceStatus{
+		{name: "database", up: false, certErr: true},
+		{name: "mcp", up: false, certErr: true},
+		{name: "web ui", up: false, certErr: true},
+	}
+	if got := overallState(svcs); got != stateDegraded {
+		t.Errorf("all cert-fail: got %v, want stateDegraded", got)
+	}
+}
+
+// TestOverallState_AllGenuinelyDown_IsStopped: with no cert errors and nothing
+// reachable, the daemon really is down.
+func TestOverallState_AllGenuinelyDown_IsStopped(t *testing.T) {
+	svcs := []serviceStatus{
+		{name: "database", up: false},
+		{name: "mcp", up: false},
+		{name: "web ui", up: false},
+	}
+	if got := overallState(svcs); got != stateStopped {
+		t.Errorf("all down: got %v, want stateStopped", got)
+	}
+}
+
+// TestOverallState_CertFailPlusUp_IsDegraded: any cert failure among otherwise
+// up services is degraded, not running.
+func TestOverallState_CertFailPlusUp_IsDegraded(t *testing.T) {
+	svcs := []serviceStatus{
+		{name: "database", up: true},
+		{name: "mcp", up: false, certErr: true},
+		{name: "web ui", up: true},
+	}
+	if got := overallState(svcs); got != stateDegraded {
+		t.Errorf("cert-fail + up: got %v, want stateDegraded", got)
+	}
+}
+
+// TestPrintStatus_AllCertFail_ShowsTrustGuidanceNotStart: the all-cert-fail
+// display must explain the trust problem and must NOT tell the user to start a
+// server that is already running.
+func TestPrintStatus_AllCertFail_ShowsTrustGuidanceNotStart(t *testing.T) {
+	restore := probeServicesFn
+	probeServicesFn = func() []serviceStatus {
+		return []serviceStatus{
+			{name: "database", port: 8475, up: false, certErr: true},
+			{name: "mcp", port: 8750, up: false, certErr: true},
+			{name: "web ui", port: 8476, up: false, certErr: true},
+		}
+	}
+	defer func() { probeServicesFn = restore }()
+
+	out := captureStdout(func() { printStatusDisplay(false) })
+
+	if !strings.Contains(out, "certificate isn't trusted") {
+		t.Errorf("expected TLS trust guidance, got:\n%s", out)
+	}
+	if strings.Contains(out, "muninn start") {
+		t.Errorf("must not suggest 'muninn start' when the server is up (cert-only failure), got:\n%s", out)
+	}
+}
+
+// TestPrintStatus_MixedCertAndDown_ShowsBothGuidances: when one service is
+// cert-failed (server up) and another is genuinely down, the output must
+// surface both the trust guidance AND the restart hint.
+func TestPrintStatus_MixedCertAndDown_ShowsBothGuidances(t *testing.T) {
+	restore := probeServicesFn
+	probeServicesFn = func() []serviceStatus {
+		return []serviceStatus{
+			{name: "database", port: 8475, up: true},
+			{name: "mcp", port: 8750, up: false, certErr: true},
+			{name: "web ui", port: 8476, up: false}, // genuinely down
+		}
+	}
+	defer func() { probeServicesFn = restore }()
+
+	out := captureStdout(func() { printStatusDisplay(false) })
+
+	if !strings.Contains(out, "certificate isn't trusted") {
+		t.Errorf("expected TLS trust guidance for the cert-failed service, got:\n%s", out)
+	}
+	if !strings.Contains(out, "muninn restart") {
+		t.Errorf("expected 'muninn restart' hint for the genuinely-down service, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Problem

Follow-up to #477 (which made `muninn status` distinguish a TLS trust failure from a dead server). Two edge cases remained:

1. **All services cert-failed → reads as "stopped".** When every probed service failed TLS verification (e.g. all three `MUNINNDB_*_URL` overrides point at the same untrusted endpoint), `overallState` counted zero `up` services and returned `stateStopped`, so the output said `stopped` and suggested `muninn start` — telling the user to start a server that is **actually running** and merely presenting an untrusted cert.
2. **Mixed cert-failed + genuinely-down → no restart hint.** With one service cert-failed (server up) and another genuinely down, the degraded block set `certIssue` and printed only the trust guidance, skipping `muninn restart` entirely — so the genuinely-down service got no actionable hint.

## Fix

- `overallState` now treats a `certErr` service as **reachable** (the daemon answered the TLS handshake; only trust failed). An all-cert-fail deployment is therefore `stateDegraded` (a fixable trust problem) with the cert guidance, not `stateStopped`.
- The degraded block tracks cert failures and genuine outages **independently** and emits guidance for each kind present, so both the trust message and `muninn restart` show when both failure kinds coexist.
- The empty-slice vacuous case still returns `stateRunning` (stopped now requires at least one genuinely-down service).

Display-only / CLI-only — no engine, scoring, or storage changes.

## Tests

TDD (RED verified first). Unit: `overallState` for all-cert-fail→degraded, all-down→stopped, cert+up→degraded. Display: all-cert-fail shows trust guidance and **not** `muninn start`; mixed shows **both** guidances. Full `cmd/muninn` suite passes.

Closes #481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)