### PR TITLE
fix(cluster): rename-on-join identity reconciliation + bidirectional heartbeats (#522 Step 1)

### DIFF
--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -573,25 +574,71 @@ func (c *ClusterCoordinator) streamFromCortex(ctx context.Context, conn net.Conn
 // sendReplAck reports this node's last-applied seq to the Cortex over the
 // replication connection. Best-effort: a write error is non-fatal — the next
 // entry's ack carries the latest seq, or the stream reconnects.
-// reconcileJoinedPeer replaces the seed-<addr> placeholder that matches addr
-// with the real joined node-id in MSP and the voter set, conserving the voter
-// count (rename, never add) (#522 Step 1). Without this the Cortex's MSP and
-// votes are keyed by seed-ids while heartbeats/votes arrive under real ids and
-// get dropped, and the never-heartbeated seed placeholder drives a false SDOWN.
-// Idempotent: a rejoin simply re-asserts the same real id.
+// reconcileJoinedPeer replaces a seed-<addr> placeholder with the real joined
+// node-id in MSP and the voter set (#522 Step 1). Without this the Cortex's MSP
+// and votes are keyed by seed-ids while heartbeats/votes arrive under real ids
+// and get dropped, and the never-heartbeated seed placeholder drives a false
+// SDOWN.
+//
+// It CONSERVES the voter count by construction so quorum can never inflate, even
+// when the dialed/seed address string differs from the advertised address (DNS
+// seed vs pod IP, 0.0.0.0 binds, etc.): on a genuinely new join it retires
+// exactly one seed placeholder — the address-matching one if present, otherwise
+// an arbitrary remaining seed (logged loudly). A rejoin (node already known)
+// retires nothing, so it cannot deflate the set or steal another node's seed
+// slot. The real identity is added BEFORE the seed is retired so a concurrent
+// quorum read can only momentarily over-count (safe), never under-count.
 func (c *ClusterCoordinator) reconcileJoinedPeer(nodeID, addr string, role NodeRole) {
 	if nodeID == "" {
 		return
 	}
-	// Drop any placeholder for this address registered under a different id.
+	isVoter := c.cfg.Role != "observer"
+
+	alreadyKnown := false
 	for _, p := range c.msp.AllPeers() {
-		if p.NodeID != nodeID && p.Addr == addr {
-			c.msp.RemovePeer(p.NodeID)
-			c.election.UnregisterVoter(p.NodeID)
+		if p.NodeID == nodeID {
+			alreadyKnown = true
+			break
 		}
 	}
+
 	c.msp.AddPeer(nodeID, addr, role)
-	c.election.RegisterVoter(nodeID)
+	if isVoter {
+		c.election.RegisterVoter(nodeID)
+	}
+	if alreadyKnown {
+		return // rejoin — already counted; retire nothing.
+	}
+
+	// New join: retire exactly one seed placeholder to conserve the voter count.
+	var matched, anySeed string
+	for _, p := range c.msp.AllPeers() {
+		if p.NodeID == nodeID || !strings.HasPrefix(p.NodeID, "seed-") {
+			continue
+		}
+		if p.Addr == addr {
+			matched = p.NodeID
+			break
+		}
+		if anySeed == "" {
+			anySeed = p.NodeID
+		}
+	}
+	retire := matched
+	if retire == "" {
+		retire = anySeed
+		if retire != "" {
+			slog.Warn("cluster: joined peer address did not match any seed; retiring a seed placeholder to conserve quorum (set advertise_addr to match the seed addresses)",
+				"node", nodeID, "addr", addr, "retired_seed", retire)
+		}
+	}
+	if retire != "" {
+		c.msp.RemovePeer(retire)
+		c.mgr.RemovePeer(retire)
+		if isVoter {
+			c.election.UnregisterVoter(retire)
+		}
+	}
 }
 
 func (c *ClusterCoordinator) sendReplAck(cortexID string, conn net.Conn) {

--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -493,7 +493,27 @@ func (c *ClusterCoordinator) streamReplication(ctx context.Context, role string)
 		}
 		slog.Info("cluster: joined", "role", role, "cortex", resp.CortexID, "epoch", resp.Epoch)
 
+		// Register the Cortex connection and reconcile its identity so the Lobe's
+		// MSP heartbeats reach it (keeping it a live voter) and so the GetPeer-based
+		// reply paths — VoteResponse, ReplAck, CogForward, HandoffAck — actually
+		// send (#522 Step 1). CortexAddr comes from the JoinResponse (Step 0);
+		// fall back to the dialed seed for an older Cortex that didn't send it.
+		cortexAddr := resp.CortexAddr
+		if cortexAddr == "" && len(c.cfg.Seeds) > 0 {
+			cortexAddr = c.cfg.Seeds[0]
+		}
+		if resp.CortexID != "" && resp.Conn != nil {
+			c.mgr.RegisterConn(resp.CortexID, cortexAddr, resp.Conn)
+			c.reconcileJoinedPeer(resp.CortexID, cortexAddr, RolePrimary)
+		}
+
 		streamErr := c.streamFromCortex(ctx, resp.Conn, resp.CortexID)
+
+		// Tear down the connection registration on stream end (RemovePeer closes
+		// the conn); the next loop iteration rejoins and re-registers.
+		if resp.CortexID != "" {
+			c.mgr.RemovePeer(resp.CortexID)
+		}
 		if resp.Conn != nil {
 			resp.Conn.Close()
 		}
@@ -545,7 +565,7 @@ func (c *ClusterCoordinator) streamFromCortex(ctx context.Context, conn net.Conn
 		// can track replica lag (#516 part 3). The Cortex reads these acks via
 		// handleClusterConn → HandleIncomingFrame → UpdateReplicaSeq.
 		if frame.Type == mbp.TypeReplEntry {
-			c.sendReplAck(conn)
+			c.sendReplAck(cortexID, conn)
 		}
 	}
 }
@@ -553,20 +573,52 @@ func (c *ClusterCoordinator) streamFromCortex(ctx context.Context, conn net.Conn
 // sendReplAck reports this node's last-applied seq to the Cortex over the
 // replication connection. Best-effort: a write error is non-fatal — the next
 // entry's ack carries the latest seq, or the stream reconnects.
-func (c *ClusterCoordinator) sendReplAck(conn net.Conn) {
-	if c.applier == nil || conn == nil {
+// reconcileJoinedPeer replaces the seed-<addr> placeholder that matches addr
+// with the real joined node-id in MSP and the voter set, conserving the voter
+// count (rename, never add) (#522 Step 1). Without this the Cortex's MSP and
+// votes are keyed by seed-ids while heartbeats/votes arrive under real ids and
+// get dropped, and the never-heartbeated seed placeholder drives a false SDOWN.
+// Idempotent: a rejoin simply re-asserts the same real id.
+func (c *ClusterCoordinator) reconcileJoinedPeer(nodeID, addr string, role NodeRole) {
+	if nodeID == "" {
+		return
+	}
+	// Drop any placeholder for this address registered under a different id.
+	for _, p := range c.msp.AllPeers() {
+		if p.NodeID != nodeID && p.Addr == addr {
+			c.msp.RemovePeer(p.NodeID)
+			c.election.UnregisterVoter(p.NodeID)
+		}
+	}
+	c.msp.AddPeer(nodeID, addr, role)
+	c.election.RegisterVoter(nodeID)
+}
+
+func (c *ClusterCoordinator) sendReplAck(cortexID string, conn net.Conn) {
+	if c.applier == nil {
 		return
 	}
 	payload, err := msgpack.Marshal(mbp.ReplAck{NodeID: c.cfg.NodeID, LastSeq: c.applier.LastApplied()})
 	if err != nil {
 		return
 	}
-	_ = mbp.WriteFrame(conn, &mbp.Frame{
-		Version:       0x01,
-		Type:          mbp.TypeReplAck,
-		PayloadLength: uint32(len(payload)),
-		Payload:       payload,
-	})
+	// Prefer the registered PeerConn so this write serializes with MSP heartbeats
+	// on the same connection (#522 Step 1). Fall back to the raw conn when the
+	// Cortex isn't registered (e.g. an older path or a test harness).
+	if cortexID != "" {
+		if peer, ok := c.mgr.GetPeer(cortexID); ok && peer.IsConnected() {
+			_ = peer.Send(mbp.TypeReplAck, payload)
+			return
+		}
+	}
+	if conn != nil {
+		_ = mbp.WriteFrame(conn, &mbp.Frame{
+			Version:       0x01,
+			Type:          mbp.TypeReplAck,
+			PayloadLength: uint32(len(payload)),
+			Payload:       payload,
+		})
+	}
 }
 
 // runAsSentinel starts MSP only, participates in voting, no data.
@@ -796,6 +848,12 @@ func (c *ClusterCoordinator) HandleIncomingJoin(conn net.Conn, payload []byte) (
 	}
 	if err := peer.Send(mbp.TypeJoinResponse, respPayload); err != nil {
 		return req.NodeID, fmt.Errorf("cluster: send JoinResponse to %s: %w", req.NodeID, err)
+	}
+
+	// Replace the seed placeholder with this Lobe's real identity in MSP + voters
+	// so heartbeats and votes keyed by its node-id are no longer dropped (#522).
+	if resp.Accepted {
+		c.reconcileJoinedPeer(req.NodeID, req.Addr, RoleReplica)
 	}
 
 	if resp.NeedsSnapshot {

--- a/internal/replication/reconcile_joined_peer_test.go
+++ b/internal/replication/reconcile_joined_peer_test.go
@@ -1,0 +1,60 @@
+package replication
+
+import "testing"
+
+// #522 Step 1: when a Lobe joins, the Cortex must replace the seed-<addr>
+// placeholder (in MSP and the voter set) with the real joined node-id —
+// CONSERVING the voter count (rename, never add) so quorum semantics don't shift,
+// and so MSP heartbeats / votes keyed by the real id are no longer dropped.
+func TestReconcileJoinedPeer_RenamesSeedConservingVoters(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "primary")
+	coord.election.RegisterVoter(coord.cfg.NodeID) // self
+	// Seed placeholder, as added at construction for a configured seed.
+	coord.msp.AddPeer("seed-lobe1:8479", "lobe1:8479", RoleUnknown)
+	coord.election.RegisterVoter("seed-lobe1:8479")
+
+	quorumBefore := coord.election.Quorum() // voters {self, seed-lobe1} = 2 → 2
+
+	coord.reconcileJoinedPeer("lobe1", "lobe1:8479", RoleReplica)
+
+	if got := coord.election.Quorum(); got != quorumBefore {
+		t.Errorf("voter count not conserved across join: quorum before=%d after=%d", quorumBefore, got)
+	}
+
+	var hasReal, hasSeed bool
+	for _, p := range coord.msp.AllPeers() {
+		switch p.NodeID {
+		case "lobe1":
+			hasReal = true
+			if p.Role != RoleReplica {
+				t.Errorf("reconciled peer role = %v, want RoleReplica", p.Role)
+			}
+		case "seed-lobe1:8479":
+			hasSeed = true
+		}
+	}
+	if !hasReal {
+		t.Error("expected real node-id lobe1 in MSP after reconciliation")
+	}
+	if hasSeed {
+		t.Error("seed-lobe1:8479 placeholder should be removed from MSP")
+	}
+}
+
+// Reconciling the same node twice (e.g. a rejoin) is idempotent and does not
+// inflate the voter set.
+func TestReconcileJoinedPeer_Idempotent(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "primary")
+	coord.election.RegisterVoter(coord.cfg.NodeID)
+	coord.msp.AddPeer("seed-lobe1:8479", "lobe1:8479", RoleUnknown)
+	coord.election.RegisterVoter("seed-lobe1:8479")
+
+	coord.reconcileJoinedPeer("lobe1", "lobe1:8479", RoleReplica)
+	q1 := coord.election.Quorum()
+	coord.reconcileJoinedPeer("lobe1", "lobe1:8479", RoleReplica)
+	q2 := coord.election.Quorum()
+
+	if q1 != q2 {
+		t.Errorf("reconcile not idempotent: quorum %d then %d", q1, q2)
+	}
+}

--- a/internal/replication/reconcile_joined_peer_test.go
+++ b/internal/replication/reconcile_joined_peer_test.go
@@ -1,6 +1,9 @@
 package replication
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // #522 Step 1: when a Lobe joins, the Cortex must replace the seed-<addr>
 // placeholder (in MSP and the voter set) with the real joined node-id —
@@ -56,5 +59,59 @@ func TestReconcileJoinedPeer_Idempotent(t *testing.T) {
 
 	if q1 != q2 {
 		t.Errorf("reconcile not idempotent: quorum %d then %d", q1, q2)
+	}
+}
+
+// Regression (PR #524 review): when the joined node's advertised address does
+// NOT match the seed string (DNS seed vs pod IP / 0.0.0.0), the voter count must
+// still be conserved — an arbitrary seed placeholder is retired so quorum cannot
+// inflate.
+func TestReconcileJoinedPeer_ConservesOnAddrMismatch(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "primary")
+	coord.election.RegisterVoter(coord.cfg.NodeID)
+	// Seed keyed by the DNS name the operator configured.
+	coord.msp.AddPeer("seed-cortex.svc:8479", "cortex.svc:8479", RoleUnknown)
+	coord.election.RegisterVoter("seed-cortex.svc:8479")
+
+	quorumBefore := coord.election.Quorum() // {self, seed} = 2 → 2
+
+	// Node joins advertising a routable IP that does NOT match the seed string.
+	coord.reconcileJoinedPeer("lobe1", "10.0.0.5:8479", RoleReplica)
+
+	if got := coord.election.Quorum(); got != quorumBefore {
+		t.Errorf("quorum inflated on addr mismatch: before=%d after=%d", quorumBefore, got)
+	}
+	for _, p := range coord.msp.AllPeers() {
+		if strings.HasPrefix(p.NodeID, "seed-") {
+			t.Errorf("seed placeholder %q not retired on mismatch (would inflate quorum)", p.NodeID)
+		}
+	}
+}
+
+// A rejoin must not steal another not-yet-joined node's seed slot (deflation).
+func TestReconcileJoinedPeer_RejoinDoesNotStealOtherSeed(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "primary")
+	coord.election.RegisterVoter(coord.cfg.NodeID)
+	coord.msp.AddPeer("seed-lobe1:8479", "lobe1:8479", RoleUnknown)
+	coord.election.RegisterVoter("seed-lobe1:8479")
+	coord.msp.AddPeer("seed-lobe2:8479", "lobe2:8479", RoleUnknown)
+	coord.election.RegisterVoter("seed-lobe2:8479")
+
+	coord.reconcileJoinedPeer("lobe1", "lobe1:8479", RoleReplica) // retires seed-lobe1
+	qAfterJoin := coord.election.Quorum()
+
+	coord.reconcileJoinedPeer("lobe1", "lobe1:8479", RoleReplica) // rejoin — must retire nothing
+	if got := coord.election.Quorum(); got != qAfterJoin {
+		t.Errorf("rejoin changed quorum (stole a seed slot?): %d -> %d", qAfterJoin, got)
+	}
+	// lobe2's seed must survive the lobe1 rejoin.
+	var hasLobe2Seed bool
+	for _, p := range coord.msp.AllPeers() {
+		if p.NodeID == "seed-lobe2:8479" {
+			hasLobe2Seed = true
+		}
+	}
+	if !hasLobe2Seed {
+		t.Error("lobe1 rejoin wrongly retired lobe2's seed slot")
 	}
 }


### PR DESCRIPTION
Step 1 of the cluster liveness overhaul (epic #522). Makes Cortex↔Lobe liveness **actually work** by fixing the peer-identity mismatch that silently dropped every heartbeat.

## Root cause (from the epic)
Cluster membership lived in four maps across two keyspaces: the Cortex held seeds as `seed-<addr>` in MSP + the voter set, but Lobes join under real node-ids that were **never added** to either. So heartbeats/votes keyed by the real id were dropped, the never-heartbeated `seed-*` placeholder drove a false SDOWN within ~3s, and the Cortex's live/quorum view collapsed to `alive=1` even though replication worked. The Lobe likewise never registered the Cortex in its own ConnManager → every Lobe→Cortex reply (`VoteResponse`, `ReplAck`, `CogForward`, `HandoffAck`) was a silent no-op in production.

## Fix
- **`reconcileJoinedPeer`** — replace the `seed-<addr>` placeholder matching an address with the real node-id in MSP + voters, **conserving the voter count** (rename, never add) so quorum semantics don't shift. Idempotent across rejoins.
- **Cortex** `HandleIncomingJoin` reconciles the joining Lobe's identity.
- **Lobe** `streamReplication` registers the Cortex conn in its ConnManager and reconciles the Cortex identity (using `JoinResponse.CortexAddr` from Step 0), so its MSP heartbeats reach the Cortex and the reply paths actually send; tears the registration down on stream end.
- **`sendReplAck`** routes through the registered `PeerConn` so it serializes with MSP heartbeats on the shared connection.

Heartbeats now flow both directions over the existing join/stream connection (both physical directions already existed — the bug was naming).

## Validated end-to-end in a 3-node Docker cluster
- **Healthy 1+2: no spurious SDOWN / quorum-lost through 35s** (was: collapse to `alive=1` within ~3s).
- Liveness tracks reality: kill **one** lobe → no false quorum-lost (quorum still met); kill **both** → `quorum lost alive=1` (real detection).
- Replication works; `last_seq=2` for both lobes via the PeerConn-routed `ReplAck`.
- Members shown by real id + role `replica`; restore lobes → quorum recovers, cortex stays primary.

## Scope
`checkQuorumHealth` stays `OnSDown`-only this step. Periodic demotion (#520) is gated on the Step 3 demotion-recovery path per the epic — do not land it before then. Tests: `reconcileJoinedPeer` renames conserving voters + idempotent; full `internal/replication` suite green under `-race`.

Refs #522, #521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)