### PR TITLE
fix(entity): prevent merge_entity case-variant data loss (#503)

### DIFF
--- a/internal/engine/engine_similarity.go
+++ b/internal/engine/engine_similarity.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/storage/keys"
 )
 
 // SimilarEntityPair represents a pair of entity names that are likely the same.
@@ -113,6 +114,13 @@ func (e *Engine) MergeEntity(ctx context.Context, vault, entityA, entityB string
 	}
 	if entityA == entityB {
 		return nil, fmt.Errorf("merge_entity: entity_a and entity_b must be different")
+	}
+	// Entity storage keys are hashed case-insensitively (lowercase + NFKC), so
+	// names that differ only by case/whitespace normalize to the SAME entity.
+	// Merging them would relink an engram from a key to itself, and the
+	// underlying Set+Delete batch would destroy the link (#503). Reject up front.
+	if keys.EntityNameHash(entityA) == keys.EntityNameHash(entityB) {
+		return nil, fmt.Errorf("merge_entity: %q and %q normalize to the same entity (entity names are case-insensitive); nothing to merge", entityA, entityB)
 	}
 
 	// Serialise concurrent merges that touch either entity.

--- a/internal/storage/entity.go
+++ b/internal/storage/entity.go
@@ -246,6 +246,15 @@ func (ps *PebbleStore) RelinkEntityEngramLink(ctx context.Context, ws [8]byte, e
 	toHash := keys.EntityNameHash(toEntity)
 	id := [16]byte(engramID)
 
+	// Entity names are hashed case-insensitively, so case/whitespace/NFKC
+	// variants collide on the same key. If from and to normalize to the same
+	// entity, the Set(toHash)+Delete(fromHash) below would target identical keys
+	// and the Delete would win — silently destroying the link. There is nothing
+	// to relink in that case (#503).
+	if fromHash == toHash {
+		return nil
+	}
+
 	batch := ps.db.NewBatch()
 	defer batch.Close()
 	// Write new links for toEntity.

--- a/internal/storage/entity_relink_casevariant_test.go
+++ b/internal/storage/entity_relink_casevariant_test.go
@@ -1,0 +1,36 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRelinkEntityEngramLink_CaseVariant_PreservesLink is the regression test
+// for #503. Entity names are hashed case-insensitively (EntityNameHash
+// lowercases/NFKC-normalizes), so "Foo" and "foo" share the same storage key.
+// RelinkEntityEngramLink does Set(toHash) then Delete(fromHash) in one batch —
+// when fromHash == toHash the Delete is sequenced after the Set and wins,
+// silently destroying the engram's link to BOTH casings. The relink must be a
+// no-op when the two names normalize to the same entity.
+func TestRelinkEntityEngramLink_CaseVariant_PreservesLink(t *testing.T) {
+	ps := newTestStore(t)
+	ctx := context.Background()
+	ws := ps.VaultPrefix("test")
+	engID := NewULID()
+
+	require.NoError(t, ps.WriteEntityEngramLink(ctx, ws, engID, "Foo"))
+
+	// Relink across case variants — these normalize to the same entity key.
+	require.NoError(t, ps.RelinkEntityEngramLink(ctx, ws, engID, "Foo", "foo"))
+
+	var found []ULID
+	require.NoError(t, ps.ScanEntityEngrams(ctx, "Foo", func(_ [8]byte, id ULID) error {
+		found = append(found, id)
+		return nil
+	}))
+	require.Len(t, found, 1, "engram link must survive a case-variant relink (#503 data loss)")
+	assert.Equal(t, engID, found[0])
+}


### PR DESCRIPTION
## Problem (silent data loss)

Entity names are hashed case-insensitively (`EntityNameHash` lowercases + NFKC-normalizes), so `"Foo"` and `"foo"` share the same storage key. `merge_entity` only guarded raw-string equality (`entityA == entityB`), so a **case-variant merge passed** — and `RelinkEntityEngramLink` then did `Set(toHash)` + `Delete(fromHash)` on the **same key** in one batch. Pebble sequences the Delete after the Set, so it won, **silently destroying the engram's link to both casings** while `merge_entity` reported success with a full relinked count.

## Fix

- **`RelinkEntityEngramLink`**: no-op when `fromHash == toHash` — defense-in-depth for every caller; never Set-then-Delete the same key.
- **`MergeEntity`**: reject up front when `EntityNameHash(a) == EntityNameHash(b)`, with a clear "normalize to the same entity" error.

Genuinely-distinct entity merges are unaffected. No cognitive-model change.

## Test (TDD, RED first)

`TestRelinkEntityEngramLink_CaseVariant_PreservesLink` — a `"Foo"→"foo"` relink preserves the link (verified RED: 0 found = destroyed, before the fix). Full storage + engine entity/merge suites green; `go vet` clean.

Credit: found by @johanneshauer (#503).

🤖 Generated with [Claude Code](https://claude.com/claude-code)