### PR TITLE
docs(embed): correct the bundled model name and document its English-only language coverage

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -101,7 +101,7 @@ Provider comparison:
 
 | Provider | Env Var | Model (default) | Dimensions | Cost | Privacy |
 |----------|---------|-----------------|------------|------|---------|
-| Bundled local | On by default | all-MiniLM-L6-v2 | 384 | Zero | Full (local) |
+| Bundled local | On by default | bge-small-en-v1.5 (English-only) | 384 | Zero | Full (local) |
 | Ollama | `MUNINN_OLLAMA_URL` | configurable | varies | Zero (local) | Full (local) |
 | OpenAI | `MUNINN_OPENAI_KEY` | text-embedding-3-small | 1536 | Per token | API |
 | Voyage AI | `MUNINN_VOYAGE_KEY` | voyage-3 | 1024 | Per token | API |
@@ -111,6 +111,65 @@ Provider comparison:
 | Mistral | `MUNINN_MISTRAL_KEY` | mistral-embed | 1024 | Per token | API |
 
 `MUNINN_OPENAI_URL` can optionally override the OpenAI base URL for compatible endpoints (for example LocalAI or an internal gateway). If set to an invalid value, MuninnDB skips OpenAI initialization instead of falling back to `api.openai.com`. This override also applies to the Enrich plugin when `MUNINN_ENRICH_URL` is set to an `openai://` provider — see [Tier 3](#4-tier-3-enrich-plugin) below.
+
+### Language Coverage
+
+The bundled local model is `bge-small-en-v1.5` — the `en` is a language tag.
+It is an English embedding model. That is a property of the chosen model, not
+a MuninnDB defect: within English it is a solid default, and it keeps Tier 2
+zero-config and offline.
+
+For non-English text the model still produces a vector — nothing fails,
+nothing is logged — but the vectors organize by **language** rather than by
+**meaning**: two unrelated German memories land closer together than a German
+memory and its English paraphrase. On a non-English or mixed-language vault
+this surfaces as:
+
+- Non-English semantic queries return the same cluster of same-language
+  memories, regardless of topic.
+- English queries on the same vault behave normally.
+- Queries that share words with the stored text still work in any language,
+  because the FTS stream matches them. The fusion keeps returning plausible
+  results, so the degradation is partial — and easy to miss.
+
+**Five-minute self-test.** If your vault holds non-English content:
+
+1. Store three memories in your language, on clearly unrelated topics.
+2. Query each topic with a same-language *paraphrase* — reworded so it shares
+   no distinctive keywords with the stored text (otherwise FTS answers the
+   query and hides the vector behavior).
+3. Repeat step 2 with English paraphrases of the same three questions.
+
+If the same-language queries all return roughly the same result set regardless
+of topic, while the English paraphrases each retrieve the right memory, your
+vault is affected.
+
+**Switching to a multilingual provider.** Any external provider serving a
+multilingual embedding model resolves this. Self-hosted example with Ollama:
+
+```bash
+# any multilingual embedding model Ollama serves, e.g. bge-m3
+export MUNINN_OLLAMA_URL="ollama://localhost:11434/bge-m3"
+muninn server
+```
+
+Several hosted providers in the table above also serve multilingual models —
+check your provider's model documentation. The same choice can be persisted in
+`plugin_config.json` in the data directory (`embed_provider`, `embed_url`,
+`embed_api_key`) or set in the web admin UI; environment variables take
+precedence over saved config.
+
+Two things to plan for when switching models:
+
+- **Re-embed the vault.** Vectors from different models are not comparable:
+  similarities across models are meaningless, and when the dimensions differ,
+  memories embedded with the previous model drop out of semantic recall
+  entirely. After switching, run `muninn vault reembed <name>` for each
+  affected vault — it clears the stored embeddings and re-embeds with the
+  current model.
+- **Scores shift.** Different models produce different similarity-score
+  distributions. If you have tuned anything against absolute vector scores,
+  re-check it after the switch.
 
 ### Retroactive Enrichment
 
@@ -228,7 +287,7 @@ of silently treating a partial write as finished.
 
 Both plugins guarantee retroactive enrichment. This is worth stating plainly, because the alternative is the norm everywhere else.
 
-Most vector database integrations require you to re-index when you switch embedding models. Most enrichment pipelines require you to write a migration that runs against existing data, wait for it to complete, verify it, and then cut over. If the migration fails halfway through, you figure out where it stopped and re-run from there.
+Most vector database integrations require a manual re-index before existing data becomes searchable. Most enrichment pipelines require you to write a migration that runs against existing data, wait for it to complete, verify it, and then cut over. If the migration fails halfway through, you figure out where it stopped and re-run from there.
 
 MuninnDB plugins do not work this way. Install a plugin against a vault with ten thousand engrams. The plugin handles the backfill. You handle your application.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -146,7 +146,7 @@ muninn init --tool cursor,claude --yes
 
 ## 6. Choose an Embedder
 
-The bundled local embedder (all-MiniLM-L6-v2, 384-dim) is included and works offline with no API key. It's the default. For higher quality or different dimensions:
+The bundled local embedder (bge-small-en-v1.5, 384-dim) is included and works offline with no API key. It's the default. It is an English-only model — for non-English or mixed-language memories, pick a multilingual external provider (see [Language Coverage](plugins.md#language-coverage)). For higher quality, different dimensions, or other languages:
 
 | Embedder | Config | Notes |
 |----------|--------|-------|

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -97,7 +97,7 @@ MuninnDB uses embeddings for semantic search and activation. Configure with envi
 
 ### Bundled (no API key, no internet) — default
 
-The bundled `all-MiniLM-L6-v2` INT8 model (384-dim, ~80MB) is active automatically when the binary was built with embedded assets. No configuration needed.
+The bundled `bge-small-en-v1.5` INT8 model (384-dim, ~80MB, English-only) is active automatically when the binary was built with embedded assets. No configuration needed. For non-English content, see [Language Coverage](plugins.md#language-coverage).
 
 To disable it and fall back to noop (or use a cloud provider instead):
 


### PR DESCRIPTION

## Summary

Two related docs gaps around the bundled local embedder, both checked against `v0.7.0`:

**1. Three docs still carry the pre-#455 model name.** #455 (bundled embedder
labeled `all-MiniLM-L6-v2`, actual bytes `bge-small-en-v1.5`) was fixed in #508
and shipped in v0.6.3 (the `CHANGELOG.md` `[0.6.3]` entry records the fix,
referenced there as #455). The code
and build agree: `Makefile:5` (`MODEL_REPO := Xenova/bge-small-en-v1.5`) and
`internal/plugin/embed/local.go:23` (`localModelDim = 384 //
bge-small-en-v1.5 output dimension`). But at `v0.7.0` the docs still name the
old model in three places:

- `docs/plugins.md:104` — provider comparison table, "Bundled local" row
- `docs/quickstart.md:149` — "Choose an Embedder" intro sentence
- `docs/self-hosting.md:100` — "Bundled (no API key, no internet)" section

**2. Nothing in the docs says the bundled model is English-only.** The `en` in
`bge-small-en-v1.5` is a language tag: it is an English embedding model. That
is a property of the model, not a MuninnDB defect — but since this embedder is
the zero-config default, the consequence for non-English vaults deserves a
docs section. The failure mode is specific and easy to miss: the model still
emits a vector for any input (nothing errors, nothing is logged), but
non-English vectors organize by *language* rather than by *meaning*, while the
FTS stream keeps answering near-lexical queries in any language — so semantic
recall degrades partially instead of failing loudly.

What prompted this: our production vault (~1,000 memories, German/English)
runs the bundled model. A controlled paired-query test showed three unrelated
German queries — three different operational topics — all returning the same
cluster of unrelated German-language memories, while the English paraphrases
of the same three questions each retrieved the correct memories. After
migrating the vault to a multilingual model, the same German queries returned
topically distinct, correct results. Nothing in logs or status ever pointed at
the embedder, which is why the proposed section includes a five-minute
self-test.

Related but independent: #583 proposes making the bundled local ONNX model
user-replaceable, and #582 reports the startup fallback hazard around external
providers. This PR only documents current `v0.7.0` behavior.

## Changes

- `docs/plugins.md` — fix the model name in the Tier 2 provider table; add a
  new `### Language Coverage` subsection to §3 (between the
  `MUNINN_OPENAI_URL` paragraph after the provider table and
  `### Retroactive Enrichment`, i.e. after line 113 at `v0.7.0`).
- `docs/quickstart.md` — fix the model name in §6 and add a one-line language
  note linking to the new subsection.
- `docs/self-hosting.md` — fix the model name and add a one-line pointer.
- Optional (take it or leave it): one-sentence rewording in
  `docs/plugins.md` §5 so it doesn't contradict the new subsection's re-embed
  guidance — details at the end.

No benchmark claims, vendor-neutral wording. Happy to move the section, rename
it, or fold it into the quickstart instead — whatever fits your structure.

---

## Proposed content

### 1. `docs/plugins.md` — provider table row (line 104 at `v0.7.0`)

Current:

```markdown
| Bundled local | On by default | all-MiniLM-L6-v2 | 384 | Zero | Full (local) |
```

Proposed:

```markdown
| Bundled local | On by default | bge-small-en-v1.5 (English-only) | 384 | Zero | Full (local) |
```

### 2. `docs/plugins.md` — new subsection in §3, after the `MUNINN_OPENAI_URL` paragraph (line 113), before `### Retroactive Enrichment` (line 115)

````markdown
### Language Coverage

The bundled local model is `bge-small-en-v1.5` — the `en` is a language tag.
It is an English embedding model. That is a property of the chosen model, not
a MuninnDB defect: within English it is a solid default, and it keeps Tier 2
zero-config and offline.

For non-English text the model still produces a vector — nothing fails,
nothing is logged — but the vectors organize by **language** rather than by
**meaning**: two unrelated German memories land closer together than a German
memory and its English paraphrase. On a non-English or mixed-language vault
this surfaces as:

- Non-English semantic queries return the same cluster of same-language
  memories, regardless of topic.
- English queries on the same vault behave normally.
- Queries that share words with the stored text still work in any language,
  because the FTS stream matches them. The fusion keeps returning plausible
  results, so the degradation is partial — and easy to miss.

**Five-minute self-test.** If your vault holds non-English content:

1. Store three memories in your language, on clearly unrelated topics.
2. Query each topic with a same-language *paraphrase* — reworded so it shares
   no distinctive keywords with the stored text (otherwise FTS answers the
   query and hides the vector behavior).
3. Repeat step 2 with English paraphrases of the same three questions.

If the same-language queries all return roughly the same result set regardless
of topic, while the English paraphrases each retrieve the right memory, your
vault is affected.

**Switching to a multilingual provider.** Any external provider serving a
multilingual embedding model resolves this. Self-hosted example with Ollama:

```bash
# any multilingual embedding model Ollama serves, e.g. bge-m3
export MUNINN_OLLAMA_URL="ollama://localhost:11434/bge-m3"
muninn server
```

Several hosted providers in the table above also serve multilingual models —
check your provider's model documentation. The same choice can be persisted in
`plugin_config.json` in the data directory (`embed_provider`, `embed_url`,
`embed_api_key`) or set in the web admin UI; environment variables take
precedence over saved config.

Two things to plan for when switching models:

- **Re-embed the vault.** Vectors from different models are not comparable:
  similarities across models are meaningless, and when the dimensions differ,
  memories embedded with the previous model drop out of semantic recall
  entirely. After switching, run `muninn vault reembed <name>` for each
  affected vault — it clears the stored embeddings and re-embeds with the
  current model.
- **Scores shift.** Different models produce different similarity-score
  distributions. If you have tuned anything against absolute vector scores,
  re-check it after the switch.
````

(The `plugin_config.json` keys and env-var precedence match
`internal/config/plugin.go:12-17` at `v0.7.0`; the `reembed` description
matches the CLI help text at `cmd/muninn/vault.go:33`, "Clear embeddings and
re-embed with current model".)

### 3. `docs/quickstart.md` — §6 intro sentence (line 149 at `v0.7.0`)

Current:

```markdown
The bundled local embedder (all-MiniLM-L6-v2, 384-dim) is included and works offline with no API key. It's the default. For higher quality or different dimensions:
```

Proposed:

```markdown
The bundled local embedder (bge-small-en-v1.5, 384-dim) is included and works offline with no API key. It's the default. It is an English-only model — for non-English or mixed-language memories, pick a multilingual external provider (see [Language Coverage](plugins.md#language-coverage)). For higher quality, different dimensions, or other languages:
```

### 4. `docs/self-hosting.md` — bundled-model line (line 100 at `v0.7.0`)

Current:

```markdown
The bundled `all-MiniLM-L6-v2` INT8 model (384-dim, ~80MB) is active automatically when the binary was built with embedded assets. No configuration needed.
```

Proposed:

```markdown
The bundled `bge-small-en-v1.5` INT8 model (384-dim, ~80MB, English-only) is active automatically when the binary was built with embedded assets. No configuration needed. For non-English content, see [Language Coverage](plugins.md#language-coverage).
```

### 5. Optional: `docs/plugins.md` §5 (line 231 at `v0.7.0`)

§5's second paragraph (line 231 at `v0.7.0`) opens with:

> Most vector database integrations require you to re-index when you switch
> embedding models.

With the new subsection stating that switching models *does* require
`muninn vault reembed`, that sentence reads as a contradiction. Its real point
is the install-time backfill guarantee, so a minimal reword keeps the point
and removes the tension:

```markdown
Most vector database integrations require a manual re-index before existing data becomes searchable.
```

Only this first sentence changes; the rest of the paragraph stays as is.

If you'd rather keep §5 untouched, the PR works without this edit.

---

## Release Checklist

- [ ] ~~`CHANGELOG.md`~~ — maintainers update this at release time, no action needed
- [ ] OpenAPI spec (`internal/transport/rest/openapi.yaml`) updated if API routes changed — N/A, docs-only
- [ ] SDK types updated if request/response schemas changed (Python, Node, PHP) — N/A, docs-only
- [x] `docs/` updated if user-facing behavior changed
- [ ] `go build ./...` clean — unaffected, docs-only
- [ ] `go vet ./...` clean — unaffected, docs-only
- [ ] `go test ./...` passes — unaffected, docs-only
