### PR TITLE
fix(cluster): convergent failover election + leader-gated joins (#531 PR1, #533)

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -680,9 +680,14 @@ func handleClusterConn(conn net.Conn, coord *replication.ClusterCoordinator) {
 			return // connection closed or error
 		}
 		if frame.Type == mbp.TypeJoinRequest {
-			nodeID, err := coord.HandleIncomingJoin(conn, frame.Payload)
+			nodeID, adopted, err := coord.HandleIncomingJoin(conn, frame.Payload)
 			if err != nil {
 				log.Printf("[cluster] join error from %s: %v", fromNodeID, err)
+				return
+			}
+			if !adopted {
+				// Non-leader rejected the join with a redirect (already written to
+				// the raw conn). The conn was NOT registered, so close it here.
 				return
 			}
 			fromNodeID = nodeID

--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -103,6 +103,9 @@ type ClusterCoordinator struct {
 	// electing single-flights the ODOWN-triggered failover election driver so
 	// concurrent ODOWN events don't spawn racing election loops (#522 Step 4c).
 	electing atomic.Bool
+	// runCtx is the lifetime context captured at Run() start, so callbacks wired
+	// before Run (e.g. OnODown) can launch ctx-aware loops (#531 PR1).
+	runCtx context.Context
 
 	// Per-Lobe streamers (Cortex only): lobeID -> cancel func
 	streamers   map[string]context.CancelFunc
@@ -247,15 +250,19 @@ func NewClusterCoordinator(
 		c.handleNewLeader(leaderID, epoch)
 	}
 
-	// Wire MSP callbacks: trigger election when Cortex goes ODOWN.
-	// Sentinels participate in ODOWN voting but never start elections themselves.
+	// Wire MSP callbacks: trigger a failover election only when the LEADER goes
+	// ODOWN. A non-leader (lobe) dying while a healthy leader is known must not
+	// start an election (#531 PR1). Sentinels never start elections.
 	msp.OnODown = func(nodeID string) {
-		slog.Warn("cluster: ODOWN detected, triggering election", "down_node", nodeID)
 		if c.IsSentinel() {
-			slog.Info("cluster: sentinel node observed ODOWN, skipping election start", "down_node", nodeID)
 			return
 		}
-		c.startElectionWithJitter()
+		if ldr := c.election.CurrentLeader(); ldr != "" && ldr != nodeID && !c.msp.IsSDown(ldr) {
+			return // a different, live leader is known — this is a lobe death, not a failover
+		}
+		slog.Warn("cluster: ODOWN detected, triggering failover election", "down_node", nodeID)
+		c.election.ClearLeader(nodeID) // forget the dead leader so we can re-elect
+		c.startElectionWithJitter(c.runCtx)
 	}
 
 	// Wire OnSDown to check quorum health — if we are Cortex and lose quorum
@@ -324,6 +331,20 @@ func NewClusterCoordinator(
 	joinHandler.OnLobeLeft = func(nodeID string) {
 		c.stopStreamerForLobe(nodeID)
 	}
+	// Only the leader accepts joins; a non-leader redirects to the leader it knows (#533).
+	joinHandler.LeaderInfo = func() (bool, string, string) {
+		if c.IsLeader() {
+			return true, c.cfg.NodeID, c.advertiseAddr
+		}
+		ldr := c.election.CurrentLeader()
+		var addr string
+		if ldr != "" && ldr != c.cfg.NodeID {
+			if p, ok := c.mgr.GetPeer(ldr); ok {
+				addr = p.Addr()
+			}
+		}
+		return false, ldr, addr
+	}
 
 	return c
 }
@@ -335,6 +356,7 @@ func NewClusterCoordinator(
 // If cfg.Role == "observer": joins replication stream, applies locally, no voting
 func (c *ClusterCoordinator) Run(ctx context.Context) error {
 	c.started.Store(true)
+	c.runCtx = ctx
 
 	// Observers do not participate in voting — do not register as voter.
 	if c.cfg.Role != "observer" {
@@ -441,6 +463,7 @@ func (c *ClusterCoordinator) runAsCortex(ctx context.Context) error {
 		c.election.currentLeader = c.cfg.NodeID
 		c.election.mu.Unlock()
 		c.handlePromotion(currentEpoch)
+		c.election.broadcastClaim(currentEpoch) // announce so peers learn the leader (#531 PR1)
 		// Clear the crash-recovery breadcrumb now that in-memory promotion is
 		// complete. Without this, every subsequent clean restart re-enters this
 		// path instead of going through a normal election. (#176)
@@ -492,6 +515,11 @@ func (c *ClusterCoordinator) bootstrapPromoteIfDesignatedPrimary() {
 	slog.Info("cluster: designated primary asserting leadership at bootstrap",
 		"node", c.cfg.NodeID, "epoch", epoch)
 	c.handlePromotion(epoch)
+	// Announce leadership so followers learn currentLeader through the normal
+	// channel (bootstrap-assert bypasses tryPromote, which is the only other
+	// broadcaster). Without this, peers never see a claim from a designated
+	// primary and can't redirect joins to it (#531 PR1).
+	c.election.broadcastClaim(epoch)
 }
 
 // joinWithRetry attempts to join the Cortex, cycling through all seeds on each
@@ -504,13 +532,28 @@ func (c *ClusterCoordinator) joinWithRetry(ctx context.Context, seeds []string, 
 	const maxBackoff = 30 * time.Second
 
 	backoff := time.Second
+	var redirect string // a leader address learned from a "not cortex" redirect (#533)
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		cortexAddr := seeds[(attempt-1)%len(seeds)]
+		cortexAddr := redirect
+		if cortexAddr == "" {
+			cortexAddr = seeds[(attempt-1)%len(seeds)]
+		}
+		redirect = ""
 		joinCtx, cancel := context.WithTimeout(context.Background(), joinTimeout)
 		resp, err := c.joinClient.Join(joinCtx, cortexAddr)
 		cancel()
 		if err == nil {
 			return resp, nil
+		}
+		// Redirect: a non-leader rejected us and pointed at the leader it knows.
+		// Try that address immediately (no backoff) instead of cycling seeds, so
+		// a Lobe finds the real Cortex fast after a failover (#533).
+		if resp.CortexAddr != "" && resp.CortexAddr != cortexAddr {
+			if ctx.Err() != nil {
+				return JoinResult{}, ctx.Err()
+			}
+			redirect = resp.CortexAddr
+			continue
 		}
 		slog.Warn("cluster: join attempt failed, will retry",
 			"role", role, "attempt", attempt, "max", maxAttempts,
@@ -905,7 +948,9 @@ func (c *ClusterCoordinator) waitQuorumTerm(ctx context.Context) runMode {
 		if ldr := c.election.CurrentLeader(); ldr != "" && ldr != c.cfg.NodeID {
 			return modeFollowing // a higher claim appeared — follow, never assert
 		}
-		if c.aliveVoters() >= c.election.Quorum() && (nextElection.IsZero() || !time.Now().Before(nextElection)) {
+		if !c.electing.Load() && c.aliveVoters() >= c.election.Quorum() && (nextElection.IsZero() || !time.Now().Before(nextElection)) {
+			// Yield if the ODOWN-triggered failover driver is already electing, so
+			// the two drivers don't race the same node into split candidacies (#531 PR1).
 			if err := c.election.StartElection(ctx); err != nil {
 				slog.Warn("cluster: re-election attempt failed", "node", c.cfg.NodeID, "err", err)
 			}

--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -630,6 +630,18 @@ func (c *ClusterCoordinator) streamReplication(ctx context.Context, role string,
 		if resp.CortexID != "" && resp.Conn != nil {
 			c.mgr.RegisterConn(resp.CortexID, cortexAddr, resp.Conn)
 			c.reconcileJoinedPeer(resp.CortexID, cortexAddr, RolePrimary)
+			// Adopt the Cortex named by the JoinResponse as our leader, so the
+			// election layer knows currentLeader even if its CortexClaim broadcast
+			// raced ahead of our join (reliable leader discovery, #531 PR1). This is
+			// what lets OnODown tell a leader's death from a mere lobe's.
+			if resp.CortexID != c.cfg.NodeID {
+				c.election.HandleCortexClaim(mbp.CortexClaim{
+					CortexID:     resp.CortexID,
+					CortexAddr:   cortexAddr,
+					Epoch:        resp.Epoch,
+					FencingToken: resp.Epoch,
+				})
+			}
 		}
 
 		streamErr := c.streamFromCortex(ctx, resp.Conn, resp.CortexID)
@@ -1188,10 +1200,41 @@ func (c *ClusterCoordinator) checkQuorumHealth() {
 // so that peer.Send works immediately (no dial required), processes the join
 // request, and returns the joining node's stable ID so that handleClusterConn
 // can use it for all subsequent frames on the same connection.
-func (c *ClusterCoordinator) HandleIncomingJoin(conn net.Conn, payload []byte) (string, error) {
+func (c *ClusterCoordinator) HandleIncomingJoin(conn net.Conn, payload []byte) (string, bool, error) {
 	var req mbp.JoinRequest
 	if err := msgpack.Unmarshal(payload, &req); err != nil {
-		return "", fmt.Errorf("unmarshal JoinRequest: %w", err)
+		return "", false, fmt.Errorf("unmarshal JoinRequest: %w", err)
+	}
+
+	// Leadership gate BEFORE registering the conn (#533): only the leader accepts
+	// joins. A non-leader must NOT RegisterConn the joiner here — that would evict
+	// an existing live conn (e.g. the lobe↔lobe hello conn carrying SDOWN gossip)
+	// and replace it with a throwaway rejected-join conn, silently breaking
+	// failover. Reply with a redirect on the raw conn and let the caller close it.
+	if !c.IsLeader() {
+		ldr := c.election.CurrentLeader()
+		var ldrAddr string
+		if ldr != "" && ldr != c.cfg.NodeID {
+			if p, ok := c.mgr.GetPeer(ldr); ok {
+				ldrAddr = p.Addr()
+			}
+		}
+		resp := mbp.JoinResponse{
+			Accepted:     false,
+			RejectReason: "not cortex",
+			Epoch:        c.epochStore.Load(),
+			CortexID:     ldr,
+			CortexAddr:   ldrAddr,
+		}
+		if respPayload, err := msgpack.Marshal(resp); err == nil {
+			_ = mbp.WriteFrame(conn, &mbp.Frame{
+				Version:       0x01,
+				Type:          mbp.TypeJoinResponse,
+				PayloadLength: uint32(len(respPayload)),
+				Payload:       respPayload,
+			})
+		}
+		return req.NodeID, false, nil
 	}
 
 	// Register the live inbound conn so peer.Send succeeds immediately.
@@ -1202,10 +1245,10 @@ func (c *ClusterCoordinator) HandleIncomingJoin(conn net.Conn, payload []byte) (
 	resp := c.joinHandler.HandleJoinRequest(req, peer)
 	respPayload, err := msgpack.Marshal(resp)
 	if err != nil {
-		return req.NodeID, fmt.Errorf("marshal JoinResponse: %w", err)
+		return req.NodeID, false, fmt.Errorf("marshal JoinResponse: %w", err)
 	}
 	if err := peer.Send(mbp.TypeJoinResponse, respPayload); err != nil {
-		return req.NodeID, fmt.Errorf("cluster: send JoinResponse to %s: %w", req.NodeID, err)
+		return req.NodeID, false, fmt.Errorf("cluster: send JoinResponse to %s: %w", req.NodeID, err)
 	}
 
 	// Replace the seed placeholder with this joiner's real identity in MSP + voters
@@ -1240,7 +1283,7 @@ func (c *ClusterCoordinator) HandleIncomingJoin(conn net.Conn, payload []byte) (
 		// the streamer immediately.
 		c.joinHandler.FireOnLobeJoined(req.NodeID)
 	}
-	return req.NodeID, nil
+	return req.NodeID, true, nil
 }
 
 // HandleIncomingFrame dispatches an incoming MBP frame from a peer to the right handler.

--- a/internal/replication/coordinator_test.go
+++ b/internal/replication/coordinator_test.go
@@ -1455,6 +1455,10 @@ func TestClusterCoordinator_HandleIncomingJoin_SnapshotFails_NoCallback(t *testi
 	if err := coord.epochStore.ForceSet(2); err != nil {
 		t.Fatalf("ForceSet: %v", err)
 	}
+	// Only the leader accepts joins (#533); mark this cortex as leader.
+	coord.roleMu.Lock()
+	coord.role = RolePrimary
+	coord.roleMu.Unlock()
 
 	// Upgrade the join handler to a DB-aware one so the JoinResponse signals
 	// NeedsSnapshot=true and HandleIncomingJoin takes the snapshot path.
@@ -1487,7 +1491,7 @@ func TestClusterCoordinator_HandleIncomingJoin_SnapshotFails_NoCallback(t *testi
 		t.Fatalf("marshal JoinRequest: %v", err)
 	}
 
-	nodeID, err := coord.HandleIncomingJoin(cortexConn, payload)
+	nodeID, _, err := coord.HandleIncomingJoin(cortexConn, payload)
 	if err != nil {
 		t.Fatalf("HandleIncomingJoin: %v", err)
 	}

--- a/internal/replication/election.go
+++ b/internal/replication/election.go
@@ -134,6 +134,20 @@ func (e *Election) ResetCandidate() {
 	}
 }
 
+// ClearLeader forgets currentLeader if it points at deadID (the known leader has
+// gone ODOWN), so the failover driver and followSeeds stop trusting it. A Follower
+// whose leader died returns to Idle so a fresh StartElection is unblocked (#531).
+func (e *Election) ClearLeader(deadID string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.currentLeader == deadID {
+		e.currentLeader = ""
+	}
+	if e.state == ElectionFollower {
+		e.state = ElectionIdle
+	}
+}
+
 // StepDown relinquishes leadership without a successor (used by the pre-emptive
 // quorum-loss demotion, which has no claimant). state→Idle so a later
 // StartElection is not blocked by errAlreadyCandidate; currentLeader is cleared

--- a/internal/replication/failover_pr1_test.go
+++ b/internal/replication/failover_pr1_test.go
@@ -1,0 +1,84 @@
+package replication
+
+import (
+	"net"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// #531 PR1: ClearLeader forgets a dead leader and returns a follower to Idle so a
+// fresh election can start.
+func TestElection_ClearLeader(t *testing.T) {
+	el := newTestElection(t, "self")
+	el.mu.Lock()
+	el.state = ElectionFollower
+	el.currentLeader = "dead-cortex"
+	el.mu.Unlock()
+
+	el.ClearLeader("dead-cortex")
+
+	if el.CurrentLeader() != "" {
+		t.Errorf("currentLeader should be cleared, got %q", el.CurrentLeader())
+	}
+	if el.State() != ElectionIdle {
+		t.Errorf("a follower whose leader died should return to Idle, got state %d", el.State())
+	}
+
+	// A different (still-live) leader must NOT be cleared.
+	el.mu.Lock()
+	el.state = ElectionFollower
+	el.currentLeader = "other-cortex"
+	el.mu.Unlock()
+	el.ClearLeader("dead-cortex")
+	if el.CurrentLeader() != "other-cortex" {
+		t.Errorf("must not clear a different leader, got %q", el.CurrentLeader())
+	}
+}
+
+// #533: only the current leader accepts joins — a non-leader rejects with a
+// redirect to the leader it knows.
+func TestHandleJoinRequest_NonLeaderRedirects(t *testing.T) {
+	es := newTestEpochStore(t)
+	if err := es.ForceSet(3); err != nil {
+		t.Fatalf("ForceSet: %v", err)
+	}
+	mgr := NewConnManager("lobe-2")
+	handler := NewJoinHandler("lobe-2", "", es, newTestRepLog(t), mgr)
+	// This node is NOT the leader; it knows the real leader's address.
+	handler.LeaderInfo = func() (bool, string, string) { return false, "cortex-1", "10.0.0.1:8479" }
+
+	req := mbp.JoinRequest{NodeID: "lobe-1", Addr: "10.0.0.2:8479", ProtocolVersion: mbp.CurrentProtocolVersion}
+	cortexConn, lobeConn := net.Pipe()
+	t.Cleanup(func() { cortexConn.Close(); lobeConn.Close() })
+	peer := mgr.RegisterConn(req.NodeID, req.Addr, cortexConn)
+
+	resp := handler.HandleJoinRequest(req, peer)
+
+	if resp.Accepted {
+		t.Fatal("a non-leader must NOT accept a join")
+	}
+	if resp.CortexID != "cortex-1" || resp.CortexAddr != "10.0.0.1:8479" {
+		t.Errorf("expected redirect to cortex-1/10.0.0.1:8479, got %q/%q", resp.CortexID, resp.CortexAddr)
+	}
+}
+
+// A node that IS the leader accepts the join.
+func TestHandleJoinRequest_LeaderAccepts(t *testing.T) {
+	es := newTestEpochStore(t)
+	if err := es.ForceSet(3); err != nil {
+		t.Fatalf("ForceSet: %v", err)
+	}
+	mgr := NewConnManager("cortex-1")
+	handler := NewJoinHandler("cortex-1", "", es, newTestRepLog(t), mgr)
+	handler.LeaderInfo = func() (bool, string, string) { return true, "cortex-1", "10.0.0.1:8479" }
+
+	req := mbp.JoinRequest{NodeID: "lobe-1", Addr: "10.0.0.2:8479", ProtocolVersion: mbp.CurrentProtocolVersion}
+	cortexConn, lobeConn := net.Pipe()
+	t.Cleanup(func() { cortexConn.Close(); lobeConn.Close() })
+	peer := mgr.RegisterConn(req.NodeID, req.Addr, cortexConn)
+
+	if resp := handler.HandleJoinRequest(req, peer); !resp.Accepted {
+		t.Errorf("the leader must accept the join, got rejected: %s", resp.RejectReason)
+	}
+}

--- a/internal/replication/hello.go
+++ b/internal/replication/hello.go
@@ -221,10 +221,12 @@ func (c *ClusterCoordinator) sendClaim(p *PeerConn) {
 	_ = p.Send(mbp.TypeCortexClaim, payload)
 }
 
-// startElectionWithJitter starts a failover election after a randomized
-// per-node delay (0–1 heartbeat) so concurrent ODOWN-triggered candidates stagger
-// instead of splitting the vote, then retries a bounded number of times if it
-// stays a stuck candidate — but only while no leader has emerged (#522 Step 4c).
+// startElectionWithJitter starts a failover election after a randomized delay
+// (0–1 heartbeat) so concurrent ODOWN-triggered candidates stagger instead of
+// splitting the vote, then retries on a re-randomized timeout until a leader
+// emerges (self or a live other). The loop is intentionally unbounded — it gives
+// up only when ctx is cancelled — so a transient split always eventually resolves
+// (#531 PR1). Rate-limited by the per-round sleep, so it never hot-spins.
 func (c *ClusterCoordinator) startElectionWithJitter(ctx context.Context) {
 	// Single-flight: a concurrent ODOWN event must not spawn a second election
 	// driver that could ResetCandidate a candidacy this one is about to win.

--- a/internal/replication/hello.go
+++ b/internal/replication/hello.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"hash/fnv"
 	"log/slog"
 	"math/rand"
 	"net"
@@ -222,11 +221,11 @@ func (c *ClusterCoordinator) sendClaim(p *PeerConn) {
 	_ = p.Send(mbp.TypeCortexClaim, payload)
 }
 
-// startElectionWithJitter starts a failover election after a deterministic
+// startElectionWithJitter starts a failover election after a randomized
 // per-node delay (0–1 heartbeat) so concurrent ODOWN-triggered candidates stagger
 // instead of splitting the vote, then retries a bounded number of times if it
 // stays a stuck candidate — but only while no leader has emerged (#522 Step 4c).
-func (c *ClusterCoordinator) startElectionWithJitter() {
+func (c *ClusterCoordinator) startElectionWithJitter(ctx context.Context) {
 	// Single-flight: a concurrent ODOWN event must not spawn a second election
 	// driver that could ResetCandidate a candidacy this one is about to win.
 	if !c.electing.CompareAndSwap(false, true) {
@@ -235,22 +234,47 @@ func (c *ClusterCoordinator) startElectionWithJitter() {
 	defer c.electing.Store(false)
 
 	hb := c.heartbeatInterval()
-	h := fnv.New32a()
-	_, _ = h.Write([]byte(c.cfg.NodeID))
-	time.Sleep(time.Duration(uint64(h.Sum32()) % uint64(hb)))
+	// Randomized initial delay (NOT a deterministic per-node constant) so two
+	// nodes that reach ODOWN together desynchronize their first start; the later
+	// one then sees the earlier's higher-epoch VoteRequest and grants it (#531 PR1).
+	sleepCtx(ctx, randDuration(0, hb))
 
-	for attempt := 0; attempt < 4; attempt++ {
+	for ctx.Err() == nil {
 		if c.IsLeader() {
 			return
 		}
-		if ldr := c.election.CurrentLeader(); ldr != "" && ldr != c.cfg.NodeID {
-			return // someone else won
+		if ldr := c.election.CurrentLeader(); ldr != "" && ldr != c.cfg.NodeID && !c.msp.IsSDown(ldr) {
+			return // a live leader emerged
 		}
-		c.election.ResetCandidate() // clear any prior stuck candidacy so we can retry
-		if err := c.election.StartElection(context.Background()); err != nil {
-			slog.Debug("cluster: failover election start", "err", err)
+		// Don't burn epochs without a live voter quorum (e.g. a total partition).
+		if c.aliveVoters() >= c.election.Quorum() {
+			c.election.ResetCandidate()
+			if err := c.election.StartElection(ctx); err != nil {
+				slog.Debug("cluster: failover election start", "err", err)
+			}
 		}
-		time.Sleep(4 * hb) // wait for the outcome (promotion or a new leader's claim)
+		// Re-randomized election timeout each round breaks any lockstep, so the
+		// split-vote probability is independent per round → converges w.p. 1. No
+		// attempt cap: keep trying until a leader (self or a live other) emerges.
+		sleepCtx(ctx, randDuration(3*hb, 6*hb))
+	}
+}
+
+// randDuration returns a uniformly random duration in [min, max).
+func randDuration(min, max time.Duration) time.Duration {
+	if max <= min {
+		return min
+	}
+	return min + time.Duration(rand.Int63n(int64(max-min)))
+}
+
+// sleepCtx sleeps for d or until ctx is done, whichever comes first.
+func sleepCtx(ctx context.Context, d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+	case <-t.C:
 	}
 }
 

--- a/internal/replication/integration_phase2_test.go
+++ b/internal/replication/integration_phase2_test.go
@@ -289,6 +289,10 @@ func TestP2Integration_JoinResponseBeforeReplEntry(t *testing.T) {
 	if err := cortex.epochStore.ForceSet(4); err != nil {
 		t.Fatalf("ForceSet: %v", err)
 	}
+	// Only the leader accepts joins (#533); mark this cortex as leader.
+	cortex.coord.roleMu.Lock()
+	cortex.coord.role = RolePrimary
+	cortex.coord.roleMu.Unlock()
 	// Pre-populate the replication log so the streamer has entries to drain and
 	// send the instant it starts (NetworkStreamer.Stream drains from seq 0).
 	appendEntries(t, cortex, "wo", 20)
@@ -328,7 +332,7 @@ func TestP2Integration_JoinResponseBeforeReplEntry(t *testing.T) {
 		t.Fatalf("marshal JoinRequest: %v", err)
 	}
 
-	if _, err := cortex.coord.HandleIncomingJoin(cortexConn, payload); err != nil {
+	if _, _, err := cortex.coord.HandleIncomingJoin(cortexConn, payload); err != nil {
 		t.Fatalf("HandleIncomingJoin: %v", err)
 	}
 

--- a/internal/replication/join.go
+++ b/internal/replication/join.go
@@ -33,6 +33,9 @@ type JoinHandler struct {
 	OnLobeJoined func(info NodeInfo)
 	// OnLobeLeft is called (without mu held) when a Lobe leaves.
 	OnLobeLeft func(nodeID string)
+	// LeaderInfo reports whether this node is the current leader, and if not, the
+	// leader it knows (for join redirects). Only the leader accepts joins (#533).
+	LeaderInfo func() (isLeader bool, leaderID, leaderAddr string)
 }
 
 // NewJoinHandler creates a JoinHandler for the Cortex.
@@ -141,6 +144,24 @@ func (h *JoinHandler) HandleJoinRequest(req mbp.JoinRequest, conn *PeerConn) mbp
 			RejectReason: "cluster not yet bootstrapped (epoch 0)",
 			Epoch:        currentEpoch,
 			CortexID:     h.localNodeID,
+		}
+	}
+
+	// Leadership gate (#533): only the current leader may accept a join. A
+	// non-leader rejects with a redirect to the leader it knows, so a Lobe that
+	// dialed the wrong node (e.g. another Lobe during a failover) doesn't get a
+	// bogus "you joined me" and start following a non-leader — the root cause of
+	// the mutual-join split-brain.
+	if h.LeaderInfo != nil {
+		isLeader, leaderID, leaderAddr := h.LeaderInfo()
+		if !isLeader {
+			return mbp.JoinResponse{
+				Accepted:     false,
+				RejectReason: "not cortex",
+				Epoch:        currentEpoch,
+				CortexID:     leaderID,
+				CortexAddr:   leaderAddr,
+			}
 		}
 	}
 


### PR DESCRIPTION
PR1 of the failover-robustness sequence (epic #522 follow-up). Makes automatic failover converge to exactly one leader every time, and fixes the split-brain root cause #533.

## Problems
1. **Split-vote, no stable leader.** Two lobes reaching ODOWN together each self-vote at the same epoch (votedFor immutability — correct for safety), so they split 1-1; the deterministic FNV jitter + fixed 4×(reset+StartElection+sleep) kept them phase-locked, leapfrogging epochs in lockstep, then gave up → permanently leaderless.
2. **#533 — any node accepted joins and called itself Cortex.** So the lobes mutually joined each other (lobe1→lobe2 AND lobe2→lobe1), and the join churn tore down the conns carrying the vote frames.

## Fix
**Convergent election:**
- `startElectionWithJitter`: randomized `U[0,hb)` initial + re-randomized `U[3hb,6hb)` per round, **unbounded** while leaderless, gated on `aliveVoters≥quorum` and ctx. Re-randomization makes each round's split probability independent → converges w.p. 1, expected ~1 round. Safety (≤1 leader/epoch) untouched.
- `ClearLeader(deadID)` on the leader's ODOWN; `OnODown` only elects when the dead node was the (only/unknown) leader — a lobe death under a healthy leader no longer triggers an election.
- Unify the two election drivers (`waitQuorumTerm` yields while the ODOWN driver holds `electing`).
- Broadcast a CortexClaim on bootstrap-assert + crash-recovery (only `tryPromote` did before).

**#533 leader-gated joins:**
- `HandleIncomingJoin` runs the leadership gate **before** `RegisterConn` (a non-leader writes a redirect on the raw conn, returns `adopted=false`, never registers — so it can't evict the live lobe↔lobe hello conn that carries SDOWN gossip, which was silently killing failover). `joinWithRetry` follows the redirect.
- On a successful join, a Lobe adopts the JoinResponse's CortexID/Epoch as its leader (reliable discovery — the claim broadcast otherwise races the join).

Invariant: a `JoinResponse{Accepted:true}` is only ever produced by the current leader.

## Validated in Docker — 8/8 convergence
1 cortex + 2 lobes, all-to-all seeds, **8 fresh kill-Cortex cycles**: every one produced **exactly one leader** with the follower pointing at it (no split, no mutual-join, no confusion). Before this PR the same loop produced 0 stable leaders.

## Tests
ClearLeader unblocks re-election + won't clear a live leader; non-leader join rejected with redirect; leader accepts. Full `internal/replication` suite green under `-race`.

Refs #531, #533. PR2 (#534 stale-conn eviction) and PR3 (#531 returning-primary deference) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)