### PR TITLE
fix(cluster): report accurate topology in /v1/cluster/info (#516)

### DIFF
--- a/internal/replication/bootstrap_promote_test.go
+++ b/internal/replication/bootstrap_promote_test.go
@@ -1,0 +1,60 @@
+package replication
+
+import "testing"
+
+// #516 part 1: a node explicitly configured role=primary never formally promotes
+// when its seeds are registered as voters but are not up yet to vote — self-vote
+// alone is short of quorum, so it stays a candidate (role "unknown") even though
+// it serves joins and streams. bootstrapPromoteIfDesignatedPrimary asserts
+// leadership in that case.
+func TestBootstrapPromote_DesignatedPrimaryPromotes(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "primary")
+
+	// Simulate StartElection having bumped the epoch and self-voted, but not
+	// reached quorum (seeds not up): still a candidate for epoch 1.
+	coord.election.mu.Lock()
+	coord.election.state = ElectionCandidate
+	coord.election.candidateEpoch = 1
+	coord.election.mu.Unlock()
+
+	coord.bootstrapPromoteIfDesignatedPrimary()
+
+	if coord.Role() != RolePrimary {
+		t.Errorf("designated primary did not promote: role=%v", coord.Role())
+	}
+	if !coord.IsLeader() {
+		t.Error("expected IsLeader() == true after bootstrap promotion")
+	}
+}
+
+// An auto-role node must NOT force-promote — it goes through the normal election.
+func TestBootstrapPromote_AutoRoleDoesNotForcePromote(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "")
+
+	coord.election.mu.Lock()
+	coord.election.state = ElectionCandidate
+	coord.election.candidateEpoch = 1
+	coord.election.mu.Unlock()
+
+	coord.bootstrapPromoteIfDesignatedPrimary()
+
+	if coord.Role() == RolePrimary {
+		t.Error("auto-role node should not bootstrap-promote")
+	}
+}
+
+// If another leader already claimed the epoch (we are no longer a candidate),
+// the designated primary must not override it.
+func TestBootstrapPromote_DoesNotOverrideExistingLeader(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "primary")
+
+	coord.election.mu.Lock()
+	coord.election.state = ElectionFollower // a CortexClaim demoted us
+	coord.election.mu.Unlock()
+
+	coord.bootstrapPromoteIfDesignatedPrimary()
+
+	if coord.Role() == RolePrimary {
+		t.Error("must not promote when no longer a candidate (another leader exists)")
+	}
+}

--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -379,8 +379,40 @@ func (c *ClusterCoordinator) runAsCortex(ctx context.Context) error {
 		return fmt.Errorf("cluster: election failed: %w", err)
 	}
 
+	// A node explicitly configured role=primary is the designated leader. If the
+	// bootstrap election did not immediately promote it (its seeds are registered
+	// as voters but are not up yet to vote, so self-vote is short of quorum),
+	// assert leadership directly so it reports as Cortex instead of "unknown".
+	c.bootstrapPromoteIfDesignatedPrimary()
+
 	<-ctx.Done()
 	return ctx.Err()
+}
+
+// bootstrapPromoteIfDesignatedPrimary asserts leadership for a node explicitly
+// configured role=primary when the bootstrap election left it a candidate —
+// typically because its seeds count toward quorum but have not voted yet (#516
+// part 1). It is guarded two ways: only for an explicit "primary" (auto-role
+// nodes use the normal election), and only while still a candidate — if another
+// node had claimed the epoch we would be a follower, so we never override a real
+// leader. This mirrors the existing crash-recovery promotion path.
+func (c *ClusterCoordinator) bootstrapPromoteIfDesignatedPrimary() {
+	if c.cfg.Role != "primary" || c.IsLeader() {
+		return
+	}
+	c.election.mu.Lock()
+	if c.election.state != ElectionCandidate {
+		c.election.mu.Unlock()
+		return
+	}
+	epoch := c.election.candidateEpoch
+	c.election.state = ElectionLeader
+	c.election.currentLeader = c.cfg.NodeID
+	c.election.mu.Unlock()
+
+	slog.Info("cluster: designated primary asserting leadership at bootstrap",
+		"node", c.cfg.NodeID, "epoch", epoch)
+	c.handlePromotion(epoch)
 }
 
 // joinWithRetry attempts to join the Cortex, cycling through all seeds on each
@@ -497,7 +529,32 @@ func (c *ClusterCoordinator) streamFromCortex(ctx context.Context, conn net.Conn
 			// A single malformed/failed frame must not tear down the stream.
 			slog.Warn("cluster: failed to apply streamed frame", "type", frame.Type, "err", err)
 		}
+		// After applying a replication entry, report our progress so the Cortex
+		// can track replica lag (#516 part 3). The Cortex reads these acks via
+		// handleClusterConn → HandleIncomingFrame → UpdateReplicaSeq.
+		if frame.Type == mbp.TypeReplEntry {
+			c.sendReplAck(conn)
+		}
 	}
+}
+
+// sendReplAck reports this node's last-applied seq to the Cortex over the
+// replication connection. Best-effort: a write error is non-fatal — the next
+// entry's ack carries the latest seq, or the stream reconnects.
+func (c *ClusterCoordinator) sendReplAck(conn net.Conn) {
+	if c.applier == nil || conn == nil {
+		return
+	}
+	payload, err := msgpack.Marshal(mbp.ReplAck{NodeID: c.cfg.NodeID, LastSeq: c.applier.LastApplied()})
+	if err != nil {
+		return
+	}
+	_ = mbp.WriteFrame(conn, &mbp.Frame{
+		Version:       0x01,
+		Type:          mbp.TypeReplAck,
+		PayloadLength: uint32(len(payload)),
+		Payload:       payload,
+	})
 }
 
 // runAsSentinel starts MSP only, participates in voting, no data.
@@ -605,6 +662,52 @@ func (c *ClusterCoordinator) FencingToken() uint64 {
 // Alias for KnownNodes for API compatibility.
 func (c *ClusterCoordinator) ClusterMembers() []NodeInfo {
 	return c.KnownNodes()
+}
+
+// ReconciledMembers returns the cluster member list with joined Lobes shown by
+// their real join-handshake identity (node-id, role, last applied seq) instead
+// of the synthetic seed-<addr> MSP placeholders (#516). Used for status
+// reporting; the raw KnownNodes()/MSP view is left untouched for internal logic.
+func (c *ClusterCoordinator) ReconciledMembers() []NodeInfo {
+	base := c.KnownNodes()
+	members := base
+	if c.joinHandler != nil {
+		members = reconcileMembers(base, c.joinHandler.Members())
+	}
+	// Overlay the latest acked seq per replica (#516 part 3) so the reported
+	// last_seq reflects live progress, not the value captured at join time.
+	for i := range members {
+		if v, ok := c.replicaSeqs.Load(members[i].NodeID); ok {
+			members[i].LastSeq = v.(uint64)
+		}
+	}
+	return members
+}
+
+// reconcileMembers replaces a base (MSP) entry with the matching joined member
+// when their addresses match, and appends any joined member not present in base.
+func reconcileMembers(base, joined []NodeInfo) []NodeInfo {
+	joinedByAddr := make(map[string]NodeInfo, len(joined))
+	for _, m := range joined {
+		joinedByAddr[m.Addr] = m
+	}
+	out := make([]NodeInfo, 0, len(base)+len(joined))
+	seen := make(map[string]bool, len(joined))
+	for _, n := range base {
+		if m, ok := joinedByAddr[n.Addr]; ok {
+			out = append(out, m)
+			seen[m.Addr] = true
+		} else {
+			out = append(out, n)
+		}
+	}
+	for _, m := range joined {
+		if !seen[m.Addr] {
+			out = append(out, m)
+			seen[m.Addr] = true
+		}
+	}
+	return out
 }
 
 // checkQuorumHealth is called periodically (from the MSP tick goroutine via

--- a/internal/replication/lobe_replack_test.go
+++ b/internal/replication/lobe_replack_test.go
@@ -1,0 +1,63 @@
+package replication
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// TestStreamFromCortex_SendsReplAck is the #516 part 3 regression: after a Lobe
+// applies a streamed ReplEntry it must send a ReplAck back over the same
+// connection (which the Cortex's handleClusterConn reads) so the Cortex can
+// track per-replica progress / lag. Before this, no ReplAck was ever produced
+// and last_seq stayed 0.
+func TestStreamFromCortex_SendsReplAck(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "replica")
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	ackCh := make(chan mbp.ReplAck, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Stream one ReplEntry to the Lobe.
+		payload, _ := msgpack.Marshal(mbp.ReplEntry{Seq: 1, Op: uint8(OpSet), Key: []byte("k"), Value: []byte("v")})
+		_ = mbp.WriteFrame(conn, &mbp.Frame{
+			Version: 0x01, Type: mbp.TypeReplEntry,
+			PayloadLength: uint32(len(payload)), Payload: payload,
+		})
+		// Read the ack the Lobe sends back.
+		f, err := mbp.ReadFrame(conn)
+		if err != nil || f.Type != mbp.TypeReplAck {
+			return
+		}
+		var ack mbp.ReplAck
+		if msgpack.Unmarshal(f.Payload, &ack) == nil {
+			ackCh <- ack
+		}
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = coord.streamFromCortex(ctx, conn, "cortex-test") }()
+
+	select {
+	case ack := <-ackCh:
+		require.Equal(t, "node-test", ack.NodeID, "ack should carry the lobe's node id")
+		require.Equal(t, uint64(1), ack.LastSeq, "ack should carry the applied seq")
+	case <-time.After(3 * time.Second):
+		t.Fatal("no ReplAck received from the lobe after it applied the entry")
+	}
+}

--- a/internal/replication/reconcile_members_test.go
+++ b/internal/replication/reconcile_members_test.go
@@ -1,0 +1,60 @@
+package replication
+
+import "testing"
+
+// #516 part 2: cluster-info shows joined lobes as synthetic seed-<addr> entries
+// with role "unknown" because the member list comes from the MSP peer set and is
+// never reconciled with the join-handshake identities. reconcileMembers replaces
+// a seed placeholder with the real joined member (node-id, role, last seq) when
+// their addresses match.
+func TestReconcileMembers_ReplacesSeedPlaceholders(t *testing.T) {
+	base := []NodeInfo{
+		{NodeID: "cortex", Addr: "cortex:8479", Role: RolePrimary},
+		{NodeID: "seed-lobe1:8479", Addr: "lobe1:8479", Role: RoleUnknown},
+		{NodeID: "seed-lobe2:8479", Addr: "lobe2:8479", Role: RoleUnknown},
+	}
+	joined := []NodeInfo{
+		{NodeID: "lobe1", Addr: "lobe1:8479", Role: RoleReplica, LastSeq: 5},
+		{NodeID: "lobe2", Addr: "lobe2:8479", Role: RoleReplica, LastSeq: 3},
+	}
+
+	got := reconcileMembers(base, joined)
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 members, got %d", len(got))
+	}
+	byAddr := make(map[string]NodeInfo, len(got))
+	for _, m := range got {
+		byAddr[m.Addr] = m
+	}
+	if m := byAddr["cortex:8479"]; m.NodeID != "cortex" || m.Role != RolePrimary {
+		t.Errorf("cortex entry altered: %+v", m)
+	}
+	if m := byAddr["lobe1:8479"]; m.NodeID != "lobe1" || m.Role != RoleReplica || m.LastSeq != 5 {
+		t.Errorf("lobe1 not reconciled to real identity: %+v", m)
+	}
+	if m := byAddr["lobe2:8479"]; m.NodeID != "lobe2" || m.Role != RoleReplica || m.LastSeq != 3 {
+		t.Errorf("lobe2 not reconciled to real identity: %+v", m)
+	}
+}
+
+// A joined member with no matching MSP peer is still included.
+func TestReconcileMembers_IncludesUnmatchedJoined(t *testing.T) {
+	base := []NodeInfo{{NodeID: "cortex", Addr: "cortex:8479", Role: RolePrimary}}
+	joined := []NodeInfo{{NodeID: "lobe9", Addr: "lobe9:8479", Role: RoleReplica, LastSeq: 1}}
+
+	got := reconcileMembers(base, joined)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 members, got %d", len(got))
+	}
+	found := false
+	for _, m := range got {
+		if m.NodeID == "lobe9" && m.Role == RoleReplica {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("unmatched joined member lobe9 missing from reconciled list")
+	}
+}

--- a/internal/transport/rest/cluster_handlers.go
+++ b/internal/transport/rest/cluster_handlers.go
@@ -112,7 +112,7 @@ func (s *Server) handleClusterNodes(w http.ResponseWriter, r *http.Request) {
 
 // membersFromCoordinator converts coordinator node info into clusterMemberInfo slices.
 func membersFromCoordinator(coord *replication.ClusterCoordinator) []clusterMemberInfo {
-	nodes := coord.ClusterMembers()
+	nodes := coord.ReconciledMembers()
 	members := make([]clusterMemberInfo, 0, len(nodes))
 	for _, n := range nodes {
 		members = append(members, clusterMemberInfo{


### PR DESCRIPTION
## Problem

Found while validating #448 in a real cluster: replication works, but `/v1/cluster/info` misrepresents the cluster three ways (diagnosed in #516).

## Fixes (each TDD'd, RED first)

**Part 1 — Cortex reports `role: unknown` instead of leader.**
A node configured `role: primary` registers its seeds as voters at construction, so the bootstrap election needs a quorum the not-yet-joined seeds can't provide; it stays a *candidate* (role "unknown") while still serving joins and streaming. `bootstrapPromoteIfDesignatedPrimary` asserts leadership in that case — **guarded** to explicit `"primary"` only, and only while still a candidate (so it never overrides a real leader that sent a CortexClaim), reusing the existing crash-recovery promotion path.

**Part 2 — joined lobes shown as `seed-<addr>` with role `unknown`.**
cluster-info read the raw MSP peer set (synthetic seed placeholders). `ReconciledMembers` merges the join-handshake members (real node-id, role, last seq) over the placeholders by address; the internal `KnownNodes()`/MSP view is left untouched.

**Part 3 — `last_seq` stuck at 0.**
No `ReplAck` was ever sent. The lobe now sends one (node-id + applied seq) after each applied `ReplEntry`, over the same connection the Cortex already reads (`handleClusterConn` → `HandleIncomingFrame` → `UpdateReplicaSeq`); `ReconciledMembers` overlays the latest acked seq per node.

## Proven end-to-end in a 3-node Docker cluster

`/v1/cluster/info` on the cortex:

| | Before | After |
|---|---|---|
| Cortex | `role: unknown`, `is_leader: false`, `cortex_id: ""` | `role: primary`, `is_leader: true`, `cortex_id: "cortex"` |
| Lobes | `seed-lobe1:8479` / `seed-lobe2:8479`, role `unknown` | `lobe1` / `lobe2`, role `replica` |
| `last_seq` | `0` | `2` (live) |

Replication still works (write→lobe verified) with **zero** broken-pipe errors after the election change. Full `internal/replication` suite green under `-race`.

Diagnosis + repro from validating #448 (@schurabot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)