### PR TITLE
fix(embed): never substitute a different model for an explicitly configured provider

### DIFF
--- a/cmd/muninn/coverage_hardening_test.go
+++ b/cmd/muninn/coverage_hardening_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	plugincfg "github.com/scrypster/muninndb/internal/config"
+	"github.com/scrypster/muninndb/internal/engine/activation"
 )
 
 // storage import is intentionally omitted — PebbleStore requires *pebble.DB.
@@ -1828,6 +1829,86 @@ func TestBuildEmbedder_AllEnvVarsTried(t *testing.T) {
 	}
 	if embedder == nil {
 		t.Error("expected embedder (one of the env vars should init or fallback to noop)")
+	}
+}
+
+// TestBuildEmbedder_ExplicitProviderFailure_DoesNotSubstituteModel covers
+// issue #582: when plugin_config.json explicitly names a non-local provider
+// and that provider is unreachable at boot, buildEmbedder must not fall
+// through to the bundled 384-dim local ONNX model — silently mixing
+// embedding models/dimensions in a populated vault is worse than disabling
+// semantic search. It must land on noop with a diagnostic naming the
+// configured provider, not the generic "no embedder configured" message
+// (which implies nothing was ever configured).
+//
+// LocalAvailable() is false in this test binary (no -tags localassets), so
+// the pre-fix code would already have skipped step 3 for the same reason
+// this test's build does — the fix is exercised for real by CI, which
+// builds with -tags localassets and real model assets. This test instead
+// pins the new branch/diagnostic itself, independent of asset availability.
+func TestBuildEmbedder_ExplicitProviderFailure_DoesNotSubstituteModel(t *testing.T) {
+	t.Setenv("MUNINN_OLLAMA_URL", "")
+	t.Setenv("MUNINN_OPENAI_KEY", "")
+	t.Setenv("MUNINN_VOYAGE_KEY", "")
+	t.Setenv("MUNINN_COHERE_KEY", "")
+	t.Setenv("MUNINN_GOOGLE_KEY", "")
+	t.Setenv("MUNINN_JINA_KEY", "")
+	t.Setenv("MUNINN_MISTRAL_KEY", "")
+
+	cfg := plugincfg.PluginConfig{EmbedProvider: "ollama", EmbedURL: "http://localhost:1/bad"}
+	var embedder activation.Embedder
+	stderr := captureStderr(func() {
+		var err error
+		embedder, _, err = buildEmbedder(context.Background(), cfg, t.TempDir())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if embedder == nil {
+		t.Error("expected noop embedder fallback")
+	}
+	if !strings.Contains(stderr, `"ollama"`) {
+		t.Errorf("expected diagnostic naming the failed provider, got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "Semantic search is DISABLED, not silently switched to a different model") {
+		t.Errorf("expected the explicit-provider-failure diagnostic, got: %s", stderr)
+	}
+	if strings.Contains(stderr, "No embedder configured") {
+		t.Errorf("must not show the generic unconfigured message when a provider was explicitly configured, got: %s", stderr)
+	}
+}
+
+// TestBuildEmbedder_NoProviderConfigured_KeepsGenericMessage is the control
+// for the test above: with nothing configured at all, the pre-existing
+// generic "no embedder configured" diagnostic must still fire — the new
+// explicit-provider branch must not fire when EmbedProvider is empty/"none".
+func TestBuildEmbedder_NoProviderConfigured_KeepsGenericMessage(t *testing.T) {
+	t.Setenv("MUNINN_OLLAMA_URL", "")
+	t.Setenv("MUNINN_OPENAI_KEY", "")
+	t.Setenv("MUNINN_VOYAGE_KEY", "")
+	t.Setenv("MUNINN_COHERE_KEY", "")
+	t.Setenv("MUNINN_GOOGLE_KEY", "")
+	t.Setenv("MUNINN_JINA_KEY", "")
+	t.Setenv("MUNINN_MISTRAL_KEY", "")
+	t.Setenv("MUNINN_LOCAL_EMBED", "0")
+
+	cfg := plugincfg.PluginConfig{EmbedProvider: "none"}
+	var embedder activation.Embedder
+	stderr := captureStderr(func() {
+		var err error
+		embedder, _, err = buildEmbedder(context.Background(), cfg, t.TempDir())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if embedder == nil {
+		t.Error("expected noop embedder")
+	}
+	if !strings.Contains(stderr, "No embedder configured") {
+		t.Errorf("expected the generic unconfigured message, got: %s", stderr)
+	}
+	if strings.Contains(stderr, "Semantic search is DISABLED, not silently switched") {
+		t.Errorf("must not show the explicit-provider-failure diagnostic when nothing was configured, got: %s", stderr)
 	}
 }
 

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -422,6 +422,14 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 		}
 	}
 
+	// explicitExternalProvider is true when the saved config names a specific
+	// non-local provider. If that provider fails to initialize below, step 3
+	// must not substitute a different embedding model into a vault that may
+	// already hold vectors from the configured one — silently mixing
+	// dimensions/models is worse than disabling semantic search until the
+	// configured provider is reachable again (issue #582).
+	explicitExternalProvider := cfg.EmbedProvider != "" && cfg.EmbedProvider != "none" && cfg.EmbedProvider != "local"
+
 	// 2. Saved config fallback
 	if cfg.EmbedProvider != "" && cfg.EmbedProvider != "none" {
 		switch cfg.EmbedProvider {
@@ -491,9 +499,11 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 	}
 
 	// 3. Bundled local ONNX model — on by default when embedded at build time.
-	// Skip only if the user explicitly opts out (MUNINN_LOCAL_EMBED=0) or chose
-	// "none" as their provider.
-	if cfg.EmbedProvider != "none" && os.Getenv(localEmbed) != "0" && embedpkg.LocalAvailable() {
+	// Skip if the user explicitly opts out (MUNINN_LOCAL_EMBED=0), chose "none"
+	// as their provider, or explicitly configured a different provider that
+	// failed to initialize above (explicitExternalProvider) — substituting a
+	// different embedding model for one the user configured is never safe.
+	if !explicitExternalProvider && cfg.EmbedProvider != "none" && os.Getenv(localEmbed) != "0" && embedpkg.LocalAvailable() {
 		slog.Info("initializing bundled local ONNX embedder", "data_dir", dataDir)
 		if svc := tryEmbedService("local://bge-small-en-v1.5", plugin.PluginConfig{DataDir: dataDir}); svc != nil {
 			return embedpkg.NewEmbedServiceAdapter(svc), svc, nil
@@ -502,6 +512,19 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 	}
 
 	// 4. Noop
+	if explicitExternalProvider {
+		slog.Error("configured embed provider unreachable at startup, refusing to substitute a different model — semantic similarity disabled",
+			"embed_provider", cfg.EmbedProvider, "embed_url", cfg.EmbedURL)
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintf(os.Stderr, "  ⚠  Configured embed provider %q could not be reached at startup.\n", cfg.EmbedProvider)
+		fmt.Fprintln(os.Stderr, "     Semantic search is DISABLED, not silently switched to a different model —")
+		fmt.Fprintln(os.Stderr, "     substituting models would split this vault into incompatible embedding spaces.")
+		fmt.Fprintln(os.Stderr, "     Fix the provider and restart, or run `muninn vault plasticity` / edit plugin_config.json")
+		fmt.Fprintln(os.Stderr, "     to switch providers, then `muninn vault reembed <name>` if you do change models.")
+		fmt.Fprintln(os.Stderr, "")
+		return activation.NewNoopEmbedder(), nil, nil
+	}
+
 	slog.Warn("no embedder configured, semantic similarity disabled")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "  ⚠  No embedder configured — semantic search disabled.")


### PR DESCRIPTION
Fixes #582.

## Problem

When `plugin_config.json` explicitly configures an embed provider (e.g. `ollama`) and that provider is unreachable at boot, `buildEmbedder` silently falls through to the bundled 384-dim `bge-small-en-v1.5` local ONNX model instead of the existing safe noop mode ("semantic similarity disabled"). Nothing errors, `muninn_status` still reports `health: "good"`, and the vault is silently split into two mutually invisible embedding spaces — any engram written during the fallback window stays permanently invisible to semantic recall after the configured provider comes back, until manually re-embedded. Full repro and root-cause with exact file:line references in the issue.

Every saved-config branch (`ollama`, `openai`, `voyage`, `cohere`, `google`, `jina`, `mistral`) shared the same gap: on init failure inside the `switch cfg.EmbedProvider` block, execution just falls out of the switch into step 3 (the bundled local model) — indistinguishable from the "nothing was ever configured" case that step 3 exists to serve.

## Fix

This implements fix direction (a) from the issue (the smaller of the two suggested, complementary fixes). `internal/config/plugin.go`'s saved config now has an `explicitExternalProvider` flag computed once (true when `EmbedProvider` names a specific non-local provider). If that provider fails to initialize, step 3 (bundled local ONNX) is skipped entirely — the code no longer distinguishes "nothing configured" from "your configured provider failed" the same way. Instead it goes straight to noop with a diagnostic naming the failed provider and stating plainly that the model was not substituted, distinct from the pre-existing generic "no embedder configured" message.

Direction (b) from the issue — a dimension guard comparing the active embedder's output dimension against a vault's existing `embed_dim` (already backfilled by migration v1) — is a larger, independent change (would need to run on the write/query hot path, not just at boot) and isn't part of this PR. Filed as a follow-up; happy to pick it up if wanted.

Separately noticed but out of scope here: `muninn_status`'s `Health` field (`internal/mcp/handlers.go`) is a hardcoded literal `"good"`, never actually computed from embedder/system state — so even with this fix, status won't reflect a degraded (noop) embedder state. That's a real gap worth its own issue if useful, since the current fix means an operator now gets a loud one-time startup log/stderr message but no ongoing signal from `muninn_status` that semantic search is disabled.

## Tests

- `TestBuildEmbedder_ExplicitProviderFailure_DoesNotSubstituteModel` — an explicitly configured, unreachable `ollama` provider must land on noop with the new diagnostic naming the provider, not the generic message.
- `TestBuildEmbedder_NoProviderConfigured_KeepsGenericMessage` — the control: with nothing configured, the existing generic "no embedder configured" message must still fire unchanged.

Note on test coverage: `embedpkg.LocalAvailable()` is false in a plain `go test` build (no `-tags localassets`), so these tests exercise the branch logic and diagnostic messages directly rather than a real local-ONNX init attempt — under this build, step 3 was already unreachable before this fix for an unrelated reason (no embedded model assets), so a naive "embedder != nil" assertion wouldn't have distinguished old from new behavior. CI builds and tests with `-tags localassets` and real model assets (`.github/workflows/ci.yml`), which exercises the actual substitution-prevention end to end.

`go build ./...`, `go test ./...`, `gofmt -l`, `go vet ./...` all clean.