### PR TITLE
feat(cluster): SDOWN gossip + failover election — automatic failover works (#522 Step 4c/d, closes #528 #529)

### DIFF
--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -100,6 +100,9 @@ type ClusterCoordinator struct {
 
 	// advertiseAddr is this node's routable address (used in PeerHello, #522 Step 4).
 	advertiseAddr string
+	// electing single-flights the ODOWN-triggered failover election driver so
+	// concurrent ODOWN events don't spawn racing election loops (#522 Step 4c).
+	electing atomic.Bool
 
 	// Per-Lobe streamers (Cortex only): lobeID -> cancel func
 	streamers   map[string]context.CancelFunc
@@ -704,7 +707,10 @@ func (c *ClusterCoordinator) reconcileJoinedPeer(nodeID, addr string, role NodeR
 		}
 	}
 	retire := matched
-	if retire == "" {
+	if retire == "" && isVoter {
+		// Only a voter join may retire an arbitrary (non-address-matching) seed —
+		// an observer that matches no seed must not retire and unregister an
+		// unrelated voter placeholder (#529).
 		retire = anySeed
 		if retire != "" {
 			slog.Warn("cluster: joined peer address did not match any seed; retiring a seed placeholder to conserve quorum (set advertise_addr to match the seed addresses)",
@@ -714,9 +720,10 @@ func (c *ClusterCoordinator) reconcileJoinedPeer(nodeID, addr string, role NodeR
 	if retire != "" {
 		c.msp.RemovePeer(retire)
 		c.mgr.RemovePeer(retire)
-		if isVoter {
-			c.election.UnregisterVoter(retire)
-		}
+		// A seed placeholder is always registered as a voter at startup, so a
+		// retired seed must always be unregistered — even on an observer join,
+		// where the "expected voter" turned out to be a non-voting observer.
+		c.election.UnregisterVoter(retire)
 	}
 }
 
@@ -1273,7 +1280,10 @@ func (c *ClusterCoordinator) HandleIncomingFrame(fromNodeID string, frameType ui
 		if err := msgpack.Unmarshal(payload, &msg); err != nil {
 			return fmt.Errorf("unmarshal SDownNotification: %w", err)
 		}
-		c.msp.RecordDownVote(msg.SenderID, msg.TargetID)
+		// Key the vote by the authenticated frame source, not the payload's
+		// SenderID — otherwise one peer could forge many sender ids to drive ODOWN
+		// unilaterally (#522 Step 4c). Gossip is one-hop, so fromNodeID is the voter.
+		c.msp.RecordDownVote(fromNodeID, msg.TargetID)
 		return nil
 
 	case mbp.TypeCogForward:

--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -196,6 +196,7 @@ func NewClusterCoordinator(
 	joinHandler := NewJoinHandler(cfg.NodeID, cfg.ClusterSecret, epochStore, repLog, mgr)
 	joinHandler.localAddr = advertiseAddr
 	joinClient := NewJoinClient(cfg.NodeID, advertiseAddr, cfg.ClusterSecret, epochStore, applier, mgr)
+	joinClient.localRole = roleFromConfigString(cfg.Role)
 
 	reconDelay := time.Duration(cfg.ReconDelayMs) * time.Millisecond
 	if reconDelay <= 0 {
@@ -251,9 +252,7 @@ func NewClusterCoordinator(
 			slog.Info("cluster: sentinel node observed ODOWN, skipping election start", "down_node", nodeID)
 			return
 		}
-		if err := c.election.StartElection(context.Background()); err != nil {
-			slog.Error("cluster: failed to start election after ODOWN", "err", err)
-		}
+		c.startElectionWithJitter()
 	}
 
 	// Wire OnSDown to check quorum health — if we are Cortex and lose quorum
@@ -1157,10 +1156,16 @@ func (c *ClusterCoordinator) HandleIncomingJoin(conn net.Conn, payload []byte) (
 		return req.NodeID, fmt.Errorf("cluster: send JoinResponse to %s: %w", req.NodeID, err)
 	}
 
-	// Replace the seed placeholder with this Lobe's real identity in MSP + voters
-	// so heartbeats and votes keyed by its node-id are no longer dropped (#522).
+	// Replace the seed placeholder with this joiner's real identity in MSP + voters
+	// so heartbeats and votes keyed by its node-id are no longer dropped (#522). Use
+	// the joiner's advertised role (0 = legacy = replica) so a joining Observer is
+	// not registered as a voter (#529).
 	if resp.Accepted {
-		c.reconcileJoinedPeer(req.NodeID, req.Addr, RoleReplica)
+		joinerRole := NodeRole(req.Role)
+		if joinerRole == RoleUnknown {
+			joinerRole = RoleReplica
+		}
+		c.reconcileJoinedPeer(req.NodeID, req.Addr, joinerRole)
 	}
 
 	if resp.NeedsSnapshot {
@@ -1261,6 +1266,14 @@ func (c *ClusterCoordinator) HandleIncomingFrame(fromNodeID string, frameType ui
 			return fmt.Errorf("unmarshal ReplAck: %w", err)
 		}
 		c.UpdateReplicaSeq(ack.NodeID, ack.LastSeq)
+		return nil
+
+	case mbp.TypeSDown:
+		var msg mbp.SDownNotification
+		if err := msgpack.Unmarshal(payload, &msg); err != nil {
+			return fmt.Errorf("unmarshal SDownNotification: %w", err)
+		}
+		c.msp.RecordDownVote(msg.SenderID, msg.TargetID)
 		return nil
 
 	case mbp.TypeCogForward:

--- a/internal/replication/election.go
+++ b/internal/replication/election.go
@@ -124,6 +124,16 @@ func (e *Election) IsVoter(nodeID string) bool {
 	return ok
 }
 
+// ResetCandidate moves a stuck candidate back to Idle so a fresh election can be
+// started (used after a split vote that never reached quorum, #522 Step 4c).
+func (e *Election) ResetCandidate() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.state == ElectionCandidate {
+		e.state = ElectionIdle
+	}
+}
+
 // StepDown relinquishes leadership without a successor (used by the pre-emptive
 // quorum-loss demotion, which has no claimant). state→Idle so a later
 // StartElection is not blocked by errAlreadyCandidate; currentLeader is cleared

--- a/internal/replication/hello.go
+++ b/internal/replication/hello.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"math/rand"
 	"net"
@@ -28,10 +29,10 @@ func helloHMAC(secret, nodeID, addr string, role uint8) []byte {
 	return h.Sum(nil)
 }
 
-// configuredRole maps the config role string to a NodeRole for PeerHello. "auto"
-// advertises a voting (non-observer) role.
-func (c *ClusterCoordinator) configuredRole() NodeRole {
-	switch c.cfg.Role {
+// roleFromConfigString maps a config role string to a NodeRole. "auto" (and any
+// unknown value) maps to a voting (non-observer) role that can lead.
+func roleFromConfigString(role string) NodeRole {
+	switch role {
 	case "primary":
 		return RolePrimary
 	case "replica":
@@ -43,6 +44,11 @@ func (c *ClusterCoordinator) configuredRole() NodeRole {
 	default:
 		return RolePrimary // auto: a voter that can lead
 	}
+}
+
+// configuredRole is this node's role for PeerHello/JoinRequest advertisement.
+func (c *ClusterCoordinator) configuredRole() NodeRole {
+	return roleFromConfigString(c.cfg.Role)
 }
 
 func (c *ClusterCoordinator) localHello() mbp.PeerHello {
@@ -214,6 +220,31 @@ func (c *ClusterCoordinator) sendClaim(p *PeerConn) {
 		return
 	}
 	_ = p.Send(mbp.TypeCortexClaim, payload)
+}
+
+// startElectionWithJitter starts a failover election after a deterministic
+// per-node delay (0–1 heartbeat) so concurrent ODOWN-triggered candidates stagger
+// instead of splitting the vote, then retries a bounded number of times if it
+// stays a stuck candidate — but only while no leader has emerged (#522 Step 4c).
+func (c *ClusterCoordinator) startElectionWithJitter() {
+	hb := c.heartbeatInterval()
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(c.cfg.NodeID))
+	time.Sleep(time.Duration(uint64(h.Sum32()) % uint64(hb)))
+
+	for attempt := 0; attempt < 4; attempt++ {
+		if c.IsLeader() {
+			return
+		}
+		if ldr := c.election.CurrentLeader(); ldr != "" && ldr != c.cfg.NodeID {
+			return // someone else won
+		}
+		c.election.ResetCandidate() // clear any prior stuck candidacy so we can retry
+		if err := c.election.StartElection(context.Background()); err != nil {
+			slog.Debug("cluster: failover election start", "err", err)
+		}
+		time.Sleep(4 * hb) // wait for the outcome (promotion or a new leader's claim)
+	}
 }
 
 // readPeerFrames reads frames from a hello-dialed (outbound) conn and dispatches

--- a/internal/replication/hello.go
+++ b/internal/replication/hello.go
@@ -227,6 +227,13 @@ func (c *ClusterCoordinator) sendClaim(p *PeerConn) {
 // instead of splitting the vote, then retries a bounded number of times if it
 // stays a stuck candidate — but only while no leader has emerged (#522 Step 4c).
 func (c *ClusterCoordinator) startElectionWithJitter() {
+	// Single-flight: a concurrent ODOWN event must not spawn a second election
+	// driver that could ResetCandidate a candidacy this one is about to win.
+	if !c.electing.CompareAndSwap(false, true) {
+		return
+	}
+	defer c.electing.Store(false)
+
 	hb := c.heartbeatInterval()
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(c.cfg.NodeID))

--- a/internal/replication/join.go
+++ b/internal/replication/join.go
@@ -279,6 +279,7 @@ type JoinResult struct {
 type JoinClient struct {
 	localNodeID   string
 	localAddr     string
+	localRole     NodeRole // this node's configured role, advertised in JoinRequest (#529)
 	clusterSecret string
 	epochStore    *EpochStore
 	applier       *Applier
@@ -379,6 +380,7 @@ func (c *JoinClient) joinConn(ctx context.Context, conn net.Conn) (JoinResult, e
 		Addr:            c.localAddr,
 		LastApplied:     lastApplied,
 		SecretHash:      secretHash,
+		Role:            uint8(c.localRole),
 		ProtocolVersion: mbp.CurrentProtocolVersion,
 	}
 

--- a/internal/replication/msp.go
+++ b/internal/replication/msp.go
@@ -20,6 +20,7 @@ type PeerState struct {
 	LastSeen    time.Time
 	MissedBeats int
 	SDown       bool
+	odownFired  bool // OnODown latch — fired once per SDOWN episode (#522 Step 4c)
 }
 
 // MSP manages heartbeats and failure detection for a node.
@@ -131,6 +132,12 @@ func (m *MSP) handleHeartbeat(fromNodeID, fromAddr string) {
 	p.LastSeen = time.Now()
 	p.MissedBeats = 0
 	p.SDown = false
+	if wasSDown {
+		// Recovery: clear the ODOWN latch and accumulated down-votes so a future
+		// SDOWN episode is judged afresh (#522 Step 4c).
+		p.odownFired = false
+		delete(m.votedDown, fromNodeID)
+	}
 
 	// Update address if the peer advertises a new one (pod restart, IP change).
 	if fromAddr != "" && fromAddr != p.Addr {
@@ -302,15 +309,61 @@ func (m *MSP) tick(pingPayload []byte, pingInterval time.Duration, missedThresho
 			// Observers do not participate in ODOWN voting: their SDOWN state
 			// is not counted toward the quorum needed to declare ODOWN.
 			if !isObserver {
+				// Gossip our down-vote so other voters can reach ODOWN (#522 Step 4c).
+				go m.gossipSDown(nodeID)
+
 				// Check ODOWN under the same lock snapshot.
 				votes := 1
 				if voters, ok := m.votedDown[nodeID]; ok {
 					votes += len(voters)
 				}
-				if votes >= effectiveQuorum && m.OnODown != nil {
+				if votes >= effectiveQuorum && !p.odownFired && m.OnODown != nil {
+					p.odownFired = true
 					go m.OnODown(nodeID)
 				}
 			}
 		}
+	}
+}
+
+// gossipSDown broadcasts this node's "I see target as down" vote so other voters
+// can accumulate it toward ODOWN (#522 Step 4c).
+func (m *MSP) gossipSDown(targetID string) {
+	payload, err := msgpack.Marshal(mbp.SDownNotification{
+		SenderID:  m.localNodeID,
+		TargetID:  targetID,
+		Timestamp: time.Now().UnixNano(),
+	})
+	if err != nil {
+		return
+	}
+	m.mgr.Broadcast(mbp.TypeSDown, payload)
+}
+
+// RecordDownVote records a peer's down-vote for target and fires OnODown once if
+// we also see the target as SDOWN and the votes reach quorum (#522 Step 4c).
+func (m *MSP) RecordDownVote(sender, target string) {
+	if sender == "" || target == "" || sender == m.localNodeID {
+		return
+	}
+	m.mu.Lock()
+	if m.votedDown[target] == nil {
+		m.votedDown[target] = make(map[string]struct{})
+	}
+	m.votedDown[target][sender] = struct{}{}
+
+	fire := false
+	if p, ok := m.peers[target]; ok && p.SDown && !p.odownFired && p.Role != RoleObserver {
+		votes := 1 + len(m.votedDown[target])
+		if votes >= m.nonObserverQuorumLocked() {
+			p.odownFired = true
+			fire = true
+		}
+	}
+	onODown := m.OnODown
+	m.mu.Unlock()
+
+	if fire && onODown != nil {
+		go onODown(target)
 	}
 }

--- a/internal/replication/msp.go
+++ b/internal/replication/msp.go
@@ -347,6 +347,13 @@ func (m *MSP) RecordDownVote(sender, target string) {
 		return
 	}
 	m.mu.Lock()
+	// The sender must be a known, non-observer voter: observers are excluded from
+	// the ODOWN quorum denominator (nonObserverQuorumLocked), so counting their
+	// votes in the numerator could spuriously fail over a healthy Cortex (#522 Step 4c).
+	if sp, ok := m.peers[sender]; ok && sp.Role == RoleObserver {
+		m.mu.Unlock()
+		return
+	}
 	if m.votedDown[target] == nil {
 		m.votedDown[target] = make(map[string]struct{})
 	}

--- a/internal/replication/sdown_gossip_test.go
+++ b/internal/replication/sdown_gossip_test.go
@@ -43,6 +43,31 @@ func TestRecordDownVote_FiresODownAtQuorum(t *testing.T) {
 	}
 }
 
+// An observer's gossiped down-vote must NOT count toward ODOWN: observers are
+// excluded from the quorum denominator, so counting them could spuriously fail
+// over a healthy Cortex (#522 Step 4c review).
+func TestRecordDownVote_ObserverSenderDoesNotCount(t *testing.T) {
+	c, _ := newTestCoordinator(t, "auto")
+	msp := c.msp
+	msp.AddPeer("target", "t:1", RoleReplica)
+	msp.AddPeer("obs-1", "o:1", RoleObserver)
+	// non-observer population = self + target = 2 → quorum 2.
+
+	msp.mu.Lock()
+	msp.peers["target"].SDown = true
+	msp.mu.Unlock()
+
+	fired := make(chan string, 1)
+	msp.OnODown = func(id string) { fired <- id }
+
+	msp.RecordDownVote("obs-1", "target") // observer vote — must be ignored
+	select {
+	case <-fired:
+		t.Error("an observer sender's vote must not count toward the ODOWN quorum")
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
 // A down-vote must NOT trigger ODOWN if this node does not also see the target
 // as SDOWN — ODOWN requires local agreement, not just remote reports.
 func TestRecordDownVote_NoODownWithoutLocalSDown(t *testing.T) {

--- a/internal/replication/sdown_gossip_test.go
+++ b/internal/replication/sdown_gossip_test.go
@@ -1,0 +1,64 @@
+package replication
+
+import (
+	"testing"
+	"time"
+)
+
+// #528 / #522 Step 4c: a gossiped down-vote that completes quorum (with self also
+// seeing the target SDOWN) fires OnODown exactly once.
+func TestRecordDownVote_FiresODownAtQuorum(t *testing.T) {
+	c, _ := newTestCoordinator(t, "auto")
+	msp := c.msp
+	msp.AddPeer("target", "t:1", RoleReplica)
+	msp.AddPeer("voter-1", "v:1", RoleReplica)
+	// non-observer population = self + target + voter-1 = 3 → quorum 2.
+
+	msp.mu.Lock()
+	msp.peers["target"].SDown = true // we also see the target as down
+	msp.mu.Unlock()
+
+	fired := make(chan string, 4)
+	msp.OnODown = func(id string) { fired <- id }
+
+	// self(1) + voter-1(1) = 2 ≥ quorum 2 → ODOWN.
+	msp.RecordDownVote("voter-1", "target")
+	select {
+	case id := <-fired:
+		if id != "target" {
+			t.Errorf("ODOWN fired for %q, want target", id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected OnODown to fire at quorum")
+	}
+
+	// Latched: a duplicate / repeat vote must not fire again.
+	msp.RecordDownVote("voter-1", "target")
+	msp.AddPeer("voter-2", "v2:1", RoleReplica)
+	msp.RecordDownVote("voter-2", "target")
+	select {
+	case <-fired:
+		t.Error("OnODown must fire only once per SDOWN episode")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// A down-vote must NOT trigger ODOWN if this node does not also see the target
+// as SDOWN — ODOWN requires local agreement, not just remote reports.
+func TestRecordDownVote_NoODownWithoutLocalSDown(t *testing.T) {
+	c, _ := newTestCoordinator(t, "auto")
+	msp := c.msp
+	msp.AddPeer("target", "t:1", RoleReplica)
+	msp.AddPeer("voter-1", "v:1", RoleReplica)
+	// target is NOT marked SDOWN locally.
+
+	fired := make(chan string, 1)
+	msp.OnODown = func(id string) { fired <- id }
+
+	msp.RecordDownVote("voter-1", "target")
+	select {
+	case <-fired:
+		t.Error("OnODown must not fire when this node does not see the target as SDOWN")
+	case <-time.After(150 * time.Millisecond):
+	}
+}

--- a/internal/transport/mbp/cluster_frames.go
+++ b/internal/transport/mbp/cluster_frames.go
@@ -87,6 +87,7 @@ type JoinRequest struct {
 	LastApplied     uint64   `msgpack:"last_applied"`
 	Capabilities    []string `msgpack:"capabilities"`
 	SecretHash      []byte   `msgpack:"secret_hash"`
+	Role            uint8    `msgpack:"role,omitempty"` // joiner's NodeRole; 0 = legacy = replica (#529)
 	ProtocolVersion uint16   `msgpack:"proto_ver,omitempty"`
 }
 


### PR DESCRIPTION
Step 4 (c)+(d) — the automatic-failover finale of the cluster liveness overhaul (epic #522). Builds on Step 4 a+b (#530).

## Problem (#528)
ODOWN could never fire in a ≥2-voter cluster: `votedDown` was never populated and `TypeSDown` was never sent or handled, so a node only ever had its own subjective SDOWN (1 vote < quorum). **Automatic failover never completed** — killing the Cortex left the Lobes waiting forever. (Masked until now because liveness itself was broken before Steps 1–3.)

## Fix
**(c) SDOWN gossip + failover election:**
- MSP broadcasts `TypeSDown{sender,target}` on a non-observer peer's SDOWN transition. `RecordDownVote` accumulates votes in `votedDown` and fires `OnODown` **once** (`odownFired` latch) when this node *also* sees the target SDOWN and votes reach the non-observer quorum. `HandleIncomingFrame` routes `TypeSDown` → `RecordDownVote`. Recovery clears the latch + votes.
- **Election jitter:** `OnODown` starts the election after a deterministic per-node delay (0–1 heartbeat, FNV of node-id) so two Lobes don't split the vote, with a bounded retry (`ResetCandidate` + re-`StartElection`) while no leader emerges.

**(d)** `JoinRequest` carries the joiner's role; `HandleIncomingJoin` registers voters by that role (0 = legacy = replica) so a joining Observer is not a voter (#529, the other half — the hello path was gated in a+b).

## Proven in Docker (the failover that never worked)
1 cortex + 2 lobes, all-to-all seeds (so the lobes form a hello-mesh vote channel):
- **Healthy**: all-to-all mesh, lobe1 sees lobe2 in members, `alive=3`.
- **Kill the Cortex** → `lobe2: ODOWN detected → promoted to Cortex epoch=2`; lobe1 follows lobe2 (`cortex_id=lobe2`); the new leader **accepts writes and replicates** to lobe1. ✅
- **Restart the old Cortex** → cluster converges to **exactly one leader** (the returning designated-primary retakes via the equal-epoch tie-break; lobe2 yields).

## Tests
`RecordDownVote` fires ODOWN once at quorum; no ODOWN without local SDOWN agreement. Full `internal/replication` + `mbp` suites green under `-race`.

## Known edge (documented, not a regression) → #531
The returning designated-primary **retakes** leadership after failover (a flap that converges to one leader), and writes accepted during the failover window can be lost on retake (Fable Risk 4/6). Tracked in **#531** (harden `bootstrapPromoteIfDesignatedPrimary` to follow an existing leader instead of asserting). Before this PR failover didn't happen at all, so this edge was unreachable.

Closes #528, #529. Refs #522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)