### PR TITLE
fix(cli): route joined exec:/logs: tokens to their handlers

### DIFF
--- a/cmd/muninn/dispatch_test.go
+++ b/cmd/muninn/dispatch_test.go
@@ -21,6 +21,12 @@ func TestParseSubcommand(t *testing.T) {
 		{[]string{"help"}, "help"},
 		{[]string{"start", "--dev"}, "start"}, // flags are not subcommands
 		{[]string{"init", "--yes"}, "init"},   // flags are not subcommands
+		// Joined container tokens main.go must route (a joined token with no
+		// route dies as Unknown command while help documents it as valid):
+		{[]string{"exec", "read"}, "exec:read"},
+		{[]string{"exec", "recall", "--query", "x"}, "exec:recall"},
+		{[]string{"logs", "50"}, "logs:50"},
+		{[]string{"cluster", "info"}, "cluster:info"},
 	}
 	for _, tc := range cases {
 		got := parseSubcommand(tc.args)

--- a/cmd/muninn/main.go
+++ b/cmd/muninn/main.go
@@ -127,6 +127,17 @@ func main() {
 			runAudit(rest)
 			return
 		}
+		// "exec read"/"logs 50" join to "exec:read"/"logs:50" like every
+		// two-word form; without these routes the joined tokens fell through
+		// to Unknown command while the help text documented them as valid.
+		if strings.HasPrefix(sub, "exec:") {
+			runExec(rest)
+			return
+		}
+		if strings.HasPrefix(sub, "logs:") {
+			runLogs(rest)
+			return
+		}
 		if strings.HasPrefix(sub, "cluster:") {
 			runCluster(rest)
 			return


### PR DESCRIPTION
## Bug

`parseSubcommand` joins any two non-flag words (`exec read` → `exec:read`), but `main.go`'s dispatch switch only matched bare `exec`/`logs` — so every documented two-word form of `exec` and `logs` (`muninn exec read --id …`, `muninn logs 50`, …) died with `Unknown command`, despite the help text documenting them as valid. `cluster:` already had a prefix route; this was an omission for the other two multi-word commands.

## Fix

Two prefix routes in `cmd/muninn/main.go`, mirroring the existing `cluster:` pattern (11 lines). `parseSubcommand`'s join behavior is untouched — it's load-bearing for completion/show/start:web.

## Tests

- Four regression cases added to the dispatch test table (`cmd/muninn/dispatch_test.go`)
- `go test ./cmd/muninn`: ok (full suite), `go vet` clean — re-verified cherry-picked onto current `develop` tip
- Behavioral: `muninn exec read --id <ulid>` now routes to the engine (clean exit-3 not-found on an empty store); `logs 5` routes with a graceful missing-file message; bogus two-word commands still fail loudly

## Provenance

Found during a backup restore drill on our production deployment (2026-07-03); fix authored by Cairn (co-author preserved in the commit), deployed and verified locally, upstreamed per our keep-fixes-regenerable practice — same lineage as #570/#572/#574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtBjGQt6torDYqxervRnqc