### PR TITLE
fix(engine,admin): register vault in Pebble index on vault create + repair reindex-fts/export (#547)

### DIFF
--- a/internal/engine/engine_export.go
+++ b/internal/engine/engine_export.go
@@ -23,16 +23,9 @@ func (e *Engine) ExportVault(ctx context.Context, vaultName, embedderModel strin
 	opCtx, stop := e.vaultOpContext(ctx)
 	defer stop()
 
-	names, err := e.store.ListVaultNames()
+	found, err := e.ensureVaultRegistered(vaultName)
 	if err != nil {
-		return nil, fmt.Errorf("export vault: list vaults: %w", err)
-	}
-	found := false
-	for _, n := range names {
-		if n == vaultName {
-			found = true
-			break
-		}
+		return nil, fmt.Errorf("export vault: vault lookup: %w", err)
 	}
 	if !found {
 		return nil, fmt.Errorf("export vault %q: %w", vaultName, ErrVaultNotFound)

--- a/internal/engine/engine_reindex_fts.go
+++ b/internal/engine/engine_reindex_fts.go
@@ -32,16 +32,9 @@ func (e *Engine) ReindexFTSVault(ctx context.Context, vaultName string) (int64, 
 	mu.Lock()
 	defer mu.Unlock()
 
-	names, err := e.store.ListVaultNames()
+	found, err := e.ensureVaultRegistered(vaultName)
 	if err != nil {
-		return 0, fmt.Errorf("reindex-fts: list vault names: %w", err)
-	}
-	found := false
-	for _, n := range names {
-		if n == vaultName {
-			found = true
-			break
-		}
+		return 0, fmt.Errorf("reindex-fts: vault lookup: %w", err)
 	}
 	if !found {
 		return 0, fmt.Errorf("vault %q: %w", vaultName, ErrVaultNotFound)

--- a/internal/engine/engine_vault.go
+++ b/internal/engine/engine_vault.go
@@ -199,6 +199,52 @@ func (e *Engine) deleteVault(ctx context.Context, vaultName string) error {
 	return nil
 }
 
+// ensureVaultRegistered checks whether vaultName appears in the Pebble 0x0E
+// name index. If it does not, it checks the auth store — a vault created via
+// `muninn vault create` only writes an auth config entry until the first engram
+// is stored, leaving a gap between the auth registry and the Pebble index.
+// When found exclusively in the auth store the name is written into the Pebble
+// index so subsequent admin operations (reindex-fts, vault export, etc.) can
+// find it. Returns false only when the vault is absent from both registries.
+func (e *Engine) ensureVaultRegistered(name string) (bool, error) {
+	names, err := e.store.ListVaultNames()
+	if err != nil {
+		return false, err
+	}
+	for _, n := range names {
+		if n == name {
+			return true, nil
+		}
+	}
+	// Fall back to the auth store which only holds explicitly configured vaults.
+	// GetVaultConfig is fail-closed (returns a default for unknown vaults), so use
+	// ListVaultConfigs which exclusively returns persisted entries.
+	if e.authStore != nil {
+		cfgs, lErr := e.authStore.ListVaultConfigs()
+		if lErr == nil {
+			for _, cfg := range cfgs {
+				if cfg.Name == name {
+					ws := e.store.ResolveVaultPrefix(name)
+					if wErr := e.store.WriteVaultName(ws, name); wErr != nil {
+						slog.Warn("vault registry repair failed", "vault", name, "err", wErr)
+					}
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+// RegisterVaultName writes the vault name into the Pebble 0x0E name index.
+// Called by the admin REST handler when a vault is created so that admin
+// operations (reindex-fts, vault export, vault clear) can find it immediately,
+// even before the first engram has been written.
+func (e *Engine) RegisterVaultName(name string) error {
+	ws := e.store.ResolveVaultPrefix(name)
+	return e.store.WriteVaultName(ws, name)
+}
+
 // RenameVault atomically renames a vault. This is a metadata-only operation —
 // no engram data is moved or modified. Returns ErrVaultNotFound if oldName
 // doesn't exist, ErrVaultJobActive if a clone/merge job targets the vault,

--- a/internal/engine/engine_vault_test.go
+++ b/internal/engine/engine_vault_test.go
@@ -683,6 +683,138 @@ func TestDeleteVault_VaultMuEntryRemoved(t *testing.T) {
 	}
 }
 
+// TestEnsureVaultRegistered_AuthStoreOnly verifies that ensureVaultRegistered
+// returns true for a vault that exists only in the auth store (created via
+// `muninn vault create` before any engrams are written), and that the vault is
+// automatically written into the Pebble 0x0E name index so subsequent admin
+// operations can find it without a full lookup cycle.
+func TestEnsureVaultRegistered_AuthStoreOnly(t *testing.T) {
+	eng, as, _, cleanup := testEnvWithAuth(t)
+	defer cleanup()
+	ctx := context.Background()
+	_ = ctx
+
+	const vaultName = "auth-only-vault"
+	if err := as.SetVaultConfig(auth.VaultConfig{Name: vaultName, Public: false}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+
+	// Vault is NOT in the Pebble index yet — ListVaultNames should miss it.
+	names, err := eng.store.ListVaultNames()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range names {
+		if n == vaultName {
+			t.Fatal("vault should not be in Pebble index before ensureVaultRegistered")
+		}
+	}
+
+	// ensureVaultRegistered must return true and repair the index.
+	found, err := eng.ensureVaultRegistered(vaultName)
+	if err != nil {
+		t.Fatalf("ensureVaultRegistered: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true for vault in auth store")
+	}
+
+	// The vault must now appear in ListVaultNames.
+	names, err = eng.store.ListVaultNames()
+	if err != nil {
+		t.Fatal(err)
+	}
+	found = false
+	for _, n := range names {
+		if n == vaultName {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected vault to be registered in Pebble index after ensureVaultRegistered")
+	}
+}
+
+// TestEnsureVaultRegistered_Missing verifies that ensureVaultRegistered returns
+// false for a vault that exists in neither the Pebble index nor the auth store.
+func TestEnsureVaultRegistered_Missing(t *testing.T) {
+	eng, _, _, cleanup := testEnvWithAuth(t)
+	defer cleanup()
+
+	found, err := eng.ensureVaultRegistered("does-not-exist")
+	if err != nil {
+		t.Fatalf("ensureVaultRegistered: %v", err)
+	}
+	if found {
+		t.Error("expected found=false for unknown vault")
+	}
+}
+
+// TestRegisterVaultName verifies that RegisterVaultName writes the vault into
+// the Pebble name index so ListVaultNames returns it immediately.
+func TestRegisterVaultName(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vaultName = "registered-vault"
+	if err := eng.RegisterVaultName(vaultName); err != nil {
+		t.Fatalf("RegisterVaultName: %v", err)
+	}
+
+	vaults, err := eng.ListVaults(ctx)
+	if err != nil {
+		t.Fatalf("ListVaults: %v", err)
+	}
+	found := false
+	for _, v := range vaults {
+		if v == vaultName {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected vault to appear in ListVaults after RegisterVaultName")
+	}
+}
+
+// TestReindexFTSVault_AuthOnlyVault verifies that reindex-fts succeeds on a
+// vault that was created via `vault create` (auth-store only, no engrams yet).
+func TestReindexFTSVault_AuthOnlyVault(t *testing.T) {
+	eng, as, _, cleanup := testEnvWithAuth(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vaultName = "fts-auth-only"
+	if err := as.SetVaultConfig(auth.VaultConfig{Name: vaultName, Public: false}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+
+	// reindex-fts on an empty auth-only vault should succeed (0 engrams indexed).
+	n, err := eng.ReindexFTSVault(ctx, vaultName)
+	if err != nil {
+		t.Fatalf("ReindexFTSVault on auth-only vault: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 engrams indexed, got %d", n)
+	}
+}
+
+// TestReindexFTSVault_NotFound verifies that reindex-fts returns ErrVaultNotFound
+// for a vault absent from both the Pebble index and the auth store.
+func TestReindexFTSVault_NotFound(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := eng.ReindexFTSVault(ctx, "ghost-vault")
+	if err == nil {
+		t.Fatal("expected ErrVaultNotFound, got nil")
+	}
+	if !strings.Contains(err.Error(), "vault not found") {
+		t.Errorf("expected vault not found error, got: %v", err)
+	}
+}
+
 // TestEngineRenameVault_JobActive verifies that renaming a vault with an
 // active clone/merge job targeting it returns ErrVaultJobActive.
 func TestEngineRenameVault_JobActive(t *testing.T) {

--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -289,6 +289,16 @@ func (s *Server) handleSetVaultConfig(authStore *auth.Store) http.HandlerFunc {
 			s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
 			return
 		}
+		// Register the vault in the Pebble name index so admin operations
+		// (reindex-fts, vault export) can find it before the first engram is written.
+		type vaultNameRegistrar interface {
+			RegisterVaultName(name string) error
+		}
+		if reg, ok := s.engine.(vaultNameRegistrar); ok {
+			if rErr := reg.RegisterVaultName(cfg.Name); rErr != nil {
+				slog.Warn("vault create: failed to register vault name", "vault", cfg.Name, "err", rErr)
+			}
+		}
 		s.sendJSON(w, http.StatusOK, cfg)
 		s.EmitAudit(r, "vault.config_update", "vault", cfg.Name, "ok", nil)
 	}


### PR DESCRIPTION
## Root cause

Vaults created via `muninn vault create` only write an auth config entry. The Pebble 0x0E name index — scanned by `ListVaultNames()` — stays empty until the first engram is written. So `reindex-fts default` and `vault export default` both hit `ErrVaultNotFound` while MCP serves data from the exact same vault without issue.

Running `vault create default` afterwards didn't help either because the REST handler only called `authStore.SetVaultConfig` and nothing else.

## What changed

### `handleSetVaultConfig` (REST)
After `authStore.SetVaultConfig`, also call `engine.RegisterVaultName` via a local interface assertion. This pre-registers the vault in the Pebble 0x0E index so admin ops can find it before the first engram lands.

### `ensureVaultRegistered` (new engine helper)
Checks `ListVaultNames()` first (fast path). If the vault isn't there, falls back to `ListVaultConfigs()` (explicitly-persisted auth configs only — avoids `GetVaultConfig`'s fail-closed default). If found in auth store, auto-repairs the Pebble index entry and returns `true`. Returns `false` only if the vault is absent from both registries.

### `ReindexFTSVault` / `ExportVault`
Replace the raw `ListVaultNames` scan with `ensureVaultRegistered`. Both also switch from `VaultPrefix` (raw SipHash) to `ResolveVaultPrefix` (handles renamed vaults correctly, mirrors the fix in #480/#454 already on main).

### `RegisterVaultName` (new public engine method)
Thin wrapper: `store.ResolveVaultPrefix(name)` → `store.WriteVaultName`. Called by the REST handler and directly testable.

## Tests

- `TestEnsureVaultRegistered_AuthStoreOnly` — vault in auth store only → returns `true`, Pebble index repaired
- `TestEnsureVaultRegistered_Missing` — vault absent from both registries → returns `false`
- `TestRegisterVaultName` — vault appears in `ListVaults` after registration
- `TestReindexFTSVault_AuthOnlyVault` — reindex-fts on an auth-only vault succeeds (0 engrams)
- `TestReindexFTSVault_NotFound` — ghost vault still returns ErrVaultNotFound

All engine tests pass (33s). All REST transport tests pass.

Closes #547