### PR TITLE
fix(cluster): periodic quorum-loss self-demotion — gated + recoverable, closes #520 (#522 Step 3 PR B)

### DIFF
--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -367,6 +367,24 @@ func (c *ClusterCoordinator) Run(ctx context.Context) error {
 		}
 	}()
 
+	// Periodically re-evaluate quorum health so a Cortex that loses quorum
+	// actually self-demotes within the timeout (#520). Previously this ran only
+	// on MSP SDOWN transitions, so sustained quorum loss set the timer once and
+	// never re-checked. Safe now that liveness is accurate (Step 1) and demotion
+	// recovers via the supervisor (PR A); the hadQuorum gate exempts bootstrap.
+	go func() {
+		ticker := time.NewTicker(heartbeat)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				c.checkQuorumHealth()
+			}
+		}
+	}()
+
 	// Start periodic WAL pruning (only prunes on Cortex when replicas are caught up).
 	c.startPeriodicPrune(ctx)
 
@@ -1047,16 +1065,26 @@ func (c *ClusterCoordinator) checkQuorumHealth() {
 		return
 	}
 
-	livePeers := c.msp.LivePeers()
 	quorum := c.election.Quorum()
-	// Count: self (1) + live peers
-	totalAlive := 1 + len(livePeers)
+	// Count self + live REGISTERED voters — the correct quorum population (plain
+	// LivePeers would also count non-voting observers, #522 Step 3).
+	totalAlive := c.aliveVoters()
 
 	c.quorumMu.Lock()
 
 	if totalAlive >= quorum {
-		// Quorum restored — reset timer
+		// Quorum healthy: latch hadQuorum for this term and reset the loss timer.
+		c.hadQuorum = true
 		c.quorumLostSince = time.Time{}
+		c.quorumMu.Unlock()
+		return
+	}
+
+	// Quorum is not met. Only a leader that has HELD a live quorum this term
+	// pre-emptively demotes — a node still forming its first quorum (a designated
+	// primary awaiting lobe joins at bootstrap) is exempt, so the periodic check
+	// can never tear down a healthy bootstrap (#522 Step 3 / #520).
+	if !c.hadQuorum {
 		c.quorumMu.Unlock()
 		return
 	}

--- a/internal/replication/coordinator_test.go
+++ b/internal/replication/coordinator_test.go
@@ -580,17 +580,23 @@ func TestClusterCoordinator_QuorumLoss_PreemptiveDemotion(t *testing.T) {
 		t.Fatal("expected to be leader after promotion")
 	}
 
-	// Register 2 voters (self + peer-1) so quorum=2, but peer-1 is SDOWN
+	// Register 2 voters (self + peer-1) so quorum=2.
 	coord.election.RegisterVoter(coord.cfg.NodeID)
 	coord.election.RegisterVoter("peer-1")
 	coord.msp.AddPeer("peer-1", "127.0.0.1:9020", RoleReplica)
+
+	// Establish a live quorum first (peer-1 alive) — pre-emptive demotion only
+	// applies once a live quorum has been held this term (#522 Step 3 hadQuorum gate).
+	coord.checkQuorumHealth()
+
+	// Now peer-1 goes SDOWN → quorum lost.
 	coord.msp.mu.Lock()
 	if p, ok := coord.msp.peers["peer-1"]; ok {
 		p.SDown = true
 	}
 	coord.msp.mu.Unlock()
 
-	// First call: sets quorumLostSince
+	// First call after loss: sets quorumLostSince
 	coord.checkQuorumHealth()
 	if coord.IsLeader() {
 		// Should still be leader — timeout hasn't elapsed

--- a/internal/replication/quorum_gate_test.go
+++ b/internal/replication/quorum_gate_test.go
@@ -1,0 +1,77 @@
+package replication
+
+import (
+	"testing"
+	"time"
+)
+
+// #520 / #522 Step 3: a leader that has NEVER held a live quorum this term (a
+// designated primary still awaiting its lobes at bootstrap) must not be demoted
+// by the periodic quorum check — otherwise it would tear down a healthy bootstrap.
+func TestCheckQuorumHealth_NeverHadQuorum_DoesNotDemote(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "auto")
+	simulatePromotion(coord, 1)
+
+	// quorum=2 (self + peer-1), peer-1 SDOWN from the start — never a live quorum.
+	coord.election.RegisterVoter(coord.cfg.NodeID)
+	coord.election.RegisterVoter("peer-1")
+	coord.msp.AddPeer("peer-1", "127.0.0.1:9031", RoleReplica)
+	coord.msp.mu.Lock()
+	coord.msp.peers["peer-1"].SDown = true
+	coord.msp.mu.Unlock()
+
+	coord.checkQuorumHealth()
+	coord.quorumMu.Lock()
+	coord.quorumLostSince = time.Now().Add(-6 * time.Second)
+	coord.quorumMu.Unlock()
+	coord.checkQuorumHealth()
+
+	time.Sleep(50 * time.Millisecond)
+	if !coord.IsLeader() {
+		t.Error("must NOT demote a leader that never held a live quorum (bootstrap exemption)")
+	}
+}
+
+// aliveVoters counts only registered voters: a live observer must not keep a
+// leader that has lost its voter quorum from demoting.
+func TestCheckQuorumHealth_CountsVotersNotObservers(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "auto")
+	simulatePromotion(coord, 1)
+
+	coord.election.RegisterVoter(coord.cfg.NodeID)
+	coord.election.RegisterVoter("voter-1")
+	coord.msp.AddPeer("voter-1", "127.0.0.1:9032", RoleReplica)
+	// An observer peer that is alive but NOT a registered voter.
+	coord.msp.AddPeer("obs-1", "127.0.0.1:9033", RoleObserver)
+
+	// voter-1 alive → live quorum observed (hadQuorum latches).
+	coord.checkQuorumHealth()
+	coord.quorumMu.Lock()
+	had := coord.hadQuorum
+	coord.quorumMu.Unlock()
+	if !had {
+		t.Fatal("expected hadQuorum after a live voter quorum")
+	}
+
+	// voter-1 SDOWN; obs-1 stays alive but must not count toward quorum.
+	coord.msp.mu.Lock()
+	coord.msp.peers["voter-1"].SDown = true
+	coord.msp.mu.Unlock()
+
+	coord.checkQuorumHealth()
+	coord.quorumMu.Lock()
+	coord.quorumLostSince = time.Now().Add(-6 * time.Second)
+	coord.quorumMu.Unlock()
+	coord.checkQuorumHealth()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !coord.IsLeader() {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if coord.IsLeader() {
+		t.Error("expected demotion: a live observer must not count toward voter quorum")
+	}
+}


### PR DESCRIPTION
Step 3 PR B — the finale of the demotion saga. Closes #520. Builds on PR A (#526).

## Problem
`checkQuorumHealth` (demote a Cortex that can't reach a live quorum, to prevent split-brain) only ran on MSP SDOWN transitions, so on **sustained** quorum loss the timer was set once and never re-checked — the node never demoted (#520). Earlier attempts to make it periodic collapsed *healthy* clusters, because liveness was broken (fixed in Step 1) and demotion had no recovery path (fixed in PR A).

## Fix
Both prerequisites now exist, so the periodic check lands safely:
- Run `checkQuorumHealth` on a heartbeat ticker (keep the OnSDown trigger).
- `aliveVoters()` = self + live **registered voters** (excludes observers — the correct quorum population).
- Gate demotion on **`hadQuorum`** (latched when a live quorum is observed this term, cleared on demotion): a leader still forming its first quorum at bootstrap is exempt, so the periodic check can never tear down a healthy bootstrap.

`DEMOTE ⇔ IsLeader ∧ hadQuorum ∧ aliveVoters < Quorum ∧ sustained ≥ timeout.`

## Proven end-to-end in Docker (the exact collapse that started this epic)
| | Result |
|---|---|
| **Healthy 40s** | 0 false-demotes |
| **Kill both lobes** | `quorum lost alive=1` → demote at the 5s timeout (`cause=quorumLoss`) → `role=replica` |
| **Restart lobes** | they rejoin the *waiting* cortex → it **re-elects at epoch 2** (fresh election) → `is_leader=True`, members=3, **no container restart** |
| **After recovery** | a new write replicates to both lobes |

The epoch bump 1→2 confirms re-promotion is a real election (exactly once), per the design invariant.

## Tests
never-had-quorum does NOT demote (bootstrap exemption); had-quorum-then-lost DOES; a live observer doesn't count toward voter quorum; the existing preemptive-demotion test updated to establish a live quorum first. Full `internal/replication` suite green under `-race`.

Closes #520. Refs #522. Remaining epic work: Step 4 (PeerHello → #519, sentinels, lobe-majority failover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)