### PR TITLE
feat(engine,mcp): fuzzy entity resolve behind exact find_by_entity lookup

### DIFF
--- a/internal/engine/engine_entity_resolve.go
+++ b/internal/engine/engine_entity_resolve.go
@@ -1,0 +1,115 @@
+package engine
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/scrypster/muninndb/internal/storage/keys"
+)
+
+// entityResolveMaxCandidates bounds how many ranked fuzzy candidates a
+// resolve returns. The best candidate serves retrieval; the rest are
+// reported to the caller as near-misses.
+const entityResolveMaxCandidates = 5
+
+// entityStopwords are article tokens ignored during fuzzy entity matching —
+// they carry no identity: "The Knock" and "knock" name the same entity
+// (issue #571).
+var entityStopwords = map[string]struct{}{"the": {}, "a": {}, "an": {}}
+
+// entityTokens returns the tokens of an entity name for fuzzy matching:
+// NFKC-normalized, lowercased (keys.NormalizeEntityName — the same
+// normalization the entity hash index uses), split on separator runes, with
+// article stopwords dropped. When a name consists only of stopwords, the raw
+// tokens are returned instead so such a name can still match itself.
+func entityTokens(name string) []string {
+	normalized := keys.NormalizeEntityName(name)
+	raw := strings.FieldsFunc(normalized, func(r rune) bool {
+		switch r {
+		case ' ', '\t', '-', '_', '/', '.':
+			return true
+		}
+		return false
+	})
+	tokens := make([]string, 0, len(raw))
+	for _, tok := range raw {
+		if _, stop := entityStopwords[tok]; !stop {
+			tokens = append(tokens, tok)
+		}
+	}
+	if len(tokens) == 0 {
+		return raw
+	}
+	return tokens
+}
+
+// resolveEntityFuzzy ranks the vault's entity names against the query by
+// token overlap. A candidate qualifies when it shares at least one
+// non-stopword token with the query, or when its concatenated token string
+// equals the query's (bridging concatenation variants such as "TokenArcade"
+// vs "Token Arcade"). Candidates are ranked by Jaccard overlap of token
+// sets — concatenation equality ranks as 1.0 — with a lexicographic
+// tie-break for determinism. The match rule is set-membership; Jaccard is
+// used only for ranking, so there is no similarity threshold to tune.
+//
+// Vaults hold few distinct entity names, so this is an in-memory scan over
+// the 0x20 forward index (ScanVaultEntityNames) — no new index required.
+func (e *Engine) resolveEntityFuzzy(ctx context.Context, ws [8]byte, query string) []string {
+	qTokens := entityTokens(query)
+	if len(qTokens) == 0 {
+		return nil
+	}
+	qSet := make(map[string]struct{}, len(qTokens))
+	for _, tok := range qTokens {
+		qSet[tok] = struct{}{}
+	}
+	qJoined := strings.Join(qTokens, "")
+
+	type candidate struct {
+		name  string
+		score float64
+	}
+	var cands []candidate
+	_ = e.store.ScanVaultEntityNames(ctx, ws, func(name string) error {
+		tokens := entityTokens(name)
+		if len(tokens) == 0 {
+			return nil
+		}
+		set := make(map[string]struct{}, len(tokens))
+		for _, tok := range tokens {
+			set[tok] = struct{}{}
+		}
+		shared := 0
+		for tok := range set {
+			if _, ok := qSet[tok]; ok {
+				shared++
+			}
+		}
+		joinedEqual := strings.Join(tokens, "") == qJoined
+		if shared == 0 && !joinedEqual {
+			return nil
+		}
+		score := float64(shared) / float64(len(set)+len(qSet)-shared)
+		if joinedEqual {
+			score = 1.0
+		}
+		cands = append(cands, candidate{name: name, score: score})
+		return nil
+	})
+
+	sort.Slice(cands, func(i, j int) bool {
+		if cands[i].score != cands[j].score {
+			return cands[i].score > cands[j].score
+		}
+		return cands[i].name < cands[j].name
+	})
+	if len(cands) > entityResolveMaxCandidates {
+		cands = cands[:entityResolveMaxCandidates]
+	}
+	names := make([]string, len(cands))
+	for i, c := range cands {
+		names[i] = c.name
+	}
+	return names
+}

--- a/internal/engine/engine_entity_resolve_test.go
+++ b/internal/engine/engine_entity_resolve_test.go
@@ -1,0 +1,167 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEntityTokens verifies the fuzzy-match tokenizer: normalization,
+// separator splitting, article-stopword dropping, and the all-stopword
+// fallback.
+func TestEntityTokens(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		want []string
+	}{
+		{"The Knock", []string{"knock"}},
+		{"knock", []string{"knock"}},
+		{"dream-cycle", []string{"dream", "cycle"}},
+		{"dream cycle", []string{"dream", "cycle"}},
+		{"Token Arcade", []string{"token", "arcade"}},
+		{"a_b/c.d", []string{"b", "c", "d"}}, // "a" dropped as article
+		{"The", []string{"the"}},             // all-stopword name falls back to raw tokens
+		{"  Spaced  Name  ", []string{"spaced", "name"}},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, entityTokens(c.name), "entityTokens(%q)", c.name)
+	}
+}
+
+// linkEntityEngram writes one engram and links it to entityName, upserting
+// the entity record first.
+func linkEntityEngram(t *testing.T, eng *Engine, ws [8]byte, concept, entityName string) storage.ULID {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, eng.store.UpsertEntityRecord(ctx, storage.EntityRecord{
+		Name:   entityName,
+		Type:   "concept",
+		Source: "inline",
+	}, "inline"))
+	id, err := eng.store.WriteEngram(ctx, ws, &storage.Engram{
+		Concept:    concept,
+		Content:    concept + " content",
+		Confidence: 0.9,
+	})
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, id, entityName))
+	return id
+}
+
+// TestFindByEntity_FuzzyArticleVariant is the issue #571 headline case:
+// the entity was recorded as "The Knock"; the caller asks for "knock".
+func TestFindByEntity_FuzzyArticleVariant(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "fuzzy-article"
+	ws := eng.store.ResolveVaultPrefix(vault)
+	id := linkEntityEngram(t, eng, ws, "knock-design", "The Knock")
+
+	res, err := eng.FindByEntity(ctx, vault, "knock", 20)
+	require.NoError(t, err)
+	require.Len(t, res.Engrams, 1)
+	require.Equal(t, id, res.Engrams[0].ID)
+	require.Equal(t, "The Knock", res.MatchedEntity, "resolution must be reported")
+	require.True(t, res.Fuzzy, "article-variant hit must be marked fuzzy")
+}
+
+// TestFindByEntity_FuzzySeparatorVariant covers hyphen/space separator
+// variants: entity recorded "dream cycle", queried as "dream-cycle".
+func TestFindByEntity_FuzzySeparatorVariant(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "fuzzy-separator"
+	ws := eng.store.ResolveVaultPrefix(vault)
+	id := linkEntityEngram(t, eng, ws, "cycle-log", "dream cycle")
+
+	res, err := eng.FindByEntity(ctx, vault, "dream-cycle", 20)
+	require.NoError(t, err)
+	require.Len(t, res.Engrams, 1)
+	require.Equal(t, id, res.Engrams[0].ID)
+	require.Equal(t, "dream cycle", res.MatchedEntity)
+	require.True(t, res.Fuzzy)
+}
+
+// TestFindByEntity_FuzzyConcatenationVariant covers concatenation variants
+// via the joined-token comparison: entity "Token Arcade", query "TokenArcade".
+func TestFindByEntity_FuzzyConcatenationVariant(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "fuzzy-concat"
+	ws := eng.store.ResolveVaultPrefix(vault)
+	id := linkEntityEngram(t, eng, ws, "arcade-platform", "Token Arcade")
+
+	res, err := eng.FindByEntity(ctx, vault, "TokenArcade", 20)
+	require.NoError(t, err)
+	require.Len(t, res.Engrams, 1)
+	require.Equal(t, id, res.Engrams[0].ID)
+	require.Equal(t, "Token Arcade", res.MatchedEntity)
+	require.True(t, res.Fuzzy)
+}
+
+// TestFindByEntity_FuzzyRanking verifies Jaccard ranking: a full token match
+// outranks a partial one, and the runner-up is reported as a candidate.
+func TestFindByEntity_FuzzyRanking(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "fuzzy-ranking"
+	ws := eng.store.ResolveVaultPrefix(vault)
+	full := linkEntityEngram(t, eng, ws, "board-doc", "Arcade Board")
+	linkEntityEngram(t, eng, ws, "arcade-doc", "Arcade")
+
+	// "the arcade board" is a token variant (article added) of "Arcade Board",
+	// so the exact hash lookup misses and the fuzzy path must rank:
+	// {arcade, board} vs "Arcade Board" → Jaccard 1.0; vs "Arcade" → 0.5.
+	// (A bare case variant like "arcade board" would hit the exact path —
+	// EntityNameHash already normalizes case.)
+	res, err := eng.FindByEntity(ctx, vault, "the arcade board", 20)
+	require.NoError(t, err)
+	require.Equal(t, "Arcade Board", res.MatchedEntity, "full token overlap (Jaccard 1.0) must outrank partial (0.5)")
+	require.True(t, res.Fuzzy)
+	require.Len(t, res.Engrams, 1)
+	require.Equal(t, full, res.Engrams[0].ID)
+	require.Contains(t, res.Candidates, "Arcade", "runner-up must be reported as a candidate")
+}
+
+// TestFindByEntity_NoPhantomMatch verifies that queries sharing no
+// non-stopword token with any vault entity return an empty, non-fuzzy
+// result — fuzzy matching must not invent matches.
+func TestFindByEntity_NoPhantomMatch(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "fuzzy-phantom"
+	ws := eng.store.ResolveVaultPrefix(vault)
+	linkEntityEngram(t, eng, ws, "knock-design", "The Knock")
+
+	// Unrelated tokens: no match.
+	res, err := eng.FindByEntity(ctx, vault, "zebra migration", 20)
+	require.NoError(t, err)
+	require.Empty(t, res.Engrams)
+	require.Empty(t, res.MatchedEntity)
+	require.False(t, res.Fuzzy)
+
+	// Stopword-only query: "the" must not match "The Knock" — the article
+	// carries no identity and the entity's non-stopword token is "knock".
+	res, err = eng.FindByEntity(ctx, vault, "the", 20)
+	require.NoError(t, err)
+	require.Empty(t, res.Engrams, "an article must not fuzzy-match every article-bearing entity")
+	require.False(t, res.Fuzzy)
+}

--- a/internal/engine/engine_find_by_entity.go
+++ b/internal/engine/engine_find_by_entity.go
@@ -2,15 +2,42 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/scrypster/muninndb/internal/storage"
 )
 
-// FindByEntity returns all engrams in vault that mention entityName,
-// using the 0x23 reverse index for O(matches) lookup.
+// errLimitReached is the internal sentinel used to stop an entity reverse
+// index scan once the caller's limit is satisfied.
+var errLimitReached = errors.New("limit reached")
+
+// FindByEntityResult is the result of a FindByEntity lookup.
+type FindByEntityResult struct {
+	// Engrams are the live engrams linked to MatchedEntity, up to the
+	// caller's limit.
+	Engrams []*storage.Engram
+	// MatchedEntity is the entity name that actually served the results:
+	// the query itself on an exact hit, a vault entity name on a fuzzy hit,
+	// empty when nothing matched.
+	MatchedEntity string
+	// Fuzzy is true when MatchedEntity was resolved by token matching
+	// rather than exact (normalized) lookup — the resolution is always
+	// reported, never silent (issue #571).
+	Fuzzy bool
+	// Candidates are the remaining ranked fuzzy candidates that were not
+	// used for retrieval, reported so the caller can see near-misses.
+	Candidates []string
+}
+
+// FindByEntity returns engrams in vault that mention entityName, using the
+// 0x23 reverse index for O(matches) lookup. The exact (normalized) name is
+// tried first; when it yields no live engrams, the vault's entity names are
+// fuzzy-resolved by token overlap (issue #571: `knock` vs `The Knock`,
+// `dream cycle` vs `dream-cycle`, `TokenArcade` vs `Token Arcade`) and the
+// best-ranked candidate with live engrams serves the results.
 // Results are limited to limit entries (default 20, max 50).
-func (e *Engine) FindByEntity(ctx context.Context, vault, entityName string, limit int) ([]*storage.Engram, error) {
+func (e *Engine) FindByEntity(ctx context.Context, vault, entityName string, limit int) (*FindByEntityResult, error) {
 	if entityName == "" {
 		return nil, fmt.Errorf("find_by_entity: entity_name is required")
 	}
@@ -21,13 +48,45 @@ func (e *Engine) FindByEntity(ctx context.Context, vault, entityName string, lim
 		limit = 50
 	}
 	ws := e.store.ResolveVaultPrefix(vault)
+
+	engrams, err := e.entityEngrams(ctx, ws, entityName, limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(engrams) > 0 {
+		return &FindByEntityResult{Engrams: engrams, MatchedEntity: entityName}, nil
+	}
+
+	// Exact lookup found nothing live — fuzzy-resolve against the vault's
+	// entity names and use the best-ranked candidate that has live engrams.
+	candidates := e.resolveEntityFuzzy(ctx, ws, entityName)
+	for i, name := range candidates {
+		engrams, err = e.entityEngrams(ctx, ws, name, limit)
+		if err != nil {
+			return nil, err
+		}
+		if len(engrams) > 0 {
+			return &FindByEntityResult{
+				Engrams:       engrams,
+				MatchedEntity: name,
+				Fuzzy:         true,
+				Candidates:    append([]string(nil), candidates[i+1:]...),
+			}, nil
+		}
+	}
+	return &FindByEntityResult{}, nil
+}
+
+// entityEngrams scans the 0x23 reverse index for live engrams in ws linked
+// to entityName, up to limit entries.
+func (e *Engine) entityEngrams(ctx context.Context, ws [8]byte, entityName string, limit int) ([]*storage.Engram, error) {
 	var results []*storage.Engram
 	err := e.store.ScanEntityEngrams(ctx, entityName, func(gotWS [8]byte, id storage.ULID) error {
 		if gotWS != ws {
 			return nil // different vault — skip
 		}
 		if len(results) >= limit {
-			return fmt.Errorf("limit reached") // sentinel to stop scanning
+			return errLimitReached // sentinel to stop scanning
 		}
 		eng, err := e.store.GetEngram(ctx, ws, id)
 		if err != nil || eng == nil {
@@ -39,7 +98,7 @@ func (e *Engine) FindByEntity(ctx context.Context, vault, entityName string, lim
 		results = append(results, eng)
 		return nil
 	})
-	if err != nil && err.Error() != "limit reached" {
+	if err != nil && !errors.Is(err, errLimitReached) {
 		return nil, fmt.Errorf("find_by_entity: scan: %w", err)
 	}
 	return results, nil

--- a/internal/engine/engine_find_by_entity_test.go
+++ b/internal/engine/engine_find_by_entity_test.go
@@ -44,11 +44,13 @@ func TestFindByEntity_ExcludesArchived(t *testing.T) {
 	require.NoError(t, err)
 
 	// FindByEntity must return only the active engram.
-	results, err := eng.FindByEntity(ctx, vault, "SharedEntity", 50)
+	res, err := eng.FindByEntity(ctx, vault, "SharedEntity", 50)
 	require.NoError(t, err)
+	require.Equal(t, "SharedEntity", res.MatchedEntity)
+	require.False(t, res.Fuzzy, "exact lookup must not be marked fuzzy")
 
 	var foundActive, foundArchived bool
-	for _, r := range results {
+	for _, r := range res.Engrams {
 		if r.ID == idA {
 			foundActive = true
 		}
@@ -93,11 +95,11 @@ func TestFindByEntity_ExcludesSoftDeleted(t *testing.T) {
 	err = eng.store.SoftDelete(ctx, ws, idB)
 	require.NoError(t, err)
 
-	results, err := eng.FindByEntity(ctx, vault, "SharedEntity2", 50)
+	res, err := eng.FindByEntity(ctx, vault, "SharedEntity2", 50)
 	require.NoError(t, err)
 
 	var foundActive, foundDeleted bool
-	for _, r := range results {
+	for _, r := range res.Engrams {
 		if r.ID == idA {
 			foundActive = true
 		}

--- a/internal/engine/engine_vault_test.go
+++ b/internal/engine/engine_vault_test.go
@@ -201,8 +201,8 @@ func TestEngineDeleteVault_RemovesEntityGraph(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindByEntity deleted vault: %v", err)
 	}
-	if len(deletedRefs) != 0 {
-		t.Fatalf("expected deleted vault to have no SharedEntity refs, got %d", len(deletedRefs))
+	if len(deletedRefs.Engrams) != 0 {
+		t.Fatalf("expected deleted vault to have no SharedEntity refs, got %d", len(deletedRefs.Engrams))
 	}
 	onlyDeleted, err := eng.store.GetEntityRecord(ctx, "OnlyDeletedVault")
 	if err != nil {
@@ -223,8 +223,8 @@ func TestEngineDeleteVault_RemovesEntityGraph(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindByEntity kept vault: %v", err)
 	}
-	if len(keptRefs) != 1 || keptRefs[0].ID != idB {
-		t.Fatalf("expected kept vault SharedEntity ref to remain, got %+v", keptRefs)
+	if len(keptRefs.Engrams) != 1 || keptRefs.Engrams[0].ID != idB {
+		t.Fatalf("expected kept vault SharedEntity ref to remain, got %+v", keptRefs.Engrams)
 	}
 }
 

--- a/internal/mcp/engine.go
+++ b/internal/mcp/engine.go
@@ -87,9 +87,11 @@ type EngineInterface interface {
 	// LastAccess descending. limit caps results (default 10, max 50).
 	WhereLeftOff(ctx context.Context, vault string, limit int) ([]WhereLeftOffEntry, error)
 
-	// FindByEntity returns all engrams that mention the given entity name,
-	// scanned from the 0x23 reverse index. Results are limited to limit entries.
-	FindByEntity(ctx context.Context, vault, entityName string, limit int) ([]*storage.Engram, error)
+	// FindByEntity returns engrams that mention the given entity name,
+	// scanned from the 0x23 reverse index; on zero exact matches the vault's
+	// entity names are fuzzy-resolved by token overlap and the result reports
+	// which entity actually served the lookup. Results are limited to limit entries.
+	FindByEntity(ctx context.Context, vault, entityName string, limit int) (*engine.FindByEntityResult, error)
 
 	// CheckIdempotency looks up an op_id receipt. Returns nil, nil if not found.
 	CheckIdempotency(ctx context.Context, opID string) (*storage.IdempotencyReceipt, error)

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -315,7 +315,7 @@ func (a *mcpEngineAdapter) AddChild(ctx context.Context, vault, parentID string,
 	return &AddChildResult{ChildID: r.ChildID, Ordinal: r.Ordinal}, nil
 }
 
-func (a *mcpEngineAdapter) FindByEntity(ctx context.Context, vault, entityName string, limit int) ([]*storage.Engram, error) {
+func (a *mcpEngineAdapter) FindByEntity(ctx context.Context, vault, entityName string, limit int) (*engine.FindByEntityResult, error) {
 	return a.eng.FindByEntity(ctx, vault, entityName, limit)
 }
 

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -978,11 +978,15 @@ func (s *MCPServer) handleFindByEntity(ctx context.Context, w http.ResponseWrite
 	if limit > 50 {
 		limit = 50
 	}
-	engrams, err := s.engine.FindByEntity(ctx, vault, entityName, limit)
+	res, err := s.engine.FindByEntity(ctx, vault, entityName, limit)
 	if err != nil {
 		sendError(w, id, -32000, "tool error: "+err.Error())
 		return
 	}
+	if res == nil {
+		res = &engine.FindByEntityResult{}
+	}
+	engrams := res.Engrams
 	type engramEntry struct {
 		ID      string `json:"id"`
 		Concept string `json:"concept"`
@@ -998,11 +1002,23 @@ func (s *MCPServer) handleFindByEntity(ctx context.Context, w http.ResponseWrite
 			State:   lifecycleStateLabel(e.State),
 		})
 	}
-	out, _ := json.Marshal(map[string]any{
+	payload := map[string]any{
 		"entity":  entityName,
 		"engrams": entries,
 		"count":   len(entries),
-	})
+	}
+	// Report the resolution when the serving entity differs from the query
+	// (fuzzy match) — never substitute silently (issue #571).
+	if res.MatchedEntity != "" {
+		payload["matched_entity"] = res.MatchedEntity
+	}
+	if res.Fuzzy {
+		payload["fuzzy"] = true
+		if len(res.Candidates) > 0 {
+			payload["other_candidates"] = res.Candidates
+		}
+	}
+	out, _ := json.Marshal(payload)
 	sendResult(w, id, textContent(string(out)))
 }
 

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -1280,14 +1280,17 @@ func TestHandleStatus_IncludesEnrichmentMode(t *testing.T) {
 
 type findByEntityEngine struct{ fakeEngine }
 
-func (f *findByEntityEngine) FindByEntity(_ context.Context, _, name string, _ int) ([]*storage.Engram, error) {
+func (f *findByEntityEngine) FindByEntity(_ context.Context, _, name string, _ int) (*engine.FindByEntityResult, error) {
 	if name == "PostgreSQL" {
 		id := storage.NewULID()
-		return []*storage.Engram{
-			{ID: id, Concept: "DB choice", Summary: "Chose PostgreSQL"},
+		return &engine.FindByEntityResult{
+			Engrams: []*storage.Engram{
+				{ID: id, Concept: "DB choice", Summary: "Chose PostgreSQL"},
+			},
+			MatchedEntity: "PostgreSQL",
 		}, nil
 	}
-	return nil, nil
+	return &engine.FindByEntityResult{}, nil
 }
 
 func TestHandleFindByEntity_HappyPath(t *testing.T) {
@@ -1359,9 +1362,9 @@ type findByEntityCapturingEngine struct {
 	lastLimit int
 }
 
-func (f *findByEntityCapturingEngine) FindByEntity(_ context.Context, _, _ string, limit int) ([]*storage.Engram, error) {
+func (f *findByEntityCapturingEngine) FindByEntity(_ context.Context, _, _ string, limit int) (*engine.FindByEntityResult, error) {
 	f.lastLimit = limit
-	return []*storage.Engram{}, nil
+	return &engine.FindByEntityResult{}, nil
 }
 
 func TestHandleFindByEntity_LimitCapped(t *testing.T) {
@@ -1715,7 +1718,7 @@ func (e *slowIdempotentEngine) GetEnrichmentMode(ctx context.Context) string {
 func (e *slowIdempotentEngine) WhereLeftOff(ctx context.Context, vault string, limit int) ([]WhereLeftOffEntry, error) {
 	return (&fakeEngine{}).WhereLeftOff(ctx, vault, limit)
 }
-func (e *slowIdempotentEngine) FindByEntity(ctx context.Context, vault, entityName string, limit int) ([]*storage.Engram, error) {
+func (e *slowIdempotentEngine) FindByEntity(ctx context.Context, vault, entityName string, limit int) (*engine.FindByEntityResult, error) {
 	return (&fakeEngine{}).FindByEntity(ctx, vault, entityName, limit)
 }
 func (e *slowIdempotentEngine) SetEntityState(ctx context.Context, entityName, state, mergedInto, entityType string) error {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -118,8 +118,8 @@ func (f *fakeEngine) GetEnrichmentMode(_ context.Context) string {
 func (f *fakeEngine) WhereLeftOff(_ context.Context, _ string, _ int) ([]WhereLeftOffEntry, error) {
 	return []WhereLeftOffEntry{}, nil
 }
-func (f *fakeEngine) FindByEntity(_ context.Context, _, _ string, _ int) ([]*storage.Engram, error) {
-	return nil, nil
+func (f *fakeEngine) FindByEntity(_ context.Context, _, _ string, _ int) (*engine.FindByEntityResult, error) {
+	return &engine.FindByEntityResult{}, nil
 }
 func (f *fakeEngine) CheckIdempotency(_ context.Context, _ string) (*storage.IdempotencyReceipt, error) {
 	return nil, nil

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -532,7 +532,7 @@ func allToolDefinitions() []ToolDefinition {
 		// Entity reverse index tool
 		{
 			Name:        "muninn_find_by_entity",
-			Description: "Return all memories that mention a given named entity. Uses the entity reverse index for fast O(matches) lookup.",
+			Description: "Return all memories that mention a given named entity. Uses the entity reverse index for fast O(matches) lookup. When the exact name has no matches, vault entity names are fuzzy-matched by token overlap (case/articles/separators ignored, e.g. 'knock' finds 'The Knock') and the response reports the resolution via matched_entity + fuzzy.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{


### PR DESCRIPTION
Fixes #571.

## What

`find_by_entity` resolves through `keys.EntityNameHash` (NFKC + trim + lowercase + SipHash), so token-level variants of a known entity silently return zero results — `knock` misses `The Knock`, `dream-cycle` misses `dream cycle`, `TokenArcade` misses `Token Arcade`. All three are real cases from a production vault. A hash index can't approximate-match by construction, so this adds a fuzzy resolve layer **behind** the exact lookup; the exact path and its semantics are unchanged.

## How

- On zero live exact matches, scan the vault's entity names (`ScanVaultEntityNames`) — an in-memory token match over the few distinct names a vault holds; **no new index**.
- Tokenizer: `keys.NormalizeEntityName` (the same normalization the hash uses), split on space/hyphen/underscore/slash/dot, drop article stopwords (`the/a/an`) with an all-stopword fallback so a name like "The" can still match itself.
- Match rule is **set-membership**: a candidate qualifies on ≥ 1 shared non-stopword token, or when its concatenated token string equals the query's (bridges `TokenArcade` ↔ `Token Arcade`). Jaccard overlap is used **only for ranking** (concatenation equality ranks 1.0), lexicographic tie-break for determinism — no similarity threshold to tune.
- The best-ranked candidate **with live engrams** serves the results (candidates whose engrams are all soft-deleted/archived are passed over).
- **Auditable, never silent:** `FindByEntity` returns `FindByEntityResult{Engrams, MatchedEntity, Fuzzy, Candidates}`; the MCP response adds `matched_entity`, `fuzzy: true`, and `other_candidates` so the caller always sees which entity actually served the lookup. The tool description documents the behavior.

## Tests

- Tokenizer table (articles, separators, all-stopword fallback, whitespace).
- Article variant (`knock` → `The Knock`), separator variant (`dream-cycle` → `dream cycle`), concatenation variant (`TokenArcade` → `Token Arcade`).
- Ranking: full token overlap outranks partial; runner-up reported in `candidates`.
- Phantom-match guards: unrelated tokens return empty/non-fuzzy; a stopword-only query (`the`) does not match every article-bearing entity.
- Existing exact-path tests (archived/soft-deleted exclusion, vault deletion) updated to the result struct and green; MCP handler tests updated incl. a nil-guard for interface implementers.
- Full `./internal/engine/... ./internal/mcp/...` green (10 packages).

## Note for review

`FindByEntity`'s signature changed from `([]*storage.Engram, error)` to `(*FindByEntityResult, error)` — callers inside the repo (MCP interface/adapter/handler) are updated. If you'd rather keep the old signature exported and add a new method, happy to rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168DVnQZuH6WNWXqxxjweq2