### PR TITLE
fix(rest): mask LLM provider API keys in admin plugin-config API

### DIFF
--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -621,7 +621,27 @@ func (s *Server) handleGetPluginConfig(w http.ResponseWriter, r *http.Request) {
 		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, "failed to load plugin config: "+err.Error())
 		return
 	}
+	// Never return provider API keys in cleartext — the admin UI only needs to
+	// confirm which key is set, not read it back.
+	cfg.EmbedAPIKey = maskSecret(cfg.EmbedAPIKey)
+	cfg.EnrichAPIKey = maskSecret(cfg.EnrichAPIKey)
 	s.sendJSON(w, http.StatusOK, cfg)
+}
+
+// maskSecret returns a display-safe form of a secret: empty stays empty;
+// otherwise a fixed bullet prefix hides the value (and its length), with the
+// last four characters shown so an admin can tell which key is configured.
+// A real provider key never contains bullets, so the masked form is
+// unambiguous and the save path can detect "unchanged" by re-masking.
+func maskSecret(s string) string {
+	if s == "" {
+		return ""
+	}
+	const mask = "••••••••"
+	if len(s) <= 4 {
+		return mask
+	}
+	return mask + s[len(s)-4:]
 }
 
 // handlePutPluginConfig saves plugin configuration to disk.
@@ -636,10 +656,25 @@ func (s *Server) handlePutPluginConfig(w http.ResponseWriter, r *http.Request) {
 		s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "invalid request body: "+err.Error())
 		return
 	}
+	// Preserve any API key the client sent back unchanged — i.e. equal to the
+	// masked value GET returned — so the mask is never persisted as the real
+	// key. A retyped key won't match the mask and is saved as-is; an explicit
+	// empty value clears the key.
+	if existing, err := plugincfg.LoadPluginConfig(s.dataDir); err == nil {
+		if cfg.EmbedAPIKey == maskSecret(existing.EmbedAPIKey) {
+			cfg.EmbedAPIKey = existing.EmbedAPIKey
+		}
+		if cfg.EnrichAPIKey == maskSecret(existing.EnrichAPIKey) {
+			cfg.EnrichAPIKey = existing.EnrichAPIKey
+		}
+	}
 	if err := plugincfg.SavePluginConfig(s.dataDir, cfg); err != nil {
 		s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, "failed to save plugin config: "+err.Error())
 		return
 	}
+	// Echo the saved config back masked so the response never carries cleartext.
+	cfg.EmbedAPIKey = maskSecret(cfg.EmbedAPIKey)
+	cfg.EnrichAPIKey = maskSecret(cfg.EnrichAPIKey)
 	s.sendJSON(w, http.StatusOK, cfg)
 	s.EmitAudit(r, "plugin.config_update", "plugin", "config", "ok", nil)
 }

--- a/internal/transport/rest/plugin_config_secrets_test.go
+++ b/internal/transport/rest/plugin_config_secrets_test.go
@@ -1,0 +1,178 @@
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/config"
+)
+
+// The admin plugin-config endpoint must never return stored LLM provider API
+// keys in cleartext, and saving a config whose key fields still carry the
+// masked value (i.e. the admin did not retype the key) must preserve the real
+// stored key rather than overwrite it with the mask.
+
+func TestMaskSecret(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"abcd", "••••••••"}, // too short to reveal any suffix
+		{"sk-1234567890", "••••••••7890"},
+		{"voy-abcdEFGH", "••••••••EFGH"},
+	}
+	for _, c := range cases {
+		if got := maskSecret(c.in); got != c.want {
+			t.Errorf("maskSecret(%q) = %q, want %q", c.in, got, c.want)
+		}
+		if c.in != "" && strings.Contains(maskSecret(c.in), c.in) {
+			t.Errorf("maskSecret(%q) leaks the full secret", c.in)
+		}
+	}
+}
+
+func TestHandleGetPluginConfig_MasksAPIKeys(t *testing.T) {
+	dir := t.TempDir()
+	const embedKey = "voy-secret-embed-key-1234"
+	const enrichKey = "sk-secret-enrich-key-abcd"
+	if err := config.SavePluginConfig(dir, config.PluginConfig{
+		EmbedProvider: "voyage", EmbedAPIKey: embedKey,
+		EnrichProvider: "openai", EnrichAPIKey: enrichKey,
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	srv := NewServer("localhost:0", &MockEngine{}, newTestAuthStore(t), nil, nil, EmbedInfo{}, EnrichInfo{}, nil, dir, nil)
+	req := httptest.NewRequest("GET", "/api/admin/plugin-config", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if strings.Contains(body, embedKey) || strings.Contains(body, enrichKey) {
+		t.Fatalf("response leaks a cleartext API key:\n%s", body)
+	}
+
+	var resp config.PluginConfig
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.EmbedAPIKey != maskSecret(embedKey) {
+		t.Errorf("embed key = %q, want masked %q", resp.EmbedAPIKey, maskSecret(embedKey))
+	}
+	if resp.EnrichAPIKey != maskSecret(enrichKey) {
+		t.Errorf("enrich key = %q, want masked %q", resp.EnrichAPIKey, maskSecret(enrichKey))
+	}
+}
+
+func TestHandlePutPluginConfig_PreservesMaskedKeys(t *testing.T) {
+	dir := t.TempDir()
+	const embedKey = "voy-secret-embed-key-1234"
+	const enrichKey = "sk-secret-enrich-key-abcd"
+	if err := config.SavePluginConfig(dir, config.PluginConfig{
+		EmbedProvider: "voyage", EmbedAPIKey: embedKey,
+		EnrichProvider: "openai", EnrichAPIKey: enrichKey,
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	srv := NewServer("localhost:0", &MockEngine{}, newTestAuthStore(t), nil, nil, EmbedInfo{}, EnrichInfo{}, nil, dir, nil)
+
+	// Simulate the UI saving the form back unchanged: the key fields carry the
+	// masked values that GET returned, and the admin changed only the provider.
+	body, _ := json.Marshal(config.PluginConfig{
+		EmbedProvider: "voyage", EmbedAPIKey: maskSecret(embedKey),
+		EnrichProvider: "anthropic", EnrichAPIKey: maskSecret(enrichKey),
+	})
+	req := httptest.NewRequest("PUT", "/api/admin/plugin-config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// The stored config must retain the real keys, not the masks.
+	stored, err := config.LoadPluginConfig(dir)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if stored.EmbedAPIKey != embedKey {
+		t.Errorf("embed key was clobbered: got %q, want %q", stored.EmbedAPIKey, embedKey)
+	}
+	if stored.EnrichAPIKey != enrichKey {
+		t.Errorf("enrich key was clobbered: got %q, want %q", stored.EnrichAPIKey, enrichKey)
+	}
+	if stored.EnrichProvider != "anthropic" {
+		t.Errorf("provider not updated: got %q", stored.EnrichProvider)
+	}
+	// The PUT response must also be masked.
+	if strings.Contains(w.Body.String(), embedKey) || strings.Contains(w.Body.String(), enrichKey) {
+		t.Errorf("PUT response leaks a cleartext key:\n%s", w.Body.String())
+	}
+}
+
+func TestHandlePutPluginConfig_UpdatesNewKey(t *testing.T) {
+	dir := t.TempDir()
+	if err := config.SavePluginConfig(dir, config.PluginConfig{
+		EmbedProvider: "voyage", EmbedAPIKey: "old-embed-key-9999",
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	srv := NewServer("localhost:0", &MockEngine{}, newTestAuthStore(t), nil, nil, EmbedInfo{}, EnrichInfo{}, nil, dir, nil)
+
+	const newKey = "voy-brand-new-key-7777"
+	body, _ := json.Marshal(config.PluginConfig{EmbedProvider: "voyage", EmbedAPIKey: newKey})
+	req := httptest.NewRequest("PUT", "/api/admin/plugin-config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	stored, err := config.LoadPluginConfig(dir)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if stored.EmbedAPIKey != newKey {
+		t.Errorf("new key not saved: got %q, want %q", stored.EmbedAPIKey, newKey)
+	}
+}
+
+func TestHandlePutPluginConfig_ClearsEmptyKey(t *testing.T) {
+	dir := t.TempDir()
+	if err := config.SavePluginConfig(dir, config.PluginConfig{
+		EmbedProvider: "voyage", EmbedAPIKey: "old-embed-key-9999",
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	srv := NewServer("localhost:0", &MockEngine{}, newTestAuthStore(t), nil, nil, EmbedInfo{}, EnrichInfo{}, nil, dir, nil)
+
+	// An explicitly empty key clears it (distinct from sending the mask back).
+	body, _ := json.Marshal(config.PluginConfig{EmbedProvider: "local", EmbedAPIKey: ""})
+	req := httptest.NewRequest("PUT", "/api/admin/plugin-config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	stored, err := config.LoadPluginConfig(dir)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if stored.EmbedAPIKey != "" {
+		t.Errorf("key should be cleared, got %q", stored.EmbedAPIKey)
+	}
+}


### PR DESCRIPTION
## Problem

`GET /api/admin/plugin-config` returned `embed_api_key` / `enrich_api_key` in **cleartext**, so anyone with an admin session (or the Web UI) could read the configured LLM provider secrets back. Flagged in the deep-dive security review (M4).

## Fix

- **Mask on read** (and on the PUT echo): a fixed bullet prefix hides the value and its length, with the last 4 chars shown so an admin can confirm *which* key is set without it being readable.
- **Preserve on unchanged save:** the PUT handler restores a key the client sends back equal to the masked value GET returned, so the mask is never persisted as the real key. A retyped key doesn't match the mask and saves as-is; an explicit empty value clears the key.

No Web UI change needed — it already echoes whatever the server returned, so an untouched field round-trips the mask (preserved) and switching to a keyless provider sends empty (cleared). Keys stay unmasked everywhere they're actually used (plugin init reads the stored config directly) and were already kept out of logs.

## Tests (TDD, RED first)

`maskSecret` unit (incl. never-leaks-full-secret); GET masks both keys and the body carries no cleartext; PUT preserves masked keys while updating other fields; PUT saves a newly-typed key; PUT clears on explicit empty. Full `internal/transport/rest` suite green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)