### PR TITLE
feat(server): warn at startup when bound off-host with default password

### DIFF
--- a/cmd/muninn/exposure_warn_test.go
+++ b/cmd/muninn/exposure_warn_test.go
@@ -1,0 +1,47 @@
+package main
+
+import "testing"
+
+func TestIsLoopbackHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"localhost", true},
+		{"0.0.0.0", false},      // bind-all
+		{"::", false},           // bind-all v6
+		{"", false},             // empty host → binds all interfaces
+		{"192.168.1.10", false}, // LAN
+		{"203.0.113.7", false},  // public
+		{"muninn.example.com", false},
+	}
+	for _, c := range cases {
+		if got := isLoopbackHost(c.host); got != c.want {
+			t.Errorf("isLoopbackHost(%q) = %v, want %v", c.host, got, c.want)
+		}
+	}
+}
+
+func TestShouldWarnDefaultPasswordExposure(t *testing.T) {
+	cases := []struct {
+		host         string
+		defaultInUse bool
+		want         bool
+		reason       string
+	}{
+		{"127.0.0.1", true, false, "loopback + default password is fine (not reachable off-host)"},
+		{"0.0.0.0", true, true, "exposed + default password must warn"},
+		{"0.0.0.0", false, false, "exposed but password changed is fine"},
+		{"192.168.1.10", true, true, "LAN + default password must warn"},
+		{"localhost", true, false, "localhost is loopback"},
+		{"", true, true, "bind-all + default password must warn"},
+	}
+	for _, c := range cases {
+		if got := shouldWarnDefaultPasswordExposure(c.host, c.defaultInUse); got != c.want {
+			t.Errorf("shouldWarnDefaultPasswordExposure(%q, %v) = %v, want %v — %s",
+				c.host, c.defaultInUse, got, c.want, c.reason)
+		}
+	}
+}

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -721,6 +721,30 @@ func parseListenHost(args []string, envVal string) string {
 	return host
 }
 
+// isLoopbackHost reports whether binding to host keeps the server reachable
+// only from the local machine. An empty host means Go binds all interfaces
+// (":port"), so it is treated as non-loopback. A non-IP hostname other than
+// "localhost" is treated as non-loopback since it can resolve anywhere.
+func isLoopbackHost(host string) bool {
+	switch host {
+	case "":
+		return false
+	case "localhost":
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// shouldWarnDefaultPasswordExposure reports whether the server is reachable
+// off-host while the admin still has the default password — the combination
+// that warrants a prominent security warning at startup.
+func shouldWarnDefaultPasswordExposure(listenHost string, defaultPasswordInUse bool) bool {
+	return defaultPasswordInUse && !isLoopbackHost(listenHost)
+}
+
 func runServer() {
 	loadEnvFile()
 
@@ -1004,6 +1028,24 @@ func runServer() {
 	if err != nil {
 		slog.Error("auth bootstrap failed", "err", err)
 		os.Exit(1)
+	}
+
+	// Loud warning when the server is reachable off-host while the admin still
+	// has the default password — an open-server posture. We warn rather than
+	// refuse so the zero-config quickstart and the shipped docker-compose keep
+	// working; the message tells the operator exactly how to close the gap.
+	if shouldWarnDefaultPasswordExposure(listenHost, authStore.ValidateAdmin("root", "password") == nil) {
+		slog.Warn("SECURITY: bound to a non-loopback address with the default admin password still set",
+			"listen_host", listenHost)
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "  ⚠  SECURITY WARNING")
+		fmt.Fprintf(os.Stderr, "     muninn is listening on %s (reachable from other hosts) while the\n", listenHost)
+		fmt.Fprintln(os.Stderr, "     admin account still uses the default password 'password'.")
+		fmt.Fprintln(os.Stderr, "     Anyone who can reach this host can take over the server.")
+		fmt.Fprintln(os.Stderr, "     Fix now: log in to the Web UI and change the password, or set")
+		fmt.Fprintln(os.Stderr, "     MUNINN_ADMIN_PASSWORD before starting. Bind to 127.0.0.1 if you")
+		fmt.Fprintln(os.Stderr, "     only need local access.")
+		fmt.Fprintln(os.Stderr, "")
 	}
 
 	// Open MOL (Write-Ahead Log)


### PR DESCRIPTION
## Problem

Binding to a non-loopback address (0.0.0.0, a LAN/public IP, or bind-all) while the admin still uses the default password `password` is an open-server posture — anyone who can reach the host can take over. The shipped `docker-compose.yml` does exactly this. The previous startup check only logged a generic one-line firewall note on `0.0.0.0` and said nothing about the credential risk. Flagged in the deep-dive (H3).

## Fix

A prominent, actionable startup warning for the specific dangerous combination — reachable off-host **and** default password still set — detected via `authStore.ValidateAdmin("root", "password")`.

**Warn, not refuse**, so the zero-config quickstart and the shipped docker-compose keep working out of the box; the message names the exact fixes (change the password, set `MUNINN_ADMIN_PASSWORD`, or bind to `127.0.0.1`). A hard refusal would break the 30-second try-it experience and the compose file, which isn't worth it for an alpha.

## Tests (TDD, RED first)

Pure helpers `isLoopbackHost` (loopback / LAN / public / bind-all / localhost / empty) and `shouldWarnDefaultPasswordExposure` (the warn decision across the host × default-password matrix). Full `cmd/muninn` suite green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)