### PR TITLE
fix(cluster): post-demotion supervisor — no more demotion zombie (#522 Step 3 PR A)

### DIFF
--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -781,12 +781,24 @@ func (c *ClusterCoordinator) initialCortexMode() runMode {
 }
 
 // leadTerm holds leadership until a demotion event arrives, then routes to the
-// recovery mode the demotion cause dictates.
+// recovery mode the demotion cause dictates. A backstop ticker re-derives role
+// from authoritative state so that even if a demotion event were ever dropped
+// (unreachable in practice — the loop drains roleCh while leading), the node
+// still recovers instead of staying parked as a leader-but-Replica zombie.
 func (c *ClusterCoordinator) leadTerm(ctx context.Context) runMode {
+	ticker := time.NewTicker(c.heartbeatInterval())
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return modeLeading
+		case <-ticker.C:
+			if !c.IsLeader() {
+				if ldr := c.election.CurrentLeader(); ldr != "" && ldr != c.cfg.NodeID {
+					return modeFollowing
+				}
+				return modeWaitingQuorum
+			}
 		case ev := <-c.roleCh:
 			if ev.promoted {
 				continue // already leading; ignore a duplicate promote
@@ -1343,9 +1355,12 @@ func (c *ClusterCoordinator) handleDemotion(cause demotionCause) {
 	// Hand the supervisor loop the recovery cue (#522 Step 3).
 	c.pushRoleEvent(roleEvent{promoted: false, cause: cause})
 
-	// Fire engine callback
+	// Fire the engine callback asynchronously: this path runs on the MSP tick
+	// goroutine (via checkQuorumHealth), and OnBecameLobe stops cognitive workers
+	// which may block — it must not stall heartbeat processing. The role flip
+	// above already gates writes, so the worker teardown can complete out of band.
 	if c.OnBecameLobe != nil {
-		c.OnBecameLobe()
+		go c.OnBecameLobe()
 	}
 }
 

--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -40,6 +40,33 @@ const (
 	StateDraining NodeState = 1
 )
 
+// demotionCause distinguishes why a Cortex stepped down, which determines its
+// recovery path in the supervisor loop (#522 Step 3).
+type demotionCause uint8
+
+const (
+	causeClaim      demotionCause = iota // another node legitimately leads (claim/handoff)
+	causeQuorumLoss                      // pre-emptive self-demotion; no other leader exists
+)
+
+// runMode is a state of the post-leadership supervisor loop (#522 Step 3).
+type runMode uint8
+
+const (
+	modeLeading       runMode = iota // hold leadership until demoted
+	modeFollowing                    // join/stream from a known leader until promoted
+	modeWaitingQuorum                // no leader; wait for quorum to return, then re-elect
+)
+
+// roleEvent is pushed to roleCh on every promotion/demotion so the supervisor
+// loop can transition promptly. Every term also re-derives authoritative state
+// (IsLeader / CurrentLeader) on entry/tick, so a dropped or duplicate event only
+// delays a transition by at most one heartbeat — it can never wedge the loop.
+type roleEvent struct {
+	promoted bool
+	cause    demotionCause // valid when !promoted
+}
+
 // ErrDraining is returned when a write is attempted while the node is draining.
 var ErrDraining = errors.New("node is draining: not accepting new writes")
 
@@ -68,6 +95,9 @@ type ClusterCoordinator struct {
 	role   NodeRole
 	roleMu sync.RWMutex
 
+	// roleCh carries promotion/demotion events to the supervisor loop (#522 Step 3).
+	roleCh chan roleEvent
+
 	// Per-Lobe streamers (Cortex only): lobeID -> cancel func
 	streamers   map[string]context.CancelFunc
 	streamersMu sync.Mutex
@@ -75,7 +105,12 @@ type ClusterCoordinator struct {
 	// quorumLostSince is the time when this Cortex first noticed it could not
 	// reach a quorum of live peers. Zero value means quorum is healthy.
 	quorumLostSince time.Time
-	quorumMu        sync.Mutex
+	// hadQuorum latches true once a leadership term has observed a live quorum,
+	// gating pre-emptive quorum-loss demotion so a node still forming its first
+	// quorum at bootstrap is exempt. Cleared on demotion (#522 Step 3; the
+	// periodic demotion that consumes it lands in PR B / #520).
+	hadQuorum bool
+	quorumMu  sync.Mutex
 
 	// Cognitive workers (Cortex only): receive forwarded side effects from Lobes.
 	hebbianWorker hebbianSubmitter
@@ -176,6 +211,7 @@ func NewClusterCoordinator(
 		joinClient:  joinClient,
 		role:        RoleUnknown,
 		streamers:   make(map[string]context.CancelFunc),
+		roleCh:      make(chan roleEvent, 4),
 		reconDelay:  reconDelay,
 	}
 	// Default reconcile-on-heal to enabled; matches config default (ReconcileHeal=true).
@@ -195,7 +231,9 @@ func NewClusterCoordinator(
 		c.handlePromotion(epoch)
 	}
 	election.OnDemoted = func() {
-		c.handleDemotion()
+		// OnDemoted is fired only by HandleCortexClaim, which has already set
+		// currentLeader to the claimant — a known leader exists.
+		c.handleDemotion(causeClaim)
 	}
 	election.OnNewLeader = func(leaderID string, epoch uint64) {
 		c.handleNewLeader(leaderID, epoch)
@@ -379,8 +417,7 @@ func (c *ClusterCoordinator) runAsCortex(ctx context.Context) error {
 		if err := c.epochStore.PersistRole(""); err != nil {
 			slog.Warn("cluster: failed to clear persisted role after crash-recovery", "err", err)
 		}
-		<-ctx.Done()
-		return ctx.Err()
+		return c.supervise(ctx, modeLeading)
 	}
 
 	// Always start an election on normal startup (epoch 0 = first boot,
@@ -398,8 +435,7 @@ func (c *ClusterCoordinator) runAsCortex(ctx context.Context) error {
 	// assert leadership directly so it reports as Cortex instead of "unknown".
 	c.bootstrapPromoteIfDesignatedPrimary()
 
-	<-ctx.Done()
-	return ctx.Err()
+	return c.supervise(ctx, c.initialCortexMode())
 }
 
 // bootstrapPromoteIfDesignatedPrimary asserts leadership for a node explicitly
@@ -476,21 +512,36 @@ func (c *ClusterCoordinator) runAsLobe(ctx context.Context) error {
 		return errors.New("cluster: lobe requires at least one seed address")
 	}
 
-	return c.streamReplication(ctx, "lobe")
+	// Run through the supervisor starting as a follower, so that a Lobe which
+	// wins an election (e.g. on Cortex ODOWN) transitions to leadership instead
+	// of staying wedged inside the stream loop (#522 Step 3 inverse zombie).
+	return c.supervise(ctx, modeFollowing)
 }
 
 // streamReplication runs the join → read-stream → reconnect loop shared by the
 // Lobe and Observer roles. The Cortex streams replication frames over the SAME
 // connection used for the join handshake (#448 Bug 2), so the role keeps that
 // connection open and reads from it; if the stream drops, it rejoins.
-func (c *ClusterCoordinator) streamReplication(ctx context.Context, role string) error {
+func (c *ClusterCoordinator) streamReplication(ctx context.Context, role string, seeds []string) error {
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		resp, err := c.joinWithRetry(ctx, c.cfg.Seeds, role)
+		resp, err := c.joinWithRetry(ctx, seeds, role)
 		if err != nil {
-			return fmt.Errorf("cluster: %s join failed: %w", role, err)
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			// Non-fatal: the leader may not be up yet (or this node is a demoted
+			// Cortex whose seeds are its now-down lobes). Back off and keep trying
+			// rather than exiting the cluster goroutine (#522 Step 3).
+			slog.Warn("cluster: join attempts exhausted, will retry", "role", role, "err", err)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(5 * time.Second):
+			}
+			continue
 		}
 		slog.Info("cluster: joined", "role", role, "cortex", resp.CortexID, "epoch", resp.Epoch)
 
@@ -500,8 +551,8 @@ func (c *ClusterCoordinator) streamReplication(ctx context.Context, role string)
 		// send (#522 Step 1). CortexAddr comes from the JoinResponse (Step 0);
 		// fall back to the dialed seed for an older Cortex that didn't send it.
 		cortexAddr := resp.CortexAddr
-		if cortexAddr == "" && len(c.cfg.Seeds) > 0 {
-			cortexAddr = c.cfg.Seeds[0]
+		if cortexAddr == "" && len(seeds) > 0 {
+			cortexAddr = seeds[0]
 		}
 		if resp.CortexID != "" && resp.Conn != nil {
 			c.mgr.RegisterConn(resp.CortexID, cortexAddr, resp.Conn)
@@ -694,7 +745,161 @@ func (c *ClusterCoordinator) runAsObserver(ctx context.Context) error {
 		return errors.New("cluster: observer requires at least one seed address")
 	}
 
-	return c.streamReplication(ctx, "observer")
+	// Observers never lead, so they don't need the supervisor — just stream.
+	return c.streamReplication(ctx, "observer", c.cfg.Seeds)
+}
+
+// supervise runs the post-leadership state machine that replaces the terminal
+// `<-ctx.Done()` parks. It transitions between leading, following, and waiting-
+// for-quorum on promotion/demotion events and never exits except on ctx cancel,
+// so a demoted Cortex (or a promoted Lobe) can never become a zombie (#522 Step 3).
+func (c *ClusterCoordinator) supervise(ctx context.Context, mode runMode) error {
+	for ctx.Err() == nil {
+		switch mode {
+		case modeLeading:
+			mode = c.leadTerm(ctx)
+		case modeFollowing:
+			mode = c.followTerm(ctx)
+		case modeWaitingQuorum:
+			mode = c.waitQuorumTerm(ctx)
+		}
+	}
+	return ctx.Err()
+}
+
+// initialCortexMode derives the supervisor's starting mode after runAsCortex's
+// election preamble: leading if we won, following if a claim was already seen,
+// else waiting for quorum (an auto/primary node that hasn't reached quorum yet).
+func (c *ClusterCoordinator) initialCortexMode() runMode {
+	if c.IsLeader() {
+		return modeLeading
+	}
+	if ldr := c.election.CurrentLeader(); ldr != "" && ldr != c.cfg.NodeID {
+		return modeFollowing
+	}
+	return modeWaitingQuorum
+}
+
+// leadTerm holds leadership until a demotion event arrives, then routes to the
+// recovery mode the demotion cause dictates.
+func (c *ClusterCoordinator) leadTerm(ctx context.Context) runMode {
+	for {
+		select {
+		case <-ctx.Done():
+			return modeLeading
+		case ev := <-c.roleCh:
+			if ev.promoted {
+				continue // already leading; ignore a duplicate promote
+			}
+			if ev.cause == causeQuorumLoss {
+				return modeWaitingQuorum
+			}
+			return modeFollowing
+		}
+	}
+}
+
+// followTerm joins and streams from a known leader until this node is promoted.
+// streamReplication runs under a per-term context so a promotion cleanly tears
+// down the stream before this node starts leading.
+func (c *ClusterCoordinator) followTerm(ctx context.Context) runMode {
+	termCtx, termCancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = c.streamReplication(termCtx, "lobe", c.followSeeds())
+	}()
+	defer func() { termCancel(); <-done }()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return modeFollowing
+		case <-done:
+			return modeFollowing // streamReplication only returns on ctx cancel
+		case ev := <-c.roleCh:
+			if ev.promoted {
+				return modeLeading
+			}
+			// A further demotion while following: stay following if a leader is
+			// still known, else wait for quorum and re-elect.
+			if ldr := c.election.CurrentLeader(); ldr == "" || ldr == c.cfg.NodeID {
+				return modeWaitingQuorum
+			}
+		}
+	}
+}
+
+// waitQuorumTerm holds, leaderless, until a live voter quorum returns, then
+// starts a fresh election (rate-limited). Defects to following if a higher claim
+// appears. This is how a quorum-loss-demoted node resumes leadership when its
+// lobes rejoin — without thrashing (re-election needs a real vote quorum).
+func (c *ClusterCoordinator) waitQuorumTerm(ctx context.Context) runMode {
+	hb := c.heartbeatInterval()
+	ticker := time.NewTicker(hb)
+	defer ticker.Stop()
+	backoff := hb
+	var nextElection time.Time // zero = eligible now
+
+	for {
+		select {
+		case <-ctx.Done():
+			return modeWaitingQuorum
+		case ev := <-c.roleCh:
+			if ev.promoted {
+				return modeLeading
+			}
+		case <-ticker.C:
+		}
+
+		if c.IsLeader() {
+			return modeLeading
+		}
+		if ldr := c.election.CurrentLeader(); ldr != "" && ldr != c.cfg.NodeID {
+			return modeFollowing // a higher claim appeared — follow, never assert
+		}
+		if c.aliveVoters() >= c.election.Quorum() && (nextElection.IsZero() || !time.Now().Before(nextElection)) {
+			if err := c.election.StartElection(ctx); err != nil {
+				slog.Warn("cluster: re-election attempt failed", "node", c.cfg.NodeID, "err", err)
+			}
+			nextElection = time.Now().Add(backoff)
+			if backoff < 8*hb {
+				backoff *= 2
+			}
+		}
+	}
+}
+
+// followSeeds returns the seed list to dial as a follower, with the known
+// leader's address tried first (a demoted Cortex's configured seeds are its
+// lobes; the actual leader must be tried before them).
+func (c *ClusterCoordinator) followSeeds() []string {
+	seeds := append([]string(nil), c.cfg.Seeds...)
+	if ldr := c.election.CurrentLeader(); ldr != "" && ldr != c.cfg.NodeID {
+		if p, ok := c.mgr.GetPeer(ldr); ok && p.Addr() != "" {
+			seeds = append([]string{p.Addr()}, seeds...)
+		}
+	}
+	return seeds
+}
+
+// aliveVoters counts self plus live MSP peers that are registered voters — the
+// correct population for quorum decisions (LivePeers alone includes observers).
+func (c *ClusterCoordinator) aliveVoters() int {
+	count := 1 // self
+	for _, p := range c.msp.LivePeers() {
+		if c.election.IsVoter(p.NodeID) {
+			count++
+		}
+	}
+	return count
+}
+
+func (c *ClusterCoordinator) heartbeatInterval() time.Duration {
+	if c.cfg.HeartbeatMS > 0 {
+		return time.Duration(c.cfg.HeartbeatMS) * time.Millisecond
+	}
+	return time.Second
 }
 
 // IsObserver returns true if this node is currently an Observer.
@@ -867,8 +1072,12 @@ func (c *ClusterCoordinator) checkQuorumHealth() {
 	c.quorumMu.Unlock()
 
 	if needsDemotion {
-		c.nodeState.Store(uint32(StateDraining))
-		go c.handleDemotion()
+		// Pre-emptive quorum-loss demotion: no successor exists, so release the
+		// election's leader state (else StartElection stays blocked) and demote
+		// with the quorum-loss cause so the supervisor enters WAITING_QUORUM and
+		// resumes leadership when quorum returns (#522 Step 3).
+		c.election.StepDown()
+		c.handleDemotion(causeQuorumLoss)
 	}
 }
 
@@ -1088,16 +1297,35 @@ func (c *ClusterCoordinator) handlePromotion(epoch uint64) {
 
 	slog.Info("cluster: promoted to Cortex", "epoch", epoch, "node", c.cfg.NodeID)
 
+	c.pushRoleEvent(roleEvent{promoted: true})
+
 	if c.OnBecameCortex != nil {
 		c.OnBecameCortex(epoch)
 	}
 }
 
+// pushRoleEvent delivers a role transition to the supervisor loop without
+// blocking. If the buffer is full the event is dropped — terms re-derive
+// authoritative state each tick, so a dropped event only delays a transition.
+func (c *ClusterCoordinator) pushRoleEvent(ev roleEvent) {
+	select {
+	case c.roleCh <- ev:
+	default:
+	}
+}
+
 // handleDemotion is called when this node loses Cortex status.
-func (c *ClusterCoordinator) handleDemotion() {
+func (c *ClusterCoordinator) handleDemotion(cause demotionCause) {
 	c.roleMu.Lock()
 	c.role = RoleReplica
 	c.roleMu.Unlock()
+
+	// A new leadership term is over: clear the "observed a live quorum" latch so
+	// the next term's pre-emptive quorum-loss demotion is gated afresh (#522).
+	c.quorumMu.Lock()
+	c.hadQuorum = false
+	c.quorumLostSince = time.Time{}
+	c.quorumMu.Unlock()
 
 	// Stop all streamers (no longer primary)
 	c.streamersMu.Lock()
@@ -1110,7 +1338,10 @@ func (c *ClusterCoordinator) handleDemotion() {
 	// Reset draining state: this node is now a Lobe and accepts no writes anyway.
 	c.nodeState.Store(uint32(StateNormal))
 
-	slog.Info("cluster: demoted from Cortex", "node", c.cfg.NodeID)
+	slog.Info("cluster: demoted from Cortex", "node", c.cfg.NodeID, "cause", cause)
+
+	// Hand the supervisor loop the recovery cue (#522 Step 3).
+	c.pushRoleEvent(roleEvent{promoted: false, cause: cause})
 
 	// Fire engine callback
 	if c.OnBecameLobe != nil {
@@ -1471,10 +1702,11 @@ func (c *ClusterCoordinator) GracefulFailover(ctx context.Context, targetNodeID 
 		return ctx.Err()
 	}
 
-	// Step 6: Handoff succeeded — demote self and clear draining state.
+	// Step 6: Handoff succeeded — demote self and clear draining state. The
+	// handoff target is the new leader, so follow it (causeClaim).
 	handoffSucceeded = true
 	c.nodeState.Store(uint32(StateNormal))
-	c.handleDemotion()
+	c.handleDemotion(causeClaim)
 
 	slog.Info("cluster: graceful failover complete", "target", targetNodeID, "epoch", epoch)
 	return nil

--- a/internal/replication/coordinator_test.go
+++ b/internal/replication/coordinator_test.go
@@ -149,7 +149,7 @@ func TestClusterCoordinator_Role_ThreadSafe(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for j := 0; j < 50; j++ {
-			coord.handleDemotion()
+			coord.handleDemotion(causeClaim)
 		}
 	}()
 
@@ -170,7 +170,7 @@ func TestClusterCoordinator_IsLeader(t *testing.T) {
 	}
 
 	// Simulate demotion
-	coord.handleDemotion()
+	coord.handleDemotion(causeClaim)
 	if coord.IsLeader() {
 		t.Error("expected IsLeader=false after demotion")
 	}
@@ -419,7 +419,7 @@ func TestClusterCoordinator_ReplicationLag(t *testing.T) {
 	}
 
 	// As Lobe (replica), lag = currentSeq - lastApplied
-	coord.handleDemotion()
+	coord.handleDemotion(causeClaim)
 
 	// Append some entries to the log
 	coord.repLog.Append(OpSet, []byte("k1"), []byte("v1"))
@@ -484,7 +484,7 @@ func TestClusterCoordinator_OnBecameLobe_Callback(t *testing.T) {
 	}
 
 	simulatePromotion(coord, 1)
-	coord.handleDemotion()
+	coord.handleDemotion(causeClaim)
 
 	if !called {
 		t.Error("expected OnBecameLobe to be called")
@@ -502,7 +502,7 @@ func TestClusterCoordinator_NilCallbacksSafe(t *testing.T) {
 	coord.OnBecameLobe = nil
 
 	simulatePromotion(coord, 1)
-	coord.handleDemotion()
+	coord.handleDemotion(causeClaim)
 }
 
 func TestClusterCoordinator_Accessors(t *testing.T) {

--- a/internal/replication/coordinator_test.go
+++ b/internal/replication/coordinator_test.go
@@ -478,15 +478,21 @@ func TestClusterCoordinator_OnBecameCortex_Callback(t *testing.T) {
 func TestClusterCoordinator_OnBecameLobe_Callback(t *testing.T) {
 	coord, _ := newTestCoordinator(t, "auto")
 
-	var called bool
+	called := make(chan struct{}, 1)
 	coord.OnBecameLobe = func() {
-		called = true
+		select {
+		case called <- struct{}{}:
+		default:
+		}
 	}
 
 	simulatePromotion(coord, 1)
 	coord.handleDemotion(causeClaim)
 
-	if !called {
+	// OnBecameLobe fires asynchronously (it must not block the MSP tick goroutine).
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
 		t.Error("expected OnBecameLobe to be called")
 	}
 	if coord.Role() != RoleReplica {

--- a/internal/replication/election.go
+++ b/internal/replication/election.go
@@ -116,6 +116,30 @@ func (e *Election) UnregisterVoter(nodeID string) {
 	delete(e.voters, nodeID)
 }
 
+// IsVoter reports whether nodeID is a registered voter.
+func (e *Election) IsVoter(nodeID string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	_, ok := e.voters[nodeID]
+	return ok
+}
+
+// StepDown relinquishes leadership without a successor (used by the pre-emptive
+// quorum-loss demotion, which has no claimant). state→Idle so a later
+// StartElection is not blocked by errAlreadyCandidate; currentLeader is cleared
+// only if it still points at us — a concurrent HandleCortexClaim that already
+// installed another leader wins (#522 Step 3).
+func (e *Election) StepDown() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.state == ElectionLeader {
+		e.state = ElectionIdle
+	}
+	if e.currentLeader == e.localNodeID {
+		e.currentLeader = ""
+	}
+}
+
 // StartElection initiates a new election from this node.
 // Returns an error if this node is already a candidate or leader.
 //

--- a/internal/replication/stepdown_test.go
+++ b/internal/replication/stepdown_test.go
@@ -1,0 +1,68 @@
+package replication
+
+import (
+	"context"
+	"testing"
+)
+
+// #522 Step 3: the quorum-loss demotion path leaves election.state == Leader, so
+// StartElection would return errAlreadyCandidate forever (the second lock on the
+// zombie). StepDown relinquishes leadership without a successor so a later
+// re-election can proceed.
+func TestElection_StepDown_AllowsReElection(t *testing.T) {
+	el := newTestElection(t, "self") // single voter → StartElection auto-promotes
+	if err := el.StartElection(context.Background()); err != nil {
+		t.Fatalf("StartElection: %v", err)
+	}
+	if el.State() != ElectionLeader {
+		t.Fatalf("expected leader, got state %d", el.State())
+	}
+
+	el.StepDown()
+
+	if el.State() != ElectionIdle {
+		t.Errorf("StepDown should set state Idle, got %d", el.State())
+	}
+	if el.CurrentLeader() != "" {
+		t.Errorf("StepDown should clear self-leadership, currentLeader=%q", el.CurrentLeader())
+	}
+	// A fresh election must now be possible (was blocked by errAlreadyCandidate).
+	if err := el.StartElection(context.Background()); err != nil {
+		t.Errorf("StartElection after StepDown should succeed, got %v", err)
+	}
+	if el.State() != ElectionLeader {
+		t.Errorf("expected re-election to promote (single voter), got state %d", el.State())
+	}
+}
+
+// StepDown must NOT clear currentLeader when another node already holds it (a
+// concurrent CortexClaim installed a real leader).
+func TestElection_StepDown_KeepsForeignLeader(t *testing.T) {
+	el := newTestElection(t, "self")
+	el.mu.Lock()
+	el.state = ElectionFollower
+	el.currentLeader = "other"
+	el.mu.Unlock()
+
+	el.StepDown()
+
+	if el.CurrentLeader() != "other" {
+		t.Errorf("StepDown must not clear a foreign leader, got %q", el.CurrentLeader())
+	}
+}
+
+// IsVoter reports registered-voter membership (used by aliveVoters()).
+func TestElection_IsVoter(t *testing.T) {
+	el := newTestElection(t, "self") // harness registers self
+	el.RegisterVoter("v1")
+	if !el.IsVoter("v1") {
+		t.Error("expected v1 to be a voter")
+	}
+	if el.IsVoter("stranger") {
+		t.Error("stranger should not be a voter")
+	}
+	el.UnregisterVoter("v1")
+	if el.IsVoter("v1") {
+		t.Error("v1 should no longer be a voter after UnregisterVoter")
+	}
+}

--- a/internal/replication/supervisor_test.go
+++ b/internal/replication/supervisor_test.go
@@ -1,0 +1,71 @@
+package replication
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// #522 Step 3: leadTerm routes a demotion to the recovery mode its cause dictates.
+func TestLeadTerm_ClaimDemotionGoesToFollowing(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "primary")
+	coord.pushRoleEvent(roleEvent{promoted: false, cause: causeClaim})
+	if mode := coord.leadTerm(context.Background()); mode != modeFollowing {
+		t.Errorf("claim demotion → got mode %d, want modeFollowing", mode)
+	}
+}
+
+func TestLeadTerm_QuorumLossGoesToWaiting(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "primary")
+	coord.pushRoleEvent(roleEvent{promoted: false, cause: causeQuorumLoss})
+	if mode := coord.leadTerm(context.Background()); mode != modeWaitingQuorum {
+		t.Errorf("quorum-loss demotion → got mode %d, want modeWaitingQuorum", mode)
+	}
+}
+
+func TestLeadTerm_ExitsOnCtxCancel(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "primary")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if mode := coord.leadTerm(ctx); mode != modeLeading {
+		t.Errorf("ctx cancel → got mode %d, want modeLeading (supervisor exits)", mode)
+	}
+}
+
+// waitQuorumTerm defects to following the moment a foreign leader is known,
+// instead of asserting leadership (the "no higher claim" guard).
+func TestWaitQuorumTerm_DefectsToFollowingOnForeignLeader(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "primary")
+	coord.election.mu.Lock()
+	coord.election.state = ElectionFollower
+	coord.election.currentLeader = "other-cortex"
+	coord.election.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	// Wake the loop immediately with a (non-promoted) event so it re-derives.
+	coord.pushRoleEvent(roleEvent{promoted: false, cause: causeClaim})
+
+	if mode := coord.waitQuorumTerm(ctx); mode != modeFollowing {
+		t.Errorf("foreign leader present → got mode %d, want modeFollowing", mode)
+	}
+}
+
+// waitQuorumTerm re-elects once a live voter quorum is present, transitioning to
+// leading. Single-voter coordinator: aliveVoters (self) == quorum (1).
+func TestWaitQuorumTerm_ReelectsWhenQuorumPresent(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "primary")
+	coord.election.RegisterVoter(coord.cfg.NodeID) // quorum = 1, self alive
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	coord.pushRoleEvent(roleEvent{promoted: false, cause: causeQuorumLoss}) // wake immediately
+
+	mode := coord.waitQuorumTerm(ctx)
+	if mode != modeLeading {
+		t.Fatalf("quorum present → got mode %d, want modeLeading (re-elected)", mode)
+	}
+	if !coord.IsLeader() {
+		t.Error("expected to be leader after re-election")
+	}
+}


### PR DESCRIPTION
Step 3 PR A of the cluster liveness overhaul (epic #522). Fixes the **demotion zombie**.

## Problem
A demoted Cortex became a zombie: `handleDemotion` set `role=Replica` but the `runAsCortex` goroutine stayed parked at `<-ctx.Done()` with no rejoin/re-election loop — **and** the quorum-loss path left `election.state=Leader`, so `StartElection` was blocked by `errAlreadyCandidate` forever. In Docker this collapsed the whole cluster to `replica/False` after a quorum blip.

## Fix — a supervisor state machine
Replace the terminal parks with `supervise()`: **LEADING / FOLLOWING / WAITING_QUORUM**, transitioning on promotion/demotion events; it never exits except on ctx cancel. Demotion carries a **cause**:
- `causeClaim` (a higher-epoch leader / handoff target exists) → **FOLLOWING**: join+stream from that leader (leader-first seed order); promote on an ODOWN-win.
- `causeQuorumLoss` (no successor) → **WAITING_QUORUM**: wait leaderless until a live voter quorum returns (lobes rejoin), then start a fresh election. Re-promotion needs a real vote quorum ⇒ no thrash.

Supporting: `election.StepDown()` (fixes the second lock), `IsVoter()`+`aliveVoters()` (correct quorum population, excludes observers), `streamReplication` seed-parametrized + **non-fatal** on join exhaustion (was a second death path that exited `Run`), `runAsLobe` now runs through the supervisor so a Lobe that wins an election leads instead of staying wedged (the inverse zombie), and a per-term `hadQuorum` latch (consumed by PR B).

## Validation
- **Docker healthy-cluster regression**: cortex stays primary, lobes live at members=3, replication works, **zero spurious demotion** — the supervisor is a no-behavior-change for healthy clusters.
- **Unit**: `StepDown` unblocks re-election; `IsVoter`; `leadTerm` routes by cause; `waitQuorumTerm` defects on a foreign leader and re-elects when quorum returns. Full `internal/replication` suite green under `-race`.

## Scope / sequencing
The periodic `checkQuorumHealth` that *triggers* the quorum-loss path (so the full demote→recover cycle fires, and D2/D3/D4 Docker scenarios can run) lands in **PR B (#520)** — kept separate per the epic so a "healthy cluster never demotes" regression bisects trivially. PR B will Docker-validate the full demote→recover. (R5 join-rejection-when-following + graceful-failover E2E also land with PR B's validation.)

Refs #522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)