### PR TITLE
fix(cluster): evict stale connections on death (#534)

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -677,6 +677,12 @@ func handleClusterConn(conn net.Conn, coord *replication.ClusterCoordinator) {
 	for {
 		frame, err := mbp.ReadFrame(conn)
 		if err != nil {
+			// The inbound conn died. If it had been adopted as a peer's registered
+			// conn, evict it (unless already replaced) so the peer's restart isn't
+			// blocked by a stale live-looking PeerConn (#534).
+			if joined {
+				coord.EvictConn(fromNodeID, conn)
+			}
 			return // connection closed or error
 		}
 		if frame.Type == mbp.TypeJoinRequest {

--- a/internal/replication/conn_manager.go
+++ b/internal/replication/conn_manager.go
@@ -61,6 +61,33 @@ func (m *ConnManager) AddPeer(nodeID, addr string) {
 	m.peers[nodeID] = NewPeerConn(nodeID, addr)
 }
 
+// EvictIfConn disconnects the peer for nodeID IFF it still wraps the given conn
+// (identity check, so a replacement conn is never evicted). The entry is kept so
+// its address survives for re-dial, but marked disconnected — so a restarted
+// peer's new hello/join is accepted and discovery re-dials it (#534).
+func (m *ConnManager) EvictIfConn(nodeID string, conn net.Conn) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	p, ok := m.peers[nodeID]
+	if !ok || !p.Is(conn) {
+		return false
+	}
+	_ = p.Close()
+	return true
+}
+
+// EvictPeerConn disconnects the peer for nodeID IFF the registered PeerConn is
+// exactly p (so a replacement is never evicted), keeping the entry for re-dial.
+func (m *ConnManager) EvictPeerConn(nodeID string, p *PeerConn) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.peers[nodeID] != p {
+		return false
+	}
+	_ = p.Close()
+	return true
+}
+
 // HasLivePeerAt reports whether any registered peer with this advertised address
 // currently has a live connection — used by the discovery loop to skip seeds
 // already covered by a join or hello conn (#522 Step 4).

--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -1195,6 +1195,13 @@ func (c *ClusterCoordinator) checkQuorumHealth() {
 	}
 }
 
+// EvictConn disconnects the registered peer for nodeID if it still wraps conn —
+// called by the connection handler when an inbound conn's read loop exits, so a
+// killed peer's stale PeerConn doesn't block its restart (#534).
+func (c *ClusterCoordinator) EvictConn(nodeID string, conn net.Conn) {
+	c.mgr.EvictIfConn(nodeID, conn)
+}
+
 // HandleIncomingJoin processes a TypeJoinRequest frame on a raw inbound conn
 // whose node ID is not yet known. It registers the live conn under req.NodeID
 // so that peer.Send works immediately (no dial required), processes the join

--- a/internal/replication/eviction_test.go
+++ b/internal/replication/eviction_test.go
@@ -1,0 +1,58 @@
+package replication
+
+import (
+	"net"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// #534: EvictIfConn disconnects only the matching conn (never a replacement), and
+// keeps the entry so the address survives for re-dial.
+func TestEvictIfConn(t *testing.T) {
+	mgr := NewConnManager("self")
+	a, b := net.Pipe()
+	t.Cleanup(func() { a.Close(); b.Close() })
+	p := mgr.RegisterConn("peer", "peer:1", a)
+	if !p.IsConnected() {
+		t.Fatal("peer should be connected after RegisterConn")
+	}
+
+	// A different conn must NOT evict (identity check protects a replacement).
+	c, d := net.Pipe()
+	t.Cleanup(func() { c.Close(); d.Close() })
+	if mgr.EvictIfConn("peer", c) {
+		t.Error("must not evict when the conn does not match")
+	}
+	if !p.IsConnected() {
+		t.Error("peer should still be connected after a non-matching evict")
+	}
+
+	// The matching conn evicts.
+	if !mgr.EvictIfConn("peer", a) {
+		t.Error("should evict the matching conn")
+	}
+	if p.IsConnected() {
+		t.Error("peer should be disconnected after evict")
+	}
+	// Entry kept so the address survives for re-dial.
+	if _, ok := mgr.GetPeer("peer"); !ok {
+		t.Error("entry should be kept after eviction (addr preserved for re-dial)")
+	}
+}
+
+// #534: a write error marks the PeerConn dead so IsConnected reports false and a
+// new conn can replace it.
+func TestPeerConn_SendMarksDeadOnError(t *testing.T) {
+	a, b := net.Pipe()
+	t.Cleanup(func() { a.Close() })
+	p := NewPeerConnFromConn("peer", "peer:1", a)
+	b.Close() // closing the far end makes the next write fail
+
+	if err := p.Send(mbp.TypePing, nil); err == nil {
+		t.Error("expected Send to fail writing to a closed pipe")
+	}
+	if p.IsConnected() {
+		t.Error("conn must be marked dead after a write error")
+	}
+}

--- a/internal/replication/hello.go
+++ b/internal/replication/hello.go
@@ -286,6 +286,9 @@ func (c *ClusterCoordinator) readPeerFrames(ctx context.Context, p *PeerConn, no
 	for {
 		ft, payload, err := p.Receive()
 		if err != nil {
+			// The conn is dead — evict it (if not already replaced) so a restarted
+			// peer's new conn is accepted and discovery re-dials it (#534).
+			c.mgr.EvictPeerConn(nodeID, p)
 			return
 		}
 		if err := c.HandleIncomingFrame(nodeID, ft, payload); err != nil {

--- a/internal/replication/peer_conn.go
+++ b/internal/replication/peer_conn.go
@@ -52,6 +52,12 @@ func NewPeerConn(nodeID, addr string) *PeerConn {
 // PeerConn. Used on the Cortex side when a Lobe dials in: the conn exists but
 // the Lobe's stable listen address (addr) comes from the JoinRequest payload.
 func NewPeerConnFromConn(nodeID, addr string, conn net.Conn) *PeerConn {
+	// TCP keepalive is a cheap backstop for detecting a silently-dead peer (the
+	// primary detection is read/write errors + MSP SDOWN, #534).
+	if tc, ok := conn.(*net.TCPConn); ok {
+		_ = tc.SetKeepAlive(true)
+		_ = tc.SetKeepAlivePeriod(15 * time.Second)
+	}
 	return &PeerConn{
 		nodeID: nodeID,
 		addr:   addr,
@@ -116,8 +122,24 @@ func (p *PeerConn) Send(frameType uint8, payload []byte) error {
 	// Bound the write so a wedged peer can't block the shared heartbeat tick.
 	_ = p.conn.SetWriteDeadline(time.Now().Add(sendWriteTimeout))
 	err := mbp.WriteFrame(p.conn, f)
+	if err != nil {
+		// A write error (incl. timeout) means the conn is dead or wedged — mark it
+		// closed so IsConnected reports false and a restarted peer's new conn can
+		// replace it via RegisterConnKind / discovery re-dial (#534).
+		_ = p.conn.Close()
+		p.conn = nil
+		p.closed = true
+		return err
+	}
 	_ = p.conn.SetWriteDeadline(time.Time{}) // clear for subsequent reads/writes
 	return err
+}
+
+// Is reports whether this PeerConn currently wraps the given net.Conn (identity).
+func (p *PeerConn) Is(conn net.Conn) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.conn == conn
 }
 
 // Receive reads one MBP frame from the connection.


### PR DESCRIPTION
PR2 of the failover-robustness sequence. Closes #534. Small, independent.

## Problem
A killed peer's `PeerConn` reported `IsConnected()==true` forever — inbound read loops didn't close it on exit, the hello reader didn't either, and `Send` swallowed write errors. So a restarted peer's new hello/join was rejected (`RegisterConnKind`: a live `kindJoin` is never evicted by a hello), discovery never re-dialed the seed (`HasLivePeerAt` saw it "live"), and claim-on-connect never fired. Stale conns silently blocked rejoin-after-restart.

## Fix
- `ConnManager.EvictIfConn` / `EvictPeerConn`: disconnect a peer **iff** it still wraps that exact conn/PeerConn (identity check — a replacement is never evicted), keeping the entry so the addr survives for re-dial.
- `handleClusterConn` evicts on read-loop exit; `readPeerFrames` evicts on `Receive` error.
- `PeerConn.Send` marks the conn dead on any write error/timeout (catches half-open links).
- TCP keepalive on conn adoption (cheap backstop).

Invariant: a `PeerConn` whose TCP conn errored reports `IsConnected()==false` within one frame-read or one bounded (≤5s) write.

## Tests
`EvictIfConn` only evicts the matching conn and keeps the entry; `Send` marks the conn dead on a write error. Full `internal/replication` suite green under `-race`. The end-to-end value (prompt rejoin after a `kill -9` restart) is exercised by **PR3's returning-primary Docker scenario** — a returning node's restart is exactly the stale-conn case.

Closes #534. Part of the #531 sequence (PR1 #535 merged; PR3 next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)