### PR TITLE
fix(ui): correct Confidence worker description — event-driven, not access-driven

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -257,7 +257,7 @@
           <!-- Last-run footer -->
           <div x-show="workerStats.length > 0"
             style="font-size:0.6875rem;color:var(--text-muted);padding-top:0.4375rem;text-align:right;">
-            Last run: <span x-text="workersLastRunSummary()"></span>
+            Most recent worker activity: <span x-text="workersLastRunSummary()"></span>
           </div>
         </div>
       </div>
@@ -3297,7 +3297,7 @@ Authorization = "Bearer &lt;token from %USERPROFILE%\.muninn\mcp.token&gt;"</pre
       </div>
       <div style="overflow-y:auto;flex:1;min-height:0;">
       <p style="color:var(--text-muted);font-size:0.875rem;margin:0 0 1.125rem;line-height:1.6;">
-        Background workers continuously refine the memory graph — strengthening associations, detecting contradictions, and updating confidence scores — without requiring user interaction.
+        Background workers continuously refine the memory graph — strengthening associations and detecting contradictions — without requiring user interaction. Confidence updates are event-driven and fire only when contradiction or explicit user-feedback evidence is available.
       </p>
 
       <!-- Hebbian -->
@@ -3376,7 +3376,7 @@ Authorization = "Bearer &lt;token from %USERPROFILE%\.muninn\mcp.token&gt;"</pre
           <span style="font-weight:600;color:var(--text-secondary);font-size:0.9375rem;">Confidence &mdash; Belief Updating</span>
         </div>
         <p style="margin:0 0 0.5rem;font-size:0.8125rem;color:var(--text-muted);line-height:1.6;">
-          Updates per-memory confidence scores using iterative Bayesian belief updating. Each access event (recall, co-activation, user confirm, contradiction) carries an evidence strength; the posterior is recalculated so frequently validated memories rank higher and contradicted memories rank lower.
+          Updates per-memory confidence scores using iterative Bayesian belief updating. It is <strong>event-driven</strong> — the worker only fires when explicit confidence evidence is generated: contradiction detection, or direct user feedback (confirm/reject) submitted via the API. Recall and co-activation do not feed this worker; that evidence is treated as relevance, not truth. If no contradiction or user-feedback events have occurred the worker stays dormant, which is expected.
         </p>
         <code style="font-size:0.75rem;color:#34d399;background:var(--bg-card);padding:0.25rem 0.5rem;border-radius:0.375rem;display:inline-block;">
           P&#x2032; = (P &times; ev) / (P &times; ev + (1&minus;P)(1&minus;ev))


### PR DESCRIPTION
## Summary

The dashboard modal incorrectly stated the Confidence worker updates on "each access event (recall, co-activation, user confirm, contradiction)". The engine explicitly does **not** feed the Confidence worker on recall or co-activation — those are treated as relevance evidence, not truth evidence. The worker only fires on `contradiction_detected` or explicit user-feedback events.

This meant any user without contradictions or user-feedback workflows would see the Confidence worker perpetually Dormant and assume it was broken.

## Changes

- **Confidence modal copy** (line 3379): Rewrites the description to clearly state the worker is event-driven and dormant-by-default unless contradiction or user-feedback evidence is generated.
- **Global workers intro** (line 3300): Removes the inaccurate claim that confidence updates happen "without requiring user interaction."
- **Footer label**: Changes "Last run:" to "Most recent worker activity:" to clarify that the footer shows an aggregate max across all workers, not a per-row value.

## Test plan
- [ ] Build passes
- [ ] CI green
- [ ] Visually confirm: cognitive workers modal copy accurately describes the Confidence worker as event-driven