### PR TITLE
feat(vault): multi_user setting — shared-vault session-start guidance

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -222,6 +222,7 @@ curl -X PUT "http://127.0.0.1:8475/api/admin/vault/default/plasticity" \
 | `preset` | string | `default` \| `reference` \| `scratchpad` \| `knowledge-graph` | Base cognitive profile; overrides applied on top |
 | `hebbian_enabled` | bool | — | Enable/disable Hebbian weight updates (coactivation learning) |
 | `temporal_enabled` | bool | — | Enable/disable time-based temporal scoring |
+| `multi_user` | bool | — | Vault shared by multiple users/agents: guide + recall hints steer clients to per-user scoped recall; `where_left_off`/`session` flagged vault-global |
 | `hop_depth` | int | 0–8 | BFS hops for associative retrieval; higher = broader context |
 | `semantic_weight` | float | 0–1 | Multiplier for semantic similarity in fusion scoring |
 | `fts_weight` | float | 0–1 | Multiplier for full-text keyword match scoring |

--- a/docs/feature-reference.md
+++ b/docs/feature-reference.md
@@ -341,6 +341,7 @@ Every cognitive behavior is tunable per vault:
 | `pas_max_injections` | 5 | 0–10 | Max PAS candidates to inject |
 | `behavior_mode` | `"autonomous"` | autonomous/prompted/selective/custom | How the AI should use memory (see below) |
 | `behavior_instructions` | `""` | string | Custom instructions for "custom" mode |
+| `multi_user` | false | bool | Vault is shared by multiple users/agents: guide + recall hints steer clients to per-user scoped recall; `muninn_where_left_off`/`muninn_session` are flagged vault-global (admin/audit) |
 | `inline_enrichment` | `"caller_preferred"` | caller_only/caller_preferred/background_only/disabled | How inline vs background enrichment interact (see below) |
 | `enrichment_enabled` | true | bool | Kill switch for all enrichment on this vault |
 | `max_engrams` | 0 (unlimited) | int | Auto-prune when exceeded |

--- a/internal/auth/plasticity.go
+++ b/internal/auth/plasticity.go
@@ -68,6 +68,13 @@ type PlasticityConfig struct {
 	// ExcludeUntrusted controls whether untrusted engrams are filtered from ACTIVATE results.
 	// nil = false (default: include all engrams regardless of trust).
 	ExcludeUntrusted *bool `json:"exclude_untrusted,omitempty"`
+
+	// MultiUser marks the vault as shared by multiple users or agents. When set,
+	// guidance surfaces (muninn_guide, empty-recall hints) steer clients away from
+	// vault-global recency tools (muninn_where_left_off, muninn_session) toward
+	// per-user scoped recall (e.g. a per-user tag in the recall context).
+	// nil = false (single-user; guidance unchanged).
+	MultiUser *bool `json:"multi_user,omitempty"`
 }
 
 // ResolvedPlasticity is the fully-merged configuration after applying preset defaults
@@ -106,6 +113,9 @@ type ResolvedPlasticity struct {
 	// Behavior mode
 	BehaviorMode         string `json:"behavior_mode"`
 	BehaviorInstructions string `json:"behavior_instructions"`
+	// MultiUser: vault is shared by multiple users/agents; guidance surfaces
+	// steer clients from vault-global recency tools to per-user scoped recall.
+	MultiUser bool `json:"multi_user"`
 	// Inline enrichment mode
 	InlineEnrichment string `json:"inline_enrichment"` // "caller_only", "caller_preferred", "background_only", "disabled"
 	// EnrichmentEnabled is a vault-level kill switch for all enrichment.
@@ -465,6 +475,9 @@ func ResolvePlasticity(cfg *PlasticityConfig) ResolvedPlasticity {
 	}
 	if cfg.ExcludeUntrusted != nil {
 		r.ExcludeUntrusted = *cfg.ExcludeUntrusted
+	}
+	if cfg.MultiUser != nil {
+		r.MultiUser = *cfg.MultiUser
 	}
 	// LTP overrides
 	if cfg.LTPThreshold != nil {

--- a/internal/auth/plasticity_test.go
+++ b/internal/auth/plasticity_test.go
@@ -523,3 +523,18 @@ func TestResolvePlasticity_ExcludeUntrusted(t *testing.T) {
 		t.Error("ExcludeUntrusted should be true when config sets it")
 	}
 }
+
+func TestMultiUser_Default(t *testing.T) {
+	r := ResolvePlasticity(nil)
+	if r.MultiUser {
+		t.Error("default: want MultiUser=false (single-user guidance)")
+	}
+}
+
+func TestMultiUser_Override(t *testing.T) {
+	on := true
+	r := ResolvePlasticity(&PlasticityConfig{MultiUser: &on})
+	if !r.MultiUser {
+		t.Error("override: want MultiUser=true")
+	}
+}

--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -14,7 +14,9 @@ const mcpSessionHeader = "Mcp-Session-Id"
 // mcpInstructions is returned in the initialize response to tell MCP clients
 // how to use MuninnDB. Kept concise — call muninn_guide for the full guide.
 const mcpInstructions = `MuninnDB is a long-term memory server for AI agents. ` +
-	`Use muninn_where_left_off at session start. ` +
+	`At session start recall recent context — muninn_where_left_off in a single-user vault; ` +
+	`in a shared vault it is vault-global, so use muninn_recall scoped to your per-user tag instead ` +
+	`(muninn_guide states whether this vault is shared, under Vault Configuration). ` +
 	`Store with muninn_remember (include type, summary, entities). ` +
 	`Update with muninn_evolve, not forget+remember. ` +
 	`Keep memories atomic — one concept each. ` +

--- a/internal/mcp/guide.go
+++ b/internal/mcp/guide.go
@@ -43,9 +43,15 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 		b.WriteString("Before starting any task, recall relevant memories. ")
 		b.WriteString("After completing work, remember key outcomes.\n\n")
 		b.WriteString("**Session start pattern:** At the start of every session, call recall twice:\n")
-		b.WriteString("1. `muninn_recall(context=[\"session start\"], mode=\"recent\")` — restores recent continuity regardless of topic.\n")
-		b.WriteString("2. Once the user provides context, call `muninn_recall(context=[<user topic>])` for semantic relevance.\n")
-		b.WriteString("Alternatively, use `muninn_where_left_off` — it is purpose-built for session resumption.\n")
+		if resolved.MultiUser {
+			b.WriteString("1. `muninn_recall(context=[\"<your per-user tag>\", \"session start\"], mode=\"recent\")` — restores YOUR recent continuity. This vault is shared: unscoped recency surfaces other users' work.\n")
+			b.WriteString("2. Once the user provides context, call `muninn_recall(context=[<user topic>])` for semantic relevance.\n")
+			b.WriteString("Avoid `muninn_where_left_off` and `muninn_session` here — they return vault-global recency across all users (admin/audit use).\n")
+		} else {
+			b.WriteString("1. `muninn_recall(context=[\"session start\"], mode=\"recent\")` — restores recent continuity regardless of topic.\n")
+			b.WriteString("2. Once the user provides context, call `muninn_recall(context=[<user topic>])` for semantic relevance.\n")
+			b.WriteString("Alternatively, use `muninn_where_left_off` — it is purpose-built for session resumption.\n")
+		}
 	}
 
 	// Enrichment guidance based on behavior mode + inline enrichment setting
@@ -72,7 +78,11 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 	b.WriteString("- **muninn_remember** — Store a new memory\n")
 	b.WriteString("- **muninn_remember_batch** — Store multiple memories at once (max 50)\n")
 	b.WriteString("- **muninn_recall** — Search memories by semantic context (use mode='recent' at session start)\n")
-	b.WriteString("- **muninn_where_left_off** — Resume a previous session; returns recent activity summary\n")
+	if resolved.MultiUser {
+		b.WriteString("- **muninn_where_left_off** — Recent activity across ALL users of this shared vault (admin/audit; not for session start)\n")
+	} else {
+		b.WriteString("- **muninn_where_left_off** — Resume a previous session; returns recent activity summary\n")
+	}
 	b.WriteString("- **muninn_read** — Fetch a single memory by ID\n")
 	b.WriteString("- **muninn_forget** — Soft-delete a memory\n")
 	b.WriteString("- **muninn_link** — Create associations between memories\n")
@@ -80,7 +90,11 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 	b.WriteString("- **muninn_status** — Get vault health and stats\n")
 	b.WriteString("- **muninn_evolve** — Update a memory with new information\n")
 	b.WriteString("- **muninn_consolidate** — Merge related memories into one\n")
-	b.WriteString("- **muninn_session** — Get recent memory activity summary\n")
+	if resolved.MultiUser {
+		b.WriteString("- **muninn_session** — Recent memory activity across ALL users of this shared vault (admin/audit)\n")
+	} else {
+		b.WriteString("- **muninn_session** — Get recent memory activity summary\n")
+	}
 	b.WriteString("- **muninn_decide** — Record a decision with rationale\n")
 	b.WriteString("- **muninn_restore** — Recover a soft-deleted memory\n")
 	b.WriteString("- **muninn_traverse** — Explore the memory graph from a starting node\n")
@@ -96,6 +110,9 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 	b.WriteString("\n## Vault Configuration\n\n")
 	fmt.Fprintf(&b, "- Memories stored: %d\n", stats.EngramCount)
 	fmt.Fprintf(&b, "- Behavior mode: %s\n", resolved.BehaviorMode)
+	if resolved.MultiUser {
+		b.WriteString("- Shared vault (multi-user): yes\n")
+	}
 	fmt.Fprintf(&b, "- Hebbian learning: %s\n", enabledStr(resolved.HebbianEnabled))
 	if resolved.LTPThreshold > 0 {
 		fmt.Fprintf(&b, "- Hebbian LTP: enabled (threshold %d, weight floor %.2f)\n", resolved.LTPThreshold, resolved.LTPWeightFloor)
@@ -160,7 +177,11 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 
 	// Tips
 	b.WriteString("\n## Tips\n\n")
-	b.WriteString("- Use muninn_where_left_off at session start — purpose-built for resuming where you left off.\n")
+	if resolved.MultiUser {
+		b.WriteString("- This vault is shared: scope recalls to your own work (include your per-user tag in the context); muninn_where_left_off and muninn_session are vault-global (admin/audit).\n")
+	} else {
+		b.WriteString("- Use muninn_where_left_off at session start — purpose-built for resuming where you left off.\n")
+	}
 	b.WriteString("- Use muninn_recall with mode='recent' when you need continuity but lack specific context.\n")
 	b.WriteString("- Use muninn_recall with mode='deep' for thorough searches across the memory graph.\n")
 	b.WriteString("- Use muninn_link to connect related memories and strengthen the knowledge graph.\n")

--- a/internal/mcp/guide_test.go
+++ b/internal/mcp/guide_test.go
@@ -229,3 +229,39 @@ func TestGenerateGuide_InlineEnrichmentInConfig(t *testing.T) {
 		t.Error("vault config should show inline enrichment setting")
 	}
 }
+
+func TestGenerateGuide_MultiUserVault(t *testing.T) {
+	on := true
+	r := auth.ResolvePlasticity(&auth.PlasticityConfig{MultiUser: &on})
+	guide := generateGuide("team", r, engineStats{})
+
+	if strings.Contains(guide, "purpose-built") {
+		t.Error("multi-user guide must not recommend where_left_off for session start")
+	}
+	if !strings.Contains(guide, "per-user tag") {
+		t.Error("multi-user guide should recommend per-user scoped recall")
+	}
+	if !strings.Contains(guide, "Shared vault (multi-user): yes") {
+		t.Error("multi-user guide should surface the setting in Vault Configuration")
+	}
+	if !strings.Contains(guide, "Recent activity across ALL users") {
+		t.Error("multi-user tool list should flag where_left_off as vault-global")
+	}
+	if strings.Contains(guide, "Resume a previous session") {
+		t.Error("multi-user tool list must not present where_left_off as session resumption")
+	}
+	if !strings.Contains(guide, "Recent memory activity across ALL users") {
+		t.Error("multi-user tool list should flag muninn_session as vault-global")
+	}
+}
+
+func TestGenerateGuide_SingleUserKeepsWhereLeftOff(t *testing.T) {
+	r := auth.ResolvePlasticity(nil)
+	guide := generateGuide("default", r, engineStats{})
+	if !strings.Contains(guide, "purpose-built for session resumption") {
+		t.Error("single-user guide should keep the where_left_off session-start tip")
+	}
+	if !strings.Contains(guide, "Resume a previous session") {
+		t.Error("single-user tool list should keep the plain where_left_off entry")
+	}
+}

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -444,7 +444,11 @@ func (s *MCPServer) handleRecall(ctx context.Context, w http.ResponseWriter, id 
 		"total":    resp.TotalFound,
 	}
 	if len(memories) == 0 {
-		result["hint"] = "No results matched. For session continuity try mode='recent', or use muninn_where_left_off. For semantic recall, provide more specific context."
+		hint := "No results matched. For session continuity try mode='recent', or use muninn_where_left_off. For semantic recall, provide more specific context."
+		if p, err := s.engine.GetVaultPlasticity(ctx, vault); err == nil && p != nil && p.MultiUser {
+			hint = "No results matched. For session continuity try mode='recent' scoped to your per-user tag (this vault is shared; muninn_where_left_off is vault-global). For semantic recall, provide more specific context."
+		}
+		result["hint"] = hint
 	}
 	sendResult(w, id, textContent(mustJSON(result)))
 }
@@ -846,10 +850,14 @@ func (s *MCPServer) handleWhereLeftOff(ctx context.Context, w http.ResponseWrite
 	if entries == nil {
 		entries = []WhereLeftOffEntry{}
 	}
+	hint := "These are your most recently accessed memories. Use them to orient yourself for this session."
+	if p, perr := s.engine.GetVaultPlasticity(ctx, vault); perr == nil && p != nil && p.MultiUser {
+		hint = "These are the most recently accessed memories across ALL users of this shared vault — not necessarily yours. For your own session context, use muninn_recall scoped to your per-user tag."
+	}
 	sendResult(w, id, textContent(mustJSON(map[string]any{
 		"memories": entries,
 		"count":    len(entries),
-		"hint":     "These are your most recently accessed memories. Use them to orient yourself for this session.",
+		"hint":     hint,
 	})))
 }
 

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -3557,3 +3557,52 @@ func TestHandleRecall_AnnotateFalse_NoAnnotations(t *testing.T) {
 		t.Error("annotations should be absent when annotate=false (or not set)")
 	}
 }
+
+// multiUserEngine reports a multi-user (shared) vault from GetVaultPlasticity.
+type multiUserEngine struct{ fakeEngine }
+
+func (e *multiUserEngine) GetVaultPlasticity(_ context.Context, _ string) (*auth.ResolvedPlasticity, error) {
+	r := auth.ResolvePlasticity(nil)
+	r.MultiUser = true
+	return &r, nil
+}
+
+func TestHandleWhereLeftOff_MultiUserHint(t *testing.T) {
+	srv := newTestServerWith(&multiUserEngine{})
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_where_left_off","arguments":{"vault":"default"}}}`
+	w := postRPC(t, srv, body)
+	content := extractInnerJSON(t, decodeResp(t, w.Body.String()))
+	hint, _ := content["hint"].(string)
+	if !strings.Contains(hint, "ALL users") {
+		t.Errorf("multi-user where_left_off hint should flag vault-global results, got %q", hint)
+	}
+	if strings.Contains(hint, "your most recently accessed memories") {
+		t.Errorf("multi-user where_left_off hint must not claim the results are the caller's own, got %q", hint)
+	}
+}
+
+func TestHandleRecall_EmptyHint_MultiUser(t *testing.T) {
+	// fakeEngine.Activate returns no activations, so the empty-result hint fires.
+	srv := newTestServerWith(&multiUserEngine{})
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_recall","arguments":{"vault":"default","context":["nothing matches"]}}}`
+	w := postRPC(t, srv, body)
+	content := extractInnerJSON(t, decodeResp(t, w.Body.String()))
+	hint, _ := content["hint"].(string)
+	if !strings.Contains(hint, "per-user tag") {
+		t.Errorf("multi-user empty-recall hint should recommend per-user scoped recall, got %q", hint)
+	}
+	if strings.Contains(hint, "or use muninn_where_left_off") {
+		t.Errorf("multi-user empty-recall hint must not recommend where_left_off, got %q", hint)
+	}
+}
+
+func TestHandleRecall_EmptyHint_SingleUser(t *testing.T) {
+	srv := newTestServer()
+	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_recall","arguments":{"vault":"default","context":["nothing matches"]}}}`
+	w := postRPC(t, srv, body)
+	content := extractInnerJSON(t, decodeResp(t, w.Body.String()))
+	hint, _ := content["hint"].(string)
+	if !strings.Contains(hint, "muninn_where_left_off") {
+		t.Errorf("single-user empty-recall hint should keep the where_left_off suggestion, got %q", hint)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -320,7 +320,7 @@ func allToolDefinitions() []ToolDefinition {
 		},
 		{
 			Name:        "muninn_session",
-			Description: "Get a summary of recent memory activity since a timestamp.",
+			Description: "Get a summary of recent memory activity since a timestamp — vault-wide: in a vault shared by multiple users or agents this includes other users' activity (admin/audit use there).",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -516,7 +516,7 @@ func allToolDefinitions() []ToolDefinition {
 		},
 		{
 			Name:        "muninn_where_left_off",
-			Description: "Surface what was being worked on at the end of the last session. Returns the most recently accessed active memories, sorted by recency. Call this at session start to orient yourself before any user queries.",
+			Description: "Surface what was being worked on at the end of the last session. Returns the most recently accessed active memories, sorted by recency — vault-wide: in a vault shared by multiple users or agents this includes other users' activity, so prefer a tag-scoped muninn_recall there. In single-user vaults, call at session start to orient yourself before any user queries.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/internal/transport/rest/openapi.yaml
+++ b/internal/transport/rest/openapi.yaml
@@ -949,6 +949,13 @@ components:
         preset:
           type: string
           enum: [default, reference, scratchpad, knowledge-graph]
+        multi_user:
+          type: boolean
+          nullable: true
+          description: >-
+            Vault is shared by multiple users/agents — guidance surfaces
+            (muninn_guide, recall hints) steer clients to per-user scoped
+            recall instead of vault-global recency tools.
         hebbian_enabled:
           type: boolean
           nullable: true

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1973,6 +1973,10 @@ document.addEventListener('alpine:init', () => {
                 '/api/admin/vault/' + encodeURIComponent(this.vault) + '/plasticity'
             );
             const cfg = data.config || {};
+            // Keep the raw stored config: savePlasticity merges it into the PUT
+            // payload so fields this panel does not edit (multi_user,
+            // behavior_mode, …) survive a save (the PUT replaces the whole config).
+            this.plasticityRawConfig = cfg;
             this.plasticityForm.preset         = cfg.preset || 'default';
             this.plasticityForm.hebbianEnabled = data.resolved?.hebbian_enabled ?? true;
             this.plasticityForm.temporalEnabled   = data.resolved?.temporal_enabled   ?? true;
@@ -2092,7 +2096,7 @@ document.addEventListener('alpine:init', () => {
         this.plasticitySaveOk = false;
         this.plasticitySaveErr = '';
         try {
-            const payload = { version: 1, preset: this.plasticityForm.preset };
+            const payload = { ...(this.plasticityRawConfig || {}), version: 1, preset: this.plasticityForm.preset };
             payload.recall_mode = this.plasticityForm.recallMode;
             if (this.plasticityForm.showAdvanced) {
                 if (this.plasticityForm.hopDepth       !== null) payload.hop_depth       = this.plasticityForm.hopDepth;


### PR DESCRIPTION
## Problem

All of MuninnDB's guidance surfaces steer clients to `muninn_where_left_off` at session start: the MCP `initialize` instructions, `muninn_guide` (session-start pattern, tool list, tips), the tool's own description, and the empty-recall hint.

That is the right advice for a single-user vault — but `muninn_where_left_off` and `muninn_session` return **vault-global** recency. In a vault shared by multiple users or agents, an assistant following the server's own guidance starts its session by surfacing *other users'* recent work and acting on it. We run a shared team vault (multiple users, per-user tags on every memory) and currently have to override the server guidance client-side in every harness — the server tells agents to do one thing, the deployment needs the opposite.

## Change

A vault-level `multi_user` plasticity setting, **default `false` — zero behavior change for existing deployments**:

- **`muninn_guide`** (`internal/mcp/guide.go`): when `multi_user` is set, the session-start pattern recommends recall scoped to the caller's per-user tag, and marks `muninn_where_left_off`/`muninn_session` as vault-global (admin/audit use). Tool list, Tips, and the Vault Configuration summary reflect it too.
- **Empty-recall hint** (`internal/mcp/handlers.go`): multi-user vaults get a scoped-recall hint instead of the `where_left_off` suggestion. The plasticity lookup runs only on the empty-result path; on lookup error the existing hint is kept.
- **`muninn_where_left_off` response hint** (`internal/mcp/handlers.go`): in a multi-user vault the response no longer claims the results are "your most recently accessed memories" — it states they span all users and points to scoped recall. This fires at the exact moment of misuse, catching agents that never consulted the guide.
- **`muninn_session`** gets the same treatment as `where_left_off` (guide tool-list entry + static tool description) — it returns vault-global activity too.
- **Web console lossy save fixed** (`web/static/js/app.js`): `savePlasticity()` built its PUT payload from scratch while the server replaces the stored config wholesale — any save from the Plasticity panel silently dropped fields the panel doesn't edit (`multi_user`, but also pre-existing ones like `behavior_mode`). The panel now merges the loaded raw config into the payload, so unedited fields survive.
- **Static surfaces reworded unconditionally** (`internal/mcp/context.go` instructions const, `internal/mcp/tools.go` tool description): these are served before/independent of vault resolution, so they now describe both modes truthfully instead of prescribing `where_left_off` for everyone.
- **Config plumbing** (`internal/auth/plasticity.go`): `MultiUser *bool` on `PlasticityConfig` (JSON `multi_user`), resolved onto `ResolvedPlasticity` following the existing pointer-override pattern. No preset changes.
- **No CLI changes needed**: the reflective field map behind `muninn vault plasticity <vault> --set key=value` picks the new field up automatically —
  ```
  muninn vault plasticity team --set multi_user=true
  ```

## Tests

- `internal/auth`: `multi_user` defaults false, pointer override works.
- `internal/mcp`: multi-user guide recommends per-user-scoped recall, drops the `where_left_off` session-start tip, and flags both recency tools in the tool list; single-user guide unchanged (pinned by its own assertions). Handler-level tests cover the multi-user `where_left_off` hint and both variants of the empty-recall hint.
- Full suite green locally (`go test ./...`, 49 packages ok; `go vet` clean, `gofmt` clean).

## Docs

`docs/feature-reference.md` and `docs/auth.md`: new row in the plasticity-field tables; `openapi.yaml`: `multi_user` added to the `PlasticityConfig` schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
