### PR TITLE
fix(mcp): normalize+coerce entity types on all user-facing write paths (#501)

### DIFF
--- a/internal/mcp/entity_type_validation_test.go
+++ b/internal/mcp/entity_type_validation_test.go
@@ -1,0 +1,158 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/engine"
+)
+
+// captureEntityStateEngine records the entityType passed to SetEntityState /
+// SetEntityStateBatch so tests can assert the coercion behavior.
+type captureEntityStateEngine struct {
+	fakeEngine
+	gotType  string
+	gotTypes []string
+}
+
+func (e *captureEntityStateEngine) SetEntityState(_ context.Context, _, _, _, entityType string) error {
+	e.gotType = entityType
+	return nil
+}
+
+func (e *captureEntityStateEngine) SetEntityStateBatch(_ context.Context, ops []engine.EntityStateOp) []error {
+	errs := make([]error, len(ops))
+	for _, op := range ops {
+		e.gotTypes = append(e.gotTypes, op.EntityType)
+	}
+	return errs
+}
+
+// captureApplyEnrichmentEngine records entity types passed through ApplyEnrichment.
+type captureApplyEnrichmentEngine struct {
+	fakeEngine
+	gotTypes []string
+}
+
+func (e *captureApplyEnrichmentEngine) ApplyEnrichment(_ context.Context, _ string, req *ApplyEnrichmentRequest) (*ApplyEnrichmentResult, error) {
+	for _, ent := range req.Entities {
+		e.gotTypes = append(e.gotTypes, ent.Type)
+	}
+	return &ApplyEnrichmentResult{
+		ID:            "01HVTESTAPPLY00000000000001",
+		AppliedStages: []string{"entities"},
+		UpdatedAt:     "2026-03-29T12:01:00Z",
+		DigestFlags:   map[string]bool{"entities": true},
+		Status:        "updated",
+	}, nil
+}
+
+// TestEntityState_CoercesInvalidTypeLikeRemember asserts that muninn_entity_state
+// coerces an unrecognised type to "other" (after lowercase/trim), matching the
+// behavior of muninn_remember's inline entities path.
+func TestEntityState_CoercesInvalidTypeLikeRemember(t *testing.T) {
+	eng := &captureEntityStateEngine{}
+	srv := newTestServerWith(eng)
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_entity_state","arguments":{"vault":"default","entity_name":"Modbus","state":"active","type":"Protocol "}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	if eng.gotType != "other" {
+		t.Errorf("entity_state invalid type: engine got %q, want \"other\" (coerced like remember)", eng.gotType)
+	}
+}
+
+// TestEntityState_NormalizesValidType asserts a recognised type passes through
+// after normalisation (lowercase/trim) rather than verbatim.
+func TestEntityState_NormalizesValidType(t *testing.T) {
+	eng := &captureEntityStateEngine{}
+	srv := newTestServerWith(eng)
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_entity_state","arguments":{"vault":"default","entity_name":"PostgreSQL","state":"active","type":" Database "}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	if eng.gotType != "database" {
+		t.Errorf("entity_state valid type: engine got %q, want \"database\" (normalized)", eng.gotType)
+	}
+}
+
+// TestEntityState_EmptyTypePreserved asserts an omitted type stays empty so the
+// engine preserves the existing type (coercion must not turn "" into "other").
+func TestEntityState_EmptyTypePreserved(t *testing.T) {
+	eng := &captureEntityStateEngine{}
+	srv := newTestServerWith(eng)
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_entity_state","arguments":{"vault":"default","entity_name":"PostgreSQL","state":"deprecated"}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	if eng.gotType != "" {
+		t.Errorf("entity_state omitted type: engine got %q, want \"\" (preserve existing)", eng.gotType)
+	}
+}
+
+// TestEntityStateBatch_CoercesInvalidType asserts the batch path coerces too.
+func TestEntityStateBatch_CoercesInvalidType(t *testing.T) {
+	eng := &captureEntityStateEngine{}
+	srv := newTestServerWith(eng)
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_entity_state_batch","arguments":{"vault":"default","operations":[{"entity_name":"Modbus","state":"active","type":"protocol"},{"entity_name":"Go","state":"active","type":"Language"}]}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	if len(eng.gotTypes) != 2 {
+		t.Fatalf("expected 2 ops captured, got %d", len(eng.gotTypes))
+	}
+	if eng.gotTypes[0] != "other" {
+		t.Errorf("batch op[0] invalid type: got %q, want \"other\"", eng.gotTypes[0])
+	}
+	if eng.gotTypes[1] != "language" {
+		t.Errorf("batch op[1] valid type: got %q, want \"language\"", eng.gotTypes[1])
+	}
+}
+
+// TestApplyEnrichment_CoercesInvalidType asserts muninn_apply_enrichment coerces
+// an unrecognised type to "other" (after lowercase/trim) — matching remember —
+// instead of storing it verbatim.
+func TestApplyEnrichment_CoercesInvalidType(t *testing.T) {
+	eng := &captureApplyEnrichmentEngine{}
+	srv := newTestServerWith(eng)
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_apply_enrichment","arguments":{"vault":"default","id":"01HVTESTAPPLY00000000000001","expected_updated_at":"2026-03-29T12:00:00Z","entities":[{"name":"Modbus","type":"Protocol "},{"name":"PostgreSQL","type":"Database"}]}}}`
+	w := postRPC(t, srv, body)
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	if len(eng.gotTypes) != 2 {
+		t.Fatalf("expected 2 entities captured, got %d", len(eng.gotTypes))
+	}
+	if eng.gotTypes[0] != "other" {
+		t.Errorf("apply_enrichment invalid type: got %q, want \"other\" (coerced like remember)", eng.gotTypes[0])
+	}
+	if eng.gotTypes[1] != "database" {
+		t.Errorf("apply_enrichment valid type: got %q, want \"database\" (normalized)", eng.gotTypes[1])
+	}
+}
+
+// TestNormalizeEntityType verifies the shared helper directly.
+func TestNormalizeEntityType(t *testing.T) {
+	cases := map[string]string{
+		"Protocol ":  "other",
+		" database ": "database",
+		"LANGUAGE":   "language",
+		"":           "",
+		"other":      "other",
+		"directive":  "other",
+	}
+	for in, want := range cases {
+		if got := normalizeEntityType(in); got != want {
+			t.Errorf("normalizeEntityType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -987,7 +987,11 @@ func (s *MCPServer) handleEntityState(ctx context.Context, w http.ResponseWriter
 		sendError(w, id, -32602, "invalid params: 'merged_into' is required when state=merged")
 		return
 	}
+	// Normalise + coerce unknown types to "other" so this deliberate user
+	// action behaves identically to muninn_remember (issue #501). Empty stays
+	// empty: the engine reads "" as "preserve the existing type".
 	entityType, _ := args["type"].(string)
+	entityType = normalizeEntityType(entityType)
 
 	if err := s.engine.SetEntityState(ctx, entityName, state, mergedInto, entityType); err != nil {
 		sendError(w, id, -32000, "tool error: "+err.Error())
@@ -1043,6 +1047,7 @@ func (s *MCPServer) handleEntityStateBatch(ctx context.Context, w http.ResponseW
 			return
 		}
 		entityType, _ := op["type"].(string)
+		entityType = normalizeEntityType(entityType)
 		ops = append(ops, engine.EntityStateOp{
 			EntityName: entityName,
 			State:      state,
@@ -1221,14 +1226,40 @@ func applyTypeArgs(args map[string]any, req *mbp.WriteRequest) {
 	}
 }
 
-// applyEnrichmentArgs parses optional inline enrichment fields (summary, entities,
-// relationships) from MCP tool call arguments onto the WriteRequest.
+// validEntityTypes is the single source of truth for the 14 recognised entity
+// types accepted on every user-facing MCP write path (remember, remember_batch,
+// entity_state, entity_state_batch, apply_enrichment).
 var validEntityTypes = map[string]bool{
 	"person": true, "organization": true, "location": true, "concept": true,
 	"technology": true, "project": true, "tool": true, "database": true,
 	"service": true, "framework": true, "language": true, "product": true,
 	"event": true, "other": true,
 }
+
+// normalizeEntityType lowercases and trims an entity type, then coerces any
+// unrecognised value to "other" — matching muninn_remember's inline-entity
+// behavior so all user-facing write paths treat the same input identically.
+//
+// An empty type is preserved as empty: callers use "" to mean "omitted", which
+// the engine interprets as "leave the existing type unchanged". Coercing "" to
+// "other" would silently overwrite a previously-correct type, so it is excluded.
+//
+// This intentionally does NOT govern the server-side enrich plugin (internal/
+// plugin/enrich/parse.go), which deliberately passes unknown LLM-produced types
+// through per #334; coercion here only covers the explicit MCP write paths.
+func normalizeEntityType(typ string) string {
+	typ = strings.ToLower(strings.TrimSpace(typ))
+	if typ == "" {
+		return ""
+	}
+	if !validEntityTypes[typ] {
+		return "other"
+	}
+	return typ
+}
+
+// applyEnrichmentArgs parses optional inline enrichment fields (summary, entities,
+// relationships) from MCP tool call arguments onto the WriteRequest.
 
 func applyEnrichmentArgs(args map[string]any, req *mbp.WriteRequest) int {
 	malformed := 0
@@ -1248,12 +1279,9 @@ func applyEnrichmentArgs(args map[string]any, req *mbp.WriteRequest) int {
 			name, _ := eMap["name"].(string)
 			typ, _ := eMap["type"].(string)
 			name = strings.TrimSpace(norm.NFKC.String(name))
-			typ = strings.ToLower(strings.TrimSpace(typ))
+			typ = normalizeEntityType(typ)
 			if name == "" || typ == "" {
 				continue
-			}
-			if !validEntityTypes[typ] {
-				typ = "other"
 			}
 			req.Entities = append(req.Entities, mbp.InlineEntity{Name: name, Type: typ})
 		}
@@ -1545,10 +1573,13 @@ func (s *MCPServer) handleApplyEnrichment(ctx context.Context, w http.ResponseWr
 			}
 			name, _ := m["name"].(string)
 			etype, _ := m["type"].(string)
-			if name == "" || etype == "" {
+			if name == "" || strings.TrimSpace(etype) == "" {
 				sendError(w, id, -32602, fmt.Sprintf("invalid params: entities[%d] requires non-empty 'name' and 'type'", i))
 				return
 			}
+			// Normalise + coerce unknown types to "other" so apply_enrichment
+			// matches muninn_remember instead of storing the type verbatim (#501).
+			etype = normalizeEntityType(etype)
 			entity := ApplyEnrichmentEntity{Name: name, Type: etype}
 			if v, ok := m["confidence"].(float64); ok {
 				entity.Confidence = float32(v)

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1260,7 +1260,6 @@ func normalizeEntityType(typ string) string {
 
 // applyEnrichmentArgs parses optional inline enrichment fields (summary, entities,
 // relationships) from MCP tool call arguments onto the WriteRequest.
-
 func applyEnrichmentArgs(args map[string]any, req *mbp.WriteRequest) int {
 	malformed := 0
 	if summary, ok := args["summary"].(string); ok && summary != "" {

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -1921,20 +1921,22 @@ func TestHandleEntityStateMergedWithoutMergedInto(t *testing.T) {
 }
 
 func TestHandleEntityStateWithType(t *testing.T) {
-	// Verify that providing a "type" field succeeds and is reflected in the response.
+	// Verify that providing a valid "type" field succeeds and is reflected in
+	// the response after normalisation (issue #501: types are now normalised
+	// and unknown values coerced to "other", matching muninn_remember).
 	srv := newTestServerWith(&entityStateEngine{})
-	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_entity_state","arguments":{"vault":"default","entity_name":"Modbus","state":"active","type":"protocol"}}}`
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_entity_state","arguments":{"vault":"default","entity_name":"PostgreSQL","state":"active","type":"Database"}}}`
 	w := postRPC(t, srv, body)
 	resp := decodeResp(t, w.Body.String())
 	if resp.Error != nil {
 		t.Fatalf("unexpected error: %v", resp.Error)
 	}
 	content := extractInnerJSON(t, resp)
-	if content["type"] != "protocol" {
-		t.Errorf("type = %v, want protocol", content["type"])
+	if content["type"] != "database" {
+		t.Errorf("type = %v, want database (normalized)", content["type"])
 	}
-	if content["entity"] != "Modbus" {
-		t.Errorf("entity = %v, want Modbus", content["entity"])
+	if content["entity"] != "PostgreSQL" {
+		t.Errorf("entity = %v, want PostgreSQL", content["entity"])
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -5,6 +5,15 @@ func allToolDefinitions() []ToolDefinition {
 		"type":        "string",
 		"description": "Vault name to scope the operation (default: 'default'). Optional when connected via a vault-pinned MCP session.",
 	}
+	// entityTypeEnum lists the 14 recognised entity types (the single source of
+	// truth is validEntityTypes in handlers.go). Any other value is coerced to
+	// "other" on every user-facing write path, so advertising the enum lets MCP
+	// clients validate before sending. Keep this in sync with validEntityTypes.
+	entityTypeEnum := []string{
+		"person", "organization", "location", "concept", "technology",
+		"project", "tool", "database", "service", "framework",
+		"language", "product", "event", "other",
+	}
 	return []ToolDefinition{
 		{
 			Name:        "muninn_remember",
@@ -28,7 +37,7 @@ func allToolDefinitions() []ToolDefinition {
 							"type": "object",
 							"properties": map[string]any{
 								"name": map[string]any{"type": "string", "description": "Entity name (e.g. 'PostgreSQL', 'Auth Service')."},
-								"type": map[string]any{"type": "string", "description": "Entity type (e.g. 'database', 'service', 'person', 'project')."},
+								"type": map[string]any{"type": "string", "enum": entityTypeEnum, "description": "Entity type. One of the 14 recognised types (e.g. 'database', 'service', 'person', 'project'); any other value is stored as 'other'."},
 							},
 							"required": []string{"name", "type"},
 						},
@@ -437,7 +446,7 @@ func allToolDefinitions() []ToolDefinition {
 							"type": "object",
 							"properties": map[string]any{
 								"name":       map[string]any{"type": "string"},
-								"type":       map[string]any{"type": "string"},
+								"type":       map[string]any{"type": "string", "enum": entityTypeEnum, "description": "Entity type. One of the 14 recognised types; any other value is stored as 'other'."},
 								"confidence": map[string]any{"type": "number"},
 							},
 							"required": []string{"name", "type"},
@@ -517,7 +526,7 @@ func allToolDefinitions() []ToolDefinition {
 					"entity_name": map[string]any{"type": "string", "description": "The entity name to update"},
 					"state":       map[string]any{"type": "string", "description": "New state: active, deprecated, merged, or resolved"},
 					"merged_into": map[string]any{"type": "string", "description": "Canonical entity name (required when state=merged)"},
-					"type":        map[string]any{"type": "string", "description": "Correct the entity type (e.g. 'directive', 'protocol', 'module'). Omit to preserve the existing type."},
+					"type":        map[string]any{"type": "string", "enum": entityTypeEnum, "description": "Correct the entity type to one of the 14 recognised types (e.g. 'concept', 'technology', 'product'). Any other value is stored as 'other'. Omit to preserve the existing type."},
 					"vault":       vaultProp,
 				},
 				"required": []string{"entity_name", "state"},
@@ -540,7 +549,7 @@ func allToolDefinitions() []ToolDefinition {
 								"entity_name": map[string]any{"type": "string", "description": "Entity name to update"},
 								"state":       map[string]any{"type": "string", "description": "New state: active, deprecated, merged, or resolved"},
 								"merged_into": map[string]any{"type": "string", "description": "Canonical entity name (required when state=merged)"},
-								"type":        map[string]any{"type": "string", "description": "Correct the entity type. Omit to preserve existing."},
+								"type":        map[string]any{"type": "string", "enum": entityTypeEnum, "description": "Correct the entity type to one of the 14 recognised types (e.g. 'concept', 'technology', 'product'). Any other value is stored as 'other'. Omit to preserve existing."},
 							},
 							"required": []string{"entity_name", "state"},
 						},


### PR DESCRIPTION
Fixes #501. Thanks to @johanneshauer for the precise three-part report (coercion path vs. two verbatim paths vs. misleading schema examples).

## Problem

The 14 recognised entity types were enforced on exactly one MCP write path and ignored on the others:

| Write path | Invalid type (e.g. `"protocol"`) became |
|---|---|
| `muninn_remember` / `_batch` | coerced to `"other"` |
| `muninn_entity_state` / `_batch` | stored **verbatim** |
| `muninn_apply_enrichment` | stored **verbatim**, not even lowercased/trimmed |

The `muninn_entity_state` schema also advertised three invalid example types (`'directive'`, `'protocol'`, `'module'`), and no entity-type field carried an `enum`.

## Fix

- New `normalizeEntityType` helper in `internal/mcp/handlers.go`, backed by the existing `validEntityTypes` allowlist (kept as the single source of truth). It lowercases + trims, then coerces any unrecognised value to `"other"`. Empty stays empty (callers use `""` to mean "preserve the existing type").
- Applied consistently in `handleEntityState`, `handleEntityStateBatch`, and `handleApplyEnrichment`, plus the existing `remember` path now routes through the same helper. All deliberate user write paths now behave identically.
- Schema: fixed the misleading `entity_state` / `entity_state_batch` examples to real allowlist types, and added an `enum` to all four entity-type schema fields (`remember`, `apply_enrichment`, `entity_state`, `entity_state_batch`) so clients can validate before sending.

## Decision: coerce, not reject — and how #334 is preserved

The issue offered reject-vs-coerce. I chose **coerce-to-`"other"`** for every path:

- **Rejecting** `entity_state` / `entity_state_batch` would be a breaking behavior change for tools that today succeed with an arbitrary type. Coercing keeps every user-facing path consistent with `remember` and is non-breaking.
- **#334** deliberately passes unknown LLM-produced types through on the enrich/replay path. A hard reject (or coercion) inside the engine would regress that intent. So normalization happens **only at the MCP handler boundary** for the explicit user-driven `apply_enrichment` payload; the server-side enrich plugin (`internal/plugin/enrich/parse.go`, its own `normalizeEntityType` with pass-through) is left completely untouched. `muninn_replay_enrichment`, which re-runs that plugin, is unaffected.

Trade-off acknowledged: coercion is silent (no `warnings` field). I kept the change surgical and consistent with `remember`'s existing silent behavior rather than expanding the response contract; a `warnings` field can be a follow-up if desired.

## Tests

TDD — added `internal/mcp/entity_type_validation_test.go` (verified RED first: types were stored verbatim). Asserts `entity_state`, `entity_state_batch`, and `apply_enrichment` now coerce an invalid type to `"other"` and normalize a valid type, exactly like `remember`; empty type is preserved; plus a direct table test of the helper. Updated `TestHandleEntityStateWithType` which previously codified the verbatim-echo behavior.

```
go test ./internal/mcp/... ./internal/storage/... ./internal/engine/... -count=1   # all green
gofmt -l   # clean
go vet     # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)