### PR TITLE
fix(install): publish + verify SHA-256 checksums in installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,25 @@ jobs:
         with:
           merge-multiple: true
 
+      - name: Generate checksums
+        run: |
+          # SHA-256 over every published asset in the standard sha256sum format
+          # ("<hash>  <filename>"). install.sh / install.ps1 download this file
+          # and verify the binary they fetched against the matching line.
+          sha256sum \
+            muninn-darwin-arm64 \
+            muninn-darwin-amd64 \
+            muninn-linux-amd64 \
+            muninn-linux-arm64 \
+            muninn-windows-amd64.exe \
+            muninn_${GITHUB_REF_NAME}_darwin_arm64.tar.gz \
+            muninn_${GITHUB_REF_NAME}_darwin_amd64.tar.gz \
+            muninn_${GITHUB_REF_NAME}_linux_amd64.tar.gz \
+            muninn_${GITHUB_REF_NAME}_linux_arm64.tar.gz \
+            muninn_${GITHUB_REF_NAME}_windows_amd64.zip \
+            > checksums.txt
+          cat checksums.txt
+
       - name: Publish release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -202,7 +221,8 @@ jobs:
             muninn_${GITHUB_REF_NAME}_darwin_amd64.tar.gz \
             muninn_${GITHUB_REF_NAME}_linux_amd64.tar.gz \
             muninn_${GITHUB_REF_NAME}_linux_arm64.tar.gz \
-            muninn_${GITHUB_REF_NAME}_windows_amd64.zip
+            muninn_${GITHUB_REF_NAME}_windows_amd64.zip \
+            checksums.txt
 
   # ── Update Homebrew formula with new version + SHA256s ──────────────────
   update-formula:

--- a/install.ps1
+++ b/install.ps1
@@ -60,6 +60,39 @@ try {
     Abort "Download failed: $_"
 }
 
+# Verify checksum against the release checksums.txt. A mismatch is fatal; a
+# missing checksums file (older release) only warns. Integrity verification,
+# not a substitute for signed releases.
+Write-Host "  Verifying checksum..." -NoNewline
+$sumsAsset = $release.assets | Where-Object { $_.name -eq "checksums.txt" }
+if ($sumsAsset) {
+    try {
+        $sums = (Invoke-WebRequest -Uri $sumsAsset.browser_download_url -UseBasicParsing).Content
+    } catch {
+        $sums = ""
+    }
+    $expected = $null
+    foreach ($line in ($sums -split "`n")) {
+        if ($line.Trim().EndsWith($assetName)) {
+            $expected = ($line.Trim() -split '\s+')[0]
+            break
+        }
+    }
+    if ($expected) {
+        $actual = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLower()
+        if ($actual -ne $expected.ToLower()) {
+            Remove-Item $zipPath -ErrorAction SilentlyContinue
+            Write-Host " FAILED" -ForegroundColor Red
+            Abort "Checksum verification failed - refusing to install.`n  expected: $expected`n  actual:   $actual"
+        }
+        Write-Host " ok" -ForegroundColor Green
+    } else {
+        Write-Host " skipped (no entry for $assetName)" -ForegroundColor DarkGray
+    }
+} else {
+    Write-Host " skipped (no checksums.txt in release)" -ForegroundColor DarkGray
+}
+
 # Extract
 Write-Host "  Extracting..." -NoNewline
 if (Test-Path $installDir) {

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,42 @@ if [ "${HTTP_CODE}" != "200" ]; then
   echo "  Download manually: https://github.com/${REPO}/releases/tag/${TAG}" >&2
   exit 1
 fi
+
+# ── Verify checksum ──────────────────────────────────────────────────────────
+# Fetch the release checksums file and verify the downloaded binary against it.
+# A mismatch is fatal. If the release predates checksums.txt, or no SHA-256 tool
+# is available, warn and continue rather than block installs — this is integrity
+# verification, not a substitute for signed releases.
+SUMS_URL="https://github.com/${REPO}/releases/download/${TAG}/checksums.txt"
+EXPECTED=$(curl -fsSL "${SUMS_URL}" 2>/dev/null \
+  | grep " ${BIN_NAME}-${PLATFORM}$" | awk '{print $1}' | head -1)
+
+if [ -z "${EXPECTED}" ]; then
+  echo "  ⚠  No checksum published for this release — skipping verification." >&2
+else
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL=$(sha256sum "${TMP}" | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL=$(shasum -a 256 "${TMP}" | awk '{print $1}')
+  else
+    ACTUAL=""
+    echo "  ⚠  No sha256sum/shasum tool found — skipping checksum verification." >&2
+  fi
+
+  if [ -n "${ACTUAL}" ]; then
+    if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+      rm -f "${TMP}"
+      echo "" >&2
+      echo "muninn: CHECKSUM VERIFICATION FAILED — refusing to install" >&2
+      echo "  expected: ${EXPECTED}" >&2
+      echo "  actual:   ${ACTUAL}" >&2
+      echo "  The downloaded binary does not match the published checksum." >&2
+      exit 1
+    fi
+    echo "  Checksum verified."
+  fi
+fi
+
 chmod +x "${TMP}"
 
 # ── Install ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`install.sh` / `install.ps1` fetched the release binary over HTTPS and ran it with **no integrity verification** — a corrupted or tampered release asset would install silently. Flagged in the deep-dive (M1). goreleaser's checksum template exists but the actual release is a custom `release.yml` that publishes raw `muninn-<os>-<arch>` binaries with **no checksums file** for them.

## Fix

- **`release.yml`** — `sha256sum` over every published asset (raw binaries + archives) into `checksums.txt`, uploaded with the release.
- **`install.sh`** — download `checksums.txt`, extract the SHA-256 for the fetched `muninn-<os>-<arch>` line, compare with `sha256sum` or `shasum -a 256`. **Mismatch is fatal.** A missing checksums file (older release) or absent SHA tool warns and continues, so current `latest` installs keep working until the next release ships the file.
- **`install.ps1`** — same via `Get-FileHash` against the Windows `.zip` entry.

Integrity verification, not a substitute for signed releases — a natural follow-up is to sign `checksums.txt` (cosign/minisign) and pin the key for active-MITM resistance. Noted in the commit.

## Verification

No Go surface; this is CI + shell. `release.yml` YAML validated; `install.sh` `sh -n` clean and its grep/awk/compare logic **simulated locally** — correct match, the `_darwin_arm64.tar.gz` line correctly skipped by the `$`-anchored grep, and tamper detected. `install.ps1` block reviewed against the script's existing asset-lookup pattern (`.Trim()` handles CRLF, fatal-on-mismatch, skip-on-missing). The Shellcheck CI job gates `install.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)