### PR TITLE
fix(engine,mcp): set inline-enrichment digest flags + clean recall serialization (#500, #502)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1034,6 +1034,7 @@ func (e *Engine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteRe
 	}
 
 	// Store caller-provided entity-to-entity relationships in the 0x21 relationship index.
+	wroteEntityRelationships := false
 	if len(req.EntityRelationships) > 0 {
 		wsER, _ := e.store.FindVaultPrefix(id)
 		for _, er := range req.EntityRelationships {
@@ -1052,7 +1053,34 @@ func (e *Engine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteRe
 				Source:     "inline",
 			}); err != nil {
 				slog.Warn("engine: failed to store entity relationship", "vault", req.Vault, "engram", id.String(), "from", er.FromEntity, "to", er.ToEntity, "rel_type", er.RelType, "err", err)
+				continue
 			}
+			wroteEntityRelationships = true
+		}
+	}
+
+	// Mark per-stage digest flags for inline (caller-supplied) enrichment so
+	// GetEnrichmentCandidates does not report these memories as un-enriched (#500).
+	// Mirror the existing DigestEntities-on-inline pattern: only set a stage's flag
+	// when that stage's data is actually present from the caller.
+	//   - summary supplied        -> DigestSummarized
+	//   - entity relationships     -> DigestRelationships
+	//   - type/classification      -> DigestClassified (req.TypeLabel is set whenever
+	//                                 the caller supplies a type or type_label)
+	var inlineStageFlags uint8
+	if callerSummary != "" {
+		inlineStageFlags |= plugin.DigestSummarized
+	}
+	if wroteEntityRelationships {
+		inlineStageFlags |= plugin.DigestRelationships
+	}
+	if req.TypeLabel != "" {
+		inlineStageFlags |= plugin.DigestClassified
+	}
+	if inlineStageFlags != 0 {
+		existing, _ := e.store.GetDigestFlags(ctx, plugin.ULID(id))
+		if flagErr := e.store.SetDigestFlag(ctx, id, existing|inlineStageFlags); flagErr != nil {
+			slog.Warn("engine: failed to set inline enrichment stage flags", "id", id.String(), "flags", inlineStageFlags, "error", flagErr)
 		}
 	}
 
@@ -1484,6 +1512,7 @@ func (e *Engine) WriteBatch(ctx context.Context, reqs []*mbp.WriteRequest) ([]*m
 		}
 
 		// Store caller-provided entity-to-entity relationships in the 0x21 relationship index.
+		wroteEntityRelationships := false
 		if len(p.callerEntityRelationships) > 0 {
 			wsER, ok := e.store.FindVaultPrefix(id)
 			if !ok {
@@ -1505,8 +1534,31 @@ func (e *Engine) WriteBatch(ctx context.Context, reqs []*mbp.WriteRequest) ([]*m
 						Source:     "inline",
 					}); err != nil {
 						slog.Warn("engine: batch: failed to store entity relationship", "vault", p.vaultName, "engram", id.String(), "from", er.FromEntity, "to", er.ToEntity, "rel_type", er.RelType, "err", err)
+						continue
 					}
+					wroteEntityRelationships = true
 				}
+			}
+		}
+
+		// Mark per-stage digest flags for inline (caller-supplied) enrichment so
+		// GetEnrichmentCandidates does not report these memories as un-enriched (#500).
+		// Mirror the single-write path: only set a stage's flag when that stage's data
+		// is actually present from the caller.
+		var inlineStageFlags uint8
+		if p.callerSummary != "" {
+			inlineStageFlags |= plugin.DigestSummarized
+		}
+		if wroteEntityRelationships {
+			inlineStageFlags |= plugin.DigestRelationships
+		}
+		if p.eng.TypeLabel != "" {
+			inlineStageFlags |= plugin.DigestClassified
+		}
+		if inlineStageFlags != 0 {
+			existing, _ := e.store.GetDigestFlags(ctx, plugin.ULID(id))
+			if flagErr := e.store.SetDigestFlag(ctx, id, existing|inlineStageFlags); flagErr != nil {
+				slog.Warn("engine: batch: failed to set inline enrichment stage flags", "id", id.String(), "flags", inlineStageFlags, "error", flagErr)
 			}
 		}
 
@@ -1968,6 +2020,7 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 			LastAccess:  scored.Engram.LastAccess.UnixNano(),
 			AccessCount: scored.Engram.AccessCount,
 			Relevance:   scored.Engram.Relevance,
+			State:       uint8(scored.Engram.State),
 			Trust:       uint8(scored.Engram.Trust),
 		}
 

--- a/internal/engine/engine_replay_test.go
+++ b/internal/engine/engine_replay_test.go
@@ -295,6 +295,121 @@ func TestGetEnrichmentCandidates_ReturnsOnlyMissingStages(t *testing.T) {
 	}
 }
 
+// TestGetEnrichmentCandidates_InlineEnrichedNotCandidate verifies that an engram
+// written with caller-supplied summary, entity relationships, and type/classification
+// (inline enrichment) has its per-stage digest flags set at write time, so it is NOT
+// reported as an enrichment candidate. Regression test for #500.
+func TestGetEnrichmentCandidates_InlineEnrichedNotCandidate(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	const vault = "default"
+
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:      vault,
+		Content:    "the full content of this memory",
+		Concept:    "inline enriched concept",
+		MemoryType: uint8(storage.TypeFact),
+		TypeLabel:  "fact",
+		Summary:    "one-line summary",
+		Entities: []mbp.InlineEntity{
+			{Name: "Example Entity", Type: "concept"},
+			{Name: "Other Entity", Type: "concept"},
+		},
+		EntityRelationships: []mbp.InlineEntityRelationship{
+			{FromEntity: "Example Entity", ToEntity: "Other Entity", RelType: "relates_to", Weight: 0.9},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Write(inline): %v", err)
+	}
+	id, err := storage.ParseULID(resp.ID)
+	if err != nil {
+		t.Fatalf("ParseULID: %v", err)
+	}
+
+	flags, err := eng.store.GetDigestFlags(ctx, plugin.ULID(id))
+	if err != nil {
+		t.Fatalf("GetDigestFlags: %v", err)
+	}
+	for _, f := range []struct {
+		name string
+		bit  uint8
+	}{
+		{"DigestEntities", plugin.DigestEntities},
+		{"DigestRelationships", plugin.DigestRelationships},
+		{"DigestClassified", plugin.DigestClassified},
+		{"DigestSummarized", plugin.DigestSummarized},
+	} {
+		if flags&f.bit == 0 {
+			t.Errorf("flag %s (0x%02x) not set after inline write; flags=0x%02x", f.name, f.bit, flags)
+		}
+	}
+
+	candidates, _, _, err := eng.GetEnrichmentCandidates(ctx, vault, nil, storage.ULID{}, 10)
+	if err != nil {
+		t.Fatalf("GetEnrichmentCandidates: %v", err)
+	}
+	for _, c := range candidates {
+		if c.ID == id {
+			t.Fatalf("fully inline-enriched engram reported as candidate; missing_stages=%v, flags=0x%02x",
+				c.MissingStages, c.DigestFlags)
+		}
+	}
+}
+
+// TestRememberBatch_InlineEnrichedSetsFlags verifies the batch write path sets
+// per-stage digest flags for caller-supplied enrichment data. Regression for #500.
+func TestRememberBatch_InlineEnrichedSetsFlags(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	const vault = "default"
+
+	resps, errs := eng.WriteBatch(ctx, []*mbp.WriteRequest{{
+		Vault:      vault,
+		Content:    "batch full content",
+		Concept:    "batch inline enriched",
+		MemoryType: uint8(storage.TypeFact),
+		TypeLabel:  "fact",
+		Summary:    "batch summary",
+		Entities: []mbp.InlineEntity{
+			{Name: "Batch Entity A", Type: "concept"},
+			{Name: "Batch Entity B", Type: "concept"},
+		},
+		EntityRelationships: []mbp.InlineEntityRelationship{
+			{FromEntity: "Batch Entity A", ToEntity: "Batch Entity B", RelType: "relates_to", Weight: 0.9},
+		},
+	}})
+	if errs[0] != nil {
+		t.Fatalf("WriteBatch: %v", errs[0])
+	}
+	id, err := storage.ParseULID(resps[0].ID)
+	if err != nil {
+		t.Fatalf("ParseULID: %v", err)
+	}
+
+	flags, err := eng.store.GetDigestFlags(ctx, plugin.ULID(id))
+	if err != nil {
+		t.Fatalf("GetDigestFlags: %v", err)
+	}
+	for _, f := range []struct {
+		name string
+		bit  uint8
+	}{
+		{"DigestEntities", plugin.DigestEntities},
+		{"DigestRelationships", plugin.DigestRelationships},
+		{"DigestClassified", plugin.DigestClassified},
+		{"DigestSummarized", plugin.DigestSummarized},
+	} {
+		if flags&f.bit == 0 {
+			t.Errorf("batch: flag %s (0x%02x) not set; flags=0x%02x", f.name, f.bit, flags)
+		}
+	}
+}
+
 func TestGetEnrichmentCandidates_CursorPaginates(t *testing.T) {
 	eng, cleanup := testEnv(t)
 	defer cleanup()

--- a/internal/mcp/convert.go
+++ b/internal/mcp/convert.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"math"
 	"time"
 
 	"github.com/scrypster/muninndb/internal/storage"
@@ -9,27 +10,35 @@ import (
 
 const contentPreviewLen = 500
 
+// roundScore widens a float32 score to float64 while stripping float32 quantization
+// noise (e.g. float64(float32(1.15)) = 1.149999976...). Rounding to 6 decimals keeps
+// meaningful precision while serializing clean values. See #502.
+func roundScore(f float32) float64 {
+	return math.Round(float64(f)*1e6) / 1e6
+}
+
 // activationToMemory converts an mbp.ActivationItem to an MCP Memory for recall responses.
-// Prefers Summary when available; falls back to a content preview (500 chars) so that
-// recall returns discovery-oriented data rather than a raw content slice.
+// Summary-first by design (#112): Summary carries the enrichment summary, while Content
+// carries the real engram content (truncated to a preview). The summary is never copied
+// into Content, so the same string is not serialized twice (#502).
 func activationToMemory(item *mbp.ActivationItem) Memory {
-	// Use the enrichment-generated summary when present; otherwise preview content.
-	displayContent := item.Summary
-	if displayContent == "" {
-		displayContent = item.Content
-		if len(displayContent) > contentPreviewLen {
-			displayContent = displayContent[:contentPreviewLen] + "..."
-		}
+	// Content is the real engram content, truncated to a preview length. The summary
+	// stays in its own field; recall never overwrites Content with Summary.
+	previewContent := item.Content
+	if len(previewContent) > contentPreviewLen {
+		previewContent = previewContent[:contentPreviewLen] + "..."
 	}
 	return Memory{
 		ID:          item.ID,
 		Concept:     item.Concept,
-		Content:     displayContent,
+		Content:     previewContent,
 		Summary:     item.Summary,
-		Score:       float64(item.Score),
-		VectorScore: float64(item.ScoreComponents.SemanticSimilarity),
+		Score:       roundScore(item.Score),
+		VectorScore: roundScore(item.ScoreComponents.SemanticSimilarity),
 		Confidence:  item.Confidence,
 		Why:         item.Why,
+		// Map the lifecycle state label the same way the read path does (#502).
+		State:       storage.LifecycleState(item.State).String(),
 		CreatedAt:   time.Unix(0, item.CreatedAt).UTC(),
 		LastAccess:  time.Unix(0, item.LastAccess).UTC(),
 		AccessCount: item.AccessCount,

--- a/internal/mcp/convert_test.go
+++ b/internal/mcp/convert_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/scrypster/muninndb/internal/storage"
 	"github.com/scrypster/muninndb/internal/transport/mbp"
 )
 
@@ -281,22 +282,91 @@ func TestReadResponseToMemory_MapsSummaryField(t *testing.T) {
 	}
 }
 
-// TestActivationToMemory_PrefersSummary verifies that muninn_recall uses the
-// enrichment summary when present instead of the truncated content preview.
+// TestActivationToMemory_PrefersSummary verifies that muninn_recall keeps the
+// enrichment summary in Summary while Content carries the real engram content
+// (not a duplicate of the summary). Regression test for #502 defect (a).
 func TestActivationToMemory_PrefersSummary(t *testing.T) {
+	const realContent = "this is the full long content that goes well beyond any preview limit"
 	item := &mbp.ActivationItem{
 		ID:      "recall-with-summary",
 		Concept: "concept",
-		Content: "this is the full long content that goes well beyond any preview limit",
+		Content: realContent,
 		Summary: "short enriched summary",
 	}
 	m := activationToMemory(item)
 	if m.Summary != "short enriched summary" {
 		t.Errorf("Summary = %q, want %q", m.Summary, "short enriched summary")
 	}
-	// Content field should carry the summary as the display value when present.
-	if m.Content != "short enriched summary" {
-		t.Errorf("Content (display) = %q, want summary %q", m.Content, "short enriched summary")
+	// Content must be the real engram content, never a duplicate of the summary.
+	if m.Content == m.Summary {
+		t.Errorf("Content duplicates Summary (#502 (a)): both = %q", m.Content)
+	}
+	if m.Content != realContent {
+		t.Errorf("Content = %q, want real content %q", m.Content, realContent)
+	}
+}
+
+// TestActivationToMemory_StatePopulated verifies that the lifecycle state is
+// carried through recall and labelled like the read path. Regression for #502 (b).
+func TestActivationToMemory_StatePopulated(t *testing.T) {
+	item := &mbp.ActivationItem{
+		ID:      "recall-state",
+		Content: "content",
+		State:   uint8(storage.StateActive),
+	}
+	m := activationToMemory(item)
+	if m.State != "active" {
+		t.Errorf("State = %q, want %q", m.State, "active")
+	}
+}
+
+// TestActivationToMemory_StateMapsNonDefault verifies that a non-default lifecycle
+// state is carried through recall and labelled. Regression for #502 (b): recall
+// used to always emit an empty state because mbp.ActivationItem had no State field.
+func TestActivationToMemory_StateMapsNonDefault(t *testing.T) {
+	item := &mbp.ActivationItem{
+		ID:      "recall-completed",
+		Content: "content",
+		State:   uint8(storage.StateCompleted),
+	}
+	m := activationToMemory(item)
+	if m.State != "completed" {
+		t.Errorf("State = %q, want %q", m.State, "completed")
+	}
+}
+
+// TestActivationToMemory_StateOmittedWhenEmpty verifies that Memory.State carries
+// the omitempty tag so a genuinely empty state label is not serialized as
+// "state":"". Regression for #502 (b).
+func TestActivationToMemory_StateOmittedWhenEmpty(t *testing.T) {
+	// A Memory with an empty State (e.g. a non-recall construction) must omit it.
+	b, err := json.Marshal(Memory{ID: "x"})
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if v, present := got["state"]; present {
+		t.Errorf("empty state should be omitted, got state=%v", v)
+	}
+}
+
+// TestActivationToMemory_ScoreNoFloat32Noise verifies that widening the float32
+// score to float64 does not reproduce quantization noise. Regression for #502 (c).
+func TestActivationToMemory_ScoreNoFloat32Noise(t *testing.T) {
+	item := &mbp.ActivationItem{
+		ID:    "noisy-score",
+		Score: 1.15,
+	}
+	item.ScoreComponents.SemanticSimilarity = 0.85
+	m := activationToMemory(item)
+	if m.Score != 1.15 {
+		t.Errorf("Score = %v, want clean 1.15 (no float32 noise)", m.Score)
+	}
+	if m.VectorScore != 0.85 {
+		t.Errorf("VectorScore = %v, want clean 0.85 (no float32 noise)", m.VectorScore)
 	}
 }
 

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -61,14 +61,14 @@ type WriteResult struct {
 type Memory struct {
 	ID          string    `json:"id"`
 	Concept     string    `json:"concept"`
-	Content     string    `json:"content"` // recall: summary or 500-char preview; read: full content
+	Content     string    `json:"content"` // recall: real content (truncated); read: full content
 	Summary     string    `json:"summary,omitempty"`
 	Score       float64   `json:"score,omitempty"`
 	VectorScore float64   `json:"vector_score,omitempty"`
 	Confidence  float32   `json:"confidence"`
 	Why         string    `json:"why,omitempty"`
 	Tags        []string  `json:"tags,omitempty"`
-	State       string    `json:"state"`
+	State       string    `json:"state,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`
 	LastAccess  time.Time `json:"last_access"`
 	AccessCount uint32    `json:"access_count,omitempty"`

--- a/internal/transport/mbp/types.go
+++ b/internal/transport/mbp/types.go
@@ -224,6 +224,8 @@ type ActivationItem struct {
 	AccessCount     uint32          `msgpack:"access_count,omitempty"      json:"access_count,omitempty"`
 	Relevance       float32         `msgpack:"relevance,omitempty"         json:"relevance,omitempty"`
 	SourceType      string          `msgpack:"source_type,omitempty" json:"source_type,omitempty"`
+	// State is the LifecycleState uint8, so recall can label engram lifecycle state.
+	State uint8 `msgpack:"state,omitempty" json:"state,omitempty"`
 	// Trust is the TrustLevel uint8. omitempty intentional — see ReadResponse.Trust comment.
 	Trust uint8 `msgpack:"trust,omitempty" json:"trust,omitempty"`
 }


### PR DESCRIPTION
Fixes two validated write-path/serialization correctness bugs reported by @johanneshauer. Both touch the engine recall + enrichment paths, so they share one branch/PR. Strict TDD: failing tests added first, then fixes.

## #500 — inline enrichment never set per-stage digest flags

On vaults using inline (agent-managed) enrichment, the write paths set only `DigestEntities` for caller-supplied data. `DigestSummarized`, `DigestRelationships`, and `DigestClassified` were never set on any remember path, while `GetEnrichmentCandidates` checks the digest flag byte exclusively. Result: inline-enriched memories were reported as un-enriched forever (~79% false positives, classification missing for 100%), and the `get_enrichment_candidates → apply_enrichment` backfill loop never converged.

**Fix** (`internal/engine/engine.go`, both single `Write` and `WriteBatch`): mirroring the existing `DigestEntities`-on-inline pattern, set
- `DigestSummarized` when the caller supplied a non-empty summary,
- `DigestRelationships` when entity relationships were actually persisted,
- `DigestClassified` when the caller supplied a type/`type_label` (`req.TypeLabel` is non-empty whenever the MCP write surface sends a type).

Each stage flag is set only when that stage's data is present. The cognitive model is unchanged.

## #502 — muninn_recall serialization defects

Three defects in `internal/mcp/convert.go` `activationToMemory`:

- **(a) content == summary:** the summary was copied into `Content`, serializing it twice and dropping the real content. `Content` now carries the real engram content (truncated to the 500-char preview); `Summary` keeps the summary, preserving the #112 summary-first design.
- **(b) state always empty:** `mbp.ActivationItem` had no `State` field. Added one, populated it in the engine recall assembly from the scored engram's lifecycle state, and mapped it in `activationToMemory` the same way the read path labels state. `Memory.State` now carries `omitempty`.
- **(c) score float32 noise:** `Score`/`VectorScore` are now rounded to 6 decimals when widening float32→float64, eliminating noise like `1.149999976`.

## Tests

TDD — each test was confirmed RED before the fix, then GREEN:
- `TestGetEnrichmentCandidates_InlineEnrichedNotCandidate`, `TestRememberBatch_InlineEnrichedSetsFlags` (#500)
- `TestActivationToMemory_PrefersSummary` (updated), `TestActivationToMemory_StatePopulated`, `TestActivationToMemory_StateMapsNonDefault`, `TestActivationToMemory_StateOmittedWhenEmpty`, `TestActivationToMemory_ScoreNoFloat32Noise` (#502)

`go test ./internal/engine/... ./internal/mcp/... -count=1` passes; `go vet` and `gofmt` clean; `go build ./...` and transport tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)