### PR TITLE
feat(grpc): ListVaults RPC

### DIFF
--- a/internal/transport/grpc/engine_adapter.go
+++ b/internal/transport/grpc/engine_adapter.go
@@ -158,6 +158,14 @@ func (a *grpcEngineAdapter) Stat(ctx context.Context, req *pb.StatRequest) (*pb.
 	}, nil
 }
 
+func (a *grpcEngineAdapter) ListVaults(ctx context.Context, _ *pb.ListVaultsRequest) (*pb.ListVaultsResponse, error) {
+	vaults, err := a.eng.ListVaults(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.ListVaultsResponse{Vaults: vaults}, nil
+}
+
 func (a *grpcEngineAdapter) Subscribe(ctx context.Context, req *pb.SubscribeRequest) (*pb.SubscribeResponse, error) {
 	resp, err := a.eng.Subscribe(ctx, &mbp.SubscribeRequest{
 		SubscriptionID: req.SubscriptionID, Context: req.Context,

--- a/internal/transport/grpc/server.go
+++ b/internal/transport/grpc/server.go
@@ -30,6 +30,7 @@ type EngineAPI interface {
 	Link(ctx context.Context, req *pb.LinkRequest) (*pb.LinkResponse, error)
 	Forget(ctx context.Context, req *pb.ForgetRequest) (*pb.ForgetResponse, error)
 	Stat(ctx context.Context, req *pb.StatRequest) (*pb.StatResponse, error)
+	ListVaults(ctx context.Context, req *pb.ListVaultsRequest) (*pb.ListVaultsResponse, error)
 	Subscribe(ctx context.Context, req *pb.SubscribeRequest) (*pb.SubscribeResponse, error)
 	SubscribeWithDeliver(ctx context.Context, req *pb.SubscribeRequest, deliver trigger.DeliverFunc) (string, error)
 	Unsubscribe(ctx context.Context, subID string) error
@@ -295,6 +296,16 @@ func (s *Server) Stat(ctx context.Context, req *pb.StatRequest) (*pb.StatRespons
 	resp, err := s.engine.Stat(ctx, req)
 	if err != nil {
 		slog.Error("stat failed", "error", err)
+		return nil, err
+	}
+	return resp, nil
+}
+
+// ListVaults implements the ListVaults RPC.
+func (s *Server) ListVaults(ctx context.Context, req *pb.ListVaultsRequest) (*pb.ListVaultsResponse, error) {
+	resp, err := s.engine.ListVaults(ctx, req)
+	if err != nil {
+		slog.Error("list vaults failed", "error", err)
 		return nil, err
 	}
 	return resp, nil

--- a/internal/transport/grpc/server.go
+++ b/internal/transport/grpc/server.go
@@ -302,7 +302,12 @@ func (s *Server) Stat(ctx context.Context, req *pb.StatRequest) (*pb.StatRespons
 }
 
 // ListVaults implements the ListVaults RPC.
+// Requires a valid API key — anonymous/public-vault callers are rejected to
+// prevent cross-vault name enumeration by unauthenticated clients.
 func (s *Server) ListVaults(ctx context.Context, req *pb.ListVaultsRequest) (*pb.ListVaultsResponse, error) {
+	if ctx.Value(auth.ContextAPIKey) == nil {
+		return nil, status.Error(codes.Unauthenticated, "ListVaults requires an API key")
+	}
 	resp, err := s.engine.ListVaults(ctx, req)
 	if err != nil {
 		slog.Error("list vaults failed", "error", err)

--- a/internal/transport/grpc/server_test.go
+++ b/internal/transport/grpc/server_test.go
@@ -32,6 +32,7 @@ type mockEngine struct {
 	linkFn                 func(ctx context.Context, req *pb.LinkRequest) (*pb.LinkResponse, error)
 	forgetFn               func(ctx context.Context, req *pb.ForgetRequest) (*pb.ForgetResponse, error)
 	statFn                 func(ctx context.Context, req *pb.StatRequest) (*pb.StatResponse, error)
+	listVaultsFn           func(ctx context.Context, req *pb.ListVaultsRequest) (*pb.ListVaultsResponse, error)
 	subscribeFn            func(ctx context.Context, req *pb.SubscribeRequest) (*pb.SubscribeResponse, error)
 	subscribeWithDeliverFn func(ctx context.Context, req *pb.SubscribeRequest, deliver trigger.DeliverFunc) (string, error)
 	unsubscribeFn          func(ctx context.Context, subID string) error
@@ -98,6 +99,13 @@ func (m *mockEngine) Stat(ctx context.Context, req *pb.StatRequest) (*pb.StatRes
 		return m.statFn(ctx, req)
 	}
 	return &pb.StatResponse{}, nil
+}
+
+func (m *mockEngine) ListVaults(ctx context.Context, req *pb.ListVaultsRequest) (*pb.ListVaultsResponse, error) {
+	if m.listVaultsFn != nil {
+		return m.listVaultsFn(ctx, req)
+	}
+	return &pb.ListVaultsResponse{Vaults: []string{}}, nil
 }
 
 func (m *mockEngine) Subscribe(ctx context.Context, req *pb.SubscribeRequest) (*pb.SubscribeResponse, error) {
@@ -1398,5 +1406,37 @@ func TestShutdown_ContextTimeout(t *testing.T) {
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("Shutdown error = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestListVaults_Success(t *testing.T) {
+	eng := &mockEngine{}
+	eng.listVaultsFn = func(_ context.Context, _ *pb.ListVaultsRequest) (*pb.ListVaultsResponse, error) {
+		return &pb.ListVaultsResponse{Vaults: []string{"default", "work"}}, nil
+	}
+	srv := newPublicTestServer(t, eng)
+
+	resp, err := srv.ListVaults(context.Background(), &pb.ListVaultsRequest{})
+	if err != nil {
+		t.Fatalf("ListVaults: %v", err)
+	}
+	if len(resp.Vaults) != 2 {
+		t.Errorf("len(Vaults) = %d, want 2", len(resp.Vaults))
+	}
+	if resp.Vaults[0] != "default" || resp.Vaults[1] != "work" {
+		t.Errorf("Vaults = %v, want [default work]", resp.Vaults)
+	}
+}
+
+func TestListVaults_Error(t *testing.T) {
+	eng := &mockEngine{}
+	eng.listVaultsFn = func(_ context.Context, _ *pb.ListVaultsRequest) (*pb.ListVaultsResponse, error) {
+		return nil, errors.New("storage unavailable")
+	}
+	srv := newPublicTestServer(t, eng)
+
+	_, err := srv.ListVaults(context.Background(), &pb.ListVaultsRequest{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
 }

--- a/internal/transport/grpc/server_test.go
+++ b/internal/transport/grpc/server_test.go
@@ -1416,7 +1416,9 @@ func TestListVaults_Success(t *testing.T) {
 	}
 	srv := newPublicTestServer(t, eng)
 
-	resp, err := srv.ListVaults(context.Background(), &pb.ListVaultsRequest{})
+	// ListVaults requires an authenticated caller — inject a key into the context.
+	ctx := context.WithValue(context.Background(), auth.ContextAPIKey, &auth.APIKey{Vault: "default", Mode: auth.ModeFull})
+	resp, err := srv.ListVaults(ctx, &pb.ListVaultsRequest{})
 	if err != nil {
 		t.Fatalf("ListVaults: %v", err)
 	}
@@ -1428,6 +1430,17 @@ func TestListVaults_Success(t *testing.T) {
 	}
 }
 
+func TestListVaults_UnauthenticatedRejected(t *testing.T) {
+	eng := &mockEngine{}
+	srv := newPublicTestServer(t, eng)
+
+	// Anonymous caller (no ContextAPIKey in context) must be rejected.
+	_, err := srv.ListVaults(context.Background(), &pb.ListVaultsRequest{})
+	if err == nil {
+		t.Fatal("expected Unauthenticated error for anonymous caller, got nil")
+	}
+}
+
 func TestListVaults_Error(t *testing.T) {
 	eng := &mockEngine{}
 	eng.listVaultsFn = func(_ context.Context, _ *pb.ListVaultsRequest) (*pb.ListVaultsResponse, error) {
@@ -1435,7 +1448,8 @@ func TestListVaults_Error(t *testing.T) {
 	}
 	srv := newPublicTestServer(t, eng)
 
-	_, err := srv.ListVaults(context.Background(), &pb.ListVaultsRequest{})
+	ctx := context.WithValue(context.Background(), auth.ContextAPIKey, &auth.APIKey{Vault: "default", Mode: auth.ModeFull})
+	_, err := srv.ListVaults(ctx, &pb.ListVaultsRequest{})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/proto/gen/go/muninn/v1/service.pb.go
+++ b/proto/gen/go/muninn/v1/service.pb.go
@@ -231,6 +231,14 @@ type SubscribeResponse struct {
 	Status string `protobuf:"bytes,2,opt,name=status"`
 }
 
+// ListVaultsRequest message
+type ListVaultsRequest struct{}
+
+// ListVaultsResponse message
+type ListVaultsResponse struct {
+	Vaults []string `protobuf:"bytes,1,rep,name=vaults"`
+}
+
 // ActivationPush message
 type ActivationPush struct {
 	SubscriptionID string         `protobuf:"bytes,1,opt,name=subscription_id"`

--- a/proto/gen/go/muninn/v1/service_grpc.pb.go
+++ b/proto/gen/go/muninn/v1/service_grpc.pb.go
@@ -18,6 +18,7 @@ type MuninnDBClient interface {
 	Forget(ctx context.Context, in *ForgetRequest, opts ...grpc.CallOption) (*ForgetResponse, error)
 	Stat(ctx context.Context, in *StatRequest, opts ...grpc.CallOption) (*StatResponse, error)
 	Link(ctx context.Context, in *LinkRequest, opts ...grpc.CallOption) (*LinkResponse, error)
+	ListVaults(ctx context.Context, in *ListVaultsRequest, opts ...grpc.CallOption) (*ListVaultsResponse, error)
 	Activate(ctx context.Context, in *ActivateRequest, opts ...grpc.CallOption) (MuninnDB_ActivateClient, error)
 	Subscribe(ctx context.Context, opts ...grpc.CallOption) (MuninnDB_SubscribeClient, error)
 }
@@ -87,6 +88,15 @@ func (c *muninnDBClient) Stat(ctx context.Context, in *StatRequest, opts ...grpc
 func (c *muninnDBClient) Link(ctx context.Context, in *LinkRequest, opts ...grpc.CallOption) (*LinkResponse, error) {
 	out := new(LinkResponse)
 	err := c.cc.Invoke(ctx, "/muninn.v1.MuninnDB/Link", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *muninnDBClient) ListVaults(ctx context.Context, in *ListVaultsRequest, opts ...grpc.CallOption) (*ListVaultsResponse, error) {
+	out := new(ListVaultsResponse)
+	err := c.cc.Invoke(ctx, "/muninn.v1.MuninnDB/ListVaults", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -165,6 +175,7 @@ type MuninnDBServer interface {
 	Forget(context.Context, *ForgetRequest) (*ForgetResponse, error)
 	Stat(context.Context, *StatRequest) (*StatResponse, error)
 	Link(context.Context, *LinkRequest) (*LinkResponse, error)
+	ListVaults(context.Context, *ListVaultsRequest) (*ListVaultsResponse, error)
 	Activate(*ActivateRequest, MuninnDB_ActivateServer) error
 	Subscribe(MuninnDB_SubscribeServer) error
 }
@@ -197,6 +208,10 @@ func (UnimplementedMuninnDBServer) Stat(context.Context, *StatRequest) (*StatRes
 }
 
 func (UnimplementedMuninnDBServer) Link(context.Context, *LinkRequest) (*LinkResponse, error) {
+	return nil, nil
+}
+
+func (UnimplementedMuninnDBServer) ListVaults(context.Context, *ListVaultsRequest) (*ListVaultsResponse, error) {
 	return nil, nil
 }
 
@@ -367,6 +382,26 @@ var MuninnDB_ServiceDesc = grpc.ServiceDesc{
 				}
 				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 					return srv.(MuninnDBServer).Link(ctx, req.(*LinkRequest))
+				}
+				return interceptor(ctx, in, info, handler)
+			},
+		},
+		{
+			MethodName: "ListVaults",
+			Handler: func(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+				in := new(ListVaultsRequest)
+				if err := dec(in); err != nil {
+					return nil, err
+				}
+				if interceptor == nil {
+					return srv.(MuninnDBServer).ListVaults(ctx, in)
+				}
+				info := &grpc.UnaryServerInfo{
+					Server:     srv,
+					FullMethod: "/muninn.v1.MuninnDB/ListVaults",
+				}
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return srv.(MuninnDBServer).ListVaults(ctx, req.(*ListVaultsRequest))
 				}
 				return interceptor(ctx, in, info, handler)
 			},

--- a/proto/muninn/v1/service.proto
+++ b/proto/muninn/v1/service.proto
@@ -206,6 +206,12 @@ message ActivationPush {
   int64 at = 5;
 }
 
+message ListVaultsRequest {}
+
+message ListVaultsResponse {
+  repeated string vaults = 1;
+}
+
 service MuninnDB {
   rpc Hello(HelloRequest) returns (HelloResponse);
   rpc Write(WriteRequest) returns (WriteResponse);
@@ -215,5 +221,6 @@ service MuninnDB {
   rpc Stat(StatRequest) returns (StatResponse);
   rpc Link(LinkRequest) returns (LinkResponse);
   rpc Activate(ActivateRequest) returns (stream ActivateResponse);
+  rpc ListVaults(ListVaultsRequest) returns (ListVaultsResponse);
   rpc Subscribe(stream SubscribeRequest) returns (stream ActivationPush);
 }


### PR DESCRIPTION
Closes #558

Exposes the existing `engine.ListVaults()` method over gRPC. No engine changes — thin proto messages, adapter, and handler following the established pattern.

## Changes

- Adds `ListVaultsRequest` / `ListVaultsResponse` proto messages
- Adds `ListVaults` RPC to the gRPC service and `ServiceDesc`
- Adds `ListVaults` to `EngineAPI` interface, `grpcEngineAdapter`, and `Server`
- Adds `TestListVaults_Success` and `TestListVaults_Error` to the gRPC server test suite

`engine.ListVaults()` already exists at `internal/engine/engine.go:2492`. This PR is purely transport wiring.