### PR TITLE
feat(memory): muninn_evolve accepts optional concept rename (closes #483)

### DIFF
--- a/internal/engine/content_hash_test.go
+++ b/internal/engine/content_hash_test.go
@@ -224,7 +224,7 @@ func TestEvolveThenWriteOldContentNoDup(t *testing.T) {
 	}
 
 	// Evolve A → B (soft-deletes A, creates B).
-	_, err = eng.Evolve(ctx, vault, resp1.ID, contentB, "update", nil)
+	_, err = eng.Evolve(ctx, vault, resp1.ID, contentB, "update", nil, "")
 	if err != nil {
 		t.Fatalf("evolve: %v", err)
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2740,10 +2740,9 @@ type EngineSessionEntry struct {
 }
 
 // Evolve creates a new version of an existing engram and soft-deletes the old one.
-// It links the new engram to the old one with RelSupersedes and returns the new ID.
-// All three writes (new engram, supersedes association, old engram state) are committed
-// in a single atomic Pebble batch so a crash cannot leave the store in an inconsistent state.
-func (e *Engine) Evolve(ctx context.Context, vault, oldID, newContent, reason string, embedding []float32) (storage.ULID, error) {
+// concept overrides the inherited concept label; empty string inherits verbatim (#483).
+// All three writes are committed in a single atomic Pebble batch.
+func (e *Engine) Evolve(ctx context.Context, vault, oldID, newContent, reason string, embedding []float32, concept string) (storage.ULID, error) {
 	wsPrefix := e.store.ResolveVaultPrefix(vault)
 
 	// Parse the old ULID before any writes.
@@ -2765,9 +2764,12 @@ func (e *Engine) Evolve(ctx context.Context, vault, oldID, newContent, reason st
 	// supersedes association within the same batch.
 	newULID := storage.NewULID()
 	now := time.Now()
+	if concept == "" {
+		concept = oldEng.Concept
+	}
 	newEng := &storage.Engram{
 		ID:         newULID,
-		Concept:    oldEng.Concept,
+		Concept:    concept,
 		Content:    newContent,
 		Tags:       oldEng.Tags,
 		Confidence: 1.0,

--- a/internal/engine/engine_evolve_test.go
+++ b/internal/engine/engine_evolve_test.go
@@ -23,7 +23,7 @@ func TestEvolve_AtomicBatch_OldSoftDeletedNewReadable(t *testing.T) {
 		t.Fatalf("Write: %v", err)
 	}
 
-	newID, err := eng.Evolve(ctx, "test", resp.ID, "new content", "update", nil)
+	newID, err := eng.Evolve(ctx, "test", resp.ID, "new content", "update", nil, "")
 	if err != nil {
 		t.Fatalf("Evolve: %v", err)
 	}
@@ -68,11 +68,9 @@ func TestEvolve_AtomicBatch_OldSoftDeletedNewReadable(t *testing.T) {
 }
 
 // TestEvolve_ConceptStableAcrossRepeatedEvolution verifies that the concept field
-// is inherited verbatim from the predecessor on every Evolve call, with no suffix
-// added or accumulated. Lineage is recorded via the RelSupersedes association, not
-// by mutating the concept string. Without this guarantee, callers that use concept
-// names as stable references (canonical-engram patterns) see the reference drift
-// further on every update: "topic" → "topic (evolved)" → "topic (evolved) (evolved)".
+// is inherited verbatim from the predecessor on every Evolve call when no new
+// concept is provided. Lineage is recorded via RelSupersedes, not by mutating
+// the concept string.
 func TestEvolve_ConceptStableAcrossRepeatedEvolution(t *testing.T) {
 	eng, cleanup := testEnv(t)
 	defer cleanup()
@@ -85,8 +83,8 @@ func TestEvolve_ConceptStableAcrossRepeatedEvolution(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// First evolution: concept must equal original (no suffix).
-	id1, err := eng.Evolve(ctx, "test", resp.ID, "v2", "first update", nil)
+	// First evolution with empty concept: must inherit original verbatim.
+	id1, err := eng.Evolve(ctx, "test", resp.ID, "v2", "first update", nil, "")
 	require.NoError(t, err)
 
 	ws := eng.store.ResolveVaultPrefix("test")
@@ -96,8 +94,8 @@ func TestEvolve_ConceptStableAcrossRepeatedEvolution(t *testing.T) {
 	assert.Equal(t, originalConcept, eng1.Concept,
 		"concept must be inherited verbatim from predecessor, no suffix")
 
-	// Second evolution: concept must still equal original (no accumulation).
-	id2, err := eng.Evolve(ctx, "test", id1.String(), "v3", "second update", nil)
+	// Second evolution with empty concept: must still equal original.
+	id2, err := eng.Evolve(ctx, "test", id1.String(), "v3", "second update", nil, "")
 	require.NoError(t, err)
 
 	eng2, err := eng.store.GetEngram(ctx, ws, id2)
@@ -105,4 +103,35 @@ func TestEvolve_ConceptStableAcrossRepeatedEvolution(t *testing.T) {
 	require.NotNil(t, eng2)
 	assert.Equal(t, originalConcept, eng2.Concept,
 		"concept must remain stable across repeated evolutions, no accumulating suffix")
+}
+
+// TestEvolve_ConceptRenameWhenProvided verifies that when a non-empty concept is
+// supplied, the new version takes that concept rather than inheriting the predecessor's.
+// This lets callers correct concepts that encode mutable state (#483).
+func TestEvolve_ConceptRenameWhenProvided(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "test", Concept: "answer owed to Alice on #895", Content: "v1",
+	})
+	require.NoError(t, err)
+
+	newID, err := eng.Evolve(ctx, "test", resp.ID, "answer sent — closed", "paid the debt", nil, "answer to Alice on #895 — CLOSED")
+	require.NoError(t, err)
+
+	ws := eng.store.ResolveVaultPrefix("test")
+	newEng, err := eng.store.GetEngram(ctx, ws, newID)
+	require.NoError(t, err)
+	require.NotNil(t, newEng)
+	assert.Equal(t, "answer to Alice on #895 — CLOSED", newEng.Concept,
+		"provided concept must be used instead of inheriting predecessor's")
+
+	// Predecessor concept is unchanged (it just becomes soft-deleted).
+	oldULID, _ := storage.ParseULID(resp.ID)
+	oldEng, err := eng.store.GetEngram(ctx, ws, oldULID)
+	require.NoError(t, err)
+	assert.Equal(t, "answer owed to Alice on #895", oldEng.Concept,
+		"predecessor concept must not be mutated")
 }

--- a/internal/engine/engine_integration_test.go
+++ b/internal/engine/engine_integration_test.go
@@ -246,7 +246,7 @@ func TestEvolve_ChainPreservesContent(t *testing.T) {
 	origID := resp.ID
 
 	// Evolve creates a new engram and soft-deletes the old one.
-	newID, err := eng.Evolve(ctx, "evolve-test", origID, "Updated content v2", "improvement", nil)
+	newID, err := eng.Evolve(ctx, "evolve-test", origID, "Updated content v2", "improvement", nil, "")
 	require.NoError(t, err)
 	require.NotEqual(t, storage.ULID{}, newID, "evolved ID should not be the zero value")
 	require.NotEqual(t, origID, newID.String(), "evolved ID should differ from original ID")

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -581,7 +581,7 @@ func TestEngineEvolve(t *testing.T) {
 	}
 	oldID := resp.ID
 
-	newID, err := eng.Evolve(ctx, "test", oldID, "new content", "updated reasoning", nil)
+	newID, err := eng.Evolve(ctx, "test", oldID, "new content", "updated reasoning", nil, "")
 	if err != nil {
 		t.Fatalf("Evolve: %v", err)
 	}
@@ -2252,7 +2252,7 @@ func TestEvolve_AutoStampsTrustInferred(t *testing.T) {
 		t.Fatalf("Write: %v", err)
 	}
 
-	newULID, err := eng.Evolve(ctx, "test", writeResp.ID, "Evolved content after trust stamp.", "trust test evolution", nil)
+	newULID, err := eng.Evolve(ctx, "test", writeResp.ID, "Evolved content after trust stamp.", "trust test evolution", nil, "")
 	if err != nil {
 		t.Fatalf("Evolve: %v", err)
 	}

--- a/internal/mcp/engine.go
+++ b/internal/mcp/engine.go
@@ -26,7 +26,7 @@ type EngineInterface interface {
 
 	// Higher-level cognitive operations (tools 1-11)
 	GetContradictions(ctx context.Context, vault string) ([]ContradictionPair, error)
-	Evolve(ctx context.Context, vault, oldID, newContent, reason string, embedding []float32) (*WriteResult, error)
+	Evolve(ctx context.Context, vault, oldID, newContent, reason string, embedding []float32, concept string) (*WriteResult, error)
 	Consolidate(ctx context.Context, vault string, ids []string, mergedContent string) (*ConsolidateResult, error)
 	Session(ctx context.Context, vault string, since time.Time) (*SessionSummary, error)
 	Decide(ctx context.Context, vault, decision, rationale string, alternatives, evidenceIDs []string) (*WriteResult, error)

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -62,8 +62,8 @@ func (a *mcpEngineAdapter) GetContradictions(ctx context.Context, vault string) 
 	}
 	return result, nil
 }
-func (a *mcpEngineAdapter) Evolve(ctx context.Context, vault, oldID, newContent, reason string, embedding []float32) (*WriteResult, error) {
-	id, err := a.eng.Evolve(ctx, vault, oldID, newContent, reason, embedding)
+func (a *mcpEngineAdapter) Evolve(ctx context.Context, vault, oldID, newContent, reason string, embedding []float32, concept string) (*WriteResult, error) {
+	id, err := a.eng.Evolve(ctx, vault, oldID, newContent, reason, embedding, concept)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -561,7 +561,11 @@ func (s *MCPServer) handleEvolve(ctx context.Context, w http.ResponseWriter, id 
 		}
 		evolveEmb = emb
 	}
-	result, err := s.engine.Evolve(ctx, vault, engramID, newContent, reason, evolveEmb)
+	var evolveConcept string
+	if c, ok := args["concept"].(string); ok {
+		evolveConcept = c
+	}
+	result, err := s.engine.Evolve(ctx, vault, engramID, newContent, reason, evolveEmb, evolveConcept)
 	if err != nil {
 		sendError(w, id, -32000, "tool error: "+err.Error())
 		return

--- a/internal/mcp/handlers_coverage_test.go
+++ b/internal/mcp/handlers_coverage_test.go
@@ -56,7 +56,7 @@ func (e *linkErrEngine) Link(_ context.Context, _ *mbp.LinkRequest) (*mbp.LinkRe
 // evolveErrEngine returns an error from Evolve.
 type evolveErrEngine struct{ fakeEngine }
 
-func (e *evolveErrEngine) Evolve(_ context.Context, _, _, _, _ string, _ []float32) (*WriteResult, error) {
+func (e *evolveErrEngine) Evolve(_ context.Context, _, _, _, _ string, _ []float32, _ string) (*WriteResult, error) {
 	return nil, fmt.Errorf("evolve storage error")
 }
 

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -1664,8 +1664,8 @@ func (e *slowIdempotentEngine) Stat(ctx context.Context, req *mbp.StatRequest) (
 func (e *slowIdempotentEngine) GetContradictions(ctx context.Context, vault string) ([]ContradictionPair, error) {
 	return (&fakeEngine{}).GetContradictions(ctx, vault)
 }
-func (e *slowIdempotentEngine) Evolve(ctx context.Context, vault, oldID, newContent, reason string, embedding []float32) (*WriteResult, error) {
-	return (&fakeEngine{}).Evolve(ctx, vault, oldID, newContent, reason, embedding)
+func (e *slowIdempotentEngine) Evolve(ctx context.Context, vault, oldID, newContent, reason string, embedding []float32, concept string) (*WriteResult, error) {
+	return (&fakeEngine{}).Evolve(ctx, vault, oldID, newContent, reason, embedding, concept)
 }
 func (e *slowIdempotentEngine) Consolidate(ctx context.Context, vault string, ids []string, merged string) (*ConsolidateResult, error) {
 	return (&fakeEngine{}).Consolidate(ctx, vault, ids, merged)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -49,7 +49,7 @@ func (f *fakeEngine) Stat(ctx context.Context, req *mbp.StatRequest) (*mbp.StatR
 func (f *fakeEngine) GetContradictions(ctx context.Context, vault string) ([]ContradictionPair, error) {
 	return nil, nil
 }
-func (f *fakeEngine) Evolve(ctx context.Context, vault, oldID, newContent, reason string, embedding []float32) (*WriteResult, error) {
+func (f *fakeEngine) Evolve(ctx context.Context, vault, oldID, newContent, reason string, embedding []float32, concept string) (*WriteResult, error) {
 	return &WriteResult{ID: "new-id"}, nil
 }
 func (f *fakeEngine) Consolidate(ctx context.Context, vault string, ids []string, merged string) (*ConsolidateResult, error) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -292,6 +292,10 @@ func allToolDefinitions() []ToolDefinition {
 					"id":          map[string]any{"type": "string", "description": "ID of the memory to evolve."},
 					"new_content": map[string]any{"type": "string", "description": "Updated information."},
 					"reason":      map[string]any{"type": "string", "description": "Why this memory is being updated."},
+					"concept": map[string]any{
+						"type":        "string",
+						"description": "Optional new label for the memory. When omitted the concept is inherited verbatim. Use this to correct concepts that encode mutable state (e.g. change \"answer owed\" to \"answer sent — closed\").",
+					},
 					"embedding": map[string]any{
 						"type":        "array",
 						"items":       map[string]any{"type": "number"},

--- a/internal/transport/rest/engine_adapter.go
+++ b/internal/transport/rest/engine_adapter.go
@@ -317,7 +317,7 @@ func lifecycleStateLabel(s storage.LifecycleState) string {
 }
 
 func (w *RESTEngineWrapper) Evolve(ctx context.Context, vault, engramID, newContent, reason string) (*EvolveResponse, error) {
-	newID, err := w.engine.Evolve(ctx, vault, engramID, newContent, reason, nil)
+	newID, err := w.engine.Evolve(ctx, vault, engramID, newContent, reason, nil, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem (#483)

`muninn_evolve` inherited the concept verbatim on every evolution (correct default from #459). But concepts that encode mutable state — `"answer owed to Alice"`, `"PR #32 blocked"`, `"migration underway"` — become permanently wrong once the state changes. `muninn_where_left_off` returns the stale concept as the orientation headline at every session boot, causing agents to re-announce resolved debts and closed work.

The only workaround was `forget + remember`, destroying the ULID, supersedes lineage, and accumulated access history that `evolve` exists to preserve.

## Fix

`Engine.Evolve` gains a `concept string` parameter:
- **Empty string** → inherit verbatim (today's behavior, `#459` regression test unchanged)
- **Non-empty** → the new version takes that concept. The `RelSupersedes` association already records lineage, so the old name remains discoverable through the chain.

Exposed on the `muninn_evolve` MCP tool as an optional `"concept"` field. REST API unchanged.

## Examples

```json
{
  "id": "01J...",
  "new_content": "answer sent — closed",
  "reason": "paid the debt",
  "concept": "answer to Alice on #895 — CLOSED"
}
```

## Scope of changes

- `Engine.Evolve` (`engine.go`) — `concept string` added as last parameter
- `EngineInterface` + `mcpEngineAdapter` — signature updated, concept passed through
- `REST engine_adapter` — passes `""` (REST API doesn't surface concept rename yet)
- `MCP tools.go` — `"concept"` field added to `muninn_evolve` schema with description
- `MCP handlers.go` — parses optional `"concept"` arg

All existing call sites updated to pass `""` (no behavior change).

## Tests (TDD, RED first)

- `TestEvolve_ConceptRenameWhenProvided` — new concept taken when non-empty; predecessor untouched
- `TestEvolve_ConceptStableAcrossRepeatedEvolution` — empty string inherits verbatim (existing test, updated call sites)

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)