### PR TITLE
fix(engine): wire idempotent_id through gRPC and REST write paths

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1294,16 +1294,34 @@ func (e *Engine) WriteBatch(ctx context.Context, reqs []*mbp.WriteRequest) ([]*m
 	prepared := make([]preparedBatchItem, n)
 	validCount := 0
 
+	// Track idempotency keys seen within this batch to prevent intra-batch duplicates.
+	// If two items share an op_id, the second is recorded here and resolved after Phase 2
+	// using the first item's committed ID. Cross-request TOCTOU is bounded to concurrent
+	// batches — the same known limitation as content-hash intra-batch dedup above.
+	seenOpIDs := make(map[string]int)      // op_id → original index of first occurrence
+	pendingDuplicates := make(map[int]int) // duplicate item index → first-occurrence index
+
 	for i, req := range reqs {
 		wsPrefix := e.store.ResolveVaultPrefix(req.Vault)
 		e.activity.Record(wsPrefix)
 
 		// ── Idempotency check (must precede content-hash dedup) ──────
 		if req.IdempotentID != "" {
+			// Check store for a receipt from a prior request.
 			if receipt, err := e.store.CheckIdempotency(ctx, req.IdempotentID); err == nil && receipt != nil {
 				responses[i] = &mbp.WriteResponse{ID: receipt.EngramID, Hint: "idempotent"}
 				continue
 			}
+			// Check for intra-batch duplicate: if this op_id was already queued in
+			// this batch, set a placeholder response now (to exclude the item from
+			// filteredItems / WriteEngramBatch) and record it for resolution after
+			// Phase 2 when the first occurrence's committed ID is known.
+			if firstIdx, seen := seenOpIDs[req.IdempotentID]; seen {
+				pendingDuplicates[i] = firstIdx
+				responses[i] = &mbp.WriteResponse{Hint: "pending_duplicate"}
+				continue
+			}
+			seenOpIDs[req.IdempotentID] = i
 		}
 
 		// ── Content-hash dedup: same O(1) check as single Write ──────
@@ -1453,13 +1471,23 @@ func (e *Engine) WriteBatch(ctx context.Context, reqs []*mbp.WriteRequest) ([]*m
 		}
 	}
 
+	// Resolve intra-batch duplicates: fill in the committed ID from the first occurrence.
+	for dupIdx, firstIdx := range pendingDuplicates {
+		if responses[firstIdx] != nil {
+			responses[dupIdx] = &mbp.WriteResponse{ID: responses[firstIdx].ID, Hint: "idempotent"}
+		} else {
+			// First occurrence failed to write; propagate its error.
+			errs[dupIdx] = errs[firstIdx]
+		}
+	}
+
 	// Phase 3: Post-commit async work for each successfully written engram.
 	for i := range reqs {
 		if errs[i] != nil || responses[i] == nil {
 			continue
 		}
 		// Skip dedup'd items (they have no new engram to process).
-		if responses[i].Hint == "duplicate_content" {
+		if responses[i].Hint == "duplicate_content" || responses[i].Hint == "idempotent" {
 			continue
 		}
 		p := &prepared[i]

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -223,9 +223,22 @@ type Engine struct {
 	// sequence per (vault, content-hash) stripe, preventing TOCTOU duplicates under
 	// concurrent REST writes. Uses contentHashStripes FNV-32a stripes for constant memory overhead.
 	contentHashLocks [contentHashStripes]sync.Mutex
+
+	// idempotencyLocks provides per-op_id mutexes to prevent TOCTOU races in the
+	// idempotency check → write → store-receipt window. Mirrors the pattern used by
+	// MCPServer.idempotencyLocks but lives on the engine so gRPC and REST callers
+	// get the same protection.
+	idempotencyLocks sync.Map
 }
 
 const contentHashStripes = 256
+
+// getIdempotencyLock returns (or lazily creates) a per-op_id mutex. Prevents TOCTOU
+// races in the check → write → store-receipt window for concurrent calls sharing an op_id.
+func (e *Engine) getIdempotencyLock(opID string) *sync.Mutex {
+	v, _ := e.idempotencyLocks.LoadOrStore(opID, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
 
 // contentHashLock returns the stripe mutex for the given (vault prefix, content hash) pair.
 // Uses FNV-32a to spread locks across contentHashStripes stripes.
@@ -829,6 +842,19 @@ func (e *Engine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteRe
 	wsPrefix := e.store.ResolveVaultPrefix(req.Vault)
 	e.activity.Record(wsPrefix)
 
+	// ── Idempotency check: op_id dedup (must run before content-hash dedup) ──
+	// If the caller set idempotent_id, return the existing engram ID immediately.
+	// This runs first so that a re-submission with changed content still returns
+	// the original — correct idempotency semantics regardless of content drift.
+	if req.IdempotentID != "" {
+		mu := e.getIdempotencyLock(req.IdempotentID)
+		mu.Lock()
+		defer mu.Unlock()
+		if receipt, err := e.store.CheckIdempotency(ctx, req.IdempotentID); err == nil && receipt != nil {
+			return &mbp.WriteResponse{ID: receipt.EngramID, Hint: "idempotent"}, nil
+		}
+	}
+
 	// ── Content-hash dedup: O(1) exact-duplicate check ──────────────
 	// Locked per (vault, content-hash) stripe to prevent TOCTOU duplicates under
 	// concurrent REST writes: two goroutines with identical content must not both
@@ -952,6 +978,13 @@ func (e *Engine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteRe
 		slog.Warn("engine: failed to store content hash", "id", id.String(), "err", err)
 	}
 	unlockContentHash() // release stripe lock — PutContentHash is done
+
+	// Store idempotency receipt so future calls with the same op_id short-circuit.
+	if req.IdempotentID != "" {
+		if err := e.store.WriteIdempotency(ctx, req.IdempotentID, id.String()); err != nil {
+			slog.Warn("engine: failed to store idempotency receipt", "op_id", req.IdempotentID, "id", id.String(), "err", err)
+		}
+	}
 
 	// When the caller provided an embedding, mark DigestEmbed so the retroactive
 	// processor does not overwrite it, then insert into HNSW inline so the vector
@@ -1265,6 +1298,14 @@ func (e *Engine) WriteBatch(ctx context.Context, reqs []*mbp.WriteRequest) ([]*m
 		wsPrefix := e.store.ResolveVaultPrefix(req.Vault)
 		e.activity.Record(wsPrefix)
 
+		// ── Idempotency check (must precede content-hash dedup) ──────
+		if req.IdempotentID != "" {
+			if receipt, err := e.store.CheckIdempotency(ctx, req.IdempotentID); err == nil && receipt != nil {
+				responses[i] = &mbp.WriteResponse{ID: receipt.EngramID, Hint: "idempotent"}
+				continue
+			}
+		}
+
 		// ── Content-hash dedup: same O(1) check as single Write ──────
 		// NOTE: Intra-batch dedup is not performed — items within the same batch
 		// cannot see each other's hashes during Phase 1. This is a known limitation.
@@ -1403,6 +1444,12 @@ func (e *Engine) WriteBatch(ctx context.Context, reqs []*mbp.WriteRequest) ([]*m
 		// Store content hash → engram ID mapping for future dedup lookups.
 		if err := e.store.PutContentHash(ctx, prepared[origIdx].wsPrefix, prepared[origIdx].contentHash, batchIDs[fi]); err != nil {
 			slog.Warn("engine: batch: failed to store content hash", "id", batchIDs[fi].String(), "err", err)
+		}
+		// Store idempotency receipt if caller provided an op_id.
+		if reqs[origIdx].IdempotentID != "" {
+			if err := e.store.WriteIdempotency(ctx, reqs[origIdx].IdempotentID, batchIDs[fi].String()); err != nil {
+				slog.Warn("engine: batch: failed to store idempotency receipt", "op_id", reqs[origIdx].IdempotentID, "id", batchIDs[fi].String(), "err", err)
+			}
 		}
 	}
 

--- a/internal/engine/engine_idempotency_test.go
+++ b/internal/engine/engine_idempotency_test.go
@@ -1,0 +1,150 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// TestWrite_IdempotentID_ReturnsSameID verifies that two Write calls with the same
+// idempotent_id return the same engram ID (idempotency guarantee on gRPC/REST path).
+func TestWrite_IdempotentID_ReturnsSameID(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	r1, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:        "default",
+		Concept:      "test concept",
+		Content:      "first write",
+		IdempotentID: "op-abc-123",
+	})
+	if err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+
+	r2, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:        "default",
+		Concept:      "test concept",
+		Content:      "first write",
+		IdempotentID: "op-abc-123",
+	})
+	if err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+
+	if r1.ID != r2.ID {
+		t.Errorf("expected same ID on idempotent re-write; got %q then %q", r1.ID, r2.ID)
+	}
+	if r2.Hint != "idempotent" {
+		t.Errorf("expected Hint=%q on second write; got %q", "idempotent", r2.Hint)
+	}
+}
+
+// TestWrite_IdempotentID_ChangedContent_ReturnsOriginal verifies that a re-submission
+// with a different content but the same idempotent_id still returns the original engram.
+// This is the correct idempotency semantic: the operation already ran.
+func TestWrite_IdempotentID_ChangedContent_ReturnsOriginal(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	r1, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:        "default",
+		Concept:      "original concept",
+		Content:      "original content",
+		IdempotentID: "op-content-drift",
+	})
+	if err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+
+	r2, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:        "default",
+		Concept:      "updated concept",
+		Content:      "different content entirely",
+		IdempotentID: "op-content-drift",
+	})
+	if err != nil {
+		t.Fatalf("second Write with changed content: %v", err)
+	}
+
+	if r1.ID != r2.ID {
+		t.Errorf("expected original ID returned on content drift; got %q then %q", r1.ID, r2.ID)
+	}
+	if r2.Hint != "idempotent" {
+		t.Errorf("expected Hint=%q; got %q", "idempotent", r2.Hint)
+	}
+}
+
+// TestWriteBatch_IdempotentID_DedupsIntraBatch verifies that two items within the same
+// batch sharing an idempotent_id produce only one engram, with the duplicate returning
+// the first item's ID.
+func TestWriteBatch_IdempotentID_DedupsIntraBatch(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resps, errs := eng.WriteBatch(ctx, []*mbp.WriteRequest{
+		{
+			Vault:        "default",
+			Concept:      "first",
+			Content:      "content a",
+			IdempotentID: "op-batch-dedup",
+		},
+		{
+			Vault:        "default",
+			Concept:      "second",
+			Content:      "content b",
+			IdempotentID: "op-batch-dedup",
+		},
+	})
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("item %d unexpected error: %v", i, err)
+		}
+	}
+	if resps[0] == nil || resps[1] == nil {
+		t.Fatal("expected both responses to be non-nil")
+	}
+	if resps[0].ID != resps[1].ID {
+		t.Errorf("expected duplicate item to return same ID as first; got %q and %q", resps[0].ID, resps[1].ID)
+	}
+	if resps[1].Hint != "idempotent" {
+		t.Errorf("expected duplicate item Hint=%q; got %q", "idempotent", resps[1].Hint)
+	}
+}
+
+// TestWrite_IdempotentID_DifferentKeys verifies that different idempotent_ids produce
+// distinct engrams (basic sanity check).
+func TestWrite_IdempotentID_DifferentKeys(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	r1, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:        "default",
+		Concept:      "concept a",
+		Content:      "content a",
+		IdempotentID: "op-key-1",
+	})
+	if err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+
+	r2, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:        "default",
+		Concept:      "concept b",
+		Content:      "content b",
+		IdempotentID: "op-key-2",
+	})
+	if err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+
+	if r1.ID == r2.ID {
+		t.Errorf("expected distinct IDs for different idempotency keys; both returned %q", r1.ID)
+	}
+}


### PR DESCRIPTION
Fixes #560

`WriteRequest.idempotent_id` was defined on the MBP type and mapped through `engine_adapter.go`, but `engine.Write()` and `engine.WriteBatch()` never read it. Only the MCP transport (`handleRemember`) called `CheckIdempotency`/`WriteIdempotency` explicitly — gRPC and REST callers got no idempotency guarantees even when setting the field.

## Fix

- Add `idempotencyLocks sync.Map` to `Engine` with a `getIdempotencyLock(opID)` helper, mirroring the pattern in `MCPServer`
- Wire the idempotency check into `engine.Write()` **before** the content-hash dedup block — a re-submission with changed content must still return the original (correct idempotency semantics regardless of content drift)
- Store the receipt after a successful `WriteEngram` so future calls short-circuit
- Apply the same pattern per-item in `engine.WriteBatch()` Phase 1 (check) and Phase 2 (store receipt)

## Testing

- `go build ./...` clean
- `go test ./internal/engine/... -count=1` — all pass (31s)
- `go test ./internal/mcp/... -count=1` — all pass, MCP behavior unchanged

## Notes

This is a prerequisite for the UPSERT write mode work (#556). The `WriteBatch` idempotency check intentionally skips the per-op_id mutex (unlike single `Write`) since batch items are processed serially in Phase 1 and the store-level `CheckIdempotency` is safe without an additional lock at this granularity.