### PR TITLE
fix(hnsw): don't cache failed loads; log load outcomes; scope iterator to vault (#499)

### DIFF
--- a/internal/index/hnsw/hnsw.go
+++ b/internal/index/hnsw/hnsw.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/scrypster/muninndb/internal/storage/keys"
@@ -76,6 +77,12 @@ type Index struct {
 	efConstruction int            // beam width during insert; 0 → uses EfConstruction constant
 	efSearch       int            // beam width during query; 0 → uses EfSearch constant
 	deleted        sync.Map       // key: [16]byte id → struct{} (tombstoned hard-deleted nodes)
+
+	// loadErrHook is a test-only seam: when non-nil, LoadFromPebble returns the
+	// hook's result immediately, allowing tests to exercise the failed-load path
+	// (e.g. the registry's no-cache-on-error behaviour) without corrupting Pebble.
+	// Always nil in production.
+	loadErrHook func() error
 }
 
 // Dim returns the vector dimension used by this index.
@@ -690,8 +697,21 @@ func decodeNeighbors(buf []byte) [][16]byte {
 // LoadFromPebble reads all HNSW nodes from Pebble into memory.
 // Loads into temporary structures first and only applies on success to maintain consistency.
 func (idx *Index) LoadFromPebble() error {
-	lowerBound := []byte{0x07}
+	if idx.loadErrHook != nil {
+		return idx.loadErrHook()
+	}
+
+	start := time.Now()
+
+	// Scope the iterator to this vault's keyspace. The 0x07 range is shared by
+	// all vaults; bounding it to 0x07‖ws … 0x07‖(ws+1) means Pebble only visits
+	// this vault's keys instead of scanning the whole 0x07 keyspace and skipping
+	// foreign keys per-key. The in-loop ws check below remains as a safety net.
+	lowerBound := append([]byte{0x07}, idx.ws[:]...)
 	upperBound := []byte{0x08}
+	if wsPlus, err := keys.IncrementWSPrefix(idx.ws); err == nil {
+		upperBound = append([]byte{0x07}, wsPlus[:]...)
+	}
 
 	iter, err := idx.db.NewIter(&pebble.IterOptions{
 		LowerBound: lowerBound,
@@ -755,12 +775,27 @@ func (idx *Index) LoadFromPebble() error {
 		return fmt.Errorf("hnsw: LoadFromPebble incomplete read: %w", err)
 	}
 
+	// Count vectors that were actually restored (nodes carrying a 0xFF slot).
+	vectorCount := 0
+	for _, node := range tempNodes {
+		if node.vec != nil {
+			vectorCount++
+		}
+	}
+
 	// Only apply to index if load completed successfully
 	idx.mu.Lock()
-	defer idx.mu.Unlock()
 	idx.nodes = tempNodes
 	idx.maxLevel = tempMaxLevel
 	idx.entryPoint = tempEntryPoint
+	idx.mu.Unlock()
+
+	slog.Info("hnsw: loaded graph from pebble",
+		"vault", idx.ws,
+		"nodes", len(tempNodes),
+		"vectors", vectorCount,
+		"duration", time.Since(start),
+	)
 
 	return nil
 }

--- a/internal/index/hnsw/registry.go
+++ b/internal/index/hnsw/registry.go
@@ -29,6 +29,11 @@ type Registry struct {
 	lastWarnNano atomic.Int64 // Unix nano of last slog.Warn emission
 	hardLimitHit atomic.Bool  // true after the first hard-limit hit (changes log level)
 	lastHardNano atomic.Int64 // Unix nano of last hard-limit log emission
+
+	// loadErrHook is a test-only seam: when non-nil, it is installed on every
+	// lazily-created Index so LoadFromPebble fails deterministically, exercising
+	// the no-cache-on-error path in getOrCreate. Always nil in production.
+	loadErrHook func() error
 }
 
 // warnThrottleInterval is the minimum gap between repeated memory-warning log lines.
@@ -107,9 +112,16 @@ func (r *Registry) getOrCreate(ws [8]byte) *Index {
 	} else {
 		idx = New(r.db, ws)
 	}
-	// Load any previously persisted nodes; log errors — empty index is still usable.
+	idx.loadErrHook = r.loadErrHook // nil in production
+	// Load any previously persisted nodes. On failure, do NOT cache the index:
+	// caching a known-empty index would pin it for the rest of the process
+	// lifetime (the fast path always returns the cached value), turning a
+	// transient load error into permanent silent recall loss. Returning the
+	// uncached empty index lets this request degrade gracefully while the next
+	// access retries the load. (issue #499)
 	if err := idx.LoadFromPebble(); err != nil {
-		slog.Error("hnsw: failed to load graph from pebble", "vault", ws, "error", err)
+		slog.Error("hnsw: failed to load graph from pebble; not caching index (load will be retried on next access)", "vault", ws, "error", err)
+		return idx
 	}
 	r.indexes[ws] = idx
 	return idx

--- a/internal/index/hnsw/registry_load_test.go
+++ b/internal/index/hnsw/registry_load_test.go
@@ -1,0 +1,84 @@
+package hnsw
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+)
+
+// TestGetOrCreate_FailedLoadNotCached verifies that when LoadFromPebble errors,
+// getOrCreate does NOT pin the empty index in r.indexes — so the next access
+// retries the load instead of serving a permanently empty cached index for the
+// rest of the process lifetime (issue #499, defect 2).
+func TestGetOrCreate_FailedLoadNotCached(t *testing.T) {
+	db, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	if err != nil {
+		t.Fatalf("pebble.Open: %v", err)
+	}
+	defer db.Close()
+
+	reg := NewRegistry(db)
+	// Force every lazily-created Index's load to fail, simulating a transient
+	// Pebble iterator error.
+	var loadCalls atomic.Int64
+	reg.loadErrHook = func() error {
+		loadCalls.Add(1)
+		return errors.New("simulated transient load error")
+	}
+
+	var ws [8]byte
+	copy(ws[:], []byte("FAILLOAD"))
+
+	// First access: load fails. The returned index degrades gracefully
+	// (non-nil, empty) but must NOT be cached.
+	idx1 := reg.getOrCreate(ws)
+	if idx1 == nil {
+		t.Fatal("getOrCreate returned nil on failed load; expected a usable empty index")
+	}
+	if cached := reg.get(ws); cached != nil {
+		t.Fatalf("failed-load index was cached in r.indexes; load will never be retried")
+	}
+
+	// Second access: must retry the load (i.e. not be served from a cached
+	// empty index). While the load keeps failing, the index must not be pinned.
+	idx2 := reg.getOrCreate(ws)
+	if idx2 == nil {
+		t.Fatal("second getOrCreate returned nil; expected retry to produce a usable empty index")
+	}
+	if cached := reg.get(ws); cached != nil {
+		t.Fatalf("failed-load index was cached on retry; load will never be retried")
+	}
+
+	// The load must have been attempted on BOTH accesses — proving the failed
+	// load is retried rather than served from a cached empty index.
+	if got := loadCalls.Load(); got != 2 {
+		t.Fatalf("expected 2 load attempts (retry on each access), got %d", got)
+	}
+}
+
+// TestGetOrCreate_SuccessfulLoadCached verifies the happy path still caches the
+// index so repeated accesses reuse it.
+func TestGetOrCreate_SuccessfulLoadCached(t *testing.T) {
+	db, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	if err != nil {
+		t.Fatalf("pebble.Open: %v", err)
+	}
+	defer db.Close()
+
+	reg := NewRegistry(db)
+	var ws [8]byte
+	copy(ws[:], []byte("OKLOADED"))
+
+	idx1 := reg.getOrCreate(ws)
+	if idx1 == nil {
+		t.Fatal("getOrCreate returned nil on successful load")
+	}
+	if cached := reg.get(ws); cached == nil {
+		t.Fatal("successful-load index was not cached")
+	}
+	if idx2 := reg.getOrCreate(ws); idx2 != idx1 {
+		t.Fatal("successful load not served from cache on second access")
+	}
+}


### PR DESCRIPTION
Fixes #499 (HNSW restore path). Thanks @johanneshauer for the detailed field report.

## What this fixes

**1. Failed load cached as permanently-empty index (correctness).** `Registry.getOrCreate` stored the index in `r.indexes` even when `LoadFromPebble` returned an error. A single transient Pebble iterator error pinned an empty index for the rest of the process lifetime — the RLock fast path always returned it, so the load was never retried and semantic recall silently shrank to "memories embedded since the last restart" while the persisted `0x07` data stayed fully intact on disk. Now: on load error we log and return the **uncached** empty index (graceful degradation for this request) and the next access **retries** the load.

**2. Load outcomes never logged (observability).** `LoadFromPebble`'s success path returned `nil` silently. It now emits a single `slog.Info` with vault, node count, vector count, and duration — so after a restart there's a log line confirming what was restored.

**3. Vault-scoped iterator bounds (efficiency, optional).** The iterator now bounds to `0x07‖ws … 0x07‖(ws+1)` (carry-correct via `keys.IncrementWSPrefix`, falling back to `{0x08}` on prefix overflow) so Pebble visits only this vault's keys instead of scanning the whole `0x07` keyspace and filtering per-key.

## Note on the cross-vault correctness aspect

The cross-vault key-leak correctness defect from the issue (every per-vault index absorbing all vaults' nodes) was **already fixed by #471's in-loop vault filter** (`key[1:9] != idx.ws`), which is present on develop. That in-loop filter is retained here as a safety net; the bounds tightening above is purely an efficiency improvement on top of it.

## Test

Adds `registry_load_test.go`:
- `TestGetOrCreate_FailedLoadNotCached` — forces a load error via a minimal unexported `loadErrHook` seam, asserts the index is not cached after a failed load and that the load is **retried** on the next access (2 load attempts).
- `TestGetOrCreate_SuccessfulLoadCached` — happy path still caches and reuses.

`go test ./internal/index/hnsw/... -count=1 -race` passes; `gofmt` and `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
