### PR TITLE
fix(web): reset advanced plasticity overrides when panel is collapsed

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -2106,6 +2106,17 @@ document.addEventListener('alpine:init', () => {
                 if (this.plasticityForm.temporalHalflife !== null) payload.temporal_halflife = this.plasticityForm.temporalHalflife;
                 payload.hebbian_enabled = this.plasticityForm.hebbianEnabled;
                 payload.temporal_enabled   = this.plasticityForm.temporalEnabled;
+            } else {
+                // Advanced panel is collapsed: reset any overrides carried over from
+                // plasticityRawConfig so the preset's defaults apply, matching the
+                // form (which shows no override in this state).
+                delete payload.hop_depth;
+                delete payload.semantic_weight;
+                delete payload.fts_weight;
+                delete payload.relevance_floor;
+                delete payload.temporal_halflife;
+                delete payload.hebbian_enabled;
+                delete payload.temporal_enabled;
             }
             await this.apiCall(
                 '/api/admin/vault/' + encodeURIComponent(this.vault) + '/plasticity',


### PR DESCRIPTION
## Problem

#575 fixed the lossy plasticity save by merging the loaded raw config into the PUT payload, so fields the panel never edits (`multi_user`, `behavior_mode`, ...) survive a save instead of being dropped by the replace-whole-config endpoint.

That merge had a side effect on fields the panel *does* edit, but only while the Advanced section is expanded: `hop_depth`, `semantic_weight`, `fts_weight`, `relevance_floor`, `temporal_halflife`, `hebbian_enabled`, `temporal_enabled`. With Advanced collapsed, stale values from the last load rode along through the spread instead of resetting to the preset's defaults, as they did before #575. So switching presets with Advanced closed and saving would silently keep the previous preset's overrides.

## Change

`savePlasticity()` now explicitly deletes those seven advanced-only keys from the payload when `showAdvanced` is false, so they fall back to the preset defaults server-side — restoring pre-#575 behavior for these fields while keeping the #575 fix for fields the panel never touches.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean (no Go changes, ran for safety)
- [ ] Manual: open a vault's Plasticity panel, expand Advanced, set a hop_depth override, save; collapse Advanced, switch preset, save again — verify the override no longer survives (previously it would)