### PR TITLE
fix(engine): tighten fuzzy entity match to token-set containment

### DIFF
--- a/internal/engine/engine_entity_resolve.go
+++ b/internal/engine/engine_entity_resolve.go
@@ -45,13 +45,20 @@ func entityTokens(name string) []string {
 }
 
 // resolveEntityFuzzy ranks the vault's entity names against the query by
-// token overlap. A candidate qualifies when it shares at least one
-// non-stopword token with the query, or when its concatenated token string
-// equals the query's (bridging concatenation variants such as "TokenArcade"
-// vs "Token Arcade"). Candidates are ranked by Jaccard overlap of token
-// sets — concatenation equality ranks as 1.0 — with a lexicographic
-// tie-break for determinism. The match rule is set-membership; Jaccard is
-// used only for ranking, so there is no similarity threshold to tune.
+// token overlap. A candidate qualifies when its token set contains, or is
+// contained by, the query's token set (one is a subset of the other), or
+// when its concatenated token string equals the query's (bridging
+// concatenation variants such as "TokenArcade" vs "Token Arcade").
+// Containment — not mere overlap — is deliberate: a query sharing only one
+// token with an unrelated multi-word entity (e.g. "Token Arcade" vs "Arcade
+// Fire") must not qualify just because nothing better exists in the vault.
+// Every token-level variant this resolves (dropped/added articles, split or
+// joined words) is a subset/superset or exact-token-set relationship, so
+// containment loses no real case while ruling out coincidental partial
+// overlap. Candidates are ranked by Jaccard overlap of token sets —
+// concatenation equality ranks as 1.0 — with a lexicographic tie-break for
+// determinism; containment is the only threshold, so there is no similarity
+// number to tune.
 //
 // Vaults hold few distinct entity names, so this is an in-memory scan over
 // the 0x20 forward index (ScanVaultEntityNames) — no new index required.
@@ -87,7 +94,10 @@ func (e *Engine) resolveEntityFuzzy(ctx context.Context, ws [8]byte, query strin
 			}
 		}
 		joinedEqual := strings.Join(tokens, "") == qJoined
-		if shared == 0 && !joinedEqual {
+		// Containment: one token set must be a subset of the other — shared
+		// equals the size of whichever set is smaller.
+		contained := shared == len(set) || shared == len(qSet)
+		if !contained && !joinedEqual {
 			return nil
 		}
 		score := float64(shared) / float64(len(set)+len(qSet)-shared)

--- a/internal/engine/engine_entity_resolve_test.go
+++ b/internal/engine/engine_entity_resolve_test.go
@@ -165,3 +165,26 @@ func TestFindByEntity_NoPhantomMatch(t *testing.T) {
 	require.Empty(t, res.Engrams, "an article must not fuzzy-match every article-bearing entity")
 	require.False(t, res.Fuzzy)
 }
+
+// TestFindByEntity_NoPartialOverlapMatch verifies that a query sharing only
+// one token with an unrelated multi-word entity does not qualify as a fuzzy
+// match, even when it is the only candidate in the vault. "Token Arcade" and
+// "Arcade Fire" share the token "arcade" but neither entity's token set is a
+// subset of the other's — this is coincidental overlap, not a token-level
+// variant of the same identity, and must not be served as a match.
+func TestFindByEntity_NoPartialOverlapMatch(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "fuzzy-partial-overlap"
+	ws := eng.store.ResolveVaultPrefix(vault)
+	linkEntityEngram(t, eng, ws, "band-doc", "Arcade Fire")
+
+	res, err := eng.FindByEntity(ctx, vault, "Token Arcade", 20)
+	require.NoError(t, err)
+	require.Empty(t, res.Engrams, "one shared token on an otherwise unrelated multi-word entity must not match")
+	require.Empty(t, res.MatchedEntity)
+	require.False(t, res.Fuzzy)
+}


### PR DESCRIPTION
## Problem

#572 (fixing #571) added a fuzzy fallback to `muninn_find_by_entity`: when the exact hash lookup misses, it resolves token-level variants of a known entity name (dropped/added articles, split vs. joined words) by scanning the vault's entity names and ranking token overlap.

Its match gate was "shares at least one non-stopword token with the query" — no minimum overlap required, by explicit design (the code comment noted there was "no similarity threshold to tune"). During review of #572 we worked through the implication: a query sharing only *one* token with an otherwise unrelated multi-word entity can still be served as the match, as long as it's the best-ranked live candidate in the vault.

Concretely: a zero-exact-match query for `Token Arcade` against a vault containing only `Arcade Fire` shares the token `arcade` and would fuzzy-match, returning Arcade Fire's engrams for a completely unrelated query. The response does mark this `fuzzy: true` and reports `matched_entity`, so it's never silent — but an LLM agent consuming the result doesn't reliably gate downstream reasoning on that flag, so a confidently-wrong retrieval still has a real cost.

## Fix

Checked whether the three cases #572 actually fixed need that permissiveness — they don't. `knock`/`The Knock`, `dream-cycle`/`dream cycle`, and `TokenArcade`/`Token Arcade` are each a **full token-set match** after normalization (equal sets, or one is a strict subset via a dropped article).

Replace the match gate with token-set containment: a candidate qualifies only when one token set is a subset of the other, or — unchanged — when the joined token strings are equal (bridging concatenation variants like `TokenArcade` vs `Token Arcade`). This:
- Passes every case #572 fixed (verified — all existing fuzzy-match tests still pass unmodified).
- Is still parameter-free, matching the original design intent — no threshold number to tune.
- Rejects the `Token Arcade` / `Arcade Fire` false positive: `{token,arcade}` is not a subset of `{arcade,fire}` and vice versa, so no match.

Jaccard ranking (for ordering multiple valid candidates) and the lexicographic tie-break are unchanged — only the qualification gate changed.

## Tests

Added `TestFindByEntity_NoPartialOverlapMatch`: a vault containing only `Arcade Fire`, queried with `Token Arcade`, must return no fuzzy match. All existing fuzzy-resolve tests (article variant, separator variant, concatenation variant, ranking, phantom-match, stopword-only) pass unmodified against the new gate.

`go build ./...`, `go test ./internal/engine/... ./internal/mcp/...`, `gofmt -l`, `go vet ./...` all clean.

Refs #571, #572.