### PR TITLE
feat(cluster): PeerHello discovery mesh + equal-epoch tie-break — converges two primaries (#522 Step 4 a+b, #519)

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -690,8 +690,23 @@ func handleClusterConn(conn net.Conn, coord *replication.ClusterCoordinator) {
 			connOwned = false // PeerConn now owns conn
 			continue
 		}
-		// Reject any frame that arrives before the join handshake completes.
-		// A well-behaved Lobe always sends TypeJoinRequest first.
+		// PeerHello discovery handshake (#522 Step 4) — an alternative first frame
+		// for peers that don't join (two primaries, sentinels, lobe↔lobe).
+		if frame.Type == mbp.TypePeerHello {
+			nodeID, adopted, err := coord.HandleIncomingHello(conn, frame.Payload)
+			if err != nil {
+				log.Printf("[cluster] hello error from %s: %v", fromNodeID, err)
+				return
+			}
+			if !adopted {
+				return // tie-break loser: conn deliberately closed in adoptHelloPeer
+			}
+			fromNodeID = nodeID
+			joined = true
+			connOwned = false // PeerConn now owns conn
+			continue
+		}
+		// Reject any frame that arrives before a join/hello handshake completes.
 		if !joined {
 			log.Printf("[cluster] unexpected frame type 0x%02x from %s before join; closing", frame.Type, fromNodeID)
 			return

--- a/internal/replication/conn_manager.go
+++ b/internal/replication/conn_manager.go
@@ -61,6 +61,20 @@ func (m *ConnManager) AddPeer(nodeID, addr string) {
 	m.peers[nodeID] = NewPeerConn(nodeID, addr)
 }
 
+// HasLivePeerAt reports whether any registered peer with this advertised address
+// currently has a live connection — used by the discovery loop to skip seeds
+// already covered by a join or hello conn (#522 Step 4).
+func (m *ConnManager) HasLivePeerAt(addr string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, p := range m.peers {
+		if p.addr == addr && p.conn != nil && !p.closed {
+			return true
+		}
+	}
+	return false
+}
+
 // UpdatePeerAddr updates a peer's advertised address WITHOUT disturbing its live
 // connection (adds a disconnected peer if none exists). Used for address-change
 // gossip — the previous path (AddPeer) closed the live conn and tore down the
@@ -90,8 +104,41 @@ func (m *ConnManager) RegisterConn(nodeID, addr string, conn net.Conn) *PeerConn
 		_ = existing.Close()
 	}
 	p := NewPeerConnFromConn(nodeID, addr, conn)
+	p.kind = kindJoin // RegisterConn is used only by the join/replication path
 	m.peers[nodeID] = p
 	return p
+}
+
+// RegisterConnKind registers a connection with a kind, enforcing the #522 Step 4
+// precedence so a pair converges on exactly one connection without flapping:
+//   - a live join conn is never evicted by a hello conn;
+//   - a non-canonical hello (the higher node-id's outbound) never evicts a live
+//     conn — only fills an empty/dead slot;
+//   - otherwise (canonical hello = lower node-id's dial, or a join) it replaces.
+//
+// Returns the adopted PeerConn and whether it was adopted (false ⇒ the caller
+// must close conn — its existing registration stands).
+func (m *ConnManager) RegisterConnKind(nodeID, addr string, conn net.Conn, kind connKind, canonical bool) (*PeerConn, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	existing, ok := m.peers[nodeID]
+	liveExisting := ok && existing.conn != nil && !existing.closed
+	if liveExisting {
+		if existing.kind == kindJoin && kind != kindJoin {
+			return existing, false // never evict a live join with a hello
+		}
+		if kind == kindHello && !canonical {
+			return existing, false // non-canonical hello yields to the live conn
+		}
+	}
+	if ok {
+		_ = existing.Close()
+	}
+	p := NewPeerConnFromConn(nodeID, addr, conn)
+	p.kind = kind
+	m.peers[nodeID] = p
+	return p, true
 }
 
 // RemovePeer closes and removes the peer identified by nodeID.

--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -98,6 +98,9 @@ type ClusterCoordinator struct {
 	// roleCh carries promotion/demotion events to the supervisor loop (#522 Step 3).
 	roleCh chan roleEvent
 
+	// advertiseAddr is this node's routable address (used in PeerHello, #522 Step 4).
+	advertiseAddr string
+
 	// Per-Lobe streamers (Cortex only): lobeID -> cancel func
 	streamers   map[string]context.CancelFunc
 	streamersMu sync.Mutex
@@ -200,19 +203,20 @@ func NewClusterCoordinator(
 	}
 
 	c := &ClusterCoordinator{
-		cfg:         cfg,
-		repLog:      repLog,
-		applier:     applier,
-		epochStore:  epochStore,
-		mgr:         mgr,
-		msp:         msp,
-		election:    election,
-		joinHandler: joinHandler,
-		joinClient:  joinClient,
-		role:        RoleUnknown,
-		streamers:   make(map[string]context.CancelFunc),
-		roleCh:      make(chan roleEvent, 4),
-		reconDelay:  reconDelay,
+		cfg:           cfg,
+		repLog:        repLog,
+		applier:       applier,
+		epochStore:    epochStore,
+		mgr:           mgr,
+		msp:           msp,
+		election:      election,
+		joinHandler:   joinHandler,
+		joinClient:    joinClient,
+		role:          RoleUnknown,
+		streamers:     make(map[string]context.CancelFunc),
+		roleCh:        make(chan roleEvent, 4),
+		advertiseAddr: advertiseAddr,
+		reconDelay:    reconDelay,
 	}
 	// Default reconcile-on-heal to enabled; matches config default (ReconcileHeal=true).
 	c.reconcileOnHeal.Store(1)
@@ -384,6 +388,12 @@ func (c *ClusterCoordinator) Run(ctx context.Context) error {
 			}
 		}
 	}()
+
+	// Start peer discovery so nodes with no join relationship (two primaries,
+	// sentinels, lobe↔lobe) establish identified connections (#522 Step 4).
+	if len(c.cfg.Seeds) > 0 {
+		go c.runPeerDiscovery(ctx)
+	}
 
 	// Start periodic WAL pruning (only prunes on Cortex when replicas are caught up).
 	c.startPeriodicPrune(ctx)
@@ -661,7 +671,8 @@ func (c *ClusterCoordinator) reconcileJoinedPeer(nodeID, addr string, role NodeR
 	if nodeID == "" {
 		return
 	}
-	isVoter := c.cfg.Role != "observer"
+	// A voter only if neither this node nor the peer is an observer (#529).
+	isVoter := c.cfg.Role != "observer" && role != RoleObserver
 
 	alreadyKnown := false
 	for _, p := range c.msp.AllPeers() {

--- a/internal/replication/election.go
+++ b/internal/replication/election.go
@@ -376,6 +376,17 @@ func (e *Election) tryPromote(epoch uint64) {
 	e.mu.Unlock()
 
 	// Broadcast CortexClaim to all peers.
+	e.broadcastClaim(epoch)
+
+	// Invoke callback without lock held.
+	if onPromoted != nil {
+		onPromoted(epoch)
+	}
+}
+
+// broadcastClaim marshals and broadcasts a CortexClaim for the given epoch to
+// all connected peers. Factored out so the equal-epoch tie-break can re-assert.
+func (e *Election) broadcastClaim(epoch uint64) {
 	claim := mbp.CortexClaim{
 		CortexID:     e.localNodeID,
 		Epoch:        epoch,
@@ -387,11 +398,6 @@ func (e *Election) tryPromote(epoch uint64) {
 		return
 	}
 	e.mgr.Broadcast(mbp.TypeCortexClaim, payload)
-
-	// Invoke callback without lock held.
-	if onPromoted != nil {
-		onPromoted(epoch)
-	}
 }
 
 // HandleCortexClaim processes an incoming CortexClaim from another node.
@@ -410,6 +416,22 @@ func (e *Election) HandleCortexClaim(claim mbp.CortexClaim) {
 	// Reject stale claims.
 	if claim.Epoch < currentEpoch {
 		e.mu.Unlock()
+		return
+	}
+
+	// Equal-epoch dueling-leaders tie-break (#519, #522 Step 4): two nodes both
+	// asserted leadership at the same epoch — only reachable when more than one is
+	// misconfigured role=primary (each force-promotes with a single self-vote).
+	// Resolve deterministically by lowest node-id: the lower id keeps leadership
+	// (ignores the conflicting claim and re-asserts), the higher id falls through
+	// to the demotion path below. Without this, two equal-epoch leaders mutually
+	// demote and the cluster can end up leaderless or flapping.
+	if claim.Epoch == currentEpoch && e.state == ElectionLeader &&
+		claim.CortexID != e.localNodeID && e.localNodeID < claim.CortexID {
+		e.mu.Unlock()
+		slog.Warn("cluster: equal-epoch CortexClaim from a higher node-id; keeping leadership (lowest id wins), re-asserting. Ensure exactly one node is configured role=primary.",
+			"claimant", claim.CortexID, "epoch", claim.Epoch, "self", e.localNodeID)
+		e.broadcastClaim(claim.Epoch)
 		return
 	}
 

--- a/internal/replication/equal_epoch_test.go
+++ b/internal/replication/equal_epoch_test.go
@@ -1,0 +1,73 @@
+package replication
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// #519 / #522 Step 4: when two nodes both assert leadership at the same epoch
+// (two misconfigured role=primary), the lower node-id keeps leadership and the
+// higher one yields — instead of both mutually demoting.
+func TestHandleCortexClaim_EqualEpoch_LowerIDKeepsLeadership(t *testing.T) {
+	el := newTestElection(t, "node-a") // lower id
+	if err := el.StartElection(context.Background()); err != nil {
+		t.Fatalf("StartElection: %v", err)
+	}
+	if el.State() != ElectionLeader {
+		t.Fatalf("expected leader at epoch 1, got %d", el.State())
+	}
+
+	var demoted int32
+	el.OnDemoted = func() { atomic.AddInt32(&demoted, 1) }
+
+	// A higher node-id claims leadership at the SAME epoch.
+	el.HandleCortexClaim(mbp.CortexClaim{CortexID: "node-z", Epoch: 1})
+
+	if el.State() != ElectionLeader {
+		t.Errorf("lower node-id must keep leadership on equal-epoch conflict, got state %d", el.State())
+	}
+	if el.CurrentLeader() != "node-a" {
+		t.Errorf("CurrentLeader = %q, want node-a", el.CurrentLeader())
+	}
+	if atomic.LoadInt32(&demoted) != 0 {
+		t.Errorf("must not demote; OnDemoted called %d times", atomic.LoadInt32(&demoted))
+	}
+}
+
+func TestHandleCortexClaim_EqualEpoch_HigherIDYields(t *testing.T) {
+	el := newTestElection(t, "node-z") // higher id
+	if err := el.StartElection(context.Background()); err != nil {
+		t.Fatalf("StartElection: %v", err)
+	}
+
+	var demoted int32
+	el.OnDemoted = func() { atomic.AddInt32(&demoted, 1) }
+
+	// A lower node-id claims leadership at the SAME epoch.
+	el.HandleCortexClaim(mbp.CortexClaim{CortexID: "node-a", Epoch: 1})
+
+	if el.State() != ElectionFollower {
+		t.Errorf("higher node-id must yield on equal-epoch conflict, got state %d", el.State())
+	}
+	if el.CurrentLeader() != "node-a" {
+		t.Errorf("CurrentLeader = %q, want node-a", el.CurrentLeader())
+	}
+	if atomic.LoadInt32(&demoted) != 1 {
+		t.Errorf("must demote once; OnDemoted called %d times", atomic.LoadInt32(&demoted))
+	}
+}
+
+// A higher-epoch claim always wins regardless of node-id.
+func TestHandleCortexClaim_HigherEpochWins(t *testing.T) {
+	el := newTestElection(t, "node-a")
+	if err := el.StartElection(context.Background()); err != nil {
+		t.Fatalf("StartElection: %v", err)
+	}
+	el.HandleCortexClaim(mbp.CortexClaim{CortexID: "node-z", Epoch: 5})
+	if el.State() != ElectionFollower {
+		t.Errorf("a higher-epoch claim must win even from a higher node-id, got state %d", el.State())
+	}
+}

--- a/internal/replication/hello.go
+++ b/internal/replication/hello.go
@@ -86,6 +86,7 @@ func (c *ClusterCoordinator) runPeerDiscovery(ctx context.Context) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	backoff := make(map[string]time.Time) // seed addr → next eligible dial time
+	seedOwner := make(map[string]string)  // seed addr → real node-id learned for it
 	for {
 		select {
 		case <-ctx.Done():
@@ -96,45 +97,59 @@ func (c *ClusterCoordinator) runPeerDiscovery(ctx context.Context) {
 			if seed == c.advertiseAddr || c.mgr.HasLivePeerAt(seed) {
 				continue
 			}
+			// Skip a seed already covered by a live conn to its node — this is how
+			// a Lobe avoids re-dialing its Cortex when the advertised address (the
+			// PeerConn key) differs from the dialed seed string (DNS vs IP).
+			if owner, ok := seedOwner[seed]; ok {
+				if p, ok2 := c.mgr.GetPeer(owner); ok2 && p.IsConnected() {
+					continue
+				}
+			}
 			if t, ok := backoff[seed]; ok && time.Now().Before(t) {
 				continue
 			}
-			if err := c.helloDial(ctx, seed); err != nil {
+			nodeID, err := c.helloDial(ctx, seed)
+			if err != nil {
 				jitter := time.Duration(rand.Int63n(int64(interval) + 1))
 				backoff[seed] = time.Now().Add(5*time.Second + jitter)
-			} else {
-				delete(backoff, seed)
+				continue
 			}
+			if nodeID != "" {
+				seedOwner[seed] = nodeID
+			}
+			delete(backoff, seed)
 		}
 	}
 }
 
 // helloDial dials a seed and runs the handshake from the initiating side.
-func (c *ClusterCoordinator) helloDial(ctx context.Context, seedAddr string) error {
+// Returns the peer's node-id (even when the conn was not adopted by the
+// tie-break — the caller uses it to stop re-dialing an already-covered seed).
+func (c *ClusterCoordinator) helloDial(ctx context.Context, seedAddr string) (string, error) {
 	var d net.Dialer
 	dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	conn, err := d.DialContext(dialCtx, "tcp", seedAddr)
 	cancel()
 	if err != nil {
-		return err
+		return "", err
 	}
 	if err := writeHelloFrame(conn, c.localHello()); err != nil {
 		conn.Close()
-		return err
+		return "", err
 	}
 	frame, err := mbp.ReadFrame(conn)
 	if err != nil || frame.Type != mbp.TypePeerHello {
 		conn.Close()
-		return fmt.Errorf("hello: bad reply from %s", seedAddr)
+		return "", fmt.Errorf("hello: bad reply from %s", seedAddr)
 	}
 	var peer mbp.PeerHello
 	if err := msgpack.Unmarshal(frame.Payload, &peer); err != nil {
 		conn.Close()
-		return err
+		return "", err
 	}
 	if peer.NodeID == "" || peer.NodeID == c.cfg.NodeID || !c.verifyHello(peer) {
 		conn.Close()
-		return fmt.Errorf("hello: invalid peer from %s", seedAddr)
+		return "", fmt.Errorf("hello: invalid peer from %s", seedAddr)
 	}
 	// Our OUTBOUND conn is canonical iff we are the lower node-id.
 	p, adopted := c.adoptHelloPeer(conn, peer, c.cfg.NodeID < peer.NodeID)
@@ -143,7 +158,7 @@ func (c *ClusterCoordinator) helloDial(ctx context.Context, seedAddr string) err
 		// votes, and claims are processed.
 		go c.readPeerFrames(ctx, p, peer.NodeID)
 	}
-	return nil
+	return peer.NodeID, nil
 }
 
 // HandleIncomingHello is the accept side: validate, reply, tie-break, adopt.

--- a/internal/replication/hello.go
+++ b/internal/replication/hello.go
@@ -1,0 +1,216 @@
+package replication
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"net"
+	"time"
+
+	"github.com/vmihailenco/msgpack/v5"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// helloHMAC computes the PeerHello SecretHash over node-id, addr, and role.
+// Role is covered because it gates voter registration on the receiver (#522 Step 4).
+func helloHMAC(secret, nodeID, addr string, role uint8) []byte {
+	if secret == "" {
+		return nil
+	}
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(nodeID + "\n" + addr + "\n"))
+	h.Write([]byte{role})
+	return h.Sum(nil)
+}
+
+// configuredRole maps the config role string to a NodeRole for PeerHello. "auto"
+// advertises a voting (non-observer) role.
+func (c *ClusterCoordinator) configuredRole() NodeRole {
+	switch c.cfg.Role {
+	case "primary":
+		return RolePrimary
+	case "replica":
+		return RoleReplica
+	case "sentinel":
+		return RoleSentinel
+	case "observer":
+		return RoleObserver
+	default:
+		return RolePrimary // auto: a voter that can lead
+	}
+}
+
+func (c *ClusterCoordinator) localHello() mbp.PeerHello {
+	role := uint8(c.configuredRole())
+	return mbp.PeerHello{
+		NodeID:          c.cfg.NodeID,
+		Addr:            c.advertiseAddr,
+		Role:            role,
+		Epoch:           c.epochStore.Load(),
+		SecretHash:      helloHMAC(c.cfg.ClusterSecret, c.cfg.NodeID, c.advertiseAddr, role),
+		ProtocolVersion: mbp.CurrentProtocolVersion,
+	}
+}
+
+func (c *ClusterCoordinator) verifyHello(h mbp.PeerHello) bool {
+	if c.cfg.ClusterSecret == "" {
+		return true // open mode
+	}
+	return hmac.Equal(h.SecretHash, helloHMAC(c.cfg.ClusterSecret, h.NodeID, h.Addr, h.Role))
+}
+
+func writeHelloFrame(conn net.Conn, h mbp.PeerHello) error {
+	payload, err := msgpack.Marshal(h)
+	if err != nil {
+		return err
+	}
+	return mbp.WriteFrame(conn, &mbp.Frame{
+		Version:       0x01,
+		Type:          mbp.TypePeerHello,
+		PayloadLength: uint32(len(payload)),
+		Payload:       payload,
+	})
+}
+
+// runPeerDiscovery dials each configured seed that has no live identified conn
+// and performs a PeerHello handshake, building the discovery mesh that lets
+// non-joining nodes (two primaries, sentinels, lobe↔lobe) reach each other so
+// their heartbeats, votes, and claims flow (#522 Step 4). Runs for every role.
+func (c *ClusterCoordinator) runPeerDiscovery(ctx context.Context) {
+	interval := c.heartbeatInterval()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	backoff := make(map[string]time.Time) // seed addr → next eligible dial time
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		for _, seed := range c.cfg.Seeds {
+			if seed == c.advertiseAddr || c.mgr.HasLivePeerAt(seed) {
+				continue
+			}
+			if t, ok := backoff[seed]; ok && time.Now().Before(t) {
+				continue
+			}
+			if err := c.helloDial(ctx, seed); err != nil {
+				jitter := time.Duration(rand.Int63n(int64(interval) + 1))
+				backoff[seed] = time.Now().Add(5*time.Second + jitter)
+			} else {
+				delete(backoff, seed)
+			}
+		}
+	}
+}
+
+// helloDial dials a seed and runs the handshake from the initiating side.
+func (c *ClusterCoordinator) helloDial(ctx context.Context, seedAddr string) error {
+	var d net.Dialer
+	dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	conn, err := d.DialContext(dialCtx, "tcp", seedAddr)
+	cancel()
+	if err != nil {
+		return err
+	}
+	if err := writeHelloFrame(conn, c.localHello()); err != nil {
+		conn.Close()
+		return err
+	}
+	frame, err := mbp.ReadFrame(conn)
+	if err != nil || frame.Type != mbp.TypePeerHello {
+		conn.Close()
+		return fmt.Errorf("hello: bad reply from %s", seedAddr)
+	}
+	var peer mbp.PeerHello
+	if err := msgpack.Unmarshal(frame.Payload, &peer); err != nil {
+		conn.Close()
+		return err
+	}
+	if peer.NodeID == "" || peer.NodeID == c.cfg.NodeID || !c.verifyHello(peer) {
+		conn.Close()
+		return fmt.Errorf("hello: invalid peer from %s", seedAddr)
+	}
+	// Our OUTBOUND conn is canonical iff we are the lower node-id.
+	p, adopted := c.adoptHelloPeer(conn, peer, c.cfg.NodeID < peer.NodeID)
+	if adopted {
+		// The outbound conn has no other reader — spawn one so the peer's pings,
+		// votes, and claims are processed.
+		go c.readPeerFrames(ctx, p, peer.NodeID)
+	}
+	return nil
+}
+
+// HandleIncomingHello is the accept side: validate, reply, tie-break, adopt.
+// Returns (peerNodeID, adopted, err). When adopted is false the caller closes
+// conn; when true, the caller's frame-dispatch loop reads subsequent frames.
+func (c *ClusterCoordinator) HandleIncomingHello(conn net.Conn, payload []byte) (string, bool, error) {
+	var peer mbp.PeerHello
+	if err := msgpack.Unmarshal(payload, &peer); err != nil {
+		return "", false, err
+	}
+	if peer.NodeID == "" || peer.NodeID == c.cfg.NodeID {
+		return "", false, fmt.Errorf("hello: invalid/self node-id %q", peer.NodeID)
+	}
+	if !c.verifyHello(peer) {
+		return peer.NodeID, false, errors.New("hello: invalid cluster secret")
+	}
+	// Reply first — the dialer is blocked reading our hello.
+	if err := writeHelloFrame(conn, c.localHello()); err != nil {
+		return peer.NodeID, false, err
+	}
+	// The dialer's (their OUTBOUND) conn is canonical iff THEY are the lower id.
+	_, adopted := c.adoptHelloPeer(conn, peer, peer.NodeID < c.cfg.NodeID)
+	return peer.NodeID, adopted, nil
+}
+
+// adoptHelloPeer registers the conn (subject to the tie-break), reconciles the
+// peer identity into MSP + voters, and announces our leadership on the new conn
+// so a dual-leader can be resolved by the equal-epoch CortexClaim tie-break.
+// Returns the adopted PeerConn (nil if not adopted) and whether it was adopted.
+func (c *ClusterCoordinator) adoptHelloPeer(conn net.Conn, peer mbp.PeerHello, canonical bool) (*PeerConn, bool) {
+	p, adopted := c.mgr.RegisterConnKind(peer.NodeID, peer.Addr, conn, kindHello, canonical)
+	if !adopted {
+		conn.Close()
+		return nil, false
+	}
+	c.reconcileJoinedPeer(peer.NodeID, peer.Addr, NodeRole(peer.Role))
+	if c.IsLeader() {
+		c.sendClaim(p)
+	}
+	return p, true
+}
+
+// sendClaim announces our current leadership to a single peer over its conn.
+func (c *ClusterCoordinator) sendClaim(p *PeerConn) {
+	epoch := c.epochStore.Load()
+	payload, err := msgpack.Marshal(mbp.CortexClaim{
+		CortexID:     c.cfg.NodeID,
+		CortexAddr:   c.advertiseAddr,
+		Epoch:        epoch,
+		FencingToken: epoch,
+	})
+	if err != nil {
+		return
+	}
+	_ = p.Send(mbp.TypeCortexClaim, payload)
+}
+
+// readPeerFrames reads frames from a hello-dialed (outbound) conn and dispatches
+// them, until the conn errors (e.g. it was replaced by the tie-break, or closed).
+func (c *ClusterCoordinator) readPeerFrames(ctx context.Context, p *PeerConn, nodeID string) {
+	for {
+		ft, payload, err := p.Receive()
+		if err != nil {
+			return
+		}
+		if err := c.HandleIncomingFrame(nodeID, ft, payload); err != nil {
+			slog.Warn("cluster: hello-peer frame error", "node", nodeID, "type", ft, "err", err)
+		}
+	}
+}

--- a/internal/replication/hello_test.go
+++ b/internal/replication/hello_test.go
@@ -1,0 +1,63 @@
+package replication
+
+import (
+	"net"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// #522 Step 4: RegisterConnKind enforces the simultaneous-dial / kind precedence
+// so a pair converges on one conn without flapping.
+func TestRegisterConnKind_Precedence(t *testing.T) {
+	mgr := NewConnManager("self")
+	mkpipe := func() net.Conn { a, b := net.Pipe(); t.Cleanup(func() { a.Close(); b.Close() }); return a }
+
+	// Canonical hello adopts an empty slot.
+	if _, ok := mgr.RegisterConnKind("peer", "peer:8479", mkpipe(), kindHello, true); !ok {
+		t.Fatal("canonical hello should adopt an empty slot")
+	}
+	// Non-canonical hello does NOT evict a live conn.
+	if _, ok := mgr.RegisterConnKind("peer", "peer:8479", mkpipe(), kindHello, false); ok {
+		t.Error("non-canonical hello must not evict a live conn")
+	}
+	// Canonical hello DOES replace a live hello conn.
+	if _, ok := mgr.RegisterConnKind("peer", "peer:8479", mkpipe(), kindHello, true); !ok {
+		t.Error("canonical hello should replace a live hello conn")
+	}
+
+	// A live JOIN conn is never evicted by a hello.
+	mgr.RegisterConn("peer2", "peer2:8479", mkpipe()) // kindJoin
+	if _, ok := mgr.RegisterConnKind("peer2", "peer2:8479", mkpipe(), kindHello, true); ok {
+		t.Error("a live join conn must not be evicted by a hello")
+	}
+}
+
+// helloHMAC covers role, so a role-tampered hello is rejected; open mode (no
+// secret) accepts anything.
+func TestVerifyHello_HMAC(t *testing.T) {
+	c, _ := newTestCoordinator(t, "primary") // ClusterSecret is empty → open mode
+
+	if !c.verifyHello(mbp.PeerHello{NodeID: "x"}) {
+		t.Error("open mode (no secret) should accept any hello")
+	}
+
+	c.cfg.ClusterSecret = "s3cr3t"
+	good := mbp.PeerHello{NodeID: "x", Addr: "x:1", Role: uint8(RoleReplica)}
+	good.SecretHash = helloHMAC("s3cr3t", "x", "x:1", uint8(RoleReplica))
+	if !c.verifyHello(good) {
+		t.Error("a valid HMAC should verify")
+	}
+
+	tampered := good
+	tampered.Role = uint8(RolePrimary) // flip role without recomputing the MAC
+	if c.verifyHello(tampered) {
+		t.Error("role-tampered hello must be rejected (HMAC covers role)")
+	}
+
+	wrongSecret := mbp.PeerHello{NodeID: "x", Addr: "x:1", Role: uint8(RoleReplica)}
+	wrongSecret.SecretHash = helloHMAC("other", "x", "x:1", uint8(RoleReplica))
+	if c.verifyHello(wrongSecret) {
+		t.Error("hello signed with the wrong secret must be rejected")
+	}
+}

--- a/internal/replication/peer_conn.go
+++ b/internal/replication/peer_conn.go
@@ -19,12 +19,23 @@ var ErrNotConnected = errors.New("peer not connected")
 // to every peer sequentially) and cascade false SDOWNs.
 const sendWriteTimeout = 5 * time.Second
 
+// connKind records how a PeerConn was established, which drives the
+// simultaneous-dial / hello-vs-join precedence in RegisterConnKind (#522 Step 4).
+type connKind uint8
+
+const (
+	kindSeed  connKind = iota // disconnected placeholder from the seed list
+	kindJoin                  // established via the join/replication handshake
+	kindHello                 // established via the PeerHello discovery handshake
+)
+
 // PeerConn is a single persistent TCP connection to one remote peer.
 // It is safe for concurrent Send calls.
 type PeerConn struct {
 	nodeID string
 	addr   string
 	conn   net.Conn
+	kind   connKind
 	mu     sync.Mutex
 	closed bool
 }

--- a/internal/transport/mbp/cluster_frames.go
+++ b/internal/transport/mbp/cluster_frames.go
@@ -23,6 +23,21 @@ type CortexClaim struct {
 	CortexAddr   string `msgpack:"cortex_addr"`
 }
 
+// PeerHello is the authenticated peer-discovery handshake (#522 Step 4). Nodes
+// with no join relationship (two primaries, sentinels, lobe↔lobe) dial each
+// configured seed and exchange these to establish identified connections that
+// feed MSP liveness and elections. SecretHash = HMAC-SHA256(clusterSecret,
+// node_id + "\n" + addr + "\n" + string(role)) — it covers role because role
+// gates voter registration on the receiving side.
+type PeerHello struct {
+	NodeID          string `msgpack:"node_id"`
+	Addr            string `msgpack:"addr"`  // sender's advertised address
+	Role            uint8  `msgpack:"role"`  // sender's NodeRole
+	Epoch           uint64 `msgpack:"epoch"` // informational only (no fencing)
+	SecretHash      []byte `msgpack:"secret_hash"`
+	ProtocolVersion uint16 `msgpack:"proto_ver,omitempty"`
+}
+
 // ReplEntry is a single entry in the replication stream.
 type ReplEntry struct {
 	Seq         uint64 `msgpack:"seq"`

--- a/internal/transport/mbp/frame.go
+++ b/internal/transport/mbp/frame.go
@@ -96,6 +96,9 @@ const (
 	TypeReconReply uint8 = 0x3E // lobe replies with its weights for those keys
 	TypeReconSync  uint8 = 0x3F // cortex sends corrected weights to divergent lobe
 	TypeReconAck   uint8 = 0x40 // lobe confirms weights applied
+
+	// Cluster: peer discovery (#522 Step 4)
+	TypePeerHello uint8 = 0x41 // authenticated peer-discovery handshake
 )
 
 // Errors


### PR DESCRIPTION
Step 4 (a)+(b) of the cluster liveness overhaul (epic #522). Closes the connectivity gap and resolves #519.

## Problem
The connection lifecycle was entirely join-driven (a Lobe dials a Cortex). Nodes with no join relationship never connected — so two `role=primary` nodes never exchanged CortexClaims (split-brain), sentinels were deaf, and Lobes couldn't reach each other.

## Fix
An authenticated peer-discovery handshake that establishes identified connections feeding the existing MSP liveness + elections:
- **`TypePeerHello` (0x41)** + `PeerHello{node-id, addr, role, epoch, HMAC over node-id+addr+role}` — role is in the MAC because it gates voter registration. Empty secret = open mode.
- **`runPeerDiscovery`**: dial each seed with no live identified conn, exchange hellos, reconcile identity into MSP+voters, spawn a reader for the outbound conn. `handleClusterConn` accepts `TypePeerHello` as an alternative first frame.
- **`RegisterConnKind` tie-break**: the lower node-id's outbound conn is canonical; a non-canonical hello never evicts a live conn; a live join conn is never evicted by a hello — a pair converges on one conn without flapping.
- **Claim-on-connect**: a leader sends its CortexClaim over a newly-established conn, so two previously-isolated leaders finally exchange claims.
- **Equal-epoch CortexClaim tie-break**: two leaders at the same epoch resolve by lowest node-id (lower keeps + re-asserts; higher yields → supervisor follows). Fixes #519.
- **Voter role-gating** (#529): a hello/join from an observer is not registered as a voter.

## Proven in Docker (#519)
Two nodes both `role=primary`, seeded at each other:
- **Converge on one leader**: cortex-a (lower id) keeps leadership; cortex-b demotes (`cause=claim`) → `role=replica`, `cortex_id=cortex-a`.
- **Stable, no flap**: still exactly one leader 25s later; **1** tie-break event total.
- **Replication works**: a write to the leader appears on the converted follower.

## Tests
Equal-epoch tie-break (lower keeps / higher yields / higher-epoch always wins); `RegisterConnKind` precedence (canonical/non-canonical/join); HMAC verify+reject (role-tamper, wrong secret, open mode). Full `internal/replication` + `mbp` suites green under `-race`.

## Scope / what's next
This is Step 4 (a)+(b). Remaining: **(c)** SDOWN gossip (#528 — ODOWN never fires today, so lobe-majority *automatic* failover still can't trigger) + election split-vote jitter; **(d)** the `JoinRequest` role field (the other half of #529). Sequenced per the epic.

Refs #522, #519, #529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)