### PR TITLE
fix(plugins): correct local embedder label to bge-small + surface enrich init errors (#455, #453)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,14 +120,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: internal/plugin/embed/assets
-          key: embed-assets-ort-1.24.2-minilm-v2-windows-amd64
+          key: embed-assets-ort-1.24.2-bge-small-en-v1.5-windows-amd64
 
       - name: Fetch model assets
         if: steps.asset-cache-win.outputs.cache-hit != 'true'
         run: |
           New-Item -ItemType Directory -Path internal/plugin/embed/assets -Force | Out-Null
-          Invoke-WebRequest -Uri "https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main/onnx/model_int8.onnx" -OutFile "internal/plugin/embed/assets/model_int8.onnx"
-          Invoke-WebRequest -Uri "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json" -OutFile "internal/plugin/embed/assets/tokenizer.json"
+          Invoke-WebRequest -Uri "https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/onnx/model_int8.onnx" -OutFile "internal/plugin/embed/assets/model_int8.onnx"
+          Invoke-WebRequest -Uri "https://huggingface.co/BAAI/bge-small-en-v1.5/resolve/main/tokenizer.json" -OutFile "internal/plugin/embed/assets/tokenizer.json"
         shell: pwsh
 
       - name: Fetch ORT DLL

--- a/cmd/muninn/coverage_hardening_test.go
+++ b/cmd/muninn/coverage_hardening_test.go
@@ -1500,18 +1500,32 @@ func TestRenderBar_OverflowPct(t *testing.T) {
 func TestBuildEnricher_NoConfig(t *testing.T) {
 	t.Setenv("MUNINN_ENRICH_URL", "")
 	cfg := plugincfg.PluginConfig{}
-	result := buildEnricher(context.Background(), cfg)
+	result, failure := buildEnricher(context.Background(), cfg)
 	if result != nil {
 		t.Error("expected nil when no enrich URL is set")
+	}
+	if failure != nil {
+		t.Error("expected no init failure when no enrich URL is set")
 	}
 }
 
 func TestBuildEnricher_InvalidURL(t *testing.T) {
 	t.Setenv("MUNINN_ENRICH_URL", "invalid://not-a-real-provider")
 	cfg := plugincfg.PluginConfig{}
-	result := buildEnricher(context.Background(), cfg)
+	result, failure := buildEnricher(context.Background(), cfg)
 	if result != nil {
 		t.Error("expected nil for invalid URL scheme")
+	}
+	// Issue #453: a configured-but-failed enrich provider must surface the
+	// init error so the UI can show it instead of "Not configured".
+	if failure == nil {
+		t.Fatal("expected an init failure to be surfaced for an invalid configured URL")
+	}
+	if failure.err == nil {
+		t.Error("init failure must carry the underlying error")
+	}
+	if failure.name == "" {
+		t.Error("init failure must carry a plugin name so it can be recorded in the registry")
 	}
 }
 
@@ -1520,9 +1534,12 @@ func TestBuildEnricher_FromSavedConfig(t *testing.T) {
 	cfg := plugincfg.PluginConfig{
 		EnrichURL: "invalid://saved-but-bad",
 	}
-	result := buildEnricher(context.Background(), cfg)
+	result, failure := buildEnricher(context.Background(), cfg)
 	if result != nil {
 		t.Error("expected nil for invalid saved URL")
+	}
+	if failure == nil {
+		t.Fatal("expected an init failure to be surfaced for an invalid saved URL")
 	}
 }
 
@@ -1530,9 +1547,13 @@ func TestBuildEnricher_OllamaURL(t *testing.T) {
 	t.Setenv("MUNINN_ENRICH_URL", "ollama://localhost:1/llama3.2")
 	t.Setenv("MUNINN_ENRICH_API_KEY", "")
 	t.Setenv("MUNINN_ANTHROPIC_KEY", "")
-	result := buildEnricher(context.Background(), plugincfg.PluginConfig{})
+	result, failure := buildEnricher(context.Background(), plugincfg.PluginConfig{})
 	if result != nil {
 		t.Log("ollama enricher init failed as expected (no server)")
+	}
+	// Connectivity to localhost:1 should fail, surfacing a failure with a name.
+	if failure != nil && failure.name == "" {
+		t.Error("init failure must carry a plugin name")
 	}
 }
 
@@ -1540,16 +1561,16 @@ func TestBuildEnricher_OpenAIURL(t *testing.T) {
 	t.Setenv("MUNINN_ENRICH_URL", "openai://gpt-4o-mini")
 	t.Setenv("MUNINN_ENRICH_API_KEY", "fake-key")
 	t.Setenv("MUNINN_ANTHROPIC_KEY", "")
-	result := buildEnricher(context.Background(), plugincfg.PluginConfig{})
-	_ = result
+	result, failure := buildEnricher(context.Background(), plugincfg.PluginConfig{})
+	_, _ = result, failure
 }
 
 func TestBuildEnricher_AnthropicURL(t *testing.T) {
 	t.Setenv("MUNINN_ENRICH_URL", "anthropic://claude-haiku-4-5-20251001")
 	t.Setenv("MUNINN_ENRICH_API_KEY", "")
 	t.Setenv("MUNINN_ANTHROPIC_KEY", "fake-anthropic-key")
-	result := buildEnricher(context.Background(), plugincfg.PluginConfig{})
-	_ = result
+	result, failure := buildEnricher(context.Background(), plugincfg.PluginConfig{})
+	_, _ = result, failure
 }
 
 func TestBuildEnricher_SavedConfigFallback(t *testing.T) {
@@ -1560,8 +1581,8 @@ func TestBuildEnricher_SavedConfigFallback(t *testing.T) {
 		EnrichURL:    "ollama://localhost:1/llama3.2",
 		EnrichAPIKey: "",
 	}
-	result := buildEnricher(context.Background(), cfg)
-	_ = result
+	result, failure := buildEnricher(context.Background(), cfg)
+	_, _ = result, failure
 }
 
 func TestBuildEnricher_SavedConfigAPIKey(t *testing.T) {
@@ -1572,8 +1593,8 @@ func TestBuildEnricher_SavedConfigAPIKey(t *testing.T) {
 		EnrichURL:    "openai://gpt-4o-mini",
 		EnrichAPIKey: "saved-key",
 	}
-	result := buildEnricher(context.Background(), cfg)
-	_ = result
+	result, failure := buildEnricher(context.Background(), cfg)
+	_, _ = result, failure
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -428,7 +428,7 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 		case "local":
 			if os.Getenv(localEmbed) != "0" && embedpkg.LocalAvailable() {
 				slog.Info("initializing bundled local ONNX embedder from saved config", "data_dir", dataDir)
-				if svc := tryEmbedService("local://all-MiniLM-L6-v2", plugin.PluginConfig{DataDir: dataDir}); svc != nil {
+				if svc := tryEmbedService("local://bge-small-en-v1.5", plugin.PluginConfig{DataDir: dataDir}); svc != nil {
 					return embedpkg.NewEmbedServiceAdapter(svc), svc, nil
 				}
 				slog.Warn("bundled local embedder init failed (saved config), falling back")
@@ -495,7 +495,7 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 	// "none" as their provider.
 	if cfg.EmbedProvider != "none" && os.Getenv(localEmbed) != "0" && embedpkg.LocalAvailable() {
 		slog.Info("initializing bundled local ONNX embedder", "data_dir", dataDir)
-		if svc := tryEmbedService("local://all-MiniLM-L6-v2", plugin.PluginConfig{DataDir: dataDir}); svc != nil {
+		if svc := tryEmbedService("local://bge-small-en-v1.5", plugin.PluginConfig{DataDir: dataDir}); svc != nil {
 			return embedpkg.NewEmbedServiceAdapter(svc), svc, nil
 		}
 		slog.Warn("bundled local embedder init failed, falling back to noop")
@@ -522,12 +522,24 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 // Returns nil without error if MUNINN_ENRICH_URL is not set — LLM enrichment
 // is optional. Logs a warning on init failure so the server starts without
 // enrichment rather than refusing to start.
+// enrichInitFailure carries the details of an enrich plugin that was configured
+// but failed to initialize. It is recorded in the plugin registry so the status
+// endpoint (and the UI) can surface the real error instead of collapsing the
+// case to "Not configured" (issue #453).
+type enrichInitFailure struct {
+	name string // plugin name (e.g. "enrich-google"); falls back to "enrich" if unknown
+	err  error  // the init/parse error
+}
+
 // buildEnricher constructs an EnrichService. Priority:
 //  1. MUNINN_ENRICH_URL env var
 //  2. Saved plugin_config.json (cfg parameter)
 //
-// Returns nil (no error) if neither is set — LLM enrichment is optional.
-func buildEnricher(ctx context.Context, cfg plugincfg.PluginConfig) plugin.EnrichPlugin {
+// Returns (nil, nil) if neither is set — LLM enrichment is optional. If an
+// enrich URL is configured but the provider fails to parse or initialize,
+// returns (nil, *enrichInitFailure) so the caller can record the failure in
+// the plugin registry; LLM enrichment stays disabled either way.
+func buildEnricher(ctx context.Context, cfg plugincfg.PluginConfig) (plugin.EnrichPlugin, *enrichInitFailure) {
 	enrichURL := os.Getenv("MUNINN_ENRICH_URL")
 
 	// Fall back to saved config if env var is not set.
@@ -537,7 +549,7 @@ func buildEnricher(ctx context.Context, cfg plugincfg.PluginConfig) plugin.Enric
 
 	if enrichURL == "" {
 		slog.Info("no enrich plugin configured, LLM enrichment disabled")
-		return nil
+		return nil, nil
 	}
 
 	enrichURL = injectOpenAIBaseURL(enrichURL, strings.TrimSpace(os.Getenv("MUNINN_OPENAI_URL")))
@@ -545,7 +557,7 @@ func buildEnricher(ctx context.Context, cfg plugincfg.PluginConfig) plugin.Enric
 	svc, err := enrichpkg.NewEnrichService(enrichURL)
 	if err != nil {
 		slog.Warn("enrich plugin URL parse failed, LLM enrichment disabled", "err", err)
-		return nil
+		return nil, &enrichInitFailure{name: enrichFailureName(enrichURL), err: err}
 	}
 
 	// MUNINN_ANTHROPIC_KEY is an alias for MUNINN_ENRICH_API_KEY when using Anthropic.
@@ -561,11 +573,22 @@ func buildEnricher(ctx context.Context, cfg plugincfg.PluginConfig) plugin.Enric
 	}
 	if err := svc.Init(ctx, plugin.PluginConfig{APIKey: apiKey}); err != nil {
 		slog.Warn("enrich plugin init failed (LLM provider may be down), LLM enrichment disabled", "err", err)
-		return nil
+		return nil, &enrichInitFailure{name: svc.Name(), err: err}
 	}
 
 	slog.Info("enrich plugin initialized", "url", enrichURL)
-	return svc
+	return svc, nil
+}
+
+// enrichFailureName derives a stable plugin name from an enrich URL for the
+// case where the service could not be constructed (so svc.Name() is unavailable).
+// Mirrors the "enrich-<scheme>" naming used by the enrich providers; falls back
+// to "enrich" when the scheme cannot be parsed.
+func enrichFailureName(enrichURL string) string {
+	if provCfg, err := plugin.ParseProviderURL(enrichURL); err == nil && provCfg.Scheme != "" {
+		return "enrich-" + string(provCfg.Scheme)
+	}
+	return "enrich"
 }
 
 // parseCORSOrigins splits a comma-separated MUNINN_CORS_ORIGINS env var into a slice.
@@ -1131,7 +1154,7 @@ func runServer() {
 
 	// Build enrich plugin (optional): env vars → saved config.
 	enrichCtx, enrichCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	enrichPlugin := buildEnricher(enrichCtx, savedPluginCfg)
+	enrichPlugin, enrichInitErr := buildEnricher(enrichCtx, savedPluginCfg)
 	enrichCancel()
 
 	// Build HNSW registry (multi-vault, lazy-loading)
@@ -1251,6 +1274,12 @@ func runServer() {
 		if err := pluginRegistry.Register(embedPlugin); err != nil {
 			slog.Warn("failed to register embed plugin in registry", "err", err)
 		}
+	}
+	// Surface a configured-but-failed enrich plugin in the registry so the status
+	// endpoint reports the init error instead of the plugin being silently absent
+	// (which the UI reads as "Not configured"). See issue #453.
+	if enrichInitErr != nil {
+		pluginRegistry.RegisterFailed(enrichInitErr.name, plugin.TierEnrich, enrichInitErr.err)
 	}
 	if enrichPlugin != nil {
 		if err := pluginRegistry.Register(enrichPlugin); err != nil {

--- a/internal/plugin/provider.go
+++ b/internal/plugin/provider.go
@@ -61,7 +61,7 @@ func ParseProviderURL(raw string) (*ProviderConfig, error) {
 			model = strings.TrimPrefix(parsed.Path, "/")
 		}
 		if model == "" {
-			model = "all-MiniLM-L6-v2"
+			model = "bge-small-en-v1.5"
 		}
 		config.Model = model
 		return config, nil

--- a/internal/plugin/provider_test.go
+++ b/internal/plugin/provider_test.go
@@ -168,3 +168,34 @@ func TestParseMalformedURL(t *testing.T) {
 		}
 	}
 }
+
+// TestParseLocalURL_DefaultModel asserts the default model reported for a
+// local:// URL that omits a model name. The bundled ONNX asset is
+// bge-small-en-v1.5 (see Makefile MODEL_REPO and embed/local.go), so the
+// self-reported default must match — this guards against the label drift
+// reported in issue #455 (the default was previously "all-MiniLM-L6-v2").
+func TestParseLocalURL_DefaultModel(t *testing.T) {
+	cfg, err := ParseProviderURL("local://")
+	if err != nil {
+		t.Fatalf("unexpected error parsing local:// URL: %v", err)
+	}
+	if cfg.Scheme != SchemeLocal {
+		t.Errorf("expected scheme %q, got %q", SchemeLocal, cfg.Scheme)
+	}
+	if cfg.Model != "bge-small-en-v1.5" {
+		t.Errorf("default local model = %q, want %q (must match the bundled ONNX asset)", cfg.Model, "bge-small-en-v1.5")
+	}
+}
+
+// TestParseLocalURL_ExplicitModel confirms the parser still accepts any model
+// name in a local:// URL, so legacy saved configs referencing the old label
+// (e.g. local://all-MiniLM-L6-v2) keep parsing without error.
+func TestParseLocalURL_ExplicitModel(t *testing.T) {
+	cfg, err := ParseProviderURL("local://all-MiniLM-L6-v2")
+	if err != nil {
+		t.Fatalf("unexpected error parsing legacy local:// URL: %v", err)
+	}
+	if cfg.Model != "all-MiniLM-L6-v2" {
+		t.Errorf("model = %q, want the explicit value to be preserved", cfg.Model)
+	}
+}

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -10,12 +10,13 @@ import (
 // Registry is the thread-safe plugin registry. Singleton per engine instance.
 type Registry struct {
 	mu        sync.RWMutex
-	plugins   map[string]Plugin    // name -> plugin
-	embed     EmbedPlugin          // at most one
-	enrich    EnrichPlugin         // at most one
-	healthy   map[string]bool      // name -> health status
-	lastCheck map[string]time.Time // name -> time of last SetHealthy/SetUnhealthy call
-	lastError map[string]string    // name -> last error message (empty if healthy)
+	plugins   map[string]Plugin     // name -> plugin
+	embed     EmbedPlugin           // at most one
+	enrich    EnrichPlugin          // at most one
+	healthy   map[string]bool       // name -> health status
+	lastCheck map[string]time.Time  // name -> time of last SetHealthy/SetUnhealthy call
+	lastError map[string]string     // name -> last error message (empty if healthy)
+	failed    map[string]PluginTier // name -> tier of a plugin that failed to init (no live instance)
 }
 
 // NewRegistry creates an empty plugin registry.
@@ -25,6 +26,33 @@ func NewRegistry() *Registry {
 		healthy:   make(map[string]bool),
 		lastCheck: make(map[string]time.Time),
 		lastError: make(map[string]string),
+		failed:    make(map[string]PluginTier),
+	}
+}
+
+// RegisterFailed records a plugin that failed to initialize and therefore has
+// no live instance to Register. It surfaces in List() as an unhealthy entry
+// with the init error populated, so the UI can distinguish a genuinely absent
+// plugin ("Not configured") from one that was configured but failed to start
+// (e.g. an invalid/unavailable enrich model). A subsequent successful
+// Register of the same name clears the recorded failure.
+func (r *Registry) RegisterFailed(name string, tier PluginTier, err error) {
+	if name == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// A live plugin of the same name takes precedence over a recorded failure.
+	if _, exists := r.plugins[name]; exists {
+		return
+	}
+	r.failed[name] = tier
+	r.healthy[name] = false
+	r.lastCheck[name] = time.Now()
+	if err != nil {
+		r.lastError[name] = err.Error()
+	} else {
+		r.lastError[name] = "plugin initialization failed"
 	}
 }
 
@@ -81,6 +109,8 @@ func (r *Registry) Register(p Plugin) error {
 	r.healthy[name] = true // Start healthy
 	r.lastCheck[name] = time.Now()
 	r.lastError[name] = ""
+	// A successful registration supersedes any prior recorded init failure.
+	delete(r.failed, name)
 
 	return nil
 }
@@ -106,6 +136,7 @@ func (r *Registry) Unregister(name string) error {
 	delete(r.healthy, name)
 	delete(r.lastCheck, name)
 	delete(r.lastError, name)
+	delete(r.failed, name)
 
 	// Clear embed or enrich reference if this was the active plugin
 	tier := p.Tier()
@@ -137,7 +168,7 @@ func (r *Registry) List() []PluginStatus {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	result := make([]PluginStatus, 0, len(r.plugins))
+	result := make([]PluginStatus, 0, len(r.plugins)+len(r.failed))
 	for name, p := range r.plugins {
 		status := PluginStatus{
 			Name:      name,
@@ -147,6 +178,20 @@ func (r *Registry) List() []PluginStatus {
 			Error:     r.lastError[name],
 		}
 		result = append(result, status)
+	}
+	// Include plugins that failed to initialize (no live instance) so the
+	// status endpoint reports the failure instead of silently omitting them.
+	for name, tier := range r.failed {
+		if _, live := r.plugins[name]; live {
+			continue // a live registration supersedes the recorded failure
+		}
+		result = append(result, PluginStatus{
+			Name:      name,
+			Tier:      tier,
+			Healthy:   false,
+			LastCheck: r.lastCheck[name],
+			Error:     r.lastError[name],
+		})
 	}
 
 	return result

--- a/internal/plugin/registry_test.go
+++ b/internal/plugin/registry_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 	"testing"
 )
 
@@ -172,5 +173,66 @@ func TestRegistrySetHealthy(t *testing.T) {
 	r.SetHealthy("test-embed", true)
 	if !r.HasEmbed() {
 		t.Error("HasEmbed() should return true when marked healthy")
+	}
+}
+
+func TestRegistryRegisterFailedSurfacesError(t *testing.T) {
+	r := NewRegistry()
+
+	// An enrich plugin failed to initialize (e.g. invalid/unavailable model).
+	r.RegisterFailed("enrich-google", TierEnrich, fmt.Errorf("google returned status 404: model no longer available"))
+
+	list := r.List()
+	var found *PluginStatus
+	for i := range list {
+		if list[i].Name == "enrich-google" {
+			found = &list[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("RegisterFailed plugin should appear in List() so the UI can show the failure instead of 'Not configured'")
+	}
+	if found.Healthy {
+		t.Error("failed plugin should be reported unhealthy")
+	}
+	if found.Tier != TierEnrich {
+		t.Errorf("expected tier %d, got %d", TierEnrich, found.Tier)
+	}
+	if found.Error == "" {
+		t.Error("failed plugin must carry the init error message, not an empty string")
+	}
+	// HasEnrich must remain false — the plugin is not usable.
+	if r.HasEnrich() {
+		t.Error("HasEnrich() should remain false for a failed-init plugin")
+	}
+}
+
+func TestRegistryRegisterSupersedesFailure(t *testing.T) {
+	r := NewRegistry()
+	r.RegisterFailed("enrich-google", TierEnrich, fmt.Errorf("transient init error"))
+
+	enrich := &mockEnrichPlugin{
+		mockPlugin: mockPlugin{name: "enrich-google", tier: TierEnrich},
+	}
+	if err := r.Register(enrich); err != nil {
+		t.Fatalf("register after failure should succeed: %v", err)
+	}
+
+	list := r.List()
+	count := 0
+	for _, p := range list {
+		if p.Name == "enrich-google" {
+			count++
+			if !p.Healthy {
+				t.Error("after successful register the plugin should be healthy")
+			}
+			if p.Error != "" {
+				t.Error("successful register should clear the recorded init error")
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one entry for enrich-google, got %d", count)
 	}
 }


### PR DESCRIPTION
Fixes #455 and #453. Both touch `cmd/muninn/server.go`, so they ship together.

## #455 — embedder label drift + Windows ships the wrong model
Reported by @johanneshauer (with the model-mismatch nuance credited to scottcrosby).

The bundled local embedder was labeled `all-MiniLM-L6-v2` in URL strings, but the actual ONNX asset is **bge-small-en-v1.5** (`Xenova/bge-small-en-v1.5`, BGE CLS-pooling). The runtime already logged `bge-small-en-v1.5`, so the label was cosmetic drift.

- Corrected the label `local://all-MiniLM-L6-v2` → `local://bge-small-en-v1.5` at the two `server.go` call sites and the `provider.go` default-model fallback. The `local://` parser accepts any model name, so legacy saved configs (`embed_url: local://all-MiniLM-L6-v2`) still parse.
- **The reporter missed a worse bug:** the Windows release job fetched `all-MiniLM-L6-v2` ONNX bytes + tokenizer, while Mac/Linux run `make fetch-model` (bge-small). So Windows binaries embedded MiniLM bytes but ran BGE CLS-pooling (MiniLM is a mean-pooling model) → wrong model + wrong pooling, silently. Repointed the Windows job at `Xenova/bge-small-en-v1.5` `onnx/model_int8.onnx` + the `BAAI/bge-small-en-v1.5` `tokenizer.json` (mirrors the Makefile) and bumped its cache key from `minilm-v2` to `bge-small-en-v1.5` so the stale MiniLM cache isn't reused.

## #453 — "Not configured" hid the real Gemini init error
Reported by @dpearson2699.

When the Google enrich provider failed to init (e.g. an unavailable model), `buildEnricher` logged a warning and returned `nil`; the plugin was never registered, so the UI's "Not configured" badge (derived from plugin presence) hid the real error.

- `buildEnricher` now returns the provider name + init error alongside the (nil) plugin.
- New `Registry.RegisterFailed(name, tier, err)` records a configured-but-failed plugin so it surfaces in `List()`/`handlePlugins` as an unhealthy tier-3 entry with `Error` populated. A later successful `Register` of the same name clears the recorded failure.
- The existing enrich UI detail block already renders a tier-3 entry as **Unhealthy** with the error message in red, so no template change was needed — users can now distinguish a rejected model from missing config.

The model-list portion of #453 (gemini-2.5-flash default) was already fixed on develop and was **not** re-done. No model names are validated against a hardcoded list — the actual init error is surfaced instead.

## Tests
- `internal/plugin/registry_test.go`: `RegisterFailed` surfaces an unhealthy entry with the error; a successful `Register` supersedes the recorded failure.
- `internal/plugin/provider_test.go`: default `local://` model is `bge-small-en-v1.5` (guards the #455 label drift); legacy explicit `all-MiniLM-L6-v2` still parses.
- `cmd/muninn/coverage_hardening_test.go`: `buildEnricher` now asserts an init failure (name + error) is surfaced for invalid configured URLs.

`go test ./cmd/muninn/... ./internal/plugin/... ./internal/transport/rest/... -count=1` passes; `gofmt`, `go vet`, and YAML lint of `release.yml` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)