### PR TITLE
feat(cli): add `vault plasticity` command to get/set per-vault plasticity (#551)

### DIFF
--- a/cmd/muninn/vault.go
+++ b/cmd/muninn/vault.go
@@ -10,9 +10,13 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/auth"
 )
 
 func printVaultUsage() {
@@ -33,6 +37,7 @@ func printVaultUsage() {
 	fmt.Println("  reembed     <name>                               Clear embeddings and re-embed with current model")
 	fmt.Println("  recall-mode <vault> [mode]                        Get or set default recall mode")
 	fmt.Println("  behavior    <vault> [--mode <mode>] [--instructions <text>]  Get or set vault behavior mode")
+	fmt.Println("  plasticity  <vault> [--preset <name>] [--set <key>=<value>]...  Get or set vault plasticity config")
 	fmt.Println()
 	fmt.Println("Auth flags (MySQL-style, optional):")
 	fmt.Println("  -u <user>         Admin username (default: root)")
@@ -65,7 +70,7 @@ func runVault(args []string) {
 
 	// Validate the subcommand before authenticating so typos get fast feedback.
 	switch sub {
-	case "create", "delete", "clear", "clone", "merge", "rename", "export", "export-markdown", "import", "reindex-fts", "reembed", "recall-mode", "behavior":
+	case "create", "delete", "clear", "clone", "merge", "rename", "export", "export-markdown", "import", "reindex-fts", "reembed", "recall-mode", "behavior", "plasticity":
 	default:
 		fmt.Printf("Unknown vault command: %q\n", sub)
 		printVaultUsage()
@@ -107,6 +112,8 @@ func runVault(args []string) {
 		runVaultRecallMode(subArgs)
 	case "behavior":
 		runVaultBehavior(subArgs)
+	case "plasticity":
+		runVaultPlasticity(subArgs)
 	}
 }
 
@@ -1354,5 +1361,265 @@ func runVaultBehavior(args []string) {
 	}
 	if newInstructions != "" {
 		fmt.Printf("  Vault %q custom instructions updated.\n", vaultName)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// vault plasticity
+// ---------------------------------------------------------------------------
+
+// plasticityFieldKinds maps each settable plasticity JSON key to the Go kind of
+// its value, derived by reflection over auth.PlasticityConfig. Pointer override
+// fields are dereferenced to their element kind. The internal "version" field is
+// excluded — it is managed by the engine, not the operator.
+func plasticityFieldKinds() map[string]reflect.Kind {
+	kinds := map[string]reflect.Kind{}
+	t := reflect.TypeOf(auth.PlasticityConfig{})
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		tag := strings.Split(f.Tag.Get("json"), ",")[0]
+		if tag == "" || tag == "-" || tag == "version" {
+			continue
+		}
+		ft := f.Type
+		if ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+		kinds[tag] = ft.Kind()
+	}
+	return kinds
+}
+
+// coercePlasticityValue converts a raw string flag value into the typed value
+// expected by the plasticity field, so the merged JSON round-trips correctly
+// through the admin PUT handler (which decodes into a typed auth.PlasticityConfig).
+func coercePlasticityValue(kind reflect.Kind, raw string) (any, error) {
+	switch kind {
+	case reflect.Bool:
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("expected a boolean (true/false), got %q", raw)
+		}
+		return b, nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("expected an integer, got %q", raw)
+		}
+		return n, nil
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return nil, fmt.Errorf("expected a number, got %q", raw)
+		}
+		return f, nil
+	default:
+		// String fields (preset, traversal_profile, behavior_*, recall_mode, …).
+		return raw, nil
+	}
+}
+
+// applyPlasticitySet parses a single "key=value" --set argument, validates the
+// key against the known plasticity fields, coerces the value to the field's type,
+// and records it in changes.
+func applyPlasticitySet(kv string, kinds map[string]reflect.Kind, changes map[string]any) error {
+	key, val, found := strings.Cut(kv, "=")
+	if !found || key == "" {
+		return fmt.Errorf("invalid --set %q (expected key=value)", kv)
+	}
+	kind, ok := kinds[key]
+	if !ok {
+		return fmt.Errorf("unknown plasticity field %q", key)
+	}
+	if key == "preset" && !auth.ValidPlasticityPreset(val) {
+		return fmt.Errorf("unknown preset %q (valid: default, reference, scratchpad, knowledge-graph)", val)
+	}
+	coerced, err := coercePlasticityValue(kind, val)
+	if err != nil {
+		return fmt.Errorf("invalid value for %q: %w", key, err)
+	}
+	changes[key] = coerced
+	return nil
+}
+
+// runVaultPlasticity implements
+// `muninn vault plasticity <vault> [--preset <name>] [--set <key>=<value>]...`.
+// With no flags it prints the vault's resolved plasticity config (and active preset).
+// With --preset and/or one or more --set flags it does a merge-PUT against the
+// admin plasticity endpoint, mirroring runVaultRecallMode/runVaultBehavior: the PUT
+// handler replaces the stored config, so we GET the current config, merge the
+// requested changes into it, and PUT the whole thing back (non-destructive).
+func runVaultPlasticity(args []string) {
+	if len(args) == 0 {
+		fmt.Println("Usage: muninn vault plasticity <vault> [--preset <name>] [--set <key>=<value>]...")
+		fmt.Println()
+		fmt.Println("  With no flags, prints the vault's resolved plasticity config.")
+		fmt.Println("  --preset <name>     Set the preset: default, reference, scratchpad, knowledge-graph")
+		fmt.Println("  --set <key>=<value> Set an individual override field (repeatable).")
+		fmt.Println()
+		fmt.Println("  Example: muninn vault plasticity research --preset knowledge-graph")
+		fmt.Println("  Example: muninn vault plasticity research --set hop_depth=4 --set actr_heb_scale=8.0")
+		return
+	}
+
+	vaultName := args[0]
+	plasticityURL := fmt.Sprintf("%s/api/admin/vault/%s/plasticity", vaultAdminBase, url.PathEscape(vaultName))
+
+	// Parse flags, collecting requested changes.
+	kinds := plasticityFieldKinds()
+	changes := map[string]any{}
+	for i := 1; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--preset" && i+1 < len(args):
+			i++
+			if err := applyPlasticitySet("preset="+args[i], kinds, changes); err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return
+			}
+		case strings.HasPrefix(a, "--preset="):
+			if err := applyPlasticitySet("preset="+strings.TrimPrefix(a, "--preset="), kinds, changes); err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return
+			}
+		case a == "--set" && i+1 < len(args):
+			i++
+			if err := applyPlasticitySet(args[i], kinds, changes); err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return
+			}
+		case strings.HasPrefix(a, "--set="):
+			if err := applyPlasticitySet(strings.TrimPrefix(a, "--set="), kinds, changes); err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return
+			}
+		default:
+			fmt.Printf("Error: unknown flag or argument %q\n", a)
+			return
+		}
+	}
+
+	client := httpClientForURL(plasticityURL, 5*time.Second)
+
+	if len(changes) == 0 {
+		// GET and pretty-print the resolved config.
+		req, err := http.NewRequest("GET", plasticityURL, nil)
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			return
+		}
+		addSessionCookie(req)
+		resp, err := client.Do(req)
+		if err != nil {
+			fmt.Printf("Error connecting to MuninnDB: %v\n", err)
+			fmt.Println("Is muninn running? Try: muninn status")
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			printHTTPError(resp)
+			return
+		}
+		var data struct {
+			Config   json.RawMessage `json:"config"`
+			Resolved json.RawMessage `json:"resolved"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			fmt.Printf("Error parsing response: %v\n", err)
+			return
+		}
+		var cfg struct {
+			Preset string `json:"preset"`
+		}
+		_ = json.Unmarshal(data.Config, &cfg)
+		preset := cfg.Preset
+		if preset == "" {
+			preset = "default"
+		}
+		fmt.Printf("  Vault %q plasticity (preset: %s)\n", vaultName, preset)
+		var resolved map[string]any
+		if err := json.Unmarshal(data.Resolved, &resolved); err == nil {
+			pretty, _ := json.MarshalIndent(resolved, "  ", "  ")
+			fmt.Printf("  Resolved config:\n  %s\n", pretty)
+		}
+		return
+	}
+
+	// SET: GET current config, merge changes, PUT back (non-destructive).
+	getReq, err := http.NewRequest("GET", plasticityURL, nil)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	addSessionCookie(getReq)
+	getResp, err := client.Do(getReq)
+	if err != nil {
+		fmt.Printf("Error connecting to MuninnDB: %v\n", err)
+		return
+	}
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusOK {
+		printHTTPError(getResp)
+		return
+	}
+	var data struct {
+		Config json.RawMessage `json:"config"`
+	}
+	if err := json.NewDecoder(getResp.Body).Decode(&data); err != nil {
+		fmt.Printf("Error parsing response: %v\n", err)
+		return
+	}
+
+	var cfgMap map[string]any
+	if data.Config != nil && string(data.Config) != "null" {
+		if err := json.Unmarshal(data.Config, &cfgMap); err != nil {
+			cfgMap = map[string]any{}
+		}
+	} else {
+		cfgMap = map[string]any{}
+	}
+	for k, v := range changes {
+		cfgMap[k] = v
+	}
+
+	bodyBytes, err := json.Marshal(cfgMap)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	putReq, err := http.NewRequest("PUT", plasticityURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	putReq.Header.Set("Content-Type", "application/json")
+	addSessionCookie(putReq)
+
+	putResp, err := client.Do(putReq)
+	if err != nil {
+		fmt.Printf("Error connecting to MuninnDB: %v\n", err)
+		return
+	}
+	defer putResp.Body.Close()
+	if putResp.StatusCode != http.StatusOK {
+		printHTTPError(putResp)
+		return
+	}
+
+	// Report what changed, with preset first and the rest sorted for stable output.
+	fmt.Printf("  Vault %q plasticity updated:\n", vaultName)
+	if v, ok := changes["preset"]; ok {
+		fmt.Printf("    preset = %v\n", v)
+	}
+	keys := make([]string, 0, len(changes))
+	for k := range changes {
+		if k != "preset" {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Printf("    %s = %v\n", k, changes[k])
 	}
 }

--- a/cmd/muninn/vault_test.go
+++ b/cmd/muninn/vault_test.go
@@ -610,3 +610,133 @@ func TestVaultRename_ConnectionRefused(t *testing.T) {
 		t.Errorf("expected connection error message, got: %q", out)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// vault plasticity tests
+// ---------------------------------------------------------------------------
+
+func TestRunVaultPlasticity_NoName(t *testing.T) {
+	out := captureStdout(func() {
+		runVaultPlasticity([]string{})
+	})
+	if !strings.Contains(out, "Usage:") {
+		t.Errorf("expected usage message, got: %q", out)
+	}
+}
+
+func TestRunVaultPlasticity_GetPrintsResolved(t *testing.T) {
+	cleanup := withMockVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %q", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"config":{"preset":"knowledge-graph"},"resolved":{"hop_depth":4,"actr_heb_scale":8}}`))
+	})
+	defer cleanup()
+
+	out := captureStdout(func() {
+		runVaultPlasticity([]string{"research"})
+	})
+	if !strings.Contains(out, "preset: knowledge-graph") {
+		t.Errorf("expected resolved preset in output, got: %q", out)
+	}
+	if !strings.Contains(out, "hop_depth") {
+		t.Errorf("expected resolved config fields in output, got: %q", out)
+	}
+}
+
+func TestRunVaultPlasticity_SetPresetMergePUT(t *testing.T) {
+	var putBody map[string]any
+	cleanup := withMockVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case "GET":
+			// Existing config carries an unrelated override that must survive the merge.
+			w.Write([]byte(`{"config":{"preset":"default","recall_mode":"deep"},"resolved":{}}`))
+		case "PUT":
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &putBody)
+			w.Write([]byte(`{"config":{},"resolved":{}}`))
+		default:
+			t.Errorf("unexpected method %q", r.Method)
+		}
+	})
+	defer cleanup()
+
+	out := captureStdout(func() {
+		runVaultPlasticity([]string{"research", "--preset", "knowledge-graph"})
+	})
+	if putBody["preset"] != "knowledge-graph" {
+		t.Errorf("expected preset set to knowledge-graph in PUT body, got: %v", putBody)
+	}
+	if putBody["recall_mode"] != "deep" {
+		t.Errorf("expected pre-existing recall_mode preserved (non-destructive merge), got: %v", putBody)
+	}
+	if !strings.Contains(out, "updated") {
+		t.Errorf("expected confirmation message, got: %q", out)
+	}
+}
+
+func TestRunVaultPlasticity_SetFieldsCoercion(t *testing.T) {
+	var putBody map[string]any
+	cleanup := withMockVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "GET" {
+			w.Write([]byte(`{"config":{},"resolved":{}}`))
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &putBody)
+		w.Write([]byte(`{"config":{},"resolved":{}}`))
+	})
+	defer cleanup()
+
+	captureStdout(func() {
+		runVaultPlasticity([]string{"research",
+			"--set", "hop_depth=4",
+			"--set", "hebbian_enabled=false",
+			"--set", "actr_heb_scale=8.0",
+			"--set", "traversal_profile=causal",
+		})
+	})
+	// JSON numbers decode to float64; bools to bool; strings to string.
+	if v, ok := putBody["hop_depth"].(float64); !ok || v != 4 {
+		t.Errorf("expected hop_depth=4 (number), got: %v (%T)", putBody["hop_depth"], putBody["hop_depth"])
+	}
+	if v, ok := putBody["hebbian_enabled"].(bool); !ok || v != false {
+		t.Errorf("expected hebbian_enabled=false (bool), got: %v (%T)", putBody["hebbian_enabled"], putBody["hebbian_enabled"])
+	}
+	if v, ok := putBody["actr_heb_scale"].(float64); !ok || v != 8.0 {
+		t.Errorf("expected actr_heb_scale=8.0 (number), got: %v (%T)", putBody["actr_heb_scale"], putBody["actr_heb_scale"])
+	}
+	if putBody["traversal_profile"] != "causal" {
+		t.Errorf("expected traversal_profile=causal (string), got: %v", putBody["traversal_profile"])
+	}
+}
+
+func TestRunVaultPlasticity_InvalidPreset(t *testing.T) {
+	out := captureStdout(func() {
+		runVaultPlasticity([]string{"research", "--preset", "bogus"})
+	})
+	if !strings.Contains(out, "unknown preset") {
+		t.Errorf("expected unknown-preset error, got: %q", out)
+	}
+}
+
+func TestRunVaultPlasticity_UnknownField(t *testing.T) {
+	out := captureStdout(func() {
+		runVaultPlasticity([]string{"research", "--set", "not_a_field=1"})
+	})
+	if !strings.Contains(out, "unknown plasticity field") {
+		t.Errorf("expected unknown-field error, got: %q", out)
+	}
+}
+
+func TestRunVaultPlasticity_InvalidValue(t *testing.T) {
+	out := captureStdout(func() {
+		runVaultPlasticity([]string{"research", "--set", "hop_depth=abc"})
+	})
+	if !strings.Contains(out, "invalid value") {
+		t.Errorf("expected invalid-value error, got: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #551.

Adds a `muninn vault plasticity <vault>` CLI subcommand so per-vault plasticity
config (preset + override fields) can be inspected and set from the command line,
instead of only through the dashboard or a hand-crafted authenticated REST `PUT`.

This closes a CLI-ergonomics gap: `muninn vault` already exposes setters for two
of the plasticity config's fields (`recall-mode` → `recall_mode`, `behavior` →
`behavior_mode`/`behavior_instructions`), but the central `preset` field and the
~30 other override fields had no CLI surface, so switching a vault to e.g. the
`knowledge-graph` preset wasn't scriptable or reproducible.

## Usage

```
muninn vault plasticity <vault>                                  # print resolved config + active preset
muninn vault plasticity <vault> --preset knowledge-graph         # set the preset
muninn vault plasticity <vault> --set hop_depth=4 --set actr_heb_scale=8.0
```

- **no flags** → GET and pretty-print the vault's resolved plasticity config and active preset
- `--preset <name>` → set `preset`, validated via `auth.ValidPlasticityPreset` (`default` | `reference` | `scratchpad` | `knowledge-graph`)
- `--set <key>=<value>` (repeatable) → set individual override fields by their JSON key

## Implementation notes

- **Reuses the existing endpoint** — no new routes, no engine changes, no OpenAPI/SDK changes.
  It calls the same `GET`/`PUT /api/admin/vault/<vault>/plasticity` that `recall-mode` and
  `behavior` already use.
- **Non-destructive merge-PUT.** The `PUT` handler *replaces* the stored config (it decodes
  the body into a fresh `auth.PlasticityConfig`), so the command GETs the current config,
  merges the requested changes into it, and PUTs the whole thing back — mirroring
  `runVaultRecallMode` / `runVaultBehavior` exactly. A test asserts a pre-existing override
  survives a `--preset` change.
- **Client-side validation.** `--set` keys are validated against the `PlasticityConfig`
  JSON fields via reflection, and values are coerced to each field's Go type (bool / int /
  float / string). Unknown fields and malformed values fail client-side with a clear message
  rather than being silently dropped by the server's lenient JSON decode. The internal
  `version` field is intentionally not settable.

## Testing

- `go build ./cmd/muninn` ✓
- `go vet ./cmd/muninn` ✓
- `go test ./cmd/muninn` ✓ (full package)
- New tests cover: usage, GET pretty-print, `--preset` merge-PUT (incl. non-destructive
  merge), `--set` type coercion (int/bool/float/string), invalid preset, unknown field,
  and invalid value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
