### PR TITLE
fix(cluster): lobe keeps the join conn and reads the replication stream (#448 Bug 2)

### DIFF
--- a/contrib/cluster/README.md
+++ b/contrib/cluster/README.md
@@ -1,0 +1,72 @@
+# Local MuninnDB cluster (1 Cortex + 2 Lobes)
+
+A runnable example that brings up a three-node MuninnDB cluster on your machine
+so you can see Cortex → Lobe replication working end to end. This is the same
+topology used to validate the replication fix in
+[#448](https://github.com/scrypster/muninndb/issues/448).
+
+For production operations (join tokens, TLS, failover, scaling, DR) see the full
+[Cluster Operations Runbook](../../docs/cluster-operations.md). This directory is
+the quickstart.
+
+## Roles
+
+| Node   | Role      | What it does                                                    |
+|--------|-----------|-----------------------------------------------------------------|
+| cortex | `primary` | Accepts writes, owns the WAL, streams replication to the Lobes. |
+| lobe1  | `replica` | Read-only copy; receives the WAL stream and applies it.         |
+| lobe2  | `replica` | Same as lobe1.                                                  |
+
+## Run it
+
+```bash
+cd contrib/cluster
+docker compose up -d --build      # first run builds the image
+
+# Watch the Lobes join (no "broken pipe" — that was the #448 bug):
+docker compose logs -f cortex lobe1 lobe2 | grep -Ei "joined|cluster"
+```
+
+Within a few seconds each Lobe logs `cluster: joined role=lobe cortex=cortex epoch=1`.
+
+## Prove replication works
+
+Write to the **Cortex**, then read the same id back from a **Lobe**:
+
+```bash
+# 1) Write to the cortex (REST on :8475). Default vault is public.
+ID=$(curl -s -X POST http://localhost:8475/api/engrams \
+  -H 'Content-Type: application/json' \
+  -d '{"concept":"hello","content":"replicated from cortex"}' \
+  | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+echo "wrote $ID"
+
+# 2) Read it from lobe1 (:18475) and lobe2 (:28475) — it replicated.
+sleep 2
+curl -s "http://localhost:18475/api/engrams/${ID}?vault=default"
+curl -s "http://localhost:28475/api/engrams/${ID}?vault=default"
+```
+
+Both Lobes return the engram. Writes go only to the Cortex; a Lobe is read-only.
+
+## Tear down
+
+```bash
+docker compose down -v
+```
+
+## Notes & gotchas
+
+- **Cluster port ≠ MBP port (in containers).** Each node binds the SDK/MBP
+  protocol on `0.0.0.0:8474`. Because `0.0.0.0` covers every interface, the
+  cluster listener (`MUNINN_CLUSTER_BIND_ADDR`) must use a *different* port — this
+  example uses `8479`. Reusing `8474` for the cluster bind address causes
+  `address already in use`, and joins then fail with `unexpected frame type
+  0xff` (they hit the MBP server instead of the cluster listener).
+- **Seeds point at the cluster port.** Lobes seed `cortex:8479`; the Cortex
+  seeds the Lobes for gossip.
+- **Secrets.** `MUNINN_CLUSTER_SECRET` and `MUNINN_ADMIN_PASSWORD` here are
+  placeholders — set strong values for anything real.
+- **Cluster status reporting.** `GET /v1/cluster/info` currently under-reports
+  topology (Cortex role and per-node lag); replication is unaffected. Tracked in
+  [#516](https://github.com/scrypster/muninndb/issues/516).

--- a/contrib/cluster/docker-compose.yml
+++ b/contrib/cluster/docker-compose.yml
@@ -1,0 +1,70 @@
+name: muninn-cluster
+
+# A runnable 1 Cortex + 2 Lobe MuninnDB cluster for local evaluation.
+# See README.md in this directory for the quickstart and how to verify replication.
+#
+# IMPORTANT — cluster port vs MBP port:
+#   Inside containers the server binds MBP on 0.0.0.0:8474 (so it's reachable),
+#   which already covers every interface on that port. The cluster therefore
+#   needs its OWN port for MUNINN_CLUSTER_BIND_ADDR — here 8479 — otherwise its
+#   listener collides with MBP ("address already in use") and joins fail with
+#   "unexpected frame type 0xff". On bare metal where MBP binds a single
+#   interface (e.g. 127.0.0.1:8474) you can reuse 8474 on a different interface.
+
+x-common: &common
+  build:
+    context: ../..
+  image: muninndb:latest
+  restart: unless-stopped
+  environment: &common-env
+    MUNINN_LISTEN_HOST: "0.0.0.0"
+    MUNINN_CLUSTER_ENABLED: "true"
+    # Use a strong shared secret in any real deployment.
+    MUNINN_CLUSTER_SECRET: "change-me-cluster-secret"
+    MUNINN_CLUSTER_HEARTBEAT_MS: "1000"
+    MUNINN_CLUSTER_LEASE_TTL: "10"
+    MUNINN_ADMIN_PASSWORD: "change-me-admin"
+
+services:
+  cortex:
+    <<: *common
+    container_name: muninn-cortex
+    hostname: cortex
+    environment:
+      <<: *common-env
+      MUNINN_CLUSTER_NODE_ID: "cortex"
+      MUNINN_CLUSTER_ROLE: "primary"
+      MUNINN_CLUSTER_BIND_ADDR: "cortex:8479"
+      MUNINN_CLUSTER_SEEDS: "lobe1:8479,lobe2:8479"
+    ports:
+      - "8475:8475"   # cortex REST  → http://localhost:8475
+      - "8476:8476"   # cortex Web UI → http://localhost:8476
+      - "8750:8750"   # cortex MCP/health
+
+  lobe1:
+    <<: *common
+    container_name: muninn-lobe1
+    hostname: lobe1
+    depends_on: [cortex]
+    environment:
+      <<: *common-env
+      MUNINN_CLUSTER_NODE_ID: "lobe1"
+      MUNINN_CLUSTER_ROLE: "replica"
+      MUNINN_CLUSTER_BIND_ADDR: "lobe1:8479"
+      MUNINN_CLUSTER_SEEDS: "cortex:8479"
+    ports:
+      - "18475:8475"  # lobe1 REST → http://localhost:18475
+
+  lobe2:
+    <<: *common
+    container_name: muninn-lobe2
+    hostname: lobe2
+    depends_on: [cortex]
+    environment:
+      <<: *common-env
+      MUNINN_CLUSTER_NODE_ID: "lobe2"
+      MUNINN_CLUSTER_ROLE: "replica"
+      MUNINN_CLUSTER_BIND_ADDR: "lobe2:8479"
+      MUNINN_CLUSTER_SEEDS: "cortex:8479"
+    ports:
+      - "28475:8475"  # lobe2 REST → http://localhost:28475

--- a/docs/cluster-operations.md
+++ b/docs/cluster-operations.md
@@ -39,11 +39,16 @@ MuninnDB uses a **Cortex/Lobe** model (internally: leader/replica terminology):
 
 ## 2. Initial Cluster Setup
 
+> **Just want to try it locally?** The [`contrib/cluster/`](../contrib/cluster/)
+> directory has a runnable `docker compose` example (1 Cortex + 2 Lobes) with a
+> step-by-step replication check. Start there, then come back here for production
+> operations.
+
 ### Prerequisites
 
 - **Network**: All nodes must reach each other on the cluster bind port (typically 8474, MBP protocol).
 - **Ports**:
-  - Cluster inter-node: `bind_addr` (default `:8474`, same as MBP)
+  - Cluster inter-node: `bind_addr` (default `:8474`, same as MBP). **In containers**, where MBP binds `0.0.0.0:8474`, give the cluster its own port (e.g. `:8479`) — a `0.0.0.0` MBP bind already owns 8474 on every interface, so a same-port cluster listener fails with `address already in use` and joins then fail with `unexpected frame type 0xff`.
   - REST API: 8475
   - gRPC: 8477
   - MCP: 8750

--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -431,15 +431,73 @@ func (c *ClusterCoordinator) runAsLobe(ctx context.Context) error {
 		return errors.New("cluster: lobe requires at least one seed address")
 	}
 
-	resp, err := c.joinWithRetry(ctx, c.cfg.Seeds, "lobe")
-	if err != nil {
-		return fmt.Errorf("cluster: join failed: %w", err)
+	return c.streamReplication(ctx, "lobe")
+}
+
+// streamReplication runs the join → read-stream → reconnect loop shared by the
+// Lobe and Observer roles. The Cortex streams replication frames over the SAME
+// connection used for the join handshake (#448 Bug 2), so the role keeps that
+// connection open and reads from it; if the stream drops, it rejoins.
+func (c *ClusterCoordinator) streamReplication(ctx context.Context, role string) error {
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		resp, err := c.joinWithRetry(ctx, c.cfg.Seeds, role)
+		if err != nil {
+			return fmt.Errorf("cluster: %s join failed: %w", role, err)
+		}
+		slog.Info("cluster: joined", "role", role, "cortex", resp.CortexID, "epoch", resp.Epoch)
+
+		streamErr := c.streamFromCortex(ctx, resp.Conn, resp.CortexID)
+		if resp.Conn != nil {
+			resp.Conn.Close()
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		slog.Warn("cluster: replication stream ended, rejoining", "role", role, "err", streamErr)
+
+		// Brief backoff before rejoin so a flapping Cortex doesn't spin us.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+		}
 	}
+}
 
-	slog.Info("cluster: joined as lobe", "cortex", resp.CortexID, "epoch", resp.Epoch)
+// streamFromCortex reads replication frames from the Cortex over the live join
+// connection and dispatches each via HandleIncomingFrame, until the connection
+// errors or ctx is cancelled. Returns nil on ctx cancellation; the read error
+// otherwise. Closing conn on ctx cancellation unblocks the in-flight ReadFrame.
+func (c *ClusterCoordinator) streamFromCortex(ctx context.Context, conn net.Conn, cortexID string) error {
+	if conn == nil {
+		return fmt.Errorf("cluster: no connection to cortex")
+	}
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		select {
+		case <-ctx.Done():
+			conn.Close()
+		case <-stop:
+		}
+	}()
 
-	<-ctx.Done()
-	return ctx.Err()
+	for {
+		frame, err := mbp.ReadFrame(conn)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+		if err := c.HandleIncomingFrame(cortexID, frame.Type, frame.Payload); err != nil {
+			// A single malformed/failed frame must not tear down the stream.
+			slog.Warn("cluster: failed to apply streamed frame", "type", frame.Type, "err", err)
+		}
+	}
 }
 
 // runAsSentinel starts MSP only, participates in voting, no data.
@@ -468,15 +526,7 @@ func (c *ClusterCoordinator) runAsObserver(ctx context.Context) error {
 		return errors.New("cluster: observer requires at least one seed address")
 	}
 
-	resp, err := c.joinWithRetry(ctx, c.cfg.Seeds, "observer")
-	if err != nil {
-		return fmt.Errorf("cluster: observer join failed: %w", err)
-	}
-
-	slog.Info("cluster: joined as observer", "cortex", resp.CortexID, "epoch", resp.Epoch)
-
-	<-ctx.Done()
-	return ctx.Err()
+	return c.streamReplication(ctx, "observer")
 }
 
 // IsObserver returns true if this node is currently an Observer.

--- a/internal/replication/join.go
+++ b/internal/replication/join.go
@@ -265,6 +265,12 @@ type JoinResult struct {
 	// in the snapshot header (authoritative). Otherwise it equals the Lobe's
 	// own LastApplied at join time.
 	StreamFromSeq uint64
+
+	// Conn is the live connection to the Cortex. On a successful Join it is
+	// returned OPEN — the Cortex streams replication frames over this same
+	// connection, so the Lobe keeps it and reads from it (see runAsLobe). The
+	// caller owns closing it. Nil for joinConn callers that pass their own conn.
+	Conn net.Conn
 }
 
 // JoinClient handles the Lobe-side join handshake.
@@ -310,9 +316,17 @@ func (c *JoinClient) Join(ctx context.Context, cortexAddr string) (JoinResult, e
 	if err != nil {
 		return JoinResult{}, fmt.Errorf("join: dial %s: %w", cortexAddr, err)
 	}
-	defer conn.Close()
 
-	return c.joinConn(ctx, conn)
+	result, err := c.joinConn(ctx, conn)
+	if err != nil {
+		// The handshake failed — close the conn here. On success we deliberately
+		// leave it OPEN: the Cortex streams replication frames over this same
+		// connection (#448 Bug 2), so the caller (runAsLobe) keeps and reads it.
+		conn.Close()
+		return result, err
+	}
+	result.Conn = conn
+	return result, nil
 }
 
 // joinConn performs the join handshake over an already-established net.Conn.

--- a/internal/replication/join_conn_lifecycle_test.go
+++ b/internal/replication/join_conn_lifecycle_test.go
@@ -1,0 +1,67 @@
+package replication
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// TestJoinClient_Join_PreservesConnForStreaming is the regression test for #448
+// Bug 2. Join previously did `defer conn.Close()`, so the connection died the
+// moment Join returned — but the Cortex registers that same inbound conn as the
+// Lobe's peer and streams ReplEntry frames over it. First write hit a closed
+// socket ("broken pipe") and replication never started.
+//
+// This test uses REAL TCP and the full Join() (not joinConn, which the existing
+// net.Pipe tests call directly, bypassing the defer-close lifecycle). It asserts
+// Join hands back the live conn and that a frame the Cortex streams *after* Join
+// returns is still readable from it.
+func TestJoinClient_Join_PreservesConnForStreaming(t *testing.T) {
+	es := newTestEpochStore(t)
+	mgr := NewConnManager("lobe-tcp")
+	client := NewJoinClient("lobe-tcp", "127.0.0.1:9999", "", es, nil, mgr)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Read the JoinRequest, send an accepting JoinResponse (no snapshot).
+		readJoinRequest(t, conn)
+		sendJoinResponse(t, conn, mbp.JoinResponse{
+			Accepted: true, CortexID: "cortex-tcp", CortexAddr: ln.Addr().String(), Epoch: 1,
+		})
+		// Stream a ReplEntry over the SAME conn, exactly as the real streamer does.
+		payload, _ := msgpack.Marshal(mbp.ReplEntry{Seq: 1, Op: 1, Key: []byte("k"), Value: []byte("v")})
+		_ = mbp.WriteFrame(conn, &mbp.Frame{
+			Version: 0x01, Type: mbp.TypeReplEntry,
+			PayloadLength: uint32(len(payload)), Payload: payload,
+		})
+		<-done // keep the conn open until the test has read the frame
+	}()
+
+	result, err := client.Join(context.Background(), ln.Addr().String())
+	require.NoError(t, err)
+	require.NotNil(t, result.Conn, "Join must return the live conn so the Lobe can read the stream (#448 Bug 2)")
+
+	// The frame the Cortex streamed after Join returned must be readable — i.e.
+	// Join did NOT close the conn.
+	_ = result.Conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	frame, err := mbp.ReadFrame(result.Conn)
+	require.NoError(t, err, "streamed frame must be readable from the preserved conn")
+	require.Equal(t, mbp.TypeReplEntry, frame.Type)
+
+	close(done)
+	_ = result.Conn.Close()
+}

--- a/internal/replication/lobe_reader_loop_test.go
+++ b/internal/replication/lobe_reader_loop_test.go
@@ -1,0 +1,58 @@
+package replication
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// TestStreamFromCortex_AppliesStreamedEntry verifies the second half of the
+// #448 Bug 2 fix: once the Lobe keeps the join connection open, its reader loop
+// (streamFromCortex) reads replication frames the Cortex streams and applies
+// them. Uses real TCP, like the production path.
+func TestStreamFromCortex_AppliesStreamedEntry(t *testing.T) {
+	coord, db := newTestCoordinator(t, "replica")
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	hold := make(chan struct{})
+	defer close(hold)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		payload, _ := msgpack.Marshal(mbp.ReplEntry{Seq: 1, Op: uint8(OpSet), Key: []byte("repl-key"), Value: []byte("repl-val")})
+		_ = mbp.WriteFrame(conn, &mbp.Frame{
+			Version: 0x01, Type: mbp.TypeReplEntry,
+			PayloadLength: uint32(len(payload)), Payload: payload,
+		})
+		<-hold // keep the conn open until the test finishes
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = coord.streamFromCortex(ctx, conn, "cortex-test") }()
+
+	// The reader loop must apply the streamed ReplEntry to the local store.
+	require.Eventually(t, func() bool {
+		v, closer, err := db.Get([]byte("repl-key"))
+		if err != nil {
+			return false
+		}
+		ok := string(v) == "repl-val"
+		closer.Close()
+		return ok
+	}, 3*time.Second, 20*time.Millisecond, "streamed ReplEntry must be applied by the reader loop")
+}


### PR DESCRIPTION
## Problem (Bug 2 of #448)

The Cortex registers the inbound join connection as the Lobe's peer and streams `ReplEntry` frames over it. But `JoinClient.Join` did `defer conn.Close()`, so the connection died the instant `Join` returned — and `runAsLobe` then just blocked on `<-ctx.Done()` with no reader. The Cortex's first write hit a closed socket (`write: broken pipe`) and **replication never started**. (Bug 1, the streamer/handshake race, was already fixed in #449.)

The existing `net.Pipe` join tests missed this because they call `joinConn` directly, never exercising `Join`'s defer-close.

## Fix — Option A (the agreed direction)

The Lobe keeps the join connection open and reads the stream over it:
- **`Join`** no longer closes the conn on success — it returns it on `JoinResult.Conn` (closing only on handshake error). **The Cortex side is unchanged.**
- **`streamReplication`** (shared by Lobe and Observer) runs join → read-stream → reconnect; **`streamFromCortex`** reads frames and dispatches each via the existing **`HandleIncomingFrame`** (which already applies `ReplEntry`), with ctx-cancellation unblocking the read and a 1s backoff before rejoin.
- **`runAsObserver`** had the identical bug and is fixed by the same loop.

**Key de-risker:** the replication stream is **unidirectional** — the streamer is fire-and-forget and no `ReplAck` is constructed/sent anywhere in the codebase — so the reader loop is read-only, with no writer or bidirectional framing. Composes cleanly with #449's Bug-1 fix (Cortex defers the stream until `JoinResponse` + snapshot are on the wire).

## Tests (real TCP — the lifecycle `net.Pipe` can't exercise)

- `TestJoinClient_Join_PreservesConnForStreaming` — `Join` returns an open conn and a frame the Cortex streams **after** `Join` returns is readable from it (verified RED: no `Conn` field / closed conn before the fix).
- `TestStreamFromCortex_AppliesStreamedEntry` — the reader loop applies a streamed `ReplEntry` to the local store.

Full `internal/replication` suite (incl. all existing join/coordinator/integration tests) green under `-race`.

Credit: production 3-node repro and two-bug diagnosis by @schurabot (#448).

🤖 Generated with [Claude Code](https://claude.com/claude-code)