### PR TITLE
fix(activation): mean-pool multi-phrase query embedding (#498)

### DIFF
--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -498,9 +498,43 @@ func (e *ActivationEngine) phase1(ctx context.Context, req *ActivateRequest) (*p
 		if err != nil {
 			return nil, fmt.Errorf("phase1 embed: %w", err)
 		}
+		// Embed returns a flat len(texts)*dim slice — each phrase's vector
+		// concatenated. A multi-phrase context must be pooled back into a single
+		// dim-sized query vector; feeding the raw N*dim slice to the dim-sized
+		// HNSW index makes CosineSimilarity's length guard return 0 for every
+		// node, silently zeroing the vector signal for any 2+ phrase context (#498).
+		if n := len(req.Context); n > 1 && len(vec) > 0 && len(vec)%n == 0 {
+			vec = meanPoolEmbeddings(vec, n)
+		}
 		result.embedding = vec
 	}
 	return result, nil
+}
+
+// meanPoolEmbeddings averages n equal-length vectors concatenated in flat
+// (dim = len(flat)/n) and L2-normalizes the result into a single dim-sized
+// query vector. Callers must ensure len(flat) is a positive multiple of n.
+func meanPoolEmbeddings(flat []float32, n int) []float32 {
+	dim := len(flat) / n
+	pooled := make([]float32, dim)
+	for p := 0; p < n; p++ {
+		base := p * dim
+		for i := 0; i < dim; i++ {
+			pooled[i] += flat[base+i]
+		}
+	}
+	var norm float64
+	for i := range pooled {
+		pooled[i] /= float32(n)
+		norm += float64(pooled[i]) * float64(pooled[i])
+	}
+	if norm > 0 {
+		inv := float32(1.0 / math.Sqrt(norm))
+		for i := range pooled {
+			pooled[i] *= inv
+		}
+	}
+	return pooled
 }
 
 // phase2 retrieves candidates from FTS, HNSW, and decay pool in parallel.

--- a/internal/engine/activation/phase1_pooling_test.go
+++ b/internal/engine/activation/phase1_pooling_test.go
@@ -1,0 +1,62 @@
+package activation
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// flatStubEmbedder mimics the real embedder contract: Embed returns a flat
+// len(texts)*dim slice (per-phrase vectors concatenated), NOT a single vector.
+type flatStubEmbedder struct{ dim int }
+
+func (s flatStubEmbedder) Embed(_ context.Context, texts []string) ([]float32, error) {
+	out := make([]float32, len(texts)*s.dim)
+	for i := range out {
+		out[i] = 1 // non-zero so pooling produces a non-zero, normalizable vector
+	}
+	return out, nil
+}
+func (s flatStubEmbedder) Tokenize(text string) []string { return strings.Fields(text) }
+
+// stubHNSW just needs to be non-nil so phase1 computes the query embedding.
+type stubHNSW struct{}
+
+func (stubHNSW) Search(context.Context, [8]byte, []float32, int) ([]ScoredID, error) {
+	return nil, nil
+}
+
+// TestPhase1_MultiPhraseEmbedding_PooledToIndexDim is the regression test for
+// #498: a multi-phrase context must yield a single dim-sized query vector. The
+// embedder returns len(context)*dim concatenated; phase1 previously used that
+// raw N*dim slice as the query vector, so HNSW's CosineSimilarity length guard
+// returned 0 for every node and semantic recall silently returned nothing for
+// any context with 2+ phrases.
+func TestPhase1_MultiPhraseEmbedding_PooledToIndexDim(t *testing.T) {
+	const dim = 8
+	e := &ActivationEngine{embedder: flatStubEmbedder{dim: dim}, hnsw: stubHNSW{}}
+	ctx := context.Background()
+
+	single, err := e.phase1(ctx, &ActivateRequest{Context: []string{"one phrase"}})
+	if err != nil {
+		t.Fatalf("phase1 single: %v", err)
+	}
+	if len(single.embedding) != dim {
+		t.Fatalf("single-phrase embedding len = %d, want %d", len(single.embedding), dim)
+	}
+
+	for _, n := range []int{2, 3, 5} {
+		ctxPhrases := make([]string, n)
+		for i := range ctxPhrases {
+			ctxPhrases[i] = "phrase"
+		}
+		multi, err := e.phase1(ctx, &ActivateRequest{Context: ctxPhrases})
+		if err != nil {
+			t.Fatalf("phase1 %d-phrase: %v", n, err)
+		}
+		if len(multi.embedding) != dim {
+			t.Errorf("%d-phrase embedding len = %d, want %d (must be pooled to index dim, not N*dim)",
+				n, len(multi.embedding), dim)
+		}
+	}
+}


### PR DESCRIPTION
## Problem (critical — core feature)

`phase1` passed `req.Context` (a `[]string` of N phrases) straight to `embedder.Embed`, which returns a **flat N*dim slice** (each phrase's vector concatenated). That raw N*dim slice was then used as the query vector against the **dim-sized** HNSW index, so `CosineSimilarity`'s length guard (`len(a) != len(b)` → return 0) returned **0 for every node** — silently zeroing the entire vector signal for **any context with 2+ phrases**.

- Single phrase worked (`1*dim == dim`); **2+ phrases returned 0 results.**
- Multi-phrase `context` is the documented happy path (and the empty-result hint tells users to add more context).
- Pre-existing — shipped in v0.6.2.

## Fix

Mean-pool the per-phrase vectors back into a single L2-normalized dim-sized query vector when `len(context) > 1` — the reporter's production-validated approach (verified live: two-phrase recall returns the expected memories at vector scores ~0.70, previously `total: 0`). The single-phrase and explicit-`embedding` paths are unchanged; the guard requires `len(vec) % n == 0` so a degenerate provider output falls back to the raw vector rather than panicking.

## Test

`TestPhase1_MultiPhraseEmbedding_PooledToIndexDim` — phase1 with 2/3/5-phrase context yields a `dim`-sized embedding, not `N*dim` (verified RED: 16/24/40 before, 8 after). Full activation + scoring-invariant suites stay green.

Credit: found and production-patched by @johanneshauer (#498).

🤖 Generated with [Claude Code](https://claude.com/claude-code)