### PR TITLE
fix(cluster): count only registered voters in HandleVoteResponse (#522 Step 2)

### DIFF
--- a/internal/replication/election.go
+++ b/internal/replication/election.go
@@ -279,6 +279,14 @@ func (e *Election) HandleVoteResponse(resp mbp.VoteResponse) {
 		return
 	}
 
+	// Count votes only from registered voters, so the vote tally (numerator) is
+	// drawn from the same population as the quorum (denominator). A vote from an
+	// unknown/stale node must never help complete quorum (#522 Step 2).
+	if _, ok := e.voters[resp.VoterID]; !ok {
+		e.mu.Unlock()
+		return
+	}
+
 	// Record the vote.
 	if e.votes[resp.Epoch] == nil {
 		e.votes[resp.Epoch] = make(map[string]bool)

--- a/internal/replication/vote_membership_test.go
+++ b/internal/replication/vote_membership_test.go
@@ -1,0 +1,43 @@
+package replication
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// #522 Step 2: HandleVoteResponse must count a vote only from a REGISTERED voter,
+// so the numerator (votes) is drawn from the same population as the denominator
+// (quorum). Otherwise a vote from an unknown/stale node could complete quorum and
+// wrongly promote — a real hazard now that real-id reply paths actually flow.
+func TestHandleVoteResponse_IgnoresUnregisteredVoter(t *testing.T) {
+	el := newTestElection(t, "self") // harness registers self as a voter
+	el.RegisterVoter("voter-1")      // voters {self, voter-1} → quorum 2
+
+	if err := el.StartElection(context.Background()); err != nil {
+		t.Fatalf("StartElection: %v", err)
+	}
+	if el.State() != ElectionCandidate {
+		t.Fatalf("expected candidate (quorum 2, self-vote 1), got state %d", el.State())
+	}
+
+	var promoted int32
+	el.OnPromoted = func(uint64) { atomic.AddInt32(&promoted, 1) }
+
+	// A granted vote from a node that is NOT a registered voter must not count.
+	el.HandleVoteResponse(mbp.VoteResponse{VoterID: "stranger", Epoch: 1, Granted: true})
+	if el.State() != ElectionCandidate {
+		t.Errorf("an unregistered vote must not reach quorum; state=%d", el.State())
+	}
+	if atomic.LoadInt32(&promoted) != 0 {
+		t.Error("must not promote on an unregistered vote")
+	}
+
+	// A vote from the registered voter DOES complete quorum and promotes.
+	el.HandleVoteResponse(mbp.VoteResponse{VoterID: "voter-1", Epoch: 1, Granted: true})
+	if el.State() != ElectionLeader {
+		t.Errorf("registered voter should complete quorum and promote, got state %d", el.State())
+	}
+}


### PR DESCRIPTION
Step 2 of the cluster liveness overhaul (epic #522).

## Problem
`HandleVoteResponse` recorded `votes[epoch][VoterID] = true` for **any** granted vote without checking the voter is registered. So the vote tally (numerator) and the quorum (denominator) were drawn from different populations — a vote from an unknown or stale node could complete quorum and wrongly promote. The adversarial review of #524 flagged this; it becomes a **live** hazard now that Step 1 makes real-id reply paths (`VoteResponse`, etc.) actually flow over the wire.

## Fix
Ignore a `VoteResponse` whose `VoterID` is not in the registered voter set — a pure tightening (rejects more, never accepts wrong votes).

## Tests
An unregistered vote does not reach quorum (node stays candidate); a registered voter's vote completes quorum and promotes. Full `internal/replication` suite green under `-race`.

## Scope note
End-to-end real-TCP **graceful-failover** validation lands with **Step 3**, which fixes the demoted-Cortex-becomes-a-functioning-Lobe path (today `handleDemotion` parks a `runAsCortex` node as a zombie — the collapse observed in the #520 Docker test). Sequenced per the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)