### PR TITLE
fix(enrich): raise Google MaxOutputTokens to 8192 + count parse failures in LLM stats

### DIFF
--- a/internal/plugin/enrich/google.go
+++ b/internal/plugin/enrich/google.go
@@ -103,7 +103,7 @@ func (p *GoogleLLMProvider) Complete(ctx context.Context, system, user string) (
 		},
 		GenerationConfig: googleGenerationConfig{
 			Temperature:      0.0,
-			MaxOutputTokens:  1024,
+			MaxOutputTokens:  8192,
 			ResponseMimeType: "application/json",
 		},
 	}

--- a/internal/plugin/enrich/pipeline.go
+++ b/internal/plugin/enrich/pipeline.go
@@ -60,6 +60,24 @@ func (p *EnrichmentPipeline) verboseLogsFlag() *bool {
 	return p.cfg.LLMVerboseLogs
 }
 
+// recordParseError increments TotalErrors when a provider call succeeded but the
+// structured-output parse failed. It does not touch TotalCalls or TotalLatencyMs
+// since those were already recorded by recordComplete.
+func (p *EnrichmentPipeline) recordParseError(ctx context.Context, callType string, err error) {
+	if err == nil {
+		return
+	}
+	p.stats.TotalErrors.Add(1)
+	if llmstats.VerboseEnabled(p.verboseLogsFlag()) {
+		slog.InfoContext(ctx, "llm.parse_error",
+			"source", "llm",
+			"subsystem", "enrich",
+			"call_type", callType,
+			"error", err.Error(),
+		)
+	}
+}
+
 // recordComplete updates aggregate stats and emits a verbose log entry when enabled.
 func (p *EnrichmentPipeline) recordComplete(ctx context.Context, callType string, latMs int64, err error) {
 	p.stats.TotalCalls.Add(1)
@@ -242,7 +260,9 @@ func (p *EnrichmentPipeline) extractEntities(ctx context.Context, eng *storage.E
 		return nil, err
 	}
 
-	return ParseEntityResponse(resp)
+	entities, parseErr := ParseEntityResponse(resp)
+	p.recordParseError(ctx, "entities", parseErr)
+	return entities, parseErr
 }
 
 // extractRelationships executes Call 2: relationship extraction.
@@ -270,7 +290,9 @@ func (p *EnrichmentPipeline) extractRelationships(ctx context.Context, eng *stor
 		return nil, err
 	}
 
-	return ParseRelationshipResponse(resp)
+	rels, parseErr := ParseRelationshipResponse(resp)
+	p.recordParseError(ctx, "relationships", parseErr)
+	return rels, parseErr
 }
 
 // classify executes Call 3: classification.
@@ -287,7 +309,9 @@ func (p *EnrichmentPipeline) classify(ctx context.Context, eng *storage.Engram) 
 		return "", "", "", "", nil, err
 	}
 
-	return ParseClassificationResponse(resp)
+	mt, tl, cat, sub, tags, parseErr := ParseClassificationResponse(resp)
+	p.recordParseError(ctx, "classification", parseErr)
+	return mt, tl, cat, sub, tags, parseErr
 }
 
 // summarize executes Call 4: summarization.
@@ -304,5 +328,7 @@ func (p *EnrichmentPipeline) summarize(ctx context.Context, eng *storage.Engram)
 		return "", nil, err
 	}
 
-	return ParseSummarizeResponse(resp)
+	summary, keyPoints, parseErr := ParseSummarizeResponse(resp)
+	p.recordParseError(ctx, "summary", parseErr)
+	return summary, keyPoints, parseErr
 }


### PR DESCRIPTION
## Summary

- **Root cause (#554):** `MaxOutputTokens` was hardcoded to `1024` in the Google Gemini provider. For engrams with long content, entity/relationship extraction responses exceeded this budget, returning HTTP 200 with truncated JSON. The parse step then failed and the retroactive processor permanently marked those engrams as enrich-failed.
- **Fix:** Raise `MaxOutputTokens` to `8192`, well within gemini-2.5-flash's output budget and sufficient for any realistic entity/relationship extraction response.

- **Root cause (#555):** `EnrichmentPipeline.recordComplete()` only incremented `TotalErrors` when `provider.Complete()` itself returned a Go error. JSON parse failures (which occur after a successful HTTP 200 response) were not counted, causing the observability page to show `0 LLM errors` while the processor reported per-engram failures.
- **Fix:** Add `recordParseError()` — a lightweight helper that increments `TotalErrors` without touching `TotalCalls` or `TotalLatencyMs` (already recorded). Called after each `Parse*` step when the provider call succeeded but parse failed.

## Test plan
- [ ] Build passes `go build ./...`
- [ ] `go test ./internal/plugin/enrich/...` passes
- [ ] CI green
- [ ] Manually confirm: after upgrading, retroactive enrich on long engrams no longer logs `invalid entity response JSON` truncation warnings with Google provider