### PR TITLE
feat(grpc): BatchForget RPC

### DIFF
--- a/internal/transport/grpc/engine_adapter.go
+++ b/internal/transport/grpc/engine_adapter.go
@@ -147,6 +147,21 @@ func (a *grpcEngineAdapter) Forget(ctx context.Context, req *pb.ForgetRequest) (
 	return &pb.ForgetResponse{OK: resp.OK}, nil
 }
 
+func (a *grpcEngineAdapter) BatchForget(ctx context.Context, req *pb.BatchForgetRequest) (*pb.BatchForgetResponse, error) {
+	results := make([]*pb.BatchForgetItemResult, len(req.Requests))
+	for i, r := range req.Requests {
+		result := &pb.BatchForgetItemResult{Index: int32(i)}
+		resp, err := a.eng.Forget(ctx, &mbp.ForgetRequest{ID: r.ID, Hard: r.Hard, Vault: r.Vault})
+		if err != nil {
+			result.Error = err.Error()
+		} else {
+			result.Ok = resp.OK
+		}
+		results[i] = result
+	}
+	return &pb.BatchForgetResponse{Results: results}, nil
+}
+
 func (a *grpcEngineAdapter) Stat(ctx context.Context, req *pb.StatRequest) (*pb.StatResponse, error) {
 	resp, err := a.eng.Stat(ctx, &mbp.StatRequest{Vault: req.Vault})
 	if err != nil {

--- a/internal/transport/grpc/server.go
+++ b/internal/transport/grpc/server.go
@@ -361,6 +361,13 @@ func (s *Server) BatchForget(ctx context.Context, req *pb.BatchForgetRequest) (*
 	if err := denyReadOnlyMutation(ctx); err != nil {
 		return nil, err
 	}
+	for _, r := range req.Requests {
+		vault, err := s.resolveRequestVault(ctx, r.Vault)
+		if err != nil {
+			return nil, err
+		}
+		r.Vault = vault
+	}
 	return s.engine.BatchForget(ctx, req)
 }
 

--- a/internal/transport/grpc/server.go
+++ b/internal/transport/grpc/server.go
@@ -29,6 +29,7 @@ type EngineAPI interface {
 	Activate(ctx context.Context, req *pb.ActivateRequest) (*pb.ActivateResponse, error)
 	Link(ctx context.Context, req *pb.LinkRequest) (*pb.LinkResponse, error)
 	Forget(ctx context.Context, req *pb.ForgetRequest) (*pb.ForgetResponse, error)
+	BatchForget(ctx context.Context, req *pb.BatchForgetRequest) (*pb.BatchForgetResponse, error)
 	Stat(ctx context.Context, req *pb.StatRequest) (*pb.StatResponse, error)
 	Subscribe(ctx context.Context, req *pb.SubscribeRequest) (*pb.SubscribeResponse, error)
 	SubscribeWithDeliver(ctx context.Context, req *pb.SubscribeRequest, deliver trigger.DeliverFunc) (string, error)
@@ -353,6 +354,14 @@ func (s *Server) Forget(ctx context.Context, req *pb.ForgetRequest) (*pb.ForgetR
 		return nil, err
 	}
 	return resp, nil
+}
+
+// BatchForget implements the BatchForget RPC.
+func (s *Server) BatchForget(ctx context.Context, req *pb.BatchForgetRequest) (*pb.BatchForgetResponse, error) {
+	if err := denyReadOnlyMutation(ctx); err != nil {
+		return nil, err
+	}
+	return s.engine.BatchForget(ctx, req)
 }
 
 // Stat implements the Stat RPC.

--- a/internal/transport/grpc/server_test.go
+++ b/internal/transport/grpc/server_test.go
@@ -93,6 +93,14 @@ func (m *mockEngine) Forget(ctx context.Context, req *pb.ForgetRequest) (*pb.For
 	return &pb.ForgetResponse{OK: true}, nil
 }
 
+func (m *mockEngine) BatchForget(ctx context.Context, req *pb.BatchForgetRequest) (*pb.BatchForgetResponse, error) {
+	results := make([]*pb.BatchForgetItemResult, len(req.Requests))
+	for i := range req.Requests {
+		results[i] = &pb.BatchForgetItemResult{Index: int32(i), Ok: true}
+	}
+	return &pb.BatchForgetResponse{Results: results}, nil
+}
+
 func (m *mockEngine) Stat(ctx context.Context, req *pb.StatRequest) (*pb.StatResponse, error) {
 	if m.statFn != nil {
 		return m.statFn(ctx, req)

--- a/internal/transport/grpc/server_test.go
+++ b/internal/transport/grpc/server_test.go
@@ -31,6 +31,7 @@ type mockEngine struct {
 	activateFn             func(ctx context.Context, req *pb.ActivateRequest) (*pb.ActivateResponse, error)
 	linkFn                 func(ctx context.Context, req *pb.LinkRequest) (*pb.LinkResponse, error)
 	forgetFn               func(ctx context.Context, req *pb.ForgetRequest) (*pb.ForgetResponse, error)
+	batchForgetFn          func(ctx context.Context, req *pb.BatchForgetRequest) (*pb.BatchForgetResponse, error)
 	statFn                 func(ctx context.Context, req *pb.StatRequest) (*pb.StatResponse, error)
 	subscribeFn            func(ctx context.Context, req *pb.SubscribeRequest) (*pb.SubscribeResponse, error)
 	subscribeWithDeliverFn func(ctx context.Context, req *pb.SubscribeRequest, deliver trigger.DeliverFunc) (string, error)
@@ -94,6 +95,9 @@ func (m *mockEngine) Forget(ctx context.Context, req *pb.ForgetRequest) (*pb.For
 }
 
 func (m *mockEngine) BatchForget(ctx context.Context, req *pb.BatchForgetRequest) (*pb.BatchForgetResponse, error) {
+	if m.batchForgetFn != nil {
+		return m.batchForgetFn(ctx, req)
+	}
 	results := make([]*pb.BatchForgetItemResult, len(req.Requests))
 	for i := range req.Requests {
 		results[i] = &pb.BatchForgetItemResult{Index: int32(i), Ok: true}
@@ -712,6 +716,7 @@ func TestPublicVaultFullMutatingUnaryRPCsAllowed(t *testing.T) {
 	batchWriteCalled := false
 	linkCalled := false
 	forgetCalled := false
+	batchForgetCalled := false
 	srv := transportgrpc.NewServer(":0", &mockEngine{
 		writeFn: func(ctx context.Context, req *pb.WriteRequest) (*pb.WriteResponse, error) {
 			writeCalled = true
@@ -728,6 +733,10 @@ func TestPublicVaultFullMutatingUnaryRPCsAllowed(t *testing.T) {
 		forgetFn: func(ctx context.Context, req *pb.ForgetRequest) (*pb.ForgetResponse, error) {
 			forgetCalled = true
 			return &pb.ForgetResponse{OK: true}, nil
+		},
+		batchForgetFn: func(ctx context.Context, req *pb.BatchForgetRequest) (*pb.BatchForgetResponse, error) {
+			batchForgetCalled = true
+			return &pb.BatchForgetResponse{}, nil
 		},
 	}, store, nil)
 
@@ -762,6 +771,14 @@ func TestPublicVaultFullMutatingUnaryRPCsAllowed(t *testing.T) {
 			req:    &pb.ForgetRequest{Vault: "default", ID: "id1"},
 			invoke: func(ctx context.Context, req any) (any, error) { return srv.Forget(ctx, req.(*pb.ForgetRequest)) },
 			called: &forgetCalled,
+		},
+		{
+			name: "BatchForget",
+			req:  &pb.BatchForgetRequest{Requests: []*pb.ForgetRequest{{Vault: "default", ID: "id1"}}},
+			invoke: func(ctx context.Context, req any) (any, error) {
+				return srv.BatchForget(ctx, req.(*pb.BatchForgetRequest))
+			},
+			called: &batchForgetCalled,
 		},
 	}
 
@@ -792,6 +809,7 @@ func TestObserveKeyMutatingUnaryRPCsDenied(t *testing.T) {
 	batchWriteCalled := false
 	linkCalled := false
 	forgetCalled := false
+	batchForgetCalled := false
 	srv := transportgrpc.NewServer(":0", &mockEngine{
 		writeFn: func(ctx context.Context, req *pb.WriteRequest) (*pb.WriteResponse, error) {
 			writeCalled = true
@@ -808,6 +826,10 @@ func TestObserveKeyMutatingUnaryRPCsDenied(t *testing.T) {
 		forgetFn: func(ctx context.Context, req *pb.ForgetRequest) (*pb.ForgetResponse, error) {
 			forgetCalled = true
 			return &pb.ForgetResponse{OK: true}, nil
+		},
+		batchForgetFn: func(ctx context.Context, req *pb.BatchForgetRequest) (*pb.BatchForgetResponse, error) {
+			batchForgetCalled = true
+			return &pb.BatchForgetResponse{}, nil
 		},
 	}, store, nil)
 
@@ -842,6 +864,14 @@ func TestObserveKeyMutatingUnaryRPCsDenied(t *testing.T) {
 			req:    &pb.ForgetRequest{Vault: "default", ID: "id1"},
 			invoke: func(ctx context.Context, req any) (any, error) { return srv.Forget(ctx, req.(*pb.ForgetRequest)) },
 			called: &forgetCalled,
+		},
+		{
+			name: "BatchForget",
+			req:  &pb.BatchForgetRequest{Requests: []*pb.ForgetRequest{{Vault: "default", ID: "id1"}}},
+			invoke: func(ctx context.Context, req any) (any, error) {
+				return srv.BatchForget(ctx, req.(*pb.BatchForgetRequest))
+			},
+			called: &batchForgetCalled,
 		},
 	}
 
@@ -1363,6 +1393,78 @@ func TestSubscribe_NilEngram(t *testing.T) {
 		if msg.Trigger == string(trigger.TriggerNewWrite) && msg.Activation != nil {
 			t.Error("expected nil Activation for push with nil Engram")
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BatchForget tests
+// ---------------------------------------------------------------------------
+
+func TestBatchForget_Success(t *testing.T) {
+	eng := &mockEngine{}
+	srv := newPublicTestServer(t, eng)
+
+	resp, err := srv.BatchForget(context.Background(), &pb.BatchForgetRequest{
+		Requests: []*pb.ForgetRequest{
+			{ID: "engram-1"},
+			{ID: "engram-2"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BatchForget: %v", err)
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("got %d results, want 2", len(resp.Results))
+	}
+	for i, r := range resp.Results {
+		if !r.Ok {
+			t.Errorf("result[%d].Ok = false, want true", i)
+		}
+		if r.Error != "" {
+			t.Errorf("result[%d].Error = %q, want empty", i, r.Error)
+		}
+	}
+}
+
+func TestBatchForget_ItemError(t *testing.T) {
+	eng := &mockEngine{
+		batchForgetFn: func(ctx context.Context, req *pb.BatchForgetRequest) (*pb.BatchForgetResponse, error) {
+			results := make([]*pb.BatchForgetItemResult, len(req.Requests))
+			for i, r := range req.Requests {
+				result := &pb.BatchForgetItemResult{Index: int32(i)}
+				if r.ID == "missing" {
+					result.Error = "not found"
+				} else {
+					result.Ok = true
+				}
+				results[i] = result
+			}
+			return &pb.BatchForgetResponse{Results: results}, nil
+		},
+	}
+	srv := newPublicTestServer(t, eng)
+
+	resp, err := srv.BatchForget(context.Background(), &pb.BatchForgetRequest{
+		Requests: []*pb.ForgetRequest{
+			{ID: "engram-1"},
+			{ID: "missing"},
+			{ID: "engram-3"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BatchForget returned unexpected batch error: %v", err)
+	}
+	if len(resp.Results) != 3 {
+		t.Fatalf("got %d results, want 3", len(resp.Results))
+	}
+	if !resp.Results[0].Ok {
+		t.Error("result[0].Ok = false, want true")
+	}
+	if resp.Results[1].Ok || resp.Results[1].Error == "" {
+		t.Errorf("result[1]: Ok=%v Error=%q, want Ok=false and non-empty error", resp.Results[1].Ok, resp.Results[1].Error)
+	}
+	if !resp.Results[2].Ok {
+		t.Error("result[2].Ok = false, want true")
 	}
 }
 

--- a/proto/gen/go/muninn/v1/service.pb.go
+++ b/proto/gen/go/muninn/v1/service.pb.go
@@ -111,6 +111,23 @@ type ForgetResponse struct {
 	OK bool `protobuf:"varint,1,opt,name=ok"`
 }
 
+// BatchForgetRequest wraps multiple ForgetRequests into a single RPC.
+type BatchForgetRequest struct {
+	Requests []*ForgetRequest `protobuf:"bytes,1,rep,name=requests"`
+}
+
+// BatchForgetItemResult is the per-item result in a BatchForgetResponse.
+type BatchForgetItemResult struct {
+	Index int32  `protobuf:"varint,1,opt,name=index"`
+	Ok    bool   `protobuf:"varint,2,opt,name=ok"`
+	Error string `protobuf:"bytes,3,opt,name=error"`
+}
+
+// BatchForgetResponse returns per-item results for a batch forget.
+type BatchForgetResponse struct {
+	Results []*BatchForgetItemResult `protobuf:"bytes,1,rep,name=results"`
+}
+
 // StatRequest message
 type StatRequest struct {
 	Vault string `protobuf:"bytes,1,opt,name=vault"`

--- a/proto/gen/go/muninn/v1/service_grpc.pb.go
+++ b/proto/gen/go/muninn/v1/service_grpc.pb.go
@@ -16,6 +16,7 @@ type MuninnDBClient interface {
 	BatchWrite(ctx context.Context, in *BatchWriteRequest, opts ...grpc.CallOption) (*BatchWriteResponse, error)
 	Read(ctx context.Context, in *ReadRequest, opts ...grpc.CallOption) (*ReadResponse, error)
 	Forget(ctx context.Context, in *ForgetRequest, opts ...grpc.CallOption) (*ForgetResponse, error)
+	BatchForget(ctx context.Context, in *BatchForgetRequest, opts ...grpc.CallOption) (*BatchForgetResponse, error)
 	Stat(ctx context.Context, in *StatRequest, opts ...grpc.CallOption) (*StatResponse, error)
 	Link(ctx context.Context, in *LinkRequest, opts ...grpc.CallOption) (*LinkResponse, error)
 	Activate(ctx context.Context, in *ActivateRequest, opts ...grpc.CallOption) (MuninnDB_ActivateClient, error)
@@ -69,6 +70,15 @@ func (c *muninnDBClient) Read(ctx context.Context, in *ReadRequest, opts ...grpc
 func (c *muninnDBClient) Forget(ctx context.Context, in *ForgetRequest, opts ...grpc.CallOption) (*ForgetResponse, error) {
 	out := new(ForgetResponse)
 	err := c.cc.Invoke(ctx, "/muninn.v1.MuninnDB/Forget", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *muninnDBClient) BatchForget(ctx context.Context, in *BatchForgetRequest, opts ...grpc.CallOption) (*BatchForgetResponse, error) {
+	out := new(BatchForgetResponse)
+	err := c.cc.Invoke(ctx, "/muninn.v1.MuninnDB/BatchForget", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -163,6 +173,7 @@ type MuninnDBServer interface {
 	BatchWrite(context.Context, *BatchWriteRequest) (*BatchWriteResponse, error)
 	Read(context.Context, *ReadRequest) (*ReadResponse, error)
 	Forget(context.Context, *ForgetRequest) (*ForgetResponse, error)
+	BatchForget(context.Context, *BatchForgetRequest) (*BatchForgetResponse, error)
 	Stat(context.Context, *StatRequest) (*StatResponse, error)
 	Link(context.Context, *LinkRequest) (*LinkResponse, error)
 	Activate(*ActivateRequest, MuninnDB_ActivateServer) error
@@ -189,6 +200,10 @@ func (UnimplementedMuninnDBServer) Read(context.Context, *ReadRequest) (*ReadRes
 }
 
 func (UnimplementedMuninnDBServer) Forget(context.Context, *ForgetRequest) (*ForgetResponse, error) {
+	return nil, nil
+}
+
+func (UnimplementedMuninnDBServer) BatchForget(context.Context, *BatchForgetRequest) (*BatchForgetResponse, error) {
 	return nil, nil
 }
 
@@ -327,6 +342,26 @@ var MuninnDB_ServiceDesc = grpc.ServiceDesc{
 				}
 				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 					return srv.(MuninnDBServer).Forget(ctx, req.(*ForgetRequest))
+				}
+				return interceptor(ctx, in, info, handler)
+			},
+		},
+		{
+			MethodName: "BatchForget",
+			Handler: func(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+				in := new(BatchForgetRequest)
+				if err := dec(in); err != nil {
+					return nil, err
+				}
+				if interceptor == nil {
+					return srv.(MuninnDBServer).BatchForget(ctx, in)
+				}
+				info := &grpc.UnaryServerInfo{
+					Server:     srv,
+					FullMethod: "/muninn.v1.MuninnDB/BatchForget",
+				}
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return srv.(MuninnDBServer).BatchForget(ctx, req.(*BatchForgetRequest))
 				}
 				return interceptor(ctx, in, info, handler)
 			},

--- a/proto/muninn/v1/service.proto
+++ b/proto/muninn/v1/service.proto
@@ -91,6 +91,20 @@ message ForgetResponse {
   bool ok = 1;
 }
 
+message BatchForgetRequest {
+  repeated ForgetRequest requests = 1;
+}
+
+message BatchForgetItemResult {
+  int32  index = 1;
+  bool   ok    = 2;
+  string error = 3;
+}
+
+message BatchForgetResponse {
+  repeated BatchForgetItemResult results = 1;
+}
+
 message StatRequest {
   string vault = 1;
 }
@@ -212,6 +226,7 @@ service MuninnDB {
   rpc BatchWrite(BatchWriteRequest) returns (BatchWriteResponse);
   rpc Read(ReadRequest) returns (ReadResponse);
   rpc Forget(ForgetRequest) returns (ForgetResponse);
+  rpc BatchForget(BatchForgetRequest) returns (BatchForgetResponse);
   rpc Stat(StatRequest) returns (StatResponse);
   rpc Link(LinkRequest) returns (LinkResponse);
   rpc Activate(ActivateRequest) returns (stream ActivateResponse);


### PR DESCRIPTION
Closes #557

Adds `BatchForget` to the gRPC service, mirroring the existing `BatchWrite` pattern. Fans out to individual `Forget` engine calls per item, returning per-item results so a single bad ID does not abort the rest of the batch.

## Changes

- `proto/muninn/v1/service.proto` — `BatchForgetRequest`, `BatchForgetItemResult`, `BatchForgetResponse` messages + `BatchForget` RPC
- `proto/gen/go/muninn/v1/service.pb.go` — new types
- `proto/gen/go/muninn/v1/service_grpc.pb.go` — client interface, client impl, server interface, `UnimplementedMuninnDBServer` stub, `MuninnDB_ServiceDesc` handler
- `internal/transport/grpc/server.go` — `EngineAPI` interface + thin handler (mirrors `BatchWrite`)
- `internal/transport/grpc/engine_adapter.go` — adapter loops over `engine.Forget()` calls
- `internal/transport/grpc/server_test.go` — `mockEngine.BatchForget` stub to satisfy updated interface

## Notes

- Errors are per-item (`BatchForgetItemResult.Error`), not fatal to the batch
- `hard: false` (soft delete) is the caller's choice per item, same as the single `Forget` RPC
- All existing gRPC tests pass