### PR TITLE
fix(storage): dedup entity scan by normalized identity, not raw casing

### DIFF
--- a/internal/engine/engine_similarity_test.go
+++ b/internal/engine/engine_similarity_test.go
@@ -109,6 +109,24 @@ func TestFindSimilarEntities_NoPairsForDifferentNames(t *testing.T) {
 	}
 }
 
+// TestFindSimilarEntities_IgnoresCaseVariants verifies that names differing only
+// by case are NOT reported as a similar pair: they are the same identity (one 0x1F
+// record) and merge_entity refuses them, so surfacing them is un-actionable noise.
+func TestFindSimilarEntities_IgnoresCaseVariants(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	writeEntityEngram(t, eng, "default", "MuninnDB is the memory store",
+		mbp.InlineEntity{Name: "MuninnDB", Type: "database"})
+	writeEntityEngram(t, eng, "default", "muninndb runs on the server",
+		mbp.InlineEntity{Name: "muninndb", Type: "database"})
+
+	pairs, err := eng.FindSimilarEntities(ctx, "default", 0.7, 20)
+	require.NoError(t, err)
+	require.Empty(t, pairs, "case-only variants share one identity and must not be reported as a similar pair")
+}
+
 func TestFindSimilarEntities_EmptyVault(t *testing.T) {
 	eng, cleanup := testEnv(t)
 	defer cleanup()

--- a/internal/storage/entity.go
+++ b/internal/storage/entity.go
@@ -1037,9 +1037,15 @@ func (ps *PebbleStore) deleteEntityLinks(ws [8]byte, engramID [16]byte, batch *p
 	return entityNames, nil
 }
 
-// ScanVaultEntityNames scans the 0x20 forward index for all distinct entity names
-// in a vault. The same entity name may appear multiple times (once per engram-link);
-// fn is called exactly once per unique name.
+// ScanVaultEntityNames scans the 0x20 forward index for all distinct entity
+// identities in a vault. The 0x20 link value stores the entity name with its
+// original casing, so one entity can appear under several case/whitespace/NFKC
+// variants. Entity identity is case-insensitive everywhere else (the 0x1F record
+// key, GetEntityRecord and the per-entity lock all normalize), so dedup here is by
+// keys.NormalizeEntityName, not the raw value — otherwise duplicate identities leak
+// into callers (duplicate rows in ListEntities, un-mergeable pairs in
+// FindSimilarEntities). fn is called exactly once per identity, with the first-seen
+// casing as the representative name.
 func (ps *PebbleStore) ScanVaultEntityNames(ctx context.Context, ws [8]byte, fn func(name string) error) error {
 	prefix := make([]byte, 1+8)
 	prefix[0] = 0x20
@@ -1067,10 +1073,11 @@ func (ps *PebbleStore) ScanVaultEntityNames(ctx context.Context, ws [8]byte, fn 
 		if name == "" {
 			continue
 		}
-		if _, already := seen[name]; already {
+		identity := keys.NormalizeEntityName(name)
+		if _, already := seen[identity]; already {
 			continue
 		}
-		seen[name] = struct{}{}
+		seen[identity] = struct{}{}
 		if err := fn(name); err != nil {
 			return err
 		}

--- a/internal/storage/entity_scan_test.go
+++ b/internal/storage/entity_scan_test.go
@@ -88,6 +88,31 @@ func TestScanVaultEntityNames_DeduplicatesAcrossEngrams(t *testing.T) {
 	require.Equal(t, []string{"Go"}, got, "duplicate entity links must be deduplicated by ScanVaultEntityNames")
 }
 
+// TestScanVaultEntityNames_DeduplicatesCaseVariants verifies that entity names
+// differing only by case (or whitespace/NFKC) collapse to a single identity: they
+// share one 0x1F record, so the scan must invoke fn exactly once. Guards the
+// muninn_entities duplicate-row / similar_entities case-pair regression.
+func TestScanVaultEntityNames_DeduplicatesCaseVariants(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("scan-entity-case-variants")
+
+	require.NoError(t, store.UpsertEntityRecord(ctx, EntityRecord{
+		Name: "MuninnDB", Type: "database", Confidence: 1,
+	}, "test"))
+
+	// Two engrams link the same entity under different casings.
+	require.NoError(t, store.WriteEntityEngramLink(ctx, ws, NewULID(), "MuninnDB"))
+	require.NoError(t, store.WriteEntityEngramLink(ctx, ws, NewULID(), "muninndb"))
+
+	var got []string
+	require.NoError(t, store.ScanVaultEntityNames(ctx, ws, func(name string) error {
+		got = append(got, name)
+		return nil
+	}))
+	require.Len(t, got, 1, "case-variant entity links must collapse to one identity")
+}
+
 // TestScanVaultEntityNames_CallbackError verifies that ScanVaultEntityNames
 // stops immediately and propagates the error returned by the callback.
 func TestScanVaultEntityNames_CallbackError(t *testing.T) {

--- a/internal/storage/keys/keys.go
+++ b/internal/storage/keys/keys.go
@@ -529,11 +529,19 @@ func Hash(s string) uint32 {
 	return h
 }
 
+// NormalizeEntityName returns the canonical identity form of an entity name:
+// NFKC-normalized, lowercased, and trimmed. This is the single source of truth
+// for entity identity. EntityNameHash hashes it for the 0x1F record key, and any
+// caller that deduplicates entity names (e.g. ScanVaultEntityNames) must key on it
+// so that case/whitespace/NFKC variants collapse onto the one record they share.
+func NormalizeEntityName(name string) string {
+	return strings.ToLower(strings.TrimSpace(norm.NFKC.String(name)))
+}
+
 // EntityNameHash computes the 8-byte SipHash of a NFKC-normalized, lowercased,
 // trimmed entity name. Used for the 0x1F entity key and 0x20 link key.
 func EntityNameHash(name string) [8]byte {
-	normalized := strings.ToLower(strings.TrimSpace(norm.NFKC.String(name)))
-	hashVal := siphash.Hash(sipKey0, sipKey1, []byte(normalized))
+	hashVal := siphash.Hash(sipKey0, sipKey1, []byte(NormalizeEntityName(name)))
 	var h [8]byte
 	binary.BigEndian.PutUint64(h[:], hashVal)
 	return h


### PR DESCRIPTION
Fixes #549 (`muninn_entities` duplicate rows for case-variant entity names).

## Problem

`ScanVaultEntityNames` deduplicated the `0x20` forward-link values by the **raw**
entity name, but entity identity is case-insensitive everywhere else (the `0x1F`
record key, `GetEntityRecord`, and the per-entity lock all `NFKC + lowercase +
trim`). So an entity linked under more than one casing (e.g. `MyService` /
`myservice`) leaked **duplicate identities** into both callers of the scan:

- **`ListEntities`** (`muninn_entities`) appended the same `0x1F` record once per
  casing → byte-identical duplicate rows (same name / type / `mention_count`),
  inflating the entity count and double-counting mentions.
- **`FindSimilarEntities`** (`muninn_similar_entities`) reported the casings as a
  `1.0` "similar" pair that `merge_entity` then refuses (`"normalize to the same
  entity; nothing to merge"`) → un-actionable noise.

## Fix

- Extract the normalization into `keys.NormalizeEntityName` (single source of
  truth; `EntityNameHash` now calls it — no behavior change).
- Key `ScanVaultEntityNames`' `seen` set on `keys.NormalizeEntityName(name)`
  instead of the raw value. `fn` still receives the first-seen casing as the
  representative name, so both callers are unchanged except for the duplicates
  disappearing.

One scan, one normalization rule, both symptoms fixed.

## Tests

- `TestScanVaultEntityNames_DeduplicatesCaseVariants` — two engrams link
  `MuninnDB` / `muninndb`; the scan must yield one identity.
- `TestFindSimilarEntities_IgnoresCaseVariants` — case-only variants are not
  reported as a similar pair.

Both **fail on `develop` without the fix** and pass with it. Full
`internal/storage/...`, `internal/engine/...`, and `internal/mcp/...` suites stay
green; `gofmt`/`go vet` clean.

## Diffstat

```
 internal/engine/engine_similarity_test.go | 18 ++++++++++++++++++
 internal/storage/entity.go                | 17 ++++++++++++-----
 internal/storage/entity_scan_test.go      | 25 +++++++++++++++++++++++++
 internal/storage/keys/keys.go             | 12 ++++++++++--
 4 files changed, 65 insertions(+), 7 deletions(-)
```

## Scope note

Existing duplicate **data** (multiple casings already in `0x20` link values) is
harmless once the listing dedups and is left as-is; collapsing it would need a
separate re-canonicalization pass over link values.
