### PR TITLE
feat(storage,engine): persist per-recall surfaced sets as recall events

### DIFF
--- a/docs/internals/keyspace-registry.md
+++ b/docs/internals/keyspace-registry.md
@@ -67,6 +67,7 @@ prefix — see the vault-reuse note at the bottom).
 | 0x26 | ws+entityHash(8)+engramID | — | rel-entity index |
 | 0x27 | ws | 16B dream state | |
 | 0x28 | ws+sha256(32) | engramID(16) | content-hash dedup |
+| 0x29 | ws+eventULID(16) | msgpack RecallEvent | recall-event calibration record (#573); event-time key order; reads purpose-gated |
 | **0x2A** | ws+ulid | JSON Lease{owner,heartbeat,ttl} | ownership-lease sidecar (advisory) |
 
 ## Auth prefixes (`internal/auth/keys.go`)
@@ -91,7 +92,7 @@ prefix — see the vault-reuse note at the bottom).
 
 ## Free bytes
 
-`0x29`, `0x2B`–`0x3F`, `0x42`+ are free for new storage/auth keys. (`0x29`/`0x40`/`0x41`
+`0x2B`–`0x3F` and `0x46`+ are free for new storage/auth keys. (`0x29`/`0x40`/`0x41`
 also appear in `internal/transport/mbp/frame.go` as **wire opcodes** — a different
 keyspace; coincidental, safe, but confusing. Prefer `0x2B+` for new storage prefixes.)
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2203,6 +2203,34 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 	}
 	wg.Wait()
 
+	// Persist the surfaced set as a recall event (issue #573): the engrams
+	// this recall actually returned (post entity-boost, post truncation),
+	// keyed by a time-ordered event ULID. Skipped in observe mode — a pure
+	// read must not write the signal that calibration reads. On success the
+	// event ID becomes the response query_id, so a later muninn_decide can
+	// be joined offline against exactly what this recall surfaced.
+	queryID := e.fastQueryID()
+	if len(items) > 0 && !auth.ObserveFromContext(ctx) {
+		eventID := storage.NewULID()
+		entries := make([]storage.RecallSurfacedEntry, len(items))
+		for i, item := range items {
+			entries[i] = storage.RecallSurfacedEntry{ID: item.ID, Score: item.Score}
+		}
+		ev := &storage.RecallEvent{
+			Context:    req.Context,
+			Threshold:  float32(actReq.Threshold),
+			SurfacedAt: time.Now().UnixNano(),
+			Entries:    entries,
+		}
+		if err := e.store.WriteRecallEvent(ctx, wsPrefix, eventID, ev); err != nil {
+			// Persistence is best-effort: a failed sink write degrades
+			// calibration ground truth, never the recall itself.
+			slog.Warn("activate: persist recall event failed", "err", err)
+		} else {
+			queryID = eventID.String()
+		}
+	}
+
 	// Submit co-activations to Hebbian worker (skipped in observe mode or when disabled by Plasticity).
 	// On Lobe nodes (hebbianWorker == nil) collect refs for forwarding to Cortex instead.
 	var lobeCoActivations []mbp.CoActivationRef
@@ -2331,7 +2359,7 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 	metrics.ActivateDuration.WithLabelValues(req.Vault).Observe(d.Seconds())
 
 	return &mbp.ActivateResponse{
-		QueryID:     e.fastQueryID(),
+		QueryID:     queryID,
 		TotalFound:  result.TotalFound,
 		Activations: items,
 		LatencyMs:   result.LatencyMs,

--- a/internal/engine/engine_recall_event_test.go
+++ b/internal/engine/engine_recall_event_test.go
@@ -43,7 +43,7 @@ func TestRecall_PersistsRecallEvent(t *testing.T) {
 	require.NoError(t, err, "query_id must be a ULID when the recall event was persisted, got %q", resp.QueryID)
 
 	ws := eng.store.ResolveVaultPrefix(vault)
-	ev, err := eng.store.GetRecallEvent(ctx, ws, eventID)
+	ev, err := eng.store.GetRecallEvent(ctx, ws, eventID, storage.RecallPurposeCalibration)
 	require.NoError(t, err)
 	require.NotNil(t, ev, "recall event must be persisted")
 
@@ -87,7 +87,7 @@ func TestRecall_ObserveModeDoesNotPersist(t *testing.T) {
 
 	ws := eng.store.ResolveVaultPrefix(vault)
 	count := 0
-	require.NoError(t, eng.store.ScanRecallEvents(ctx, ws, func(_ storage.ULID, _ *storage.RecallEvent) error {
+	require.NoError(t, eng.store.ScanRecallEvents(ctx, ws, storage.RecallPurposeCalibration, func(_ storage.ULID, _ *storage.RecallEvent) error {
 		count++
 		return nil
 	}))
@@ -116,7 +116,7 @@ func TestRecall_NoResultsNoEvent(t *testing.T) {
 
 	ws := eng.store.ResolveVaultPrefix(vault)
 	count := 0
-	require.NoError(t, eng.store.ScanRecallEvents(ctx, ws, func(_ storage.ULID, _ *storage.RecallEvent) error {
+	require.NoError(t, eng.store.ScanRecallEvents(ctx, ws, storage.RecallPurposeCalibration, func(_ storage.ULID, _ *storage.RecallEvent) error {
 		count++
 		return nil
 	}))

--- a/internal/engine/engine_recall_event_test.go
+++ b/internal/engine/engine_recall_event_test.go
@@ -1,0 +1,124 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/auth"
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecall_PersistsRecallEvent verifies that a recall persists its
+// surfaced set keyed by the event ULID returned as the response query_id
+// (issue #573).
+func TestRecall_PersistsRecallEvent(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "recall-event-persist"
+	_, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   vault,
+		Concept: "primary database",
+		Content: "PostgreSQL is the primary relational database for transactional workloads",
+	})
+	require.NoError(t, err)
+	awaitFTS(t, eng)
+
+	resp, err := eng.Activate(ctx, &mbp.ActivateRequest{
+		Vault:      vault,
+		Context:    []string{"primary relational database"},
+		MaxResults: 10,
+		Threshold:  0.01,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Activations, "test needs at least one surfaced engram")
+
+	// The response query_id must be the persisted event's ULID.
+	eventID, err := storage.ParseULID(resp.QueryID)
+	require.NoError(t, err, "query_id must be a ULID when the recall event was persisted, got %q", resp.QueryID)
+
+	ws := eng.store.ResolveVaultPrefix(vault)
+	ev, err := eng.store.GetRecallEvent(ctx, ws, eventID)
+	require.NoError(t, err)
+	require.NotNil(t, ev, "recall event must be persisted")
+
+	require.Equal(t, []string{"primary relational database"}, ev.Context)
+	require.Len(t, ev.Entries, len(resp.Activations))
+	for i, item := range resp.Activations {
+		require.Equal(t, item.ID, ev.Entries[i].ID, "entry %d ID must match the surfaced activation", i)
+		require.InDelta(t, item.Score, ev.Entries[i].Score, 1e-6, "entry %d score must match", i)
+	}
+}
+
+// TestRecall_ObserveModeDoesNotPersist verifies that observe-mode recalls —
+// pure reads — write no recall event. The calibration harness reads in
+// observe mode precisely so it cannot poison the signal it is fitting.
+func TestRecall_ObserveModeDoesNotPersist(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "recall-event-observe"
+	_, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   vault,
+		Concept: "primary database",
+		Content: "PostgreSQL is the primary relational database for transactional workloads",
+	})
+	require.NoError(t, err)
+	awaitFTS(t, eng)
+
+	observeCtx := context.WithValue(ctx, auth.ContextMode, auth.ModeObserve)
+	resp, err := eng.Activate(observeCtx, &mbp.ActivateRequest{
+		Vault:      vault,
+		Context:    []string{"primary relational database"},
+		MaxResults: 10,
+		Threshold:  0.01,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Activations)
+	require.True(t, strings.HasPrefix(resp.QueryID, "q-"),
+		"observe-mode query_id must stay the ephemeral counter, got %q", resp.QueryID)
+
+	ws := eng.store.ResolveVaultPrefix(vault)
+	count := 0
+	require.NoError(t, eng.store.ScanRecallEvents(ctx, ws, func(_ storage.ULID, _ *storage.RecallEvent) error {
+		count++
+		return nil
+	}))
+	require.Zero(t, count, "observe mode must persist no recall events")
+}
+
+// TestRecall_NoResultsNoEvent verifies that a recall surfacing nothing
+// persists nothing.
+func TestRecall_NoResultsNoEvent(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "recall-event-empty"
+	resp, err := eng.Activate(ctx, &mbp.ActivateRequest{
+		Vault:      vault,
+		Context:    []string{"nothing matches this"},
+		MaxResults: 10,
+		Threshold:  0.99,
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.Activations)
+	require.True(t, strings.HasPrefix(resp.QueryID, "q-"),
+		"empty recalls keep the ephemeral query_id, got %q", resp.QueryID)
+
+	ws := eng.store.ResolveVaultPrefix(vault)
+	count := 0
+	require.NoError(t, eng.store.ScanRecallEvents(ctx, ws, func(_ storage.ULID, _ *storage.RecallEvent) error {
+		count++
+		return nil
+	}))
+	require.Zero(t, count)
+}

--- a/internal/prefix/prefix.go
+++ b/internal/prefix/prefix.go
@@ -51,6 +51,7 @@ const (
 	RelEntityIndex     byte = 0x26
 	DreamState         byte = 0x27
 	ContentHash        byte = 0x28
+	RecallEvent        byte = 0x29
 	Lease              byte = 0x2A
 	// Capability (0x40/0x41 — clean since #612)
 	Capability         byte = 0x40
@@ -127,6 +128,7 @@ var registry = []Entry{
 	{RelEntityIndex, "storage", "RelEntityIndex", "vault-scoped-data"},
 	{DreamState, "storage", "DreamState", "vault-scoped-data"},
 	{ContentHash, "storage", "ContentHash", "vault-scoped-data"},
+	{RecallEvent, "storage", "RecallEvent", "vault-scoped-data"},
 	{Lease, "storage", "Lease", "lease"},
 	{Capability, "capability", "Capability", "capability"},
 	{CapabilityVaultIdx, "capability", "CapabilityVaultIdx", "capability"},

--- a/internal/prefix/prefix_test.go
+++ b/internal/prefix/prefix_test.go
@@ -113,6 +113,7 @@ func TestAll_ConstSliceComplete(t *testing.T) {
 		{"RelEntityIndex", RelEntityIndex},
 		{"DreamState", DreamState},
 		{"ContentHash", ContentHash},
+		{"RecallEvent", RecallEvent},
 		{"Lease", Lease},
 		// Capability (0x40/0x41)
 		{"Capability", Capability},

--- a/internal/storage/keys/keys.go
+++ b/internal/storage/keys/keys.go
@@ -786,6 +786,28 @@ func ContentHashKey(ws [8]byte, hash [32]byte) []byte {
 	return key
 }
 
+// RecallEventKey constructs the recall-event record key (0x29 prefix).
+// Persists the surfaced set of one recall, keyed by a time-ordered event
+// ULID (issue #573).
+// Key: 0x29 | wsPrefix(8) | eventID(16) = 25 bytes
+// Value: msgpack-encoded RecallEvent
+func RecallEventKey(ws [8]byte, eventID [16]byte) []byte {
+	key := make([]byte, 1+8+16)
+	key[0] = 0x29
+	copy(key[1:9], ws[:])
+	copy(key[9:25], eventID[:])
+	return key
+}
+
+// RecallEventPrefix returns the 9-byte scan prefix for all recall events in
+// a vault. ULID key ordering means iteration runs in event-time order.
+func RecallEventPrefix(ws [8]byte) []byte {
+	key := make([]byte, 1+8)
+	key[0] = 0x29
+	copy(key[1:9], ws[:])
+	return key
+}
+
 // LeaseKey constructs the ownership-lease sidecar key (0x2A prefix) for an engram.
 // The lease is a work-queue checkout attribute stored next to the engram it
 // guards, not a separate lock object.

--- a/internal/storage/keys/keys.go
+++ b/internal/storage/keys/keys.go
@@ -793,7 +793,7 @@ func ContentHashKey(ws [8]byte, hash [32]byte) []byte {
 // Value: msgpack-encoded RecallEvent
 func RecallEventKey(ws [8]byte, eventID [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x29
+	key[0] = prefix.RecallEvent
 	copy(key[1:9], ws[:])
 	copy(key[9:25], eventID[:])
 	return key
@@ -803,7 +803,7 @@ func RecallEventKey(ws [8]byte, eventID [16]byte) []byte {
 // a vault. ULID key ordering means iteration runs in event-time order.
 func RecallEventPrefix(ws [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x29
+	key[0] = prefix.RecallEvent
 	copy(key[1:9], ws[:])
 	return key
 }

--- a/internal/storage/prefix_lists_test.go
+++ b/internal/storage/prefix_lists_test.go
@@ -79,7 +79,8 @@ func TestClearVaultDataPrefixes_Scope(t *testing.T) {
 		prefix.CreatorIndex, prefix.RelevanceBucket, prefix.Coherence, prefix.VaultWeights,
 		prefix.AssocWeightIndex, prefix.VaultCount, prefix.Provenance, prefix.BucketMigration,
 		prefix.EntityEngramLink, prefix.Relationship, prefix.LastAccess, prefix.CoOccurrence,
-		prefix.ArchiveAssoc, prefix.RelEntityIndex, prefix.DreamState, prefix.ContentHash, prefix.Lease,
+		prefix.ArchiveAssoc, prefix.RelEntityIndex, prefix.DreamState, prefix.ContentHash,
+		prefix.RecallEvent, prefix.Lease,
 	}
 	assertPrefixListEqual(t, "clearVaultDataPrefixes", clearVaultDataPrefixes, want)
 }

--- a/internal/storage/recall_event.go
+++ b/internal/storage/recall_event.go
@@ -1,0 +1,187 @@
+package storage
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/oklog/ulid/v2"
+	"github.com/vmihailenco/msgpack/v5"
+
+	"github.com/scrypster/muninndb/internal/storage/keys"
+)
+
+const (
+	// recallEventRetentionDays is how long persisted recall events are kept.
+	// Pinned rather than configurable: calibration ground truth wants weeks
+	// to months of events, and the records are small (one per recall).
+	recallEventRetentionDays = 90
+
+	// recallEventPruneInterval amortizes retention pruning: every Nth
+	// WriteRecallEvent per process also prunes the writing vault's expired
+	// events. Keeps retention maintenance inside the write path — no
+	// background job or external hook required.
+	recallEventPruneInterval = 256
+)
+
+// recallEventWriteSeq drives the amortized prune schedule.
+var recallEventWriteSeq atomic.Uint64
+
+// RecallSurfacedEntry is one engram surfaced by a recall, with the final
+// score the caller saw (post entity-boost, post truncation).
+type RecallSurfacedEntry struct {
+	ID    string  `msgpack:"id"`
+	Score float32 `msgpack:"score"`
+}
+
+// RecallEvent is the persisted record of what one recall surfaced (issue
+// #573). Together with the decision→evidence edges written by Decide(), it
+// makes scoring ground truth regenerable by rule: positives = surfaced AND
+// cited; negatives = surfaced minus cited, per event.
+type RecallEvent struct {
+	// Context is the query context the caller passed to the recall.
+	Context []string `msgpack:"context,omitempty"`
+	// Threshold is the effective score threshold the recall ran with.
+	Threshold float32 `msgpack:"threshold,omitempty"`
+	// SurfacedAt is the event wall-clock time in Unix nanoseconds.
+	SurfacedAt int64 `msgpack:"surfaced_at"`
+	// Entries are the surfaced engrams in returned order.
+	Entries []RecallSurfacedEntry `msgpack:"entries"`
+}
+
+// WriteRecallEvent persists ev under (wsPrefix, eventID). Event IDs are
+// ULIDs, so keys within a vault sort by event time. Every
+// recallEventPruneInterval-th call also prunes the vault's events older
+// than the retention window.
+func (ps *PebbleStore) WriteRecallEvent(ctx context.Context, wsPrefix [8]byte, eventID ULID, ev *RecallEvent) error {
+	if ev == nil {
+		return fmt.Errorf("write recall event: nil event")
+	}
+	val, err := msgpack.Marshal(ev)
+	if err != nil {
+		return fmt.Errorf("recall event marshal: %w", err)
+	}
+	key := keys.RecallEventKey(wsPrefix, [16]byte(eventID))
+	if err := ps.db.Set(key, val, pebble.NoSync); err != nil {
+		return fmt.Errorf("write recall event: %w", err)
+	}
+	if recallEventWriteSeq.Add(1)%recallEventPruneInterval == 0 {
+		cutoff := time.Now().AddDate(0, 0, -recallEventRetentionDays)
+		if _, err := ps.PruneRecallEvents(ctx, wsPrefix, cutoff); err != nil {
+			return fmt.Errorf("write recall event: amortized prune: %w", err)
+		}
+	}
+	return nil
+}
+
+// GetRecallEvent fetches one recall event. Returns nil, nil when absent.
+func (ps *PebbleStore) GetRecallEvent(ctx context.Context, wsPrefix [8]byte, eventID ULID) (*RecallEvent, error) {
+	key := keys.RecallEventKey(wsPrefix, [16]byte(eventID))
+	val, closer, err := ps.db.Get(key)
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get recall event: %w", err)
+	}
+	defer closer.Close()
+	var ev RecallEvent
+	if err := msgpack.Unmarshal(val, &ev); err != nil {
+		return nil, fmt.Errorf("recall event unmarshal: %w", err)
+	}
+	return &ev, nil
+}
+
+// ScanRecallEvents iterates all recall events in a vault in event-time order
+// (ULID key order). fn may return a non-nil error to stop the scan; that
+// error is returned to the caller.
+func (ps *PebbleStore) ScanRecallEvents(ctx context.Context, wsPrefix [8]byte, fn func(eventID ULID, ev *RecallEvent) error) error {
+	prefix := keys.RecallEventPrefix(wsPrefix)
+	iter, err := ps.db.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: prefixUpperBound(prefix),
+	})
+	if err != nil {
+		return fmt.Errorf("scan recall events: iter: %w", err)
+	}
+	defer iter.Close()
+
+	for valid := iter.First(); valid; valid = iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		k := iter.Key()
+		if len(k) != 25 { // 1 + 8 + 16
+			continue
+		}
+		var id ULID
+		copy(id[:], k[9:25])
+		var ev RecallEvent
+		if err := msgpack.Unmarshal(iter.Value(), &ev); err != nil {
+			return fmt.Errorf("recall event unmarshal (%s): %w", id.String(), err)
+		}
+		if err := fn(id, &ev); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PruneRecallEvents deletes all recall events in a vault whose event time is
+// before the cutoff, using the ULID timestamp embedded in the key — no value
+// reads needed. Returns the number of events deleted.
+func (ps *PebbleStore) PruneRecallEvents(ctx context.Context, wsPrefix [8]byte, before time.Time) (int, error) {
+	prefix := keys.RecallEventPrefix(wsPrefix)
+	// Smallest possible ULID at the cutoff timestamp: 6-byte big-endian
+	// milliseconds, zero entropy. Every key below it is older than cutoff.
+	var bound [16]byte
+	ms := ulid.Timestamp(before)
+	binary.BigEndian.PutUint64(bound[:8], ms<<16) // left-align 48-bit ms into first 6 bytes
+	upper := keys.RecallEventKey(wsPrefix, bound)
+
+	iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		return 0, fmt.Errorf("prune recall events: iter: %w", err)
+	}
+	batch := ps.db.NewBatch()
+	count := 0
+	for valid := iter.First(); valid; valid = iter.Next() {
+		if err := ctx.Err(); err != nil {
+			iter.Close()
+			batch.Close()
+			return 0, err
+		}
+		if err := batch.Delete(iter.Key(), nil); err != nil {
+			iter.Close()
+			batch.Close()
+			return 0, fmt.Errorf("prune recall events: delete: %w", err)
+		}
+		count++
+	}
+	iter.Close()
+	if count == 0 {
+		batch.Close()
+		return 0, nil
+	}
+	if err := batch.Commit(pebble.NoSync); err != nil {
+		return 0, fmt.Errorf("prune recall events: commit: %w", err)
+	}
+	return count, nil
+}
+
+// prefixUpperBound returns the smallest key greater than every key with the
+// given prefix, for use as an exclusive iterator upper bound.
+func prefixUpperBound(prefix []byte) []byte {
+	upper := make([]byte, len(prefix))
+	copy(upper, prefix)
+	for i := len(upper) - 1; i >= 0; i-- {
+		upper[i]++
+		if upper[i] != 0 {
+			return upper[:i+1]
+		}
+	}
+	return nil // prefix was all 0xFF — no upper bound
+}

--- a/internal/storage/recall_event.go
+++ b/internal/storage/recall_event.go
@@ -85,6 +85,11 @@ type RecallEvent struct {
 // ULIDs, so keys within a vault sort by event time. Every
 // recallEventPruneInterval-th call also prunes the vault's events older
 // than the retention window.
+//
+// The write goes through a replicated batch like every other storage write:
+// in a cluster, recalls are exactly the read traffic served by Lobe replicas,
+// and an unreplicated event write would strand the calibration record on
+// whichever node happened to serve the recall.
 func (ps *PebbleStore) WriteRecallEvent(ctx context.Context, wsPrefix [8]byte, eventID ULID, ev *RecallEvent) error {
 	if ev == nil {
 		return fmt.Errorf("write recall event: nil event")
@@ -94,9 +99,13 @@ func (ps *PebbleStore) WriteRecallEvent(ctx context.Context, wsPrefix [8]byte, e
 		return fmt.Errorf("recall event marshal: %w", err)
 	}
 	key := keys.RecallEventKey(wsPrefix, [16]byte(eventID))
-	if err := ps.db.Set(key, val, pebble.NoSync); err != nil {
+	batch := ps.db.NewBatch()
+	defer batch.Close()
+	batch.Set(key, val, nil)
+	if err := batch.Commit(pebble.NoSync); err != nil {
 		return fmt.Errorf("write recall event: %w", err)
 	}
+	ps.replicateBatch(batch)
 	if recallEventWriteSeq.Add(1)%recallEventPruneInterval == 0 {
 		cutoff := time.Now().AddDate(0, 0, -recallEventRetentionDays)
 		if _, err := ps.PruneRecallEvents(ctx, wsPrefix, cutoff); err != nil {

--- a/internal/storage/recall_event.go
+++ b/internal/storage/recall_event.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"log/slog"
 	"sync/atomic"
 	"time"
 
@@ -29,6 +30,34 @@ const (
 
 // recallEventWriteSeq drives the amortized prune schedule.
 var recallEventWriteSeq atomic.Uint64
+
+// RecallEventPurpose declares why a reader is accessing recall events.
+// Recall events are calibration instrument data, not a memory surface:
+// nothing may recall FROM them, and every read path is purpose-gated
+// against a closed allowlist by construction — an unknown purpose is
+// refused loudly, not logged quietly. Widening the allowlist requires
+// editing validRecallPurposes, so any change to who may read this data is
+// a reviewable diff rather than a remembered promise (issue #573).
+type RecallEventPurpose string
+
+// RecallPurposeCalibration marks reads by scoring-calibration tooling —
+// fitting weights against recorded ground truth. The only permitted purpose.
+const RecallPurposeCalibration RecallEventPurpose = "calibration"
+
+// validRecallPurposes is the closed allowlist for recall-event reads.
+var validRecallPurposes = map[RecallEventPurpose]struct{}{
+	RecallPurposeCalibration: {},
+}
+
+// checkRecallPurpose refuses reads whose purpose is not in the allowlist.
+func checkRecallPurpose(action string, purpose RecallEventPurpose) error {
+	if _, ok := validRecallPurposes[purpose]; !ok {
+		slog.Error("storage: recall-event read refused — purpose not in allowlist",
+			"action", action, "purpose", string(purpose))
+		return fmt.Errorf("%s: recall events are purpose-gated instrument data; purpose %q is not in the allowlist", action, purpose)
+	}
+	return nil
+}
 
 // RecallSurfacedEntry is one engram surfaced by a recall, with the final
 // score the caller saw (post entity-boost, post truncation).
@@ -78,7 +107,12 @@ func (ps *PebbleStore) WriteRecallEvent(ctx context.Context, wsPrefix [8]byte, e
 }
 
 // GetRecallEvent fetches one recall event. Returns nil, nil when absent.
-func (ps *PebbleStore) GetRecallEvent(ctx context.Context, wsPrefix [8]byte, eventID ULID) (*RecallEvent, error) {
+// Reads are purpose-gated and logged — see RecallEventPurpose.
+func (ps *PebbleStore) GetRecallEvent(ctx context.Context, wsPrefix [8]byte, eventID ULID, purpose RecallEventPurpose) (*RecallEvent, error) {
+	if err := checkRecallPurpose("get recall event", purpose); err != nil {
+		return nil, err
+	}
+	slog.Info("storage: recall event read", "action", "get", "purpose", string(purpose), "event_id", eventID.String())
 	key := keys.RecallEventKey(wsPrefix, [16]byte(eventID))
 	val, closer, err := ps.db.Get(key)
 	if err == pebble.ErrNotFound {
@@ -98,7 +132,12 @@ func (ps *PebbleStore) GetRecallEvent(ctx context.Context, wsPrefix [8]byte, eve
 // ScanRecallEvents iterates all recall events in a vault in event-time order
 // (ULID key order). fn may return a non-nil error to stop the scan; that
 // error is returned to the caller.
-func (ps *PebbleStore) ScanRecallEvents(ctx context.Context, wsPrefix [8]byte, fn func(eventID ULID, ev *RecallEvent) error) error {
+// Reads are purpose-gated and logged — see RecallEventPurpose.
+func (ps *PebbleStore) ScanRecallEvents(ctx context.Context, wsPrefix [8]byte, purpose RecallEventPurpose, fn func(eventID ULID, ev *RecallEvent) error) error {
+	if err := checkRecallPurpose("scan recall events", purpose); err != nil {
+		return err
+	}
+	slog.Info("storage: recall event read", "action", "scan", "purpose", string(purpose))
 	prefix := keys.RecallEventPrefix(wsPrefix)
 	iter, err := ps.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
@@ -169,6 +208,7 @@ func (ps *PebbleStore) PruneRecallEvents(ctx context.Context, wsPrefix [8]byte, 
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return 0, fmt.Errorf("prune recall events: commit: %w", err)
 	}
+	slog.Info("storage: recall events pruned", "count", count)
 	return count, nil
 }
 

--- a/internal/storage/recall_event_test.go
+++ b/internal/storage/recall_event_test.go
@@ -135,3 +135,40 @@ func TestRecallEvent_PurposeGate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 }
+
+// TestRecallEvent_ClearVaultRemovesEvents is the privacy regression from the
+// #574 review: RecallEvent.Context stores raw, unredacted query text, so a
+// cleared vault must not leave its recall events behind for the remainder of
+// the retention window. A sibling vault's events must survive untouched.
+func TestRecallEvent_ClearVaultRemovesEvents(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.ResolveVaultPrefix("recall-event-cleared")
+	otherWS := store.ResolveVaultPrefix("recall-event-survivor")
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, store.WriteRecallEvent(ctx, ws, NewULID(), &RecallEvent{
+			Context:    []string{"private query text"},
+			SurfacedAt: time.Now().UnixNano(),
+			Entries:    []RecallSurfacedEntry{{ID: NewULID().String(), Score: 0.5}},
+		}))
+	}
+	require.NoError(t, store.WriteRecallEvent(ctx, otherWS, NewULID(), &RecallEvent{
+		Context:    []string{"unrelated vault query"},
+		SurfacedAt: time.Now().UnixNano(),
+		Entries:    []RecallSurfacedEntry{{ID: NewULID().String(), Score: 0.5}},
+	}))
+
+	_, err := store.ClearVault(ctx, ws)
+	require.NoError(t, err)
+
+	cleared := 0
+	require.NoError(t, store.ScanRecallEvents(ctx, ws, RecallPurposeCalibration,
+		func(ULID, *RecallEvent) error { cleared++; return nil }))
+	require.Zero(t, cleared, "cleared vault must retain no recall events (raw query text)")
+
+	survived := 0
+	require.NoError(t, store.ScanRecallEvents(ctx, otherWS, RecallPurposeCalibration,
+		func(ULID, *RecallEvent) error { survived++; return nil }))
+	require.Equal(t, 1, survived, "sibling vault's events must survive the clear")
+}

--- a/internal/storage/recall_event_test.go
+++ b/internal/storage/recall_event_test.go
@@ -1,0 +1,105 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecallEvent_WriteGetRoundtrip verifies the msgpack roundtrip and the
+// nil,nil contract for absent events.
+func TestRecallEvent_WriteGetRoundtrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.ResolveVaultPrefix("recall-event-roundtrip")
+
+	id := NewULID()
+	ev := &RecallEvent{
+		Context:    []string{"primary relational database"},
+		Threshold:  0.1,
+		SurfacedAt: time.Now().UnixNano(),
+		Entries: []RecallSurfacedEntry{
+			{ID: NewULID().String(), Score: 0.81},
+			{ID: NewULID().String(), Score: 0.44},
+		},
+	}
+	require.NoError(t, store.WriteRecallEvent(ctx, ws, id, ev))
+
+	got, err := store.GetRecallEvent(ctx, ws, id)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, ev.Context, got.Context)
+	require.Equal(t, ev.Threshold, got.Threshold)
+	require.Equal(t, ev.SurfacedAt, got.SurfacedAt)
+	require.Equal(t, ev.Entries, got.Entries)
+
+	// Absent event: nil, nil.
+	absent, err := store.GetRecallEvent(ctx, ws, NewULID())
+	require.NoError(t, err)
+	require.Nil(t, absent)
+}
+
+// TestRecallEvent_ScanOrder verifies events iterate in event-time (ULID key)
+// order and stay vault-scoped.
+func TestRecallEvent_ScanOrder(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.ResolveVaultPrefix("recall-event-order")
+	otherWS := store.ResolveVaultPrefix("recall-event-other")
+
+	base := time.Now().Add(-time.Hour)
+	var ids []ULID
+	for i := 0; i < 3; i++ {
+		id := NewULIDWithTime(base.Add(time.Duration(i) * time.Minute))
+		ids = append(ids, id)
+		require.NoError(t, store.WriteRecallEvent(ctx, ws, id, &RecallEvent{
+			SurfacedAt: base.Add(time.Duration(i) * time.Minute).UnixNano(),
+			Entries:    []RecallSurfacedEntry{{ID: NewULID().String(), Score: 0.5}},
+		}))
+	}
+	// An event in a different vault must not appear in the scan.
+	require.NoError(t, store.WriteRecallEvent(ctx, otherWS, NewULID(), &RecallEvent{
+		SurfacedAt: time.Now().UnixNano(),
+		Entries:    []RecallSurfacedEntry{{ID: NewULID().String(), Score: 0.5}},
+	}))
+
+	var seen []ULID
+	require.NoError(t, store.ScanRecallEvents(ctx, ws, func(id ULID, ev *RecallEvent) error {
+		seen = append(seen, id)
+		return nil
+	}))
+	require.Equal(t, ids, seen, "scan must return this vault's events in event-time order")
+}
+
+// TestRecallEvent_Prune verifies time-based pruning via the ULID timestamp
+// embedded in the key: events older than the cutoff are deleted, newer ones
+// survive.
+func TestRecallEvent_Prune(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.ResolveVaultPrefix("recall-event-prune")
+
+	now := time.Now()
+	oldA := NewULIDWithTime(now.AddDate(0, 0, -10))
+	oldB := NewULIDWithTime(now.AddDate(0, 0, -5))
+	fresh := NewULIDWithTime(now.Add(-time.Hour))
+	for _, id := range []ULID{oldA, oldB, fresh} {
+		require.NoError(t, store.WriteRecallEvent(ctx, ws, id, &RecallEvent{
+			SurfacedAt: now.UnixNano(),
+			Entries:    []RecallSurfacedEntry{{ID: NewULID().String(), Score: 0.5}},
+		}))
+	}
+
+	deleted, err := store.PruneRecallEvents(ctx, ws, now.AddDate(0, 0, -2))
+	require.NoError(t, err)
+	require.Equal(t, 2, deleted, "both events older than the cutoff must be pruned")
+
+	gone, err := store.GetRecallEvent(ctx, ws, oldA)
+	require.NoError(t, err)
+	require.Nil(t, gone)
+	kept, err := store.GetRecallEvent(ctx, ws, fresh)
+	require.NoError(t, err)
+	require.NotNil(t, kept, "event newer than the cutoff must survive")
+}

--- a/internal/storage/recall_event_test.go
+++ b/internal/storage/recall_event_test.go
@@ -27,7 +27,7 @@ func TestRecallEvent_WriteGetRoundtrip(t *testing.T) {
 	}
 	require.NoError(t, store.WriteRecallEvent(ctx, ws, id, ev))
 
-	got, err := store.GetRecallEvent(ctx, ws, id)
+	got, err := store.GetRecallEvent(ctx, ws, id, RecallPurposeCalibration)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Equal(t, ev.Context, got.Context)
@@ -36,7 +36,7 @@ func TestRecallEvent_WriteGetRoundtrip(t *testing.T) {
 	require.Equal(t, ev.Entries, got.Entries)
 
 	// Absent event: nil, nil.
-	absent, err := store.GetRecallEvent(ctx, ws, NewULID())
+	absent, err := store.GetRecallEvent(ctx, ws, NewULID(), RecallPurposeCalibration)
 	require.NoError(t, err)
 	require.Nil(t, absent)
 }
@@ -66,7 +66,7 @@ func TestRecallEvent_ScanOrder(t *testing.T) {
 	}))
 
 	var seen []ULID
-	require.NoError(t, store.ScanRecallEvents(ctx, ws, func(id ULID, ev *RecallEvent) error {
+	require.NoError(t, store.ScanRecallEvents(ctx, ws, RecallPurposeCalibration, func(id ULID, ev *RecallEvent) error {
 		seen = append(seen, id)
 		return nil
 	}))
@@ -96,10 +96,42 @@ func TestRecallEvent_Prune(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, deleted, "both events older than the cutoff must be pruned")
 
-	gone, err := store.GetRecallEvent(ctx, ws, oldA)
+	gone, err := store.GetRecallEvent(ctx, ws, oldA, RecallPurposeCalibration)
 	require.NoError(t, err)
 	require.Nil(t, gone)
-	kept, err := store.GetRecallEvent(ctx, ws, fresh)
+	kept, err := store.GetRecallEvent(ctx, ws, fresh, RecallPurposeCalibration)
 	require.NoError(t, err)
 	require.NotNil(t, kept, "event newer than the cutoff must survive")
+}
+
+// TestRecallEvent_PurposeGate verifies the read fence: recall events are
+// purpose-gated instrument data, and reads without an allowlisted purpose
+// fail loudly by construction — no watcher required.
+func TestRecallEvent_PurposeGate(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.ResolveVaultPrefix("recall-event-fence")
+
+	id := NewULID()
+	require.NoError(t, store.WriteRecallEvent(ctx, ws, id, &RecallEvent{
+		SurfacedAt: time.Now().UnixNano(),
+		Entries:    []RecallSurfacedEntry{{ID: NewULID().String(), Score: 0.5}},
+	}))
+
+	// Empty purpose: refused.
+	_, err := store.GetRecallEvent(ctx, ws, id, "")
+	require.Error(t, err, "read with empty purpose must be refused")
+	require.Contains(t, err.Error(), "purpose-gated")
+
+	// Unknown purpose: refused — narrative reading is not a purpose.
+	_, err = store.GetRecallEvent(ctx, ws, id, "narrative")
+	require.Error(t, err, "read with non-allowlisted purpose must be refused")
+
+	err = store.ScanRecallEvents(ctx, ws, "recall", func(ULID, *RecallEvent) error { return nil })
+	require.Error(t, err, "scan with non-allowlisted purpose must be refused")
+
+	// Allowlisted purpose: permitted.
+	got, err := store.GetRecallEvent(ctx, ws, id, RecallPurposeCalibration)
+	require.NoError(t, err)
+	require.NotNil(t, got)
 }

--- a/internal/storage/replication_hook_test.go
+++ b/internal/storage/replication_hook_test.go
@@ -257,3 +257,28 @@ func TestRepLogHook_WriteEntityEngramLink(t *testing.T) {
 		t.Error("WriteEntityEngramLink: RepLogAppend not called")
 	}
 }
+
+// TestRepLogHook_WriteRecallEvent verifies callback fires on recall-event
+// writes. Regression for the #574 review: a bare db.Set left Lobe-served
+// recalls' events stranded on the serving node, outside the replicated
+// calibration dataset.
+func TestRepLogHook_WriteRecallEvent(t *testing.T) {
+	db, cleanup := openRepHookDB(t)
+	defer cleanup()
+
+	cfg, count := opBatchCounter(t)
+	store := storage.NewPebbleStore(db, cfg)
+	ws := store.VaultPrefix("recall-event-rep-vault")
+	ctx := context.Background()
+
+	before := count()
+	if err := store.WriteRecallEvent(ctx, ws, storage.NewULID(), &storage.RecallEvent{
+		Context: []string{"replicated query"},
+		Entries: []storage.RecallSurfacedEntry{{ID: storage.NewULID().String(), Score: 0.7}},
+	}); err != nil {
+		t.Fatalf("WriteRecallEvent: %v", err)
+	}
+	if count() <= before {
+		t.Error("WriteRecallEvent: RepLogAppend not called")
+	}
+}

--- a/internal/storage/vault_lifecycle.go
+++ b/internal/storage/vault_lifecycle.go
@@ -27,7 +27,9 @@ var clearVaultDataPrefixes = []byte{
 	prefix.CreatorIndex, prefix.RelevanceBucket, prefix.Coherence, prefix.VaultWeights,
 	prefix.AssocWeightIndex, prefix.VaultCount, prefix.Provenance, prefix.BucketMigration,
 	prefix.EntityEngramLink, prefix.Relationship, prefix.LastAccess, prefix.CoOccurrence,
-	prefix.ArchiveAssoc, prefix.RelEntityIndex, prefix.DreamState, prefix.ContentHash, prefix.Lease,
+	prefix.ArchiveAssoc, prefix.RelEntityIndex, prefix.DreamState, prefix.ContentHash,
+	prefix.RecallEvent, // recall events hold raw query text; must not outlive a cleared vault
+	prefix.Lease,
 }
 
 // ClearVault deletes all data keys for a vault using Pebble range tombstones.
@@ -44,7 +46,7 @@ var clearVaultDataPrefixes = []byte{
 //  4. Evict all in-memory caches (L1, assocCache, metaCache, recentActiveCache).
 //
 // Prefixes cleared (vault-scoped): 0x01–0x0D, 0x10, 0x12–0x17,
-// 0x20–0x22, 0x24–0x28, 0x2A
+// 0x20–0x22, 0x24–0x2A
 // Prefixes NOT cleared (global or name keys):
 //   - 0x0E vault meta key (preserved by Clear, deleted by DeleteVaultNameOnly)
 //   - 0x0F name index    (global by name hash, deleted by DeleteVaultNameOnly)


### PR DESCRIPTION
Fixes #573.

## What

Recalls build the surfaced-engram set (the `CoActivationEvent`) and discard it once the Hebbian worker folds it into aggregate pairwise weights — the per-event record dies at the comment `// optional, reserved for future persistence` (hebbian.go). This PR persists that set, keyed per recall event, which completes self-regenerating ground truth for scoring calibration: **positives** = `Decide()`'s decision→evidence edges (already recorded); **negatives** = surfaced-for-this-recall minus cited — now computable by rule, no hand-labeling. (The aggregate-co-activation fallback is not a substitute: it folds in every unrelated retrieval that co-surfaced the same memories.)

## How

- **New `0x29` keyspace:** `0x29 | ws(8) | eventULID(16)` → msgpack `RecallEvent{context, threshold, surfaced_at, [engram id + score]}`. The record is what the caller actually saw (post entity-boost, post truncation). ULID keys sort by event time, so vault scans run in event order and pruning uses the key-embedded timestamp — no value reads, no secondary index.
- **Engine hook** after result assembly: mint an event ULID, persist the set, and return the event ID as the response `query_id`. A later decision can then be joined offline against exactly what its recall surfaced. Persistence is best-effort — a failed write logs a warning and falls back to the counter; a recall never fails on the sink.
- **Observe mode persists nothing**, matching the existing Hebbian-submit guard: a calibration probe must not write the signal it reads.
- **Retention:** pinned 90-day window, amortized pruning (every 256th write per process prunes the writing vault's expired events), plus an explicit `PruneRecallEvents` for direct maintenance.

## Behavior notes for review

- `query_id` was an in-process counter (`q-<n>`), documented as opaque and **not unique across daemon restarts**. Successful non-observe recalls now return the durable event ULID; observe-mode and empty recalls keep the counter. If any consumer depends on the `q-` shape, flag it — I found no such assertion in the repo's tests.
- Write cost is one `pebble.NoSync` set per non-empty recall (~200 bytes typical), consistent with the store's group-commit convention.
- The methods live on `PebbleStore` (the engine holds the concrete type); `EngineStore` is untouched, so existing adapters and fakes are unaffected.

## Tests

- Storage: write/get roundtrip + absent-get `nil,nil`; vault-scoped scan in event-time order; prune boundary via key-embedded ULID timestamps (older deleted, newer survive, count returned).
- Engine: recall persists the event and `query_id` == event ULID with entries matching the response exactly; observe mode persists nothing and keeps the `q-` counter; empty recalls persist nothing.
- Full `./internal/storage/... ./internal/engine/... ./internal/mcp/... ./internal/transport/... ./internal/cognitive/... ./internal/replication/...` green.

Related: #569/#570 (entity-boost flood), #571/#572 (fuzzy entity resolve) — together these are the retrieval-quality arc; this PR is the data-collection half that lets scoring weights be fit against real usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168DVnQZuH6WNWXqxxjweq2