### PR TITLE
chore(cluster): Step 0 safe prep for the liveness overhaul (#522)

### DIFF
--- a/internal/config/advertise_addr_test.go
+++ b/internal/config/advertise_addr_test.go
@@ -1,0 +1,36 @@
+package config
+
+import "testing"
+
+// #522 Step 0: AdvertiseAddr defaults to BindAddr, and an explicit value (env)
+// wins — so wildcard binds (0.0.0.0) in containers can advertise a routable addr.
+func TestClusterConfig_AdvertiseAddr_DefaultsToBindAddr(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MUNINN_CLUSTER_ENABLED", "true")
+	t.Setenv("MUNINN_CLUSTER_NODE_ID", "n1")
+	t.Setenv("MUNINN_CLUSTER_BIND_ADDR", "0.0.0.0:8479")
+
+	cfg, err := LoadClusterConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadClusterConfig: %v", err)
+	}
+	if cfg.AdvertiseAddr != "0.0.0.0:8479" {
+		t.Errorf("AdvertiseAddr should default to BindAddr, got %q", cfg.AdvertiseAddr)
+	}
+}
+
+func TestClusterConfig_AdvertiseAddr_ExplicitWins(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MUNINN_CLUSTER_ENABLED", "true")
+	t.Setenv("MUNINN_CLUSTER_NODE_ID", "n1")
+	t.Setenv("MUNINN_CLUSTER_BIND_ADDR", "0.0.0.0:8479")
+	t.Setenv("MUNINN_CLUSTER_ADVERTISE_ADDR", "node1:8479")
+
+	cfg, err := LoadClusterConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadClusterConfig: %v", err)
+	}
+	if cfg.AdvertiseAddr != "node1:8479" {
+		t.Errorf("explicit AdvertiseAddr not honored, got %q", cfg.AdvertiseAddr)
+	}
+}

--- a/internal/config/cluster.go
+++ b/internal/config/cluster.go
@@ -15,9 +15,14 @@ import (
 
 // ClusterConfig holds configuration for multi-node cluster mode.
 type ClusterConfig struct {
-	Enabled       bool     `yaml:"enabled" json:"enabled"`
-	NodeID        string   `yaml:"node_id" json:"node_id"`
-	BindAddr      string   `yaml:"bind_addr" json:"bind_addr"`
+	Enabled  bool   `yaml:"enabled" json:"enabled"`
+	NodeID   string `yaml:"node_id" json:"node_id"`
+	BindAddr string `yaml:"bind_addr" json:"bind_addr"`
+	// AdvertiseAddr is the host:port other nodes use to reach this one. Defaults
+	// to BindAddr; set it explicitly when BindAddr is a wildcard (e.g.
+	// 0.0.0.0:8479 in containers) so peer-identity reconciliation and dials use a
+	// routable address rather than the unmatchable wildcard.
+	AdvertiseAddr string   `yaml:"advertise_addr" json:"advertise_addr"`
 	Seeds         []string `yaml:"seeds" json:"seeds"`
 	ClusterSecret string   `yaml:"cluster_secret" json:"cluster_secret"`
 	// "auto" | "primary" | "replica" | "sentinel" | "observer"
@@ -106,6 +111,12 @@ func LoadClusterConfig(dataDir string) (ClusterConfig, error) {
 	applyEnvOverrides(&cfg)
 	autoNodeID(&cfg, dataDir)
 
+	// AdvertiseAddr defaults to BindAddr — most deployments bind a routable
+	// address and need no separate advertise address.
+	if cfg.AdvertiseAddr == "" {
+		cfg.AdvertiseAddr = cfg.BindAddr
+	}
+
 	// Default AutoGenDir to dataDir/cluster-tls if TLS is enabled but no dir specified.
 	if cfg.TLS.Enabled && cfg.TLS.AutoGenDir == "" {
 		cfg.TLS.AutoGenDir = filepath.Join(dataDir, "cluster-tls")
@@ -187,6 +198,9 @@ func applyEnvOverrides(cfg *ClusterConfig) {
 	}
 	if v := os.Getenv("MUNINN_CLUSTER_BIND_ADDR"); v != "" {
 		cfg.BindAddr = v
+	}
+	if v := os.Getenv("MUNINN_CLUSTER_ADVERTISE_ADDR"); v != "" {
+		cfg.AdvertiseAddr = v
 	}
 	if v := os.Getenv("MUNINN_CLUSTER_SEEDS"); v != "" {
 		var seeds []string

--- a/internal/replication/conn_manager.go
+++ b/internal/replication/conn_manager.go
@@ -61,6 +61,23 @@ func (m *ConnManager) AddPeer(nodeID, addr string) {
 	m.peers[nodeID] = NewPeerConn(nodeID, addr)
 }
 
+// UpdatePeerAddr updates a peer's advertised address WITHOUT disturbing its live
+// connection (adds a disconnected peer if none exists). Used for address-change
+// gossip — the previous path (AddPeer) closed the live conn and tore down the
+// replication stream on any benign addr readvertisement (#522 Step 0).
+func (m *ConnManager) UpdatePeerAddr(nodeID, addr string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if existing, ok := m.peers[nodeID]; ok {
+		existing.mu.Lock()
+		existing.addr = addr
+		existing.mu.Unlock()
+		return
+	}
+	m.peers[nodeID] = NewPeerConn(nodeID, addr)
+}
+
 // RegisterConn registers an already-established inbound connection as a peer
 // and returns the new PeerConn. Unlike AddPeer, the PeerConn wraps the live
 // conn so Send works immediately without a separate Connect call. If a peer

--- a/internal/replication/conn_manager_addr_test.go
+++ b/internal/replication/conn_manager_addr_test.go
@@ -1,0 +1,54 @@
+package replication
+
+import (
+	"net"
+	"testing"
+)
+
+// #522 Step 0: OnAddrChanged previously routed through AddPeer, which closes the
+// live connection and replaces it — tearing down the replication stream on a
+// benign address readvertisement. UpdatePeerAddr must update the address while
+// leaving the live connection intact.
+func TestConnManager_UpdatePeerAddr_PreservesLiveConn(t *testing.T) {
+	mgr := NewConnManager("self")
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	p := mgr.RegisterConn("peer-1", "old:8479", c1)
+	if !p.IsConnected() {
+		t.Fatal("expected connected peer after RegisterConn")
+	}
+
+	mgr.UpdatePeerAddr("peer-1", "new:8479")
+
+	p2, ok := mgr.GetPeer("peer-1")
+	if !ok {
+		t.Fatal("peer missing after UpdatePeerAddr")
+	}
+	if p2 != p {
+		t.Error("expected the SAME PeerConn (live conn preserved), got a replacement")
+	}
+	if !p2.IsConnected() {
+		t.Error("UpdatePeerAddr must NOT close the live connection")
+	}
+	if p2.Addr() != "new:8479" {
+		t.Errorf("addr = %q, want new:8479", p2.Addr())
+	}
+}
+
+// For a peer that has no entry yet, UpdatePeerAddr adds a disconnected one.
+func TestConnManager_UpdatePeerAddr_AddsWhenAbsent(t *testing.T) {
+	mgr := NewConnManager("self")
+	mgr.UpdatePeerAddr("peer-x", "host:8479")
+	p, ok := mgr.GetPeer("peer-x")
+	if !ok {
+		t.Fatal("expected peer to be added")
+	}
+	if p.Addr() != "host:8479" {
+		t.Errorf("addr = %q, want host:8479", p.Addr())
+	}
+	if p.IsConnected() {
+		t.Error("expected disconnected placeholder")
+	}
+}

--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -143,11 +143,20 @@ func NewClusterCoordinator(
 	applier *Applier,
 	epochStore *EpochStore,
 ) *ClusterCoordinator {
+	// The address other nodes use to reach this one. Defaults to BindAddr (the
+	// config loader applies the same default; this fallback covers callers that
+	// build ClusterConfig directly, e.g. tests).
+	advertiseAddr := cfg.AdvertiseAddr
+	if advertiseAddr == "" {
+		advertiseAddr = cfg.BindAddr
+	}
+
 	mgr := NewConnManager(cfg.NodeID)
-	msp := NewMSP(cfg.NodeID, cfg.BindAddr, mgr)
+	msp := NewMSP(cfg.NodeID, advertiseAddr, mgr)
 	election := NewElection(cfg.NodeID, epochStore, mgr)
 	joinHandler := NewJoinHandler(cfg.NodeID, cfg.ClusterSecret, epochStore, repLog, mgr)
-	joinClient := NewJoinClient(cfg.NodeID, cfg.BindAddr, cfg.ClusterSecret, epochStore, applier, mgr)
+	joinHandler.localAddr = advertiseAddr
+	joinClient := NewJoinClient(cfg.NodeID, advertiseAddr, cfg.ClusterSecret, epochStore, applier, mgr)
 
 	reconDelay := time.Duration(cfg.ReconDelayMs) * time.Millisecond
 	if reconDelay <= 0 {
@@ -257,7 +266,10 @@ func NewClusterCoordinator(
 	msp.OnAddrChanged = func(nodeID, newAddr string) {
 		slog.Info("cluster: peer address changed, updating connection manager",
 			"node", nodeID, "new_addr", newAddr)
-		c.mgr.AddPeer(nodeID, newAddr)
+		// Metadata-only: must NOT close the live connection (a benign addr
+		// readvertisement would otherwise tear down the replication stream). A
+		// genuinely dead conn is detected via MSP SDOWN / read errors (#522).
+		c.mgr.UpdatePeerAddr(nodeID, newAddr)
 	}
 
 	// Wire join handler callbacks

--- a/internal/replication/join.go
+++ b/internal/replication/join.go
@@ -19,6 +19,7 @@ import (
 // It is safe for concurrent access.
 type JoinHandler struct {
 	localNodeID   string
+	localAddr     string // this Cortex's advertised address (for JoinResponse.CortexAddr)
 	clusterSecret string
 	epochStore    *EpochStore
 	repLog        *ReplicationLog
@@ -170,9 +171,10 @@ func (h *JoinHandler) HandleJoinRequest(req mbp.JoinRequest, conn *PeerConn) mbp
 	// have been fully written to the wire.
 
 	resp := mbp.JoinResponse{
-		Accepted: true,
-		CortexID: h.localNodeID,
-		Epoch:    currentEpoch,
+		Accepted:   true,
+		CortexID:   h.localNodeID,
+		CortexAddr: h.localAddr,
+		Epoch:      currentEpoch,
 	}
 
 	// Phase 2: if this handler has a DB, every joining Lobe gets a snapshot.

--- a/internal/replication/peer_conn.go
+++ b/internal/replication/peer_conn.go
@@ -6,12 +6,18 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/scrypster/muninndb/internal/transport/mbp"
 )
 
 // ErrNotConnected is returned when Send or Receive is called before Connect.
 var ErrNotConnected = errors.New("peer not connected")
+
+// sendWriteTimeout bounds a single frame write so one peer with a full TCP
+// buffer cannot stall the shared MSP tick goroutine (which broadcasts heartbeats
+// to every peer sequentially) and cascade false SDOWNs.
+const sendWriteTimeout = 5 * time.Second
 
 // PeerConn is a single persistent TCP connection to one remote peer.
 // It is safe for concurrent Send calls.
@@ -96,7 +102,11 @@ func (p *PeerConn) Send(frameType uint8, payload []byte) error {
 		PayloadLength: uint32(len(payload)),
 		Payload:       payload,
 	}
-	return mbp.WriteFrame(p.conn, f)
+	// Bound the write so a wedged peer can't block the shared heartbeat tick.
+	_ = p.conn.SetWriteDeadline(time.Now().Add(sendWriteTimeout))
+	err := mbp.WriteFrame(p.conn, f)
+	_ = p.conn.SetWriteDeadline(time.Time{}) // clear for subsequent reads/writes
+	return err
 }
 
 // Receive reads one MBP frame from the connection.


### PR DESCRIPTION
First increment of the cluster liveness/membership overhaul (epic #522). **No behavior change** for existing single-routable-address deployments — this is the hardening that Step 1 (rename-on-join identity reconciliation) depends on, landed separately so the behavior change gets its own scrutiny + Docker validation.

## Changes
- **`advertise_addr` config** (`MUNINN_CLUSTER_ADVERTISE_ADDR` / yaml), default = `bind_addr`. Lets a node bound to a wildcard (`0.0.0.0` in containers) advertise a routable address for peer-identity reconciliation and dials. Plumbed into MSP + JoinClient.
- **Populate `JoinResponse.CortexAddr`** (was always empty) from the Cortex's advertise addr, so a joining Lobe can learn how to reach the Cortex — needed for Lobe-side conn registration in Step 1, and un-deadens the existing `CortexAddr` branch in `joinConn`.
- **`PeerConn.Send` write deadline (5s)** so one wedged peer can't stall the shared MSP tick goroutine (sequential heartbeat broadcast) and cascade false SDOWNs — a prerequisite before heartbeats share the join/stream conn.
- **`ConnManager.UpdatePeerAddr`**: update a peer's address **without** closing its live conn; `OnAddrChanged` now uses it. Previously `OnAddrChanged → AddPeer` closed and replaced the live conn, tearing down the replication stream on any benign address readvertisement.

## Tests
`advertise_addr` default + explicit-override; `UpdatePeerAddr` preserves the live conn (and adds a placeholder when absent). Full `internal/replication` + `internal/config` suites green under `-race`; `cmd/muninn` green.

## Why staged
See epic #522 for the full root-cause analysis (peer-identity failure across four membership maps / two keyspaces) and the Step 0→4 landing plan. Step 1 (rename-on-join + bidirectional heartbeats) is the behavior change and will be its own Docker-validated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)