### PR TITLE
fix(consolidation): stop dedup mutating the cache-shared representative

### DIFF
--- a/internal/consolidation/dedup.go
+++ b/internal/consolidation/dedup.go
@@ -171,9 +171,16 @@ func (w *Worker) runPhase2Dedup(ctx context.Context, store *storage.PebbleStore,
 
 		// Persist representative updates when anything changed: tag-merge
 		// added tags, or frequency-absorption bumped AccessCount.
+		//
+		// Compute the new access count locally — do NOT mutate representative.
+		// GetEngrams returns pointers into the L1 cache that concurrent recalls
+		// may be reading (see the immutability contract on storage.L1Cache.Get);
+		// mutating the shared struct here is a data race. UpdateMetadata persists
+		// the value and invalidates the cache, so the next read is fresh.
 		tagsChanged := len(mergedTags) != len(representative.Tags)
+		newAccessCount := representative.AccessCount
 		if !w.DryRun && archivedCount > 0 {
-			representative.AccessCount += archivedCount
+			newAccessCount += archivedCount
 		}
 		if !w.DryRun && (tagsChanged || archivedCount > 0) {
 			if err := store.UpdateMetadata(ctx, wsPrefix, representative.ID, &storage.EngramMeta{
@@ -181,7 +188,7 @@ func (w *Worker) runPhase2Dedup(ctx context.Context, store *storage.PebbleStore,
 				Confidence:  representative.Confidence,
 				Relevance:   representative.Relevance,
 				Stability:   representative.Stability,
-				AccessCount: representative.AccessCount,
+				AccessCount: newAccessCount,
 				UpdatedAt:   representative.UpdatedAt,
 				LastAccess:  representative.LastAccess,
 			}); err != nil {

--- a/internal/consolidation/dedup_nomutate_test.go
+++ b/internal/consolidation/dedup_nomutate_test.go
@@ -1,0 +1,71 @@
+package consolidation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// TestDedup_DoesNotMutateCachedRepresentative pins the contract that dedup's
+// frequency-absorption must NOT mutate the representative engram in place.
+// GetEngrams returns pointers into the L1 cache that concurrent recalls may be
+// reading; mutating representative.AccessCount there is a data race. The new
+// access count must be computed locally and only persisted via UpdateMetadata
+// (which invalidates the cache), leaving any already-handed-out pointer intact.
+func TestDedup_DoesNotMutateCachedRepresentative(t *testing.T) {
+	store, db, cleanup := testStoreWithDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	vault := "dedup_no_mutate"
+	wsPrefix := store.ResolveVaultPrefix(vault)
+
+	embed := []float32{1, 0, 0, 0}
+	const startAccess uint32 = 5
+
+	repID := writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+		Concept: "rep", Content: "rep content", Confidence: 0.9, Relevance: 0.9,
+		Stability: 30, Embedding: embed, AccessCount: startAccess,
+	})
+	for i := 0; i < 3; i++ {
+		writeEngramWithEmbedding(t, ctx, store, db, wsPrefix, &storage.Engram{
+			Concept: "dup", Content: "dup content", Confidence: 0.5, Relevance: 0.5,
+			Stability: 30, Embedding: embed, AccessCount: 0,
+		})
+	}
+
+	// Pre-warm the L1 cache and hold the representative pointer, exactly as a
+	// concurrent recall would. dedup will fetch the same pointer from the cache.
+	held, err := store.GetEngrams(ctx, wsPrefix, []storage.ULID{repID})
+	if err != nil || len(held) != 1 || held[0] == nil {
+		t.Fatalf("pre-warm GetEngrams: %v (n=%d)", err, len(held))
+	}
+	heldRep := held[0]
+	if heldRep.AccessCount != startAccess {
+		t.Fatalf("setup: held AccessCount = %d, want %d", heldRep.AccessCount, startAccess)
+	}
+
+	mock := &mockEngineInterface{store: store}
+	w := &Worker{Engine: mock, MaxDedup: 100, MaxTransitive: 100}
+	if err := w.runPhase2Dedup(ctx, store, wsPrefix, &ConsolidationReport{}, vault); err != nil {
+		t.Fatal(err)
+	}
+
+	// The pointer handed out before dedup must be unchanged — dedup must not
+	// have mutated the shared cache struct in place.
+	if heldRep.AccessCount != startAccess {
+		t.Errorf("dedup mutated the cached representative in place: AccessCount = %d, want %d (unchanged)",
+			heldRep.AccessCount, startAccess)
+	}
+
+	// The persisted value must still reflect the absorbed duplicates (cache was
+	// invalidated by UpdateMetadata, so this re-reads from storage).
+	rep, err := store.GetEngram(ctx, wsPrefix, repID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.AccessCount != startAccess+3 {
+		t.Errorf("persisted AccessCount = %d, want %d (5 starting + 3 absorbed)", rep.AccessCount, startAccess+3)
+	}
+}

--- a/internal/storage/cache.go
+++ b/internal/storage/cache.go
@@ -43,6 +43,13 @@ func NewL1Cache(maxSize int) *L1Cache {
 // Get retrieves an engram from the cache.
 // Returns (engram, found). The vault prefix is included in the lookup
 // so engrams from different vaults are never served to each other.
+//
+// IMMUTABILITY CONTRACT: the returned *Engram is shared — the same pointer may
+// be handed to concurrent readers (and is also what GetEngrams returns). Treat
+// it as read-only. Callers that need to change an engram must deep-copy first
+// (as the write path does before invoking triggers) or go through an Update*
+// method, which persists the change and invalidates this entry. Mutating the
+// returned struct in place is a data race against concurrent recalls.
 func (c *L1Cache) Get(ws [8]byte, id ULID) (*Engram, bool) {
 	val, ok := c.data.Load(cacheKeyFor(ws, id))
 	if !ok {


### PR DESCRIPTION
## Problem

dedup's frequency-absorption did `representative.AccessCount += archivedCount` **in place**. `representative` is a pointer from `store.GetEngrams`, which returns L1-cache pointers that concurrent recalls read (`activation` reads `eng.AccessCount` / `eng.LastAccess`). So a dream-during-recall mutated a shared struct — a data race. Flagged in the deep-dive core review (concern #4).

## Fix

Compute the new access count in a local and pass it to `UpdateMetadata` (which persists it and invalidates the cache) instead of mutating the struct. The persisted value is unchanged, so frequency absorption still works; the shared pointer is left untouched.

Also documents the **`L1Cache.Get` immutability contract** — returned engrams are shared and read-only; mutate only after a deep-copy or via an `Update*` method — so future callers don't reintroduce this.

## Tests (TDD, RED first)

`TestDedup_DoesNotMutateCachedRepresentative` pre-warms the cache, holds the representative pointer as a concurrent recall would, runs dedup, and asserts the held pointer's `AccessCount` is unchanged (was `8`, now stays `5`) **while** the persisted value is still bumped to `8`. The existing `TestDedup_AccessCountAbsorbsArchivedDuplicates` (persisted bump) stays green. Full consolidation suite passes under `-race`; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)