### PR TITLE
fix(cluster): cover JoinRequest.Role in HMAC at protocol v2 (closes #538)

### DIFF
--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -1304,7 +1304,7 @@ func (c *ClusterCoordinator) HandleIncomingJoin(conn net.Conn, payload []byte) (
 	if req.Probe {
 		// Authenticate the probe so an unauthenticated party can't learn cluster
 		// topology (parity with the normal join's secret check, #531 PR3 review).
-		if !c.joinHandler.ValidSecret(req.NodeID, req.SecretHash) {
+		if !c.joinHandler.ValidSecret(req.NodeID, req.Role, req.ProtocolVersion, req.SecretHash) {
 			return req.NodeID, false, nil
 		}
 		isLeader := c.IsLeader()

--- a/internal/replication/hmac_role_test.go
+++ b/internal/replication/hmac_role_test.go
@@ -1,0 +1,125 @@
+package replication
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"net"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// #538: JoinRequest.Role must be covered by the HMAC at protocol v2+.
+// A v2 sender hashes nodeID+role; a v1 sender hashes nodeID only (backward compat).
+
+func TestHandleJoinRequest_V2_RoleInHMAC_Accepted(t *testing.T) {
+	const secret = "test-secret"
+	es := newTestEpochStore(t)
+	if err := es.ForceSet(1); err != nil {
+		t.Fatal(err)
+	}
+	mgr := NewConnManager("cortex-1")
+	handler := NewJoinHandler("cortex-1", secret, es, newTestRepLog(t), mgr)
+	handler.LeaderInfo = func() (bool, string, string) { return true, "cortex-1", "" }
+
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte("lobe-1"))
+	h.Write([]byte{uint8(RoleReplica)})
+	correctHash := h.Sum(nil)
+
+	cortexConn, lobeConn := net.Pipe()
+	t.Cleanup(func() { cortexConn.Close(); lobeConn.Close() })
+	peer := mgr.RegisterConn("lobe-1", "10.0.0.2:8479", cortexConn)
+
+	req := mbp.JoinRequest{
+		NodeID: "lobe-1", Addr: "10.0.0.2:8479",
+		SecretHash: correctHash, Role: uint8(RoleReplica),
+		ProtocolVersion: 2,
+	}
+	if resp := handler.HandleJoinRequest(req, peer); !resp.Accepted {
+		t.Errorf("v2 join with role-in-HMAC should be accepted: %s", resp.RejectReason)
+	}
+}
+
+func TestHandleJoinRequest_V2_LegacyHMAC_Rejected(t *testing.T) {
+	const secret = "test-secret"
+	es := newTestEpochStore(t)
+	if err := es.ForceSet(1); err != nil {
+		t.Fatal(err)
+	}
+	mgr := NewConnManager("cortex-1")
+	handler := NewJoinHandler("cortex-1", secret, es, newTestRepLog(t), mgr)
+	handler.LeaderInfo = func() (bool, string, string) { return true, "cortex-1", "" }
+
+	// Legacy HMAC (no role) sent in a v2 request — must be rejected.
+	hLegacy := hmac.New(sha256.New, []byte(secret))
+	hLegacy.Write([]byte("lobe-1"))
+	legacyHash := hLegacy.Sum(nil)
+
+	cortexConn, lobeConn := net.Pipe()
+	t.Cleanup(func() { cortexConn.Close(); lobeConn.Close() })
+	peer := mgr.RegisterConn("lobe-1", "10.0.0.2:8479", cortexConn)
+
+	req := mbp.JoinRequest{
+		NodeID: "lobe-1", Addr: "10.0.0.2:8479",
+		SecretHash: legacyHash, Role: uint8(RoleReplica),
+		ProtocolVersion: 2,
+	}
+	if resp := handler.HandleJoinRequest(req, peer); resp.Accepted {
+		t.Error("v2 join with old (no-role) HMAC should be rejected")
+	}
+}
+
+func TestHandleJoinRequest_V1_LegacyHMAC_Accepted(t *testing.T) {
+	const secret = "test-secret"
+	es := newTestEpochStore(t)
+	if err := es.ForceSet(1); err != nil {
+		t.Fatal(err)
+	}
+	mgr := NewConnManager("cortex-1")
+	handler := NewJoinHandler("cortex-1", secret, es, newTestRepLog(t), mgr)
+	handler.LeaderInfo = func() (bool, string, string) { return true, "cortex-1", "" }
+
+	// v1 senders hash only nodeID — must remain accepted for rolling-upgrade compat.
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte("lobe-1"))
+	legacyHash := h.Sum(nil)
+
+	cortexConn, lobeConn := net.Pipe()
+	t.Cleanup(func() { cortexConn.Close(); lobeConn.Close() })
+	peer := mgr.RegisterConn("lobe-1", "10.0.0.2:8479", cortexConn)
+
+	req := mbp.JoinRequest{
+		NodeID: "lobe-1", Addr: "10.0.0.2:8479",
+		SecretHash: legacyHash, Role: uint8(RoleReplica),
+		ProtocolVersion: 1, // old binary
+	}
+	if resp := handler.HandleJoinRequest(req, peer); !resp.Accepted {
+		t.Errorf("v1 join with legacy HMAC must still be accepted (rolling upgrade): %s", resp.RejectReason)
+	}
+}
+
+func TestValidSecret_V2_RoleInHMAC(t *testing.T) {
+	const secret = "test-secret"
+	es := newTestEpochStore(t)
+	handler := NewJoinHandler("cortex-1", secret, es, newTestRepLog(t), NewConnManager("cortex-1"))
+
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte("probe-node"))
+	h.Write([]byte{uint8(RolePrimary)})
+	v2Hash := h.Sum(nil)
+
+	hOld := hmac.New(sha256.New, []byte(secret))
+	hOld.Write([]byte("probe-node"))
+	v1Hash := hOld.Sum(nil)
+
+	if !handler.ValidSecret("probe-node", uint8(RolePrimary), 2, v2Hash) {
+		t.Error("v2 probe with role-in-HMAC should be valid")
+	}
+	if handler.ValidSecret("probe-node", uint8(RolePrimary), 2, v1Hash) {
+		t.Error("v2 probe with legacy HMAC (no role) should be invalid")
+	}
+	if !handler.ValidSecret("probe-node", uint8(RolePrimary), 1, v1Hash) {
+		t.Error("v1 probe with legacy HMAC should still be valid")
+	}
+}

--- a/internal/replication/join.go
+++ b/internal/replication/join.go
@@ -58,14 +58,19 @@ func NewJoinHandlerWithDB(localNodeID, clusterSecret string, epochStore *EpochSt
 	return h
 }
 
-// ValidSecret reports whether secretHash is a valid HMAC of nodeID under the
-// cluster secret (always true in open mode). Used to authenticate probes (#531 PR3).
-func (h *JoinHandler) ValidSecret(nodeID string, secretHash []byte) bool {
+// ValidSecret reports whether secretHash is a valid HMAC of nodeID (+ role for
+// protocol v2+) under the cluster secret. Always true in open mode.
+// Used to authenticate probes (#531 PR3). The role+protoVer gate matches the
+// logic in HandleJoinRequest so probe and join auth stay in parity (#538).
+func (h *JoinHandler) ValidSecret(nodeID string, role uint8, protoVer uint16, secretHash []byte) bool {
 	if h.clusterSecret == "" {
 		return true
 	}
 	expected := hmac.New(sha256.New, []byte(h.clusterSecret))
 	expected.Write([]byte(nodeID))
+	if protoVer >= 2 {
+		expected.Write([]byte{role})
+	}
 	return hmac.Equal(secretHash, expected.Sum(nil))
 }
 
@@ -94,10 +99,14 @@ func (h *JoinHandler) HandleJoinRequest(req mbp.JoinRequest, conn *PeerConn) mbp
 		}
 	}
 
-	// Validate cluster secret if configured
+	// Validate cluster secret if configured. Protocol v2+ covers Role in the HMAC
+	// to prevent role spoofing (#538); v1 senders use nodeID-only for rolling-upgrade compat.
 	if h.clusterSecret != "" {
 		expectedHash := hmac.New(sha256.New, []byte(h.clusterSecret))
 		expectedHash.Write([]byte(req.NodeID))
+		if req.ProtocolVersion >= 2 {
+			expectedHash.Write([]byte{req.Role})
+		}
 		if !hmac.Equal(req.SecretHash, expectedHash.Sum(nil)) {
 			return mbp.JoinResponse{
 				Accepted:     false,
@@ -361,6 +370,7 @@ func (c *JoinClient) Probe(ctx context.Context, cortexAddr string) (mbp.JoinResp
 	if c.clusterSecret != "" {
 		h := hmac.New(sha256.New, []byte(c.clusterSecret))
 		h.Write([]byte(c.localNodeID))
+		h.Write([]byte{uint8(c.localRole)})
 		secretHash = h.Sum(nil)
 	}
 	req := mbp.JoinRequest{
@@ -454,11 +464,12 @@ func (c *JoinClient) joinConn(ctx context.Context, conn net.Conn) (JoinResult, e
 		lastApplied = c.applier.LastApplied()
 	}
 
-	// Compute HMAC-SHA256 of nodeID using clusterSecret
+	// Compute HMAC-SHA256 of nodeID+role (#538: role covered at proto v2+).
 	var secretHash []byte
 	if c.clusterSecret != "" {
 		h := hmac.New(sha256.New, []byte(c.clusterSecret))
 		h.Write([]byte(c.localNodeID))
+		h.Write([]byte{uint8(c.localRole)})
 		secretHash = h.Sum(nil)
 	}
 

--- a/internal/transport/mbp/protocol_version.go
+++ b/internal/transport/mbp/protocol_version.go
@@ -7,7 +7,8 @@ package mbp
 //
 //	0 = legacy (pre-versioned binaries)
 //	1 = initial versioned release
-const CurrentProtocolVersion uint16 = 1
+//	2 = JoinRequest HMAC covers Role field (#538)
+const CurrentProtocolVersion uint16 = 2
 
 // MinSupportedProtocolVersion is the oldest protocol version this binary will
 // accept from connecting peers. Peers below this version are hard-rejected.


### PR DESCRIPTION
## Problem

The join HMAC covered only `node_id`, leaving the new `Role` field (#529) unauthenticated. A node on the same cluster secret could claim voter status when it is an observer or replica.

## Fix

Protocol v2 senders (`joinConn` + `Probe`) now include the role byte in the HMAC: `HMAC(secret, nodeID + role)`. The receiver gates on `req.ProtocolVersion >= 2`; v1 nodes use the old nodeID-only HMAC and remain accepted during rolling upgrades.

`ValidSecret` (probe auth, #531 PR3) receives `role + protoVer` and applies the same gate, keeping join and probe auth in parity.

`PeerHello` already covered role — this brings `JoinRequest` up to parity with it.

## Protocol version bump

`CurrentProtocolVersion` 1 → 2. Version history comment updated.

## Tests (TDD, RED first)

- v2 join with correct role-in-HMAC → accepted
- v2 join with legacy (no-role) HMAC → rejected
- v1 join with legacy HMAC → still accepted (rolling upgrade)
- `ValidSecret` gate for v2 probe auth

Full suite green, `-race` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)