### PR TITLE
fix(hnsw): rebuild graph from vectors when the restored structure is disconnected

### DIFF
--- a/internal/index/hnsw/disconnected_rebuild_test.go
+++ b/internal/index/hnsw/disconnected_rebuild_test.go
@@ -1,0 +1,118 @@
+package hnsw
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/storage/keys"
+)
+
+// buildPersistedGraph stores n random vectors and inserts them into a fresh
+// Index, then blocks until async persistence completes. It mirrors the
+// production write path (StoreVector persists the 0xFF vector slot; Insert
+// persists the per-layer neighbor lists).
+func buildPersistedGraph(t *testing.T, db *pebble.DB, ws [8]byte, n, dim int, seed int64) (*Index, [][16]byte, [][]float32) {
+	t.Helper()
+	rng := rand.New(rand.NewSource(seed))
+	idx := New(db, ws)
+	ids := make([][16]byte, n)
+	vecs := make([][]float32, n)
+	for i := 0; i < n; i++ {
+		var id [16]byte
+		rng.Read(id[:])
+		v := make([]float32, dim)
+		for j := range v {
+			v[j] = rng.Float32()*2 - 1
+		}
+		ids[i], vecs[i] = id, v
+		if err := idx.StoreVector(id, v); err != nil {
+			t.Fatalf("StoreVector: %v", err)
+		}
+		idx.Insert(id, v)
+	}
+	idx.Close() // wait for async persistNode goroutines
+	return idx, ids, vecs
+}
+
+// TestLoadFromPebble_DisconnectedEntryPoint_Rebuilds reproduces the production
+// failure (an entry point whose persisted neighbor list is only itself) and
+// asserts the load path detects the disconnection and rebuilds the graph from
+// the still-intact vectors. Without the rebuild, bfsReachable from the
+// self-looped entry point is 1 and this test fails.
+func TestLoadFromPebble_DisconnectedEntryPoint_Rebuilds(t *testing.T) {
+	db, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var ws [8]byte
+	copy(ws[:], []byte("REBUILD1"))
+	const n, dim = 60, 16
+
+	_, _, vecs := buildPersistedGraph(t, db, ws, n, dim, 11)
+
+	// Discover the node the restore path deterministically selects as entry
+	// point (the highest persisted layer), and confirm the freshly built graph
+	// is navigable — so the only thing that can make the reload navigable again
+	// is the rebuild.
+	probe := New(db, ws)
+	if err := probe.LoadFromPebble(); err != nil {
+		t.Fatalf("probe LoadFromPebble: %v", err)
+	}
+	entry := probe.entryPoint
+	if got := bfsReachable(probe.nodes, entry); got < n*9/10 {
+		t.Fatalf("precondition: freshly built graph not navigable (reachable=%d/%d)", got, n)
+	}
+
+	// Corrupt the persisted entry point's layer-0 neighbor list to [self] — the
+	// degenerate apex observed in production. The 0xFF vector slots are left
+	// intact, so the vectors remain the reliable source of truth for a rebuild.
+	if err := db.Set(keys.HNSWNodeKey(ws, entry, 0), encodeNeighbors([][16]byte{entry}), pebble.Sync); err != nil {
+		t.Fatalf("corrupt entry point: %v", err)
+	}
+
+	idx2 := New(db, ws)
+	if err := idx2.LoadFromPebble(); err != nil {
+		t.Fatalf("LoadFromPebble: %v", err)
+	}
+
+	if got := bfsReachable(idx2.nodes, idx2.entryPoint); got < n*9/10 {
+		t.Fatalf("post-load reachable=%d/%d — disconnected graph was not rebuilt", got, n)
+	}
+
+	res, err := idx2.Search(context.Background(), vecs[0], 5)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) == 0 || res[0].Score <= 0 {
+		t.Fatalf("search on rebuilt index returned no usable result: %+v", res)
+	}
+}
+
+// TestLoadFromPebble_HealthyGraph_LoadsNavigable guards the common path: a
+// healthy persisted graph must load already-navigable, so the rebuild branch is
+// a no-op and load remains correct.
+func TestLoadFromPebble_HealthyGraph_LoadsNavigable(t *testing.T) {
+	db, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var ws [8]byte
+	copy(ws[:], []byte("HEALTHY1"))
+	const n, dim = 60, 16
+
+	buildPersistedGraph(t, db, ws, n, dim, 23)
+
+	idx2 := New(db, ws)
+	if err := idx2.LoadFromPebble(); err != nil {
+		t.Fatalf("LoadFromPebble: %v", err)
+	}
+	if got := bfsReachable(idx2.nodes, idx2.entryPoint); got < n*9/10 {
+		t.Fatalf("healthy graph loaded with reachable=%d/%d", got, n)
+	}
+}

--- a/internal/index/hnsw/hnsw.go
+++ b/internal/index/hnsw/hnsw.go
@@ -783,6 +783,47 @@ func (idx *Index) LoadFromPebble() error {
 		}
 	}
 
+	// Persisted neighbor lists are written asynchronously with NoSync and can be
+	// stale or degenerate (observed in production: an entry point whose every
+	// neighbor on every layer was itself — one such node at the graph apex makes
+	// the entire vault unreachable for vector search while the rest of the
+	// persisted graph looks healthy). Restoring structure we cannot trust is
+	// worse than rebuilding from the vectors, which ARE reliable (written once,
+	// validated on read). So: check connectivity from the restored entry point
+	// and rebuild the graph in memory from the vectors when the structure is
+	// broken, then re-persist the healthy neighbor lists.
+	reachable := bfsReachable(tempNodes, tempEntryPoint)
+	rebuilt := false
+	if vectorCount > 1 && reachable*2 < vectorCount {
+		slog.Warn("hnsw: restored graph is disconnected — rebuilding from vectors",
+			"vault", idx.ws,
+			"nodes", len(tempNodes),
+			"reachable_from_entry", reachable,
+		)
+		tmp := New(idx.db, idx.ws)
+		tmp.efConstruction = idx.efConstruction
+		tmp.efSearch = idx.efSearch
+		// Deterministic order: ULIDs ascending (map iteration is random).
+		ids := make([][16]byte, 0, len(tempNodes))
+		for id, n := range tempNodes {
+			if n.vec != nil {
+				ids = append(ids, id)
+			}
+		}
+		sort.Slice(ids, func(i, j int) bool { return string(ids[i][:]) < string(ids[j][:]) })
+		for _, id := range ids {
+			tmp.Insert(id, tempNodes[id].vec)
+		}
+		tmp.persistWg.Wait() // flush re-persisted (healthy) neighbor lists
+		tmp.mu.Lock()
+		tempNodes = tmp.nodes
+		tempMaxLevel = tmp.maxLevel
+		tempEntryPoint = tmp.entryPoint
+		tmp.mu.Unlock()
+		reachable = bfsReachable(tempNodes, tempEntryPoint)
+		rebuilt = true
+	}
+
 	// Only apply to index if load completed successfully
 	idx.mu.Lock()
 	idx.nodes = tempNodes
@@ -795,9 +836,37 @@ func (idx *Index) LoadFromPebble() error {
 		"nodes", len(tempNodes),
 		"vectors", vectorCount,
 		"duration", time.Since(start),
+		"reachable_from_entry", reachable,
+		"rebuilt", rebuilt,
 	)
 
 	return nil
+}
+
+// bfsReachable counts the nodes reachable from the entry point over layer-0
+// edges. A healthy graph reaches ~all nodes; a small count on a populated graph
+// indicates a disconnected (e.g. self-looped) entry point.
+func bfsReachable(nodes map[[16]byte]*HNSWNode, entry [16]byte) int {
+	if nodes[entry] == nil {
+		return 0
+	}
+	seen := map[[16]byte]bool{entry: true}
+	queue := [][16]byte{entry}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		n := nodes[cur]
+		if n == nil || len(n.layers) == 0 {
+			continue
+		}
+		for _, nb := range n.layers[0] {
+			if !seen[nb] && nodes[nb] != nil {
+				seen[nb] = true
+				queue = append(queue, nb)
+			}
+		}
+	}
+	return len(seen)
 }
 
 func min(a, b int) int {


### PR DESCRIPTION
Closes #544. Follow-up to #499 — lands the connectivity-rebuild from that
issue's field-report addendum that #506 didn't take. Additive to #471 (insert
prevention) and #506 (scoped load / no-cache-on-error / logging).

## Problem

A persisted HNSW graph can be **intact-but-disconnected**: every node, neighbor
list, and `0xFF` vector slot decodes cleanly, but the entry point's edges are
degenerate (in production: an apex whose every neighbor on every layer was
itself, from a pre-#471 bulk reembed that self-linked the entry point and was
never re-persisted). `LoadFromPebble` restores that structure faithfully, greedy
descent dies at the apex, and vector search returns ~nothing for the whole
vault. The load **succeeds**, so #506's no-cache-on-error never triggers and
`rebuilt=false` is logged on a graph that is in fact dead. FTS masks it; `status`
stays green.

#471 stops new inserts from creating this, but does not heal a graph already
persisted in the broken state — which any instance upgrading across the
reembed era carries on disk.

## Fix

In `Index.LoadFromPebble`, after the temp maps are populated and `vectorCount`
is computed (immediately before the existing "apply to index" block), check
connectivity from the restored entry point and rebuild from the vectors if the
structure is untrustworthy. The vectors are reliable (written once, validated on
read); the neighbor lists are not (written async with `NoSync`, and backlink
mutations are never re-persisted).

```go
// internal/index/hnsw/hnsw.go — after vectorCount is computed, before idx.mu.Lock()

// Persisted neighbor lists are written asynchronously with NoSync and can be
// stale or degenerate (observed in production: an entry point whose every
// neighbor on every layer was itself — one such node at the graph apex makes
// the entire vault unreachable for vector search while the rest of the
// persisted graph looks healthy). Restoring structure we cannot trust is worse
// than rebuilding from the vectors, which ARE reliable. So: check connectivity
// from the entry point, and rebuild from the vectors if the structure is broken.
reachable := bfsReachable(tempNodes, tempEntryPoint)
rebuilt := false
if vectorCount > 1 && reachable*2 < vectorCount {
    slog.Warn("hnsw: restored graph is disconnected — rebuilding from vectors",
        "vault", idx.ws,
        "nodes", len(tempNodes),
        "reachable_from_entry", reachable,
    )
    tmp := New(idx.db, idx.ws)
    tmp.efConstruction = idx.efConstruction
    tmp.efSearch = idx.efSearch
    // Deterministic order: ULIDs ascending (map iteration is random).
    ids := make([][16]byte, 0, len(tempNodes))
    for id, n := range tempNodes {
        if n.vec != nil {
            ids = append(ids, id)
        }
    }
    sort.Slice(ids, func(i, j int) bool { return string(ids[i][:]) < string(ids[j][:]) })
    for _, id := range ids {
        tmp.Insert(id, tempNodes[id].vec)
    }
    tmp.persistWg.Wait() // flush re-persisted (healthy) neighbor lists
    tmp.mu.Lock()
    tempNodes = tmp.nodes
    tempMaxLevel = tmp.maxLevel
    tempEntryPoint = tmp.entryPoint
    tmp.mu.Unlock()
    reachable = bfsReachable(tempNodes, tempEntryPoint)
    rebuilt = true
}
```

The existing load line gains two fields so the repair is visible at restore time:

```go
slog.Info("hnsw: loaded graph from pebble",
    "vault", idx.ws,
    "nodes", len(tempNodes),
    "vectors", vectorCount,
    "duration", time.Since(start),
    "reachable_from_entry", reachable,
    "rebuilt", rebuilt,
)
```

New helper:

```go
// bfsReachable counts nodes reachable from the entry point over layer-0 edges.
func bfsReachable(nodes map[[16]byte]*HNSWNode, entry [16]byte) int {
    if nodes[entry] == nil {
        return 0
    }
    seen := map[[16]byte]bool{entry: true}
    queue := [][16]byte{entry}
    for len(queue) > 0 {
        cur := queue[0]
        queue = queue[1:]
        n := nodes[cur]
        if n == nil || len(n.layers) == 0 {
            continue
        }
        for _, nb := range n.layers[0] {
            if !seen[nb] && nodes[nb] != nil {
                seen[nb] = true
                queue = append(queue, nb)
            }
        }
    }
    return len(seen)
}
```

No new imports — `sort` is already imported by `hnsw.go` in v0.7.0. (Field names
— `persistWg`, `efConstruction`, `efSearch`, `layers`, `vec` — match the current
`Index`/`HNSWNode` defs; the flush is `tmp.persistWg.Wait()`, which is exactly
what `Index.Close()` does, so the throwaway `tmp` leaks nothing.)

## Why rebuild rather than repair in place

The vectors are the ground truth; the edges are the corruptible derived data.
Re-`Insert`ing every vectored node reconstructs correct neighbor lists and, on
`v0.7.0`, runs through #471's fixed `Insert` — so the rebuilt graph is
well-connected (the bulk-reinsertion degeneration seen on v0.6.1 was a symptom
of the insert bugs #471 fixed). The post-rebuild `bfsReachable` re-check, logged
as `reachable_from_entry`, makes that assertion observable rather than assumed.

## Threshold

`reachable*2 < vectorCount` (fewer than half reachable) deliberately fires only
on gross structural failure, not on a few transiently-stranded nodes. A healthy
graph reaches ~all nodes, so the branch is skipped and the cost is one O(N)
layer-0 BFS per load.

## Tests

Both white-box (`package hnsw`), so they call `bfsReachable` directly and inject
corruption through the real key encoding (`keys.HNSWNodeKey` + `encodeNeighbors`):

- `TestLoadFromPebble_DisconnectedEntryPoint_Rebuilds`: build and persist a
  healthy graph, probe-load to find the node the restore path deterministically
  selects as entry point, overwrite *that* node's persisted layer-0 list with
  `[self]`, then reload. Asserts the reload comes back navigable (`bfsReachable`
  jumps from 1 to ~N) and vector search returns a usable result. Fails without
  the rebuild — the load would otherwise restore `reachable == 1`.
- `TestLoadFromPebble_HealthyGraph_LoadsNavigable`: an uncorrupted graph loads
  already-navigable, so the rebuild branch is a no-op and the common path stays
  correct.

Verified run: corrupted reload logs `reachable_from_entry=1 … rebuilt=true`,
healthy reload logs `rebuilt=false`; full `internal/index/hnsw` package passes
under `-race`.

## Scope / non-goals

- No key-format or API changes; load-path only.
- Startup warm-up and the optional small-scale brute-force search fallback (both
  raised in #499) are **out of scope here** to keep this focused on the
  data-visibility repair. Happy to follow up with either on request.

## Risk

Bounded: the rebuild path only runs when the graph is already non-functional for
vector search (`reachable < vectorCount/2`), where doing nothing is strictly
worse. Worst case for a false trigger is one extra in-memory rebuild from
vectors at load — correct, just not free. Healthy graphs never enter it.
