### PR TITLE
refactor(storage): add ErrNotFound sentinel; replace string-matching

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"log/slog"
@@ -349,8 +350,8 @@ func NewEngine(cfg EngineConfig) *Engine {
 		activity:         cognitive.NewActivityTracker(),
 		embedder:         cfg.Embedder,
 		autoAssoc:        autoassoc.New(stopCtx, store, cfg.FTSIndex),
-		neighborWorker:  autoassoc.NewNeighborWorker(stopCtx, store, cfg.HNSWRegistry),
-		goalLinkWorker:  autoassoc.NewGoalLinkWorker(stopCtx, store, cfg.HNSWRegistry),
+		neighborWorker:   autoassoc.NewNeighborWorker(stopCtx, store, cfg.HNSWRegistry),
+		goalLinkWorker:   autoassoc.NewGoalLinkWorker(stopCtx, store, cfg.HNSWRegistry),
 		noveltyDet:       novelty.New(),
 		noveltyJobs:      make(chan noveltyJob, 256),
 		noveltyDone:      make(chan struct{}),
@@ -361,8 +362,8 @@ func NewEngine(cfg EngineConfig) *Engine {
 		stopCtx:          stopCtx,
 		stopCancel:       stopCancel,
 		hnswRegistry:     cfg.HNSWRegistry,
-		jobManager:          vaultjob.NewManager(),
-		replayFailCounts:    make(map[storage.ULID]int),
+		jobManager:       vaultjob.NewManager(),
+		replayFailCounts: make(map[storage.ULID]int),
 	}
 	// Start async novelty worker to decouple O(N) Jaccard scan from write hot path.
 	// engine:spawn-ok — tracked by noveltyDone channel, drained in Stop()
@@ -1656,7 +1657,7 @@ func (e *Engine) Read(ctx context.Context, req *mbp.ReadRequest) (*mbp.ReadRespo
 
 	eng, err := e.store.GetEngram(ctx, wsPrefix, id)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, storage.ErrNotFound) {
 			return nil, ErrEngramNotFound
 		}
 		return nil, fmt.Errorf("get engram: %w", err)
@@ -1710,21 +1711,21 @@ func (e *Engine) Read(ctx context.Context, req *mbp.ReadRequest) (*mbp.ReadRespo
 	metrics.ReadDuration.WithLabelValues(req.Vault).Observe(d.Seconds())
 
 	return &mbp.ReadResponse{
-		ID:             eng.ID.String(),
-		Concept:        eng.Concept,
-		Content:        eng.Content,
-		Confidence:     eng.Confidence,
-		Relevance:      eng.Relevance,
-		Stability:      eng.Stability,
-		AccessCount:    eng.AccessCount,
-		Tags:           eng.Tags,
-		State:          uint8(eng.State),
-		CreatedAt:      eng.CreatedAt.UnixNano(),
-		UpdatedAt:      eng.UpdatedAt.UnixNano(),
-		LastAccess:     eng.LastAccess.UnixNano(),
-		Summary:        eng.Summary,
-		KeyPoints:      eng.KeyPoints,
-		MemoryType:     uint8(eng.MemoryType),
+		ID:                  eng.ID.String(),
+		Concept:             eng.Concept,
+		Content:             eng.Content,
+		Confidence:          eng.Confidence,
+		Relevance:           eng.Relevance,
+		Stability:           eng.Stability,
+		AccessCount:         eng.AccessCount,
+		Tags:                eng.Tags,
+		State:               uint8(eng.State),
+		CreatedAt:           eng.CreatedAt.UnixNano(),
+		UpdatedAt:           eng.UpdatedAt.UnixNano(),
+		LastAccess:          eng.LastAccess.UnixNano(),
+		Summary:             eng.Summary,
+		KeyPoints:           eng.KeyPoints,
+		MemoryType:          uint8(eng.MemoryType),
 		TypeLabel:           eng.TypeLabel,
 		Classification:      eng.Classification,
 		EmbedDim:            uint8(eng.EmbedDim),
@@ -2326,7 +2327,7 @@ func (e *Engine) Forget(ctx context.Context, req *mbp.ForgetRequest) (*mbp.Forge
 		eng, _ := e.store.GetEngram(ctx, wsPrefix, id)
 
 		if err := e.store.DeleteEngram(ctx, wsPrefix, id); err != nil {
-			if strings.Contains(err.Error(), "not found") {
+			if errors.Is(err, storage.ErrNotFound) {
 				return nil, ErrEngramNotFound
 			}
 			return nil, fmt.Errorf("hard delete: %w", err)
@@ -2361,7 +2362,7 @@ func (e *Engine) Forget(ctx context.Context, req *mbp.ForgetRequest) (*mbp.Forge
 		// Read the engram before soft-deleting so we can clean up FTS index entries.
 		eng, readErr := e.store.GetEngram(ctx, wsPrefix, id)
 		if err := e.store.SoftDelete(ctx, wsPrefix, id); err != nil {
-			if strings.Contains(err.Error(), "not found") {
+			if errors.Is(err, storage.ErrNotFound) {
 				return nil, ErrEngramNotFound
 			}
 			return nil, fmt.Errorf("soft delete: %w", err)
@@ -2518,7 +2519,7 @@ func (e *Engine) Restore(ctx context.Context, vault, id string) (*storage.Engram
 	}
 	eng, err := e.store.GetEngram(ctx, ws, ulid)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, storage.ErrNotFound) {
 			return nil, ErrEngramNotFound
 		}
 		return nil, fmt.Errorf("restore: %w", err)
@@ -2588,7 +2589,7 @@ func (e *Engine) SetTrust(ctx context.Context, vault, id, trust string) error {
 		return fmt.Errorf("parse id: %w", err)
 	}
 	if err := e.store.UpdateTrust(ctx, ws, ulid, level); err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, storage.ErrNotFound) {
 			return ErrEngramNotFound
 		}
 		return err

--- a/internal/storage/engram.go
+++ b/internal/storage/engram.go
@@ -29,7 +29,7 @@ func (ps *PebbleStore) GetEngram(ctx context.Context, wsPrefix [8]byte, id ULID)
 		return nil, fmt.Errorf("get engram: %w", err)
 	}
 	if val == nil {
-		return nil, fmt.Errorf("engram not found")
+		return nil, fmt.Errorf("engram %w", ErrNotFound)
 	}
 
 	// Decode
@@ -239,7 +239,7 @@ func (ps *PebbleStore) UpdateMetadata(ctx context.Context, wsPrefix [8]byte, id 
 		return err
 	}
 	if len(oldMetas) == 0 || oldMetas[0] == nil {
-		return fmt.Errorf("engram not found")
+		return fmt.Errorf("engram %w", ErrNotFound)
 	}
 	oldState := oldMetas[0].State
 	var prevLastAccessMillis int64
@@ -254,7 +254,7 @@ func (ps *PebbleStore) UpdateMetadata(ctx context.Context, wsPrefix [8]byte, id 
 		return fmt.Errorf("get engram raw: %w", err)
 	}
 	if rawBytes == nil {
-		return fmt.Errorf("engram not found")
+		return fmt.Errorf("engram %w", ErrNotFound)
 	}
 
 	// Patch all mutable metadata fields in-place and recompute CRC32.
@@ -322,7 +322,7 @@ func (ps *PebbleStore) UpdateRelevance(ctx context.Context, wsPrefix [8]byte, id
 		return err
 	}
 	if len(metas) == 0 || metas[0] == nil {
-		return fmt.Errorf("engram not found")
+		return fmt.Errorf("engram %w", ErrNotFound)
 	}
 	oldRelevance := metas[0].Relevance
 
@@ -333,7 +333,7 @@ func (ps *PebbleStore) UpdateRelevance(ctx context.Context, wsPrefix [8]byte, id
 		return fmt.Errorf("get engram raw: %w", err)
 	}
 	if rawBytes == nil {
-		return fmt.Errorf("engram not found")
+		return fmt.Errorf("engram %w", ErrNotFound)
 	}
 
 	// Patch relevance/stability/updatedAt in-place and recompute CRC32.
@@ -387,7 +387,7 @@ func (ps *PebbleStore) UpdateTrust(ctx context.Context, wsPrefix [8]byte, id ULI
 		return fmt.Errorf("get engram raw: %w", err)
 	}
 	if rawBytes == nil {
-		return fmt.Errorf("engram not found")
+		return fmt.Errorf("engram %w", ErrNotFound)
 	}
 
 	if err := erf.PatchTrust(rawBytes, uint8(trust)); err != nil {
@@ -749,7 +749,7 @@ func (ps *PebbleStore) GetConfidence(ctx context.Context, wsPrefix [8]byte, id U
 		return 0.0, fmt.Errorf("get metadata: %w", err)
 	}
 	if val == nil {
-		return 0.0, fmt.Errorf("metadata not found")
+		return 0.0, fmt.Errorf("metadata %w", ErrNotFound)
 	}
 
 	// Decode metadata to extract confidence

--- a/internal/storage/errnotfound_test.go
+++ b/internal/storage/errnotfound_test.go
@@ -1,0 +1,25 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestErrNotFound_Sentinel pins the contract that "not found" storage errors
+// wrap the ErrNotFound sentinel, so callers can use errors.Is instead of
+// fragile strings.Contains(err.Error(), "not found") matching.
+func TestErrNotFound_Sentinel(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	var ws [8]byte
+
+	missing := NewULID()
+
+	if _, err := store.GetEngram(ctx, ws, missing); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetEngram(missing): err = %v, want errors.Is(..., ErrNotFound)", err)
+	}
+	if err := store.UpdateTrust(ctx, ws, missing, TrustVerified); !errors.Is(err, ErrNotFound) {
+		t.Errorf("UpdateTrust(missing): err = %v, want errors.Is(..., ErrNotFound)", err)
+	}
+}

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -1,0 +1,8 @@
+package storage
+
+import "errors"
+
+// ErrNotFound is the sentinel wrapped by storage "not found" errors (missing
+// engram, metadata, etc.). Callers should test for it with errors.Is rather
+// than matching on the error string.
+var ErrNotFound = errors.New("not found")


### PR DESCRIPTION
## Problem

Storage returned bare `fmt.Errorf("engram not found")` / `"metadata not found"`, so the engine had to detect missing records with `strings.Contains(err.Error(), "not found")` in **five** places — fragile against any message rewording. Flagged in the deep-dive core review (concern #6).

## Fix

- Add `storage.ErrNotFound` and wrap the storage returns with it. `fmt.Errorf("engram %w", ErrNotFound)` keeps the exact `"engram not found"` message text while making the error matchable via `errors.Is`.
- Replace the five engine `strings.Contains(...)` checks with `errors.Is(err, storage.ErrNotFound)`.

**Behaviour-preserving:** error message strings are byte-identical (verified), and the wrapped errors still contain `"not found"`, so any other substring matcher keeps working.

## Tests

`TestErrNotFound_Sentinel` pins the contract (`GetEngram` and `UpdateTrust` on a missing id satisfy `errors.Is(..., ErrNotFound)`). Full `internal/storage` and `internal/engine` suites pass; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)