### PR TITLE
feat(embed): vault dimension guard (#582) + user-supplied local ONNX model (#583)

### DIFF
--- a/cmd/muninn/coverage_hardening_test.go
+++ b/cmd/muninn/coverage_hardening_test.go
@@ -2476,3 +2476,119 @@ func TestRunVaultDelete_CancelledByUser(t *testing.T) {
 		t.Errorf("expected 'Cancelled': %s", out)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// buildEmbedder: user-supplied local ONNX model (#583)
+// ---------------------------------------------------------------------------
+
+func TestBuildEmbedder_UserModelHalfConfigured_Errors(t *testing.T) {
+	clearEmbedEnv(t)
+	t.Setenv("MUNINN_LOCAL_EMBED", "")
+
+	cfg := plugincfg.PluginConfig{EmbedProvider: "local", EmbedModelPath: "/nonexistent/model.onnx"}
+	embedder, plug, err := buildEmbedder(context.Background(), cfg, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error when only one of embed_model_path/embed_tokenizer_path is set")
+	}
+	if !strings.Contains(err.Error(), "embed_tokenizer_path") {
+		t.Errorf("error should name the missing key, got: %v", err)
+	}
+	if embedder != nil || plug != nil {
+		t.Error("no embedder may be returned on a user-model configuration error")
+	}
+}
+
+func TestBuildEmbedder_UserModelConflictsWithLocalEmbedOff(t *testing.T) {
+	clearEmbedEnv(t) // leaves MUNINN_LOCAL_EMBED=0, which this test needs
+
+	dir := t.TempDir()
+	cfg := plugincfg.PluginConfig{
+		EmbedProvider:      "local",
+		EmbedModelPath:     filepath.Join(dir, "m.onnx"),
+		EmbedTokenizerPath: filepath.Join(dir, "t.json"),
+	}
+	_, _, err := buildEmbedder(context.Background(), cfg, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error when MUNINN_LOCAL_EMBED=0 conflicts with a configured user model")
+	}
+	if !strings.Contains(err.Error(), "MUNINN_LOCAL_EMBED") {
+		t.Errorf("error should name the conflicting env var, got: %v", err)
+	}
+}
+
+// TestBuildEmbedder_UserModelBrokenPaths_NoFallback pins the #583 fail-loud
+// contract at the buildEmbedder level: a configured user model whose files do
+// not exist is a hard error — never the bundled model, never noop-with-a-
+// warning. In a localassets build the failure comes from provider init
+// (missing files); in a noembed build it comes earlier (no ONNX runtime).
+// Both build variants must produce an error.
+func TestBuildEmbedder_UserModelBrokenPaths_NoFallback(t *testing.T) {
+	clearEmbedEnv(t)
+	t.Setenv("MUNINN_LOCAL_EMBED", "") // must not trip the =0 conflict check
+
+	dir := t.TempDir()
+	cfg := plugincfg.PluginConfig{
+		EmbedProvider:      "local",
+		EmbedModelPath:     filepath.Join(dir, "does-not-exist.onnx"),
+		EmbedTokenizerPath: filepath.Join(dir, "does-not-exist.json"),
+	}
+	embedder, plug, err := buildEmbedder(context.Background(), cfg, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for a user model whose files do not exist")
+	}
+	if embedder != nil || plug != nil {
+		t.Error("no embedder may be returned when the configured user model fails to initialize")
+	}
+}
+
+// TestBuildEmbedder_UserModelConflictsWithEnvProvider pins that an embed
+// provider env var plus a configured user local model is a hard startup error
+// — env precedence would silently override the explicit model, the exact
+// silent-substitution class of #582.
+func TestBuildEmbedder_UserModelConflictsWithEnvProvider(t *testing.T) {
+	clearEmbedEnv(t)
+	t.Setenv("MUNINN_LOCAL_EMBED", "")
+	t.Setenv("MUNINN_OLLAMA_URL", "ollama://localhost:1/some-model")
+
+	dir := t.TempDir()
+	cfg := plugincfg.PluginConfig{
+		EmbedProvider:      "local",
+		EmbedModelPath:     filepath.Join(dir, "m.onnx"),
+		EmbedTokenizerPath: filepath.Join(dir, "t.json"),
+	}
+	_, _, err := buildEmbedder(context.Background(), cfg, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error when an env provider conflicts with a configured user model")
+	}
+	if !strings.Contains(err.Error(), "MUNINN_OLLAMA_URL") {
+		t.Errorf("error should name the conflicting env var, got: %v", err)
+	}
+}
+
+// TestBuildEmbedder_UserModelKeysInactive_OtherProvider pins that user-model
+// keys configured alongside a non-"local" provider are inactive (warned, not
+// fatal): the explicitly configured provider still governs the outcome.
+func TestBuildEmbedder_UserModelKeysInactive_OtherProvider(t *testing.T) {
+	clearEmbedEnv(t) // leaves MUNINN_LOCAL_EMBED=0, which this test wants
+
+	cfg := plugincfg.PluginConfig{
+		EmbedProvider:      "ollama",
+		EmbedURL:           "http://localhost:1/bad",
+		EmbedModelPath:     "/nonexistent/model.onnx",
+		EmbedTokenizerPath: "/nonexistent/tokenizer.json",
+	}
+	var embedder activation.Embedder
+	stderr := captureStderr(func() {
+		var err error
+		embedder, _, err = buildEmbedder(context.Background(), cfg, t.TempDir())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if embedder == nil {
+		t.Error("expected noop embedder fallback for the failed explicit provider")
+	}
+	if !strings.Contains(stderr, `"ollama"`) {
+		t.Errorf("expected diagnostic naming the failed provider, got: %s", stderr)
+	}
+}

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -676,6 +676,40 @@ func runStartupMigrations(ctx context.Context, store *storage.PebbleStore) {
 	slog.Info("startup migration complete", "vaults", len(names))
 }
 
+// warnVaultDimMismatches compares the active embedder's dimension against each
+// vault's stored embedding dimension (read from the first persisted embedding,
+// without loading any HNSW graph) and prints a prominent warning per mismatch.
+// Advisory only: the per-operation guards in the HNSW registry and the plugin
+// store adapter do the actual refusing (issue #582).
+func warnVaultDimMismatches(store *storage.PebbleStore, embedderDim int) {
+	if embedderDim <= 0 {
+		return
+	}
+	names, err := store.ListVaultNames()
+	if err != nil {
+		slog.Warn("vault dimension check: failed to list vault names", "err", err)
+		return
+	}
+	for _, name := range names {
+		dim, err := store.VaultEmbedDimOnDisk(store.ResolveVaultPrefix(name))
+		if err != nil {
+			slog.Warn("vault dimension check failed", "vault", name, "err", err)
+			continue
+		}
+		if dim == 0 || dim == embedderDim {
+			continue
+		}
+		slog.Error("vault embedding dimension does not match active embedder — new embeddings for this vault will be refused until it is re-embedded",
+			"vault", name, "vault_dim", dim, "embedder_dim", embedderDim)
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintf(os.Stderr, "  ⚠  Vault %q holds %d-dimensional embeddings but the active embedder produces %d dimensions.\n", name, dim, embedderDim)
+		fmt.Fprintln(os.Stderr, "     New memories in this vault will NOT be semantically searchable, and semantic")
+		fmt.Fprintln(os.Stderr, "     queries against it degrade to full-text search only.")
+		fmt.Fprintf(os.Stderr, "     Run `muninn vault reembed %s` to re-embed it with the active model.\n", name)
+		fmt.Fprintln(os.Stderr, "")
+	}
+}
+
 // handleClusterConn reads MBP frames from an incoming cluster TCP connection
 // and dispatches them to the coordinator. Exits when the connection is closed.
 //
@@ -1199,6 +1233,15 @@ func runServer() {
 			v := h.HardwareAccelerated()
 			embedInfo.HardwareAccelerated = &v
 		}
+	}
+
+	// Warn loudly when the active embedder's dimension differs from a vault's
+	// existing vectors: per-operation guards will refuse mismatched embeddings
+	// rather than silently splitting the vault (issue #582). Advisory only —
+	// a mismatched vault keeps serving FTS recall (#578 contract), and one
+	// legacy vault must not prevent the server from starting for the others.
+	if embedPlugin != nil {
+		warnVaultDimMismatches(store, embedPlugin.Dimension())
 	}
 
 	// Build enrich plugin (optional): env vars → saved config.

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -159,6 +159,11 @@ func resolveEmbedInfo(cfg plugincfg.PluginConfig) rest.EmbedInfo {
 		return rest.EmbedInfo{Provider: "jina", Model: "jina-embeddings-v3"}
 	case "mistral":
 		return rest.EmbedInfo{Provider: "mistral", Model: "mistral-embed"}
+	case "local":
+		// User-supplied model (#583); the bundled default is reported below.
+		if cfg.EmbedModelPath != "" && cfg.EmbedTokenizerPath != "" {
+			return rest.EmbedInfo{Provider: "local", Model: filepath.Base(cfg.EmbedModelPath)}
+		}
 	case "none":
 		return rest.EmbedInfo{Provider: "none", Model: ""}
 	}
@@ -344,6 +349,41 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 		}
 	}
 
+	// User-supplied local ONNX model configuration (issue #583), validated up
+	// front: an explicit misconfiguration fails startup rather than being
+	// silently ignored or substituted — the principle #582 established.
+	// (The provider re-validates paths/pooling at Init for non-server callers;
+	// the checks here are the ones that must fire before the env-provider
+	// precedence chain, or that only this layer can see.)
+	hasModelPaths := cfg.EmbedModelPath != "" || cfg.EmbedTokenizerPath != ""
+	hasUserModelKeys := hasModelPaths || cfg.EmbedPooling != "" || cfg.EmbedMaxTokens != 0 ||
+		cfg.EmbedQueryPrefix != "" || cfg.EmbedPassagePrefix != ""
+	userLocalModel := hasModelPaths && cfg.EmbedProvider == "local"
+	if hasUserModelKeys && cfg.EmbedProvider != "local" {
+		slog.Warn("user local model settings (embed_model_path, embed_pooling, prefixes, …) are configured but embed_provider is not \"local\" — they are inactive",
+			"embed_provider", cfg.EmbedProvider)
+	}
+	if hasUserModelKeys && !hasModelPaths && cfg.EmbedProvider == "local" {
+		slog.Warn("embed_pooling, embed_max_tokens and prefix settings apply only to a user-supplied model (embed_model_path) — they are inactive for the bundled local model")
+	}
+	if userLocalModel {
+		if cfg.EmbedModelPath == "" || cfg.EmbedTokenizerPath == "" {
+			return nil, nil, fmt.Errorf("embed_model_path and embed_tokenizer_path must both be set (got model=%q, tokenizer=%q)", cfg.EmbedModelPath, cfg.EmbedTokenizerPath)
+		}
+		if os.Getenv(localEmbed) == "0" {
+			return nil, nil, fmt.Errorf("%s=0 conflicts with the configured user local embed model (embed_model_path) — unset one of them", localEmbed)
+		}
+		// An env provider would silently win over the explicitly configured
+		// user model (env precedence) and could quietly embed at the wrong
+		// dimension — the exact failure class of #582. Explicit configurations
+		// must not fight each other: fail loud.
+		for _, v := range []string{ollamaURL, openaiKey, voyageKey, cohereKey, googleKey, jinaKey, mistralKey} {
+			if os.Getenv(v) != "" {
+				return nil, nil, fmt.Errorf("%s conflicts with the configured user local embed model (embed_model_path) — unset one of them", v)
+			}
+		}
+	}
+
 	tryEmbedService := func(providerURL string, pcfg plugin.PluginConfig) *embedpkg.EmbedService {
 		logURL := sanitizeProviderURLForLog(providerURL)
 		svc, err := embedpkg.NewEmbedService(providerURL)
@@ -434,6 +474,43 @@ func buildEmbedder(ctx context.Context, cfg plugincfg.PluginConfig, dataDir stri
 	if cfg.EmbedProvider != "" && cfg.EmbedProvider != "none" {
 		switch cfg.EmbedProvider {
 		case "local":
+			if userLocalModel {
+				svc, err := embedpkg.NewEmbedService("local://user-model")
+				if err != nil {
+					return nil, nil, fmt.Errorf("user local embed model: %w", err)
+				}
+				slog.Info("initializing user-supplied local ONNX embedder from saved config",
+					"model_path", cfg.EmbedModelPath, "tokenizer_path", cfg.EmbedTokenizerPath)
+				if err := svc.Init(ctx, plugin.PluginConfig{
+					DataDir:            dataDir,
+					LocalModelPath:     cfg.EmbedModelPath,
+					LocalTokenizerPath: cfg.EmbedTokenizerPath,
+					LocalPooling:       cfg.EmbedPooling,
+					LocalMaxTokens:     cfg.EmbedMaxTokens,
+				}); err != nil {
+					_ = svc.Close()
+					// Fail loud (#583): an explicitly configured user model never
+					// falls back to the bundled one — a broken path, tokenizer, or
+					// probe is a deterministic configuration error the operator
+					// must fix, unlike a transient provider outage (#582/#585).
+					return nil, nil, fmt.Errorf("user-supplied local embed model failed to initialize (refusing to fall back to the bundled model): %w", err)
+				}
+				// A filename hinting at the e5 family combined with e5-unsuitable
+				// settings is the silent-degradation class this feature guards
+				// against — warn, since a filename guess is not certain enough
+				// to error on.
+				if strings.Contains(strings.ToLower(filepath.Base(cfg.EmbedModelPath)), "e5") {
+					if cfg.EmbedQueryPrefix == "" && cfg.EmbedPassagePrefix == "" {
+						slog.Warn("model filename suggests the e5 family, which requires instruction prefixes for retrieval quality — set embed_query_prefix (e.g. \"query: \") and embed_passage_prefix (e.g. \"passage: \"), or results will look plausible but quietly degraded")
+					}
+					if cfg.EmbedPooling != "mean" {
+						slog.Warn("model filename suggests the e5 family, which is mean-pooled — set embed_pooling to \"mean\", or results will look plausible but quietly degraded",
+							"embed_pooling", cfg.EmbedPooling)
+					}
+				}
+				return embedpkg.NewEmbedServiceAdapter(embedpkg.NewPrefixedEmbedPlugin(svc, cfg.EmbedQueryPrefix)),
+					embedpkg.NewPrefixedEmbedPlugin(svc, cfg.EmbedPassagePrefix), nil
+			}
 			if os.Getenv(localEmbed) != "0" && embedpkg.LocalAvailable() {
 				slog.Info("initializing bundled local ONNX embedder from saved config", "data_dir", dataDir)
 				if svc := tryEmbedService("local://bge-small-en-v1.5", plugin.PluginConfig{DataDir: dataDir}); svc != nil {

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -171,6 +171,53 @@ Two things to plan for when switching models:
   distributions. If you have tuned anything against absolute vector scores,
   re-check it after the switch.
 
+### User-Supplied Local ONNX Model
+
+The local provider can also serve a model you supply instead of the bundled
+`bge-small-en-v1.5` — the in-process alternative to an external provider,
+keeping the zero-network, single-binary properties. Typical use: a
+multilingual model on a vault that fails the self-test above.
+
+```json
+{
+  "embed_provider": "local",
+  "embed_model_path": "/opt/models/multilingual-e5-small/model_quantized.onnx",
+  "embed_tokenizer_path": "/opt/models/multilingual-e5-small/tokenizer.json",
+  "embed_pooling": "mean",
+  "embed_max_tokens": 512,
+  "embed_query_prefix": "query: ",
+  "embed_passage_prefix": "passage: "
+}
+```
+
+- **Both paths are required** — a `.onnx` model file and its HuggingFace
+  `tokenizer.json`. The model must take BERT-style inputs (`input_ids`,
+  `attention_mask`, optionally `token_type_ids`) and produce a hidden-state
+  tensor; the provider reads the model's declared inputs and feeds exactly
+  those. Quantized exports (e.g. the Xenova ONNX conversions on Hugging Face)
+  keep downloads small and run well on CPU.
+- **Dimension is probed, never declared.** At startup the provider runs one
+  real inference and takes the output dimension from the returned tensor
+  shape. There is no dimension knob to get wrong.
+- **Init fails loudly.** A missing file, unloadable tokenizer, or failed probe
+  stops server startup with a clear error. A configured user model is never
+  silently replaced by the bundled one — the same principle #582 established
+  for explicitly configured network providers.
+- **Pooling must match the model family** (`embed_pooling`): `cls` (default)
+  for bge-style models, `mean` for e5-style models. Wrong pooling degrades
+  quality silently — check the model's documentation.
+- **Instruction prefixes**: e5-family models require `"query: "` /
+  `"passage: "` prefixes for retrieval quality. `embed_query_prefix` is
+  prepended to recall queries, `embed_passage_prefix` to stored memories.
+  The server warns when the model filename looks like the e5 family and no
+  prefixes are configured.
+- **Requires a `localassets` build** (all official release binaries): the
+  bundled ONNX runtime library serves the user model too.
+- **Re-embed after switching**, exactly as with any model change:
+  `muninn vault reembed <name>`. If the new model's dimension differs from a
+  vault's existing vectors, the server refuses mismatched embeddings and says
+  so at startup instead of silently splitting the vault.
+
 ### Retroactive Enrichment
 
 Install the Embed plugin against a vault with existing data. You don't re-index manually. You don't write a migration script. You start the plugin and walk away.

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -16,6 +16,17 @@ type PluginConfig struct {
 	EmbedURL      string `json:"embed_url"`      // provider URL override (ollama) or OpenAI base/provider URL override
 	EmbedAPIKey   string `json:"embed_api_key"`  // API key (openai, voyage)
 
+	// User-supplied local ONNX model, active when EmbedProvider is "local"
+	// (issue #583). Both paths must be set together; the model's output
+	// dimension is probed at init, never declared. Init fails loudly on any
+	// problem — a user-supplied model never falls back to the bundled one.
+	EmbedModelPath     string `json:"embed_model_path,omitempty"`     // path to the .onnx model file
+	EmbedTokenizerPath string `json:"embed_tokenizer_path,omitempty"` // path to the HuggingFace tokenizer.json
+	EmbedPooling       string `json:"embed_pooling,omitempty"`        // "cls" (default) or "mean"
+	EmbedMaxTokens     int    `json:"embed_max_tokens,omitempty"`     // max sequence length (default 256)
+	EmbedQueryPrefix   string `json:"embed_query_prefix,omitempty"`   // prepended to recall queries (e.g. "query: " for e5-family models)
+	EmbedPassagePrefix string `json:"embed_passage_prefix,omitempty"` // prepended to stored texts (e.g. "passage: " for e5-family models)
+
 	// Enrich provider settings
 	EnrichProvider string `json:"enrich_provider"` // "ollama", "openai", "anthropic"
 	EnrichURL      string `json:"enrich_url"`      // full provider URL

--- a/internal/config/plugin_test.go
+++ b/internal/config/plugin_test.go
@@ -1,8 +1,56 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func boolPtr(b bool) *bool { return &b }
+
+func TestPluginConfig_UserModelKeysRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	in := PluginConfig{
+		EmbedProvider:      "local",
+		EmbedModelPath:     "/opt/models/multilingual-e5-small/model_quantized.onnx",
+		EmbedTokenizerPath: "/opt/models/multilingual-e5-small/tokenizer.json",
+		EmbedPooling:       "mean",
+		EmbedMaxTokens:     512,
+		EmbedQueryPrefix:   "query: ",
+		EmbedPassagePrefix: "passage: ",
+	}
+	if err := SavePluginConfig(dir, in); err != nil {
+		t.Fatalf("SavePluginConfig: %v", err)
+	}
+	out, err := LoadPluginConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadPluginConfig: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch:\n got %+v\nwant %+v", out, in)
+	}
+}
+
+// TestPluginConfig_OldFileWithoutUserModelKeys pins backward compatibility:
+// a config written before the user-model keys existed loads with zero values.
+func TestPluginConfig_OldFileWithoutUserModelKeys(t *testing.T) {
+	dir := t.TempDir()
+	old := []byte(`{"embed_provider":"ollama","embed_url":"ollama://localhost:11434/some-model"}`)
+	if err := os.WriteFile(filepath.Join(dir, "plugin_config.json"), old, 0o600); err != nil {
+		t.Fatalf("write old config: %v", err)
+	}
+	out, err := LoadPluginConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadPluginConfig: %v", err)
+	}
+	if out.EmbedProvider != "ollama" {
+		t.Errorf("EmbedProvider = %q, want ollama", out.EmbedProvider)
+	}
+	if out.EmbedModelPath != "" || out.EmbedTokenizerPath != "" || out.EmbedPooling != "" ||
+		out.EmbedMaxTokens != 0 || out.EmbedQueryPrefix != "" || out.EmbedPassagePrefix != "" {
+		t.Errorf("user-model keys must be zero for an old config file, got %+v", out)
+	}
+}
 
 func TestEnrichStageEnabled_DefaultsTrue(t *testing.T) {
 	cfg := &PluginConfig{}

--- a/internal/engine/activation/adapters.go
+++ b/internal/engine/activation/adapters.go
@@ -49,18 +49,24 @@ func NewFTSAdapter(idx *fts.Index) FTSIndex {
 	return &ftsActivationAdapter{idx: idx}
 }
 
-// noopEmbedder is a stub embedder that returns zero vectors.
+// noopEmbedder is a stub embedder used when no embedding provider is
+// configured. It returns no embedding at all, which routes recall through the
+// FTS-only fast path in phase2 — the same degradation contract as an
+// unreachable embed backend (#578). Returning fixed-size zero vectors instead
+// would send every recall through a pointless HNSW walk that scores 0 against
+// each node, and would trip the vault dimension guard (#582) on any vault
+// whose vectors are not 384-dimensional.
 type noopEmbedder struct{}
 
 func (e *noopEmbedder) Embed(ctx context.Context, texts []string) ([]float32, error) {
-	return make([]float32, len(texts)*384), nil
+	return nil, nil
 }
 
 func (e *noopEmbedder) Tokenize(text string) []string {
 	return strings.Fields(text)
 }
 
-// NewNoopEmbedder returns an Embedder that returns zero vectors.
+// NewNoopEmbedder returns an Embedder that produces no embeddings.
 func NewNoopEmbedder() Embedder {
 	return &noopEmbedder{}
 }

--- a/internal/engine/activation/adapters_test.go
+++ b/internal/engine/activation/adapters_test.go
@@ -5,21 +5,19 @@ import (
 	"testing"
 )
 
-func TestNoopEmbedderReturnsZeroVector(t *testing.T) {
+// TestNoopEmbedderReturnsNoEmbedding pins the noop contract: no embedding at
+// all, so recall takes the FTS-only fast path (len(embedding)==0 in phase2)
+// instead of walking HNSW with a zero vector — and a fixed 384-dim stub can
+// never trip the vault dimension guard (#582) on non-384-dim vaults.
+func TestNoopEmbedderReturnsNoEmbedding(t *testing.T) {
 	e := NewNoopEmbedder()
 	texts := []string{"hello", "world", "test"}
 	vecs, err := e.Embed(context.Background(), texts)
 	if err != nil {
 		t.Fatalf("Embed returned unexpected error: %v", err)
 	}
-	expectedLen := len(texts) * 384
-	if len(vecs) != expectedLen {
-		t.Fatalf("expected %d floats, got %d", expectedLen, len(vecs))
-	}
-	for i, v := range vecs {
-		if v != 0 {
-			t.Fatalf("expected zero vector at index %d, got %f", i, v)
-		}
+	if len(vecs) != 0 {
+		t.Fatalf("expected no embedding from noop embedder, got %d floats", len(vecs))
 	}
 }
 

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -2,6 +2,7 @@ package activation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -14,6 +15,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	hnswpkg "github.com/scrypster/muninndb/internal/index/hnsw"
 	"github.com/scrypster/muninndb/internal/storage"
 	"github.com/scrypster/muninndb/internal/transport/mbp"
 )
@@ -638,7 +640,16 @@ func (e *ActivationEngine) phase2(ctx context.Context, req *ActivateRequest, p1 
 	g.Go(func() error {
 		results, err := e.hnsw.Search(gctx, ws, p1.embedding, k)
 		if err != nil {
-			slog.Warn("activation: hnsw search degraded", "vault", req.VaultID, "err", err)
+			var dimErr *hnswpkg.DimMismatchError
+			if errors.As(err, &dimErr) {
+				// The active embedder's dimension does not match this vault's
+				// existing vectors (#582). FTS results below still apply — same
+				// degrade-not-abort contract as an unreachable embed backend (#578).
+				slog.Warn("activation: query embedding dimension does not match vault vectors — recall degraded to BM25-only; run `muninn vault reembed` after changing embedding models",
+					"vault", req.VaultID, "query_dim", dimErr.Got, "vault_dim", dimErr.Want)
+			} else {
+				slog.Warn("activation: hnsw search degraded", "vault", req.VaultID, "err", err)
+			}
 			return nil
 		}
 		sets.vector = results

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -790,6 +790,28 @@ func (e *Engine) GetVaultEmbedDim(_ context.Context, vault string) int {
 	return e.hnswRegistry.VaultEmbedDim(ws)
 }
 
+// validateClientEmbeddingDim refuses a caller-supplied embedding whose
+// dimension differs from the vault's established dimension (issue #582),
+// BEFORE anything is persisted — the MCP layer already enforces this with
+// -32602; checking here extends the same contract to every other transport
+// (MBP, gRPC, SDKs, embedded library). The dimension peek never loads a
+// graph: cached index first, one Pebble seek otherwise. Registry.Insert
+// remains the atomic authority; this check exists so a refused vector is
+// never persisted first.
+func (e *Engine) validateClientEmbeddingDim(wsPrefix [8]byte, vec []float32) error {
+	if len(vec) == 0 || e.hnswRegistry == nil {
+		return nil
+	}
+	want := e.hnswRegistry.CachedVaultDim(wsPrefix)
+	if want == 0 && e.store != nil {
+		want, _ = e.store.VaultEmbedDimOnDisk(wsPrefix)
+	}
+	if err := hnsw.CheckDim(want, len(vec)); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidRequest, err)
+	}
+	return nil
+}
+
 // UpdateTags replaces the tags on an engram.
 func (e *Engine) UpdateTags(ctx context.Context, vault string, id storage.ULID, tags []string) error {
 	wsPrefix := e.store.ResolveVaultPrefix(vault)
@@ -984,6 +1006,12 @@ func (e *Engine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteRe
 	}
 	eng.Associations = assocs
 
+	// Refuse a mismatched caller-supplied embedding before anything is
+	// persisted (issue #582).
+	if err := e.validateClientEmbeddingDim(wsPrefix, req.Embedding); err != nil {
+		return nil, err
+	}
+
 	// Write to store
 	id, err := e.store.WriteEngram(ctx, wsPrefix, eng)
 	if err != nil {
@@ -1003,17 +1031,21 @@ func (e *Engine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteRe
 		}
 	}
 
-	// When the caller provided an embedding, mark DigestEmbed so the retroactive
-	// processor does not overwrite it, then insert into HNSW inline so the vector
-	// is searchable immediately (the retroactive processor skips DigestEmbed-flagged
-	// engrams and therefore never calls HNSWInsert for them).
+	// When the caller provided an embedding, insert into HNSW inline so the
+	// vector is searchable immediately, then mark DigestEmbed so the
+	// retroactive processor does not overwrite it. Insert first: if it is
+	// refused (e.g. a dimension race lost against a concurrent first insert,
+	// #582), the engram stays unflagged and the retroactive processor embeds
+	// it with the server's own embedder instead — self-healing rather than a
+	// stranded, never-searchable memory.
 	if len(req.Embedding) > 0 {
-		existing, _ := e.store.GetDigestFlags(ctx, plugin.ULID(id))
-		if err := e.store.SetDigestFlag(ctx, id, existing|plugin.DigestEmbed); err != nil {
-			slog.Warn("engine: failed to set DigestEmbed flag", "id", id.String(), "err", err)
-		}
 		if err := e.hnswRegistry.Insert(ctx, wsPrefix, [16]byte(id), req.Embedding); err != nil {
-			slog.Warn("engine: failed to insert client embedding into HNSW", "id", id.String(), "err", err)
+			slog.Warn("engine: client embedding not inserted into HNSW; engram left for the retroactive processor", "id", id.String(), "err", err)
+		} else {
+			existing, _ := e.store.GetDigestFlags(ctx, plugin.ULID(id))
+			if err := e.store.SetDigestFlag(ctx, id, existing|plugin.DigestEmbed); err != nil {
+				slog.Warn("engine: failed to set DigestEmbed flag", "id", id.String(), "err", err)
+			}
 		}
 	}
 
@@ -1464,6 +1496,13 @@ func (e *Engine) WriteBatch(ctx context.Context, reqs []*mbp.WriteRequest) ([]*m
 		callerProvidedAny := callerSummary != "" || len(callerEntities) > 0
 		skipBG := (inlineMode == "caller_only" && callerProvidedAny) || inlineMode == "disabled"
 
+		// Refuse a mismatched caller-supplied embedding before anything is
+		// persisted (issue #582).
+		if err := e.validateClientEmbeddingDim(wsPrefix, req.Embedding); err != nil {
+			errs[i] = err
+			continue
+		}
+
 		items[i] = storage.EngramBatchItem{WSPrefix: wsPrefix, Engram: eng}
 		prepared[i] = preparedBatchItem{
 			wsPrefix:                  wsPrefix,
@@ -1653,16 +1692,17 @@ func (e *Engine) WriteBatch(ctx context.Context, reqs []*mbp.WriteRequest) ([]*m
 			}
 		}
 
-		// When the caller provided an embedding, mark DigestEmbed so the retroactive
-		// processor does not overwrite it, then insert into HNSW inline so the vector
-		// is searchable immediately.
+		// When the caller provided an embedding, insert into HNSW inline first
+		// and only mark DigestEmbed on success — a refused insert (#582) leaves
+		// the engram for the retroactive processor to embed server-side.
 		if len(reqs[i].Embedding) > 0 {
-			existing, _ := e.store.GetDigestFlags(ctx, plugin.ULID(id))
-			if err := e.store.SetDigestFlag(ctx, id, existing|plugin.DigestEmbed); err != nil {
-				slog.Warn("engine: batch: failed to set DigestEmbed flag", "id", id.String(), "err", err)
-			}
 			if err := e.hnswRegistry.Insert(ctx, p.wsPrefix, [16]byte(id), reqs[i].Embedding); err != nil {
-				slog.Warn("engine: batch: failed to insert client embedding into HNSW", "id", id.String(), "err", err)
+				slog.Warn("engine: batch: client embedding not inserted into HNSW; engram left for the retroactive processor", "id", id.String(), "err", err)
+			} else {
+				existing, _ := e.store.GetDigestFlags(ctx, plugin.ULID(id))
+				if err := e.store.SetDigestFlag(ctx, id, existing|plugin.DigestEmbed); err != nil {
+					slog.Warn("engine: batch: failed to set DigestEmbed flag", "id", id.String(), "err", err)
+				}
 			}
 		}
 
@@ -2820,6 +2860,12 @@ type EngineSessionEntry struct {
 func (e *Engine) Evolve(ctx context.Context, vault, oldID, newContent, reason string, embedding []float32, concept string) (storage.ULID, error) {
 	wsPrefix := e.store.ResolveVaultPrefix(vault)
 
+	// Refuse a mismatched caller-supplied embedding before anything is
+	// persisted (issue #582).
+	if err := e.validateClientEmbeddingDim(wsPrefix, embedding); err != nil {
+		return storage.ULID{}, err
+	}
+
 	// Parse the old ULID before any writes.
 	oldULID, err := storage.ParseULID(oldID)
 	if err != nil {
@@ -2899,15 +2945,17 @@ func (e *Engine) Evolve(ctx context.Context, vault, oldID, newContent, reason st
 		slog.Warn("engine: failed to persist vault name", "vault", vault, "err", err)
 	}
 
-	// When the caller provided an embedding, mark DigestEmbed and insert into
-	// HNSW inline (the retroactive processor skips DigestEmbed-flagged engrams).
+	// When the caller provided an embedding, insert into HNSW inline first and
+	// only mark DigestEmbed on success — a refused insert (#582) leaves the
+	// engram for the retroactive processor to embed server-side.
 	if len(embedding) > 0 {
-		existing, _ := e.store.GetDigestFlags(ctx, plugin.ULID(newULID))
-		if err := e.store.SetDigestFlag(ctx, newULID, existing|plugin.DigestEmbed); err != nil {
-			slog.Warn("engine: evolve: failed to set DigestEmbed flag", "id", newULID.String(), "err", err)
-		}
 		if err := e.hnswRegistry.Insert(ctx, wsPrefix, [16]byte(newULID), embedding); err != nil {
-			slog.Warn("engine: evolve: failed to insert client embedding into HNSW", "id", newULID.String(), "err", err)
+			slog.Warn("engine: evolve: client embedding not inserted into HNSW; engram left for the retroactive processor", "id", newULID.String(), "err", err)
+		} else {
+			existing, _ := e.store.GetDigestFlags(ctx, plugin.ULID(newULID))
+			if err := e.store.SetDigestFlag(ctx, newULID, existing|plugin.DigestEmbed); err != nil {
+				slog.Warn("engine: evolve: failed to set DigestEmbed flag", "id", newULID.String(), "err", err)
+			}
 		}
 	}
 

--- a/internal/engine/tree.go
+++ b/internal/engine/tree.go
@@ -228,6 +228,12 @@ func (e *Engine) AddChild(ctx context.Context, vault, parentID string, input *Ad
 		return nil, fmt.Errorf("add child: parse parent id: %w", err)
 	}
 
+	// Refuse a mismatched caller-supplied embedding before anything is
+	// persisted (issue #582).
+	if err := e.validateClientEmbeddingDim(ws, input.Embedding); err != nil {
+		return nil, err
+	}
+
 	// Verify parent exists and is active or archived.
 	parentEng, err := e.store.GetEngram(ctx, ws, pid)
 	if err != nil {
@@ -312,15 +318,17 @@ func (e *Engine) AddChild(ctx context.Context, vault, parentID string, input *Ad
 		}
 	}
 
-	// When the caller provided an embedding, mark DigestEmbed and insert into
-	// HNSW inline (the retroactive processor skips DigestEmbed-flagged engrams).
+	// When the caller provided an embedding, insert into HNSW inline first and
+	// only mark DigestEmbed on success — a refused insert (#582) leaves the
+	// engram for the retroactive processor to embed server-side.
 	if len(input.Embedding) > 0 {
-		existing, _ := e.store.GetDigestFlags(ctx, plugin.ULID(child.ID))
-		if err := e.store.SetDigestFlag(ctx, child.ID, existing|plugin.DigestEmbed); err != nil {
-			slog.Warn("engine: add child: failed to set DigestEmbed flag", "id", child.ID.String(), "err", err)
-		}
 		if err := e.hnswRegistry.Insert(ctx, ws, [16]byte(child.ID), input.Embedding); err != nil {
-			slog.Warn("engine: add child: failed to insert client embedding into HNSW", "id", child.ID.String(), "err", err)
+			slog.Warn("engine: add child: client embedding not inserted into HNSW; engram left for the retroactive processor", "id", child.ID.String(), "err", err)
+		} else {
+			existing, _ := e.store.GetDigestFlags(ctx, plugin.ULID(child.ID))
+			if err := e.store.SetDigestFlag(ctx, child.ID, existing|plugin.DigestEmbed); err != nil {
+				slog.Warn("engine: add child: failed to set DigestEmbed flag", "id", child.ID.String(), "err", err)
+			}
 		}
 	}
 

--- a/internal/index/hnsw/hnsw.go
+++ b/internal/index/hnsw/hnsw.go
@@ -83,17 +83,52 @@ type Index struct {
 	// (e.g. the registry's no-cache-on-error behaviour) without corrupting Pebble.
 	// Always nil in production.
 	loadErrHook func() error
+
+	// dim is the vault's established vector dimension; 0 until the first
+	// vector is inserted or loaded. On load it is taken from the vector with
+	// the smallest ID, so it is deterministic per process AND across restarts
+	// (and agrees with the storage layer's first-key derivation) even for a
+	// legacy vault that already holds mixed dimensions. Guarded by mu.
+	dim int
+
+	// loadErr is set by the registry when LoadFromPebble failed for this
+	// (uncached) index, so writes can refuse instead of treating the vault as
+	// empty — inserting into a vault whose real dimension is unknown could
+	// recreate the #582 split. Set once before the index escapes getOrCreate.
+	loadErr error
 }
 
-// Dim returns the vector dimension used by this index.
+// Dim returns the vault's established vector dimension.
 // Returns 0 if the index is empty (no vectors inserted yet).
 func (idx *Index) Dim() int {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
-	for _, node := range idx.nodes {
-		return len(node.vec)
+	return idx.dim
+}
+
+// LoadError reports the load failure recorded for this index, if any.
+func (idx *Index) LoadError() error {
+	return idx.loadErr
+}
+
+// establishDim atomically checks a vector's dimension against the vault's
+// established dimension, establishing it on first use — check and
+// establishment happen under one lock, so two concurrent first inserts with
+// different dimensions cannot both pass (one establishes, the other is
+// refused). The established dimension deliberately survives the deletion of
+// the vector that set it: refusing until a reload/reset is safer than letting
+// the dimension flap.
+func (idx *Index) establishDim(n int) error {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	if idx.dim == 0 {
+		idx.dim = n
+		return nil
 	}
-	return 0
+	if idx.dim != n {
+		return &DimMismatchError{Got: n, Want: idx.dim}
+	}
+	return nil
 }
 
 // Tombstone marks a node as deleted so it is skipped in future Search results.
@@ -824,11 +859,27 @@ func (idx *Index) LoadFromPebble() error {
 		rebuilt = true
 	}
 
+	// Derive the vault's dimension from the vector with the smallest ID —
+	// deterministic across calls and restarts (map iteration is random), and
+	// consistent with the storage layer's first-embedding-key derivation.
+	tempDim := 0
+	var dimID [16]byte
+	for id, node := range tempNodes {
+		if node.vec == nil {
+			continue
+		}
+		if tempDim == 0 || string(id[:]) < string(dimID[:]) {
+			tempDim = len(node.vec)
+			dimID = id
+		}
+	}
+
 	// Only apply to index if load completed successfully
 	idx.mu.Lock()
 	idx.nodes = tempNodes
 	idx.maxLevel = tempMaxLevel
 	idx.entryPoint = tempEntryPoint
+	idx.dim = tempDim
 	idx.mu.Unlock()
 
 	slog.Info("hnsw: loaded graph from pebble",

--- a/internal/index/hnsw/registry.go
+++ b/internal/index/hnsw/registry.go
@@ -2,6 +2,7 @@ package hnsw
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -9,6 +10,31 @@ import (
 
 	"github.com/cockroachdb/pebble"
 )
+
+// DimMismatchError reports a vector whose dimension differs from the dimension
+// already established by a vault's existing vectors. Mixing dimensions inside
+// one vault silently splits it into mutually invisible embedding spaces
+// (issue #582): CosineSimilarity scores length-mismatched pairs 0, so a
+// mismatched vector would be stored but never surface in semantic search.
+type DimMismatchError struct {
+	Got  int // dimension of the offending vector
+	Want int // dimension established by the vault's existing vectors
+}
+
+func (e *DimMismatchError) Error() string {
+	return fmt.Sprintf("embedding dimension %d does not match vault dimension %d — run `muninn vault reembed <vault>` after changing embedding models", e.Got, e.Want)
+}
+
+// CheckDim is the single definition of the vault-dimension invariant: a vault
+// whose dimension is established (want > 0) only accepts vectors of exactly
+// that dimension; an empty vault (want == 0) accepts any — the first insert
+// establishes it.
+func CheckDim(want, got int) error {
+	if want > 0 && got != want {
+		return &DimMismatchError{Got: got, Want: want}
+	}
+	return nil
+}
 
 // Registry is a multi-vault HNSW index registry.
 // It lazily creates and caches one *Index per vault workspace prefix.
@@ -121,6 +147,10 @@ func (r *Registry) getOrCreate(ws [8]byte) *Index {
 	// access retries the load. (issue #499)
 	if err := idx.LoadFromPebble(); err != nil {
 		slog.Error("hnsw: failed to load graph from pebble; not caching index (load will be retried on next access)", "vault", ws, "error", err)
+		// Record the failure so Insert refuses writes instead of treating the
+		// vault as empty (Dim()==0 would let a mismatched vector through and
+		// recreate the #582 split). Reads keep their degraded-empty behavior.
+		idx.loadErr = err
 		return idx
 	}
 	r.indexes[ws] = idx
@@ -129,8 +159,14 @@ func (r *Registry) getOrCreate(ws [8]byte) *Index {
 
 // Search implements activation.HNSWIndex and trigger.HNSWIndex.
 // It delegates to the per-vault Index.
+// A query vector whose dimension differs from the vault's established
+// dimension returns a *DimMismatchError instead of silently scoring 0 against
+// every node (issue #582); callers already degrade to FTS on search errors.
 func (r *Registry) Search(ctx context.Context, ws [8]byte, vec []float32, topK int) ([]ScoredID, error) {
 	idx := r.getOrCreate(ws)
+	if err := CheckDim(idx.Dim(), len(vec)); err != nil {
+		return nil, err
+	}
 	return idx.Search(ctx, vec, topK)
 }
 
@@ -156,6 +192,18 @@ func (r *Registry) VaultVectors(ws [8]byte) int {
 // Returns 0 if the vault has no indexed vectors yet (dimension not yet established).
 func (r *Registry) VaultEmbedDim(ws [8]byte) int {
 	return r.getOrCreate(ws).Dim()
+}
+
+// CachedVaultDim returns the vault's vector dimension when its index is
+// already in memory, and 0 otherwise — unlike VaultEmbedDim it never triggers
+// a graph load, so callers that only need a cheap dimension peek (e.g. the
+// write-side dimension guard) don't pull a whole vault into memory just to
+// refuse a vector.
+func (r *Registry) CachedVaultDim(ws [8]byte) int {
+	if idx := r.get(ws); idx != nil {
+		return idx.Dim()
+	}
+	return 0
 }
 
 // TotalVectorBytes returns the total in-memory vector size across all vaults.
@@ -256,6 +304,22 @@ func (r *Registry) maybeLogMemoryPressure(totalBytes int64) (skipInsert bool) {
 // FTS remains intact; only semantic (HNSW) search degrades gracefully.
 func (r *Registry) Insert(ctx context.Context, ws [8]byte, id [16]byte, vec []float32) error {
 	idx := r.getOrCreate(ws)
+
+	// A vault whose graph failed to load has an UNKNOWN dimension — refuse
+	// the write rather than fail open (Dim()==0 would accept anything and
+	// could recreate the #582 split). The load is retried on next access, so
+	// a transient read error only defers the insert.
+	if err := idx.LoadError(); err != nil {
+		return fmt.Errorf("hnsw: refusing insert, vault graph failed to load (retried on next access): %w", err)
+	}
+
+	// Refuse a vector whose dimension differs from the vault's established
+	// dimension (issue #582) — check and first-insert establishment are
+	// atomic, and both happen before StoreVector so a mismatched vector is
+	// never persisted.
+	if err := idx.establishDim(len(vec)); err != nil {
+		return err
+	}
 
 	// Store vector first so the graph can fetch it during traversal.
 	if err := idx.StoreVector(id, vec); err != nil {

--- a/internal/index/hnsw/registry_dim_test.go
+++ b/internal/index/hnsw/registry_dim_test.go
@@ -1,0 +1,170 @@
+package hnsw
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+)
+
+func newDimTestRegistry(t *testing.T) (*Registry, *pebble.DB) {
+	t.Helper()
+	db, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	if err != nil {
+		t.Fatalf("pebble.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return NewRegistry(db), db
+}
+
+// drainRegistry waits for async persistNode goroutines of the given vaults'
+// indexes so a subsequent db.Close() cannot race them (see hnsw_test.go).
+func drainRegistry(reg *Registry, wss ...[8]byte) {
+	for _, ws := range wss {
+		if idx := reg.get(ws); idx != nil {
+			idx.Close()
+		}
+	}
+}
+
+func dimTestVec(dim int) []float32 {
+	vec := make([]float32, dim)
+	for i := range vec {
+		vec[i] = float32(i%7) + 0.5
+	}
+	return vec
+}
+
+func TestRegistryInsertDimMismatch(t *testing.T) {
+	reg, db := newDimTestRegistry(t)
+	ctx := context.Background()
+	ws := [8]byte{1}
+
+	// An empty vault accepts any dimension; the first insert establishes it.
+	if err := reg.Insert(ctx, ws, [16]byte{1}, dimTestVec(384)); err != nil {
+		t.Fatalf("first insert into empty vault: %v", err)
+	}
+	if err := reg.Insert(ctx, ws, [16]byte{2}, dimTestVec(384)); err != nil {
+		t.Fatalf("matching-dimension insert: %v", err)
+	}
+
+	// A mismatched vector is refused with a typed error.
+	err := reg.Insert(ctx, ws, [16]byte{3}, dimTestVec(768))
+	var dimErr *DimMismatchError
+	if !errors.As(err, &dimErr) {
+		t.Fatalf("expected *DimMismatchError, got %v", err)
+	}
+	if dimErr.Got != 768 || dimErr.Want != 384 {
+		t.Fatalf("DimMismatchError = got %d want %d; expected got 768 want 384", dimErr.Got, dimErr.Want)
+	}
+
+	// The refused vector must not be persisted: both the live index and a
+	// fresh registry reloading from Pebble see only the two valid vectors.
+	if n := reg.VaultVectors(ws); n != 2 {
+		t.Errorf("live index holds %d vectors, want 2", n)
+	}
+	reg2 := NewRegistry(db)
+	if n := reg2.VaultVectors(ws); n != 2 {
+		t.Errorf("reloaded index holds %d vectors, want 2", n)
+	}
+
+	// Other vaults establish their own dimension independently.
+	if err := reg.Insert(ctx, [8]byte{2}, [16]byte{9}, dimTestVec(768)); err != nil {
+		t.Fatalf("768-dim insert into a different empty vault: %v", err)
+	}
+
+	drainRegistry(reg, ws, [8]byte{2})
+	drainRegistry(reg2, ws)
+}
+
+func TestRegistrySearchDimMismatch(t *testing.T) {
+	reg, _ := newDimTestRegistry(t)
+	ctx := context.Background()
+	ws := [8]byte{1}
+
+	// Searching an empty vault never dim-errors, regardless of query size.
+	if _, err := reg.Search(ctx, ws, dimTestVec(768), 5); err != nil {
+		t.Fatalf("search on empty vault: %v", err)
+	}
+
+	if err := reg.Insert(ctx, ws, [16]byte{1}, dimTestVec(384)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Matching query dimension searches normally.
+	if _, err := reg.Search(ctx, ws, dimTestVec(384), 5); err != nil {
+		t.Fatalf("matching-dimension search: %v", err)
+	}
+
+	// Mismatched query dimension returns the typed error instead of silently
+	// scoring 0 against every node.
+	_, err := reg.Search(ctx, ws, dimTestVec(768), 5)
+	var dimErr *DimMismatchError
+	if !errors.As(err, &dimErr) {
+		t.Fatalf("expected *DimMismatchError, got %v", err)
+	}
+	if dimErr.Got != 768 || dimErr.Want != 384 {
+		t.Fatalf("DimMismatchError = got %d want %d; expected got 768 want 384", dimErr.Got, dimErr.Want)
+	}
+
+	drainRegistry(reg, ws)
+}
+
+// TestRegistryInsertRefusesOnLoadFailure pins that a vault whose graph failed
+// to load refuses writes (its real dimension is unknown — failing open with
+// Dim()==0 could recreate the #582 split) while reads keep the pre-existing
+// degraded-empty behavior.
+func TestRegistryInsertRefusesOnLoadFailure(t *testing.T) {
+	reg, _ := newDimTestRegistry(t)
+	ctx := context.Background()
+	reg.loadErrHook = func() error { return errors.New("simulated pebble read error") }
+	ws := [8]byte{1}
+
+	if err := reg.Insert(ctx, ws, [16]byte{1}, dimTestVec(384)); err == nil {
+		t.Fatal("expected Insert to refuse a vault whose graph failed to load")
+	}
+	// Reads stay degraded-not-erroring (#499 contract).
+	if _, err := reg.Search(ctx, ws, dimTestVec(384), 5); err != nil {
+		t.Fatalf("Search on a load-failed vault should degrade, got error: %v", err)
+	}
+
+	// Once the load succeeds again, inserts proceed.
+	reg.loadErrHook = nil
+	if err := reg.Insert(ctx, ws, [16]byte{1}, dimTestVec(384)); err != nil {
+		t.Fatalf("Insert after load recovery: %v", err)
+	}
+	drainRegistry(reg, ws)
+}
+
+// TestRegistryConcurrentFirstInsertEstablishesOneDim pins that dimension
+// check and first-insert establishment are atomic: of two concurrent first
+// inserts with different dimensions, exactly one wins.
+func TestRegistryConcurrentFirstInsertEstablishesOneDim(t *testing.T) {
+	reg, _ := newDimTestRegistry(t)
+	ctx := context.Background()
+	ws := [8]byte{1}
+
+	errs := make(chan error, 2)
+	go func() { errs <- reg.Insert(ctx, ws, [16]byte{1}, dimTestVec(384)) }()
+	go func() { errs <- reg.Insert(ctx, ws, [16]byte{2}, dimTestVec(768)) }()
+
+	var refused, accepted int
+	var dimErr *DimMismatchError
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err == nil {
+			accepted++
+		} else if errors.As(err, &dimErr) {
+			refused++
+		} else {
+			t.Fatalf("unexpected error type: %v", err)
+		}
+	}
+	if accepted != 1 || refused != 1 {
+		t.Fatalf("expected exactly one accepted and one refused insert, got accepted=%d refused=%d", accepted, refused)
+	}
+	if n := reg.VaultVectors(ws); n != 1 {
+		t.Fatalf("vault holds %d vectors, want 1", n)
+	}
+	drainRegistry(reg, ws)
+}

--- a/internal/mcp/engine_adapter_test.go
+++ b/internal/mcp/engine_adapter_test.go
@@ -58,6 +58,9 @@ func (m *mockPluginStore) UpsertRelationship(_ context.Context, _ plugin.ULID, _
 func (m *mockPluginStore) HNSWInsert(_ context.Context, _ plugin.ULID, _ []float32) error {
 	return nil
 }
+func (m *mockPluginStore) CheckEmbedDim(_ context.Context, _ plugin.ULID, _ int) error {
+	return nil
+}
 func (m *mockPluginStore) AutoLinkByEmbedding(_ context.Context, _ plugin.ULID, _ []float32) error {
 	return nil
 }

--- a/internal/plugin/admin_test.go
+++ b/internal/plugin/admin_test.go
@@ -23,6 +23,7 @@ type mockPluginStore struct {
 	getFlagsErr     error
 	updateEmbedErr  error
 	updateDigestErr error
+	checkDimErr     error
 	upsertEntityErr error
 	linkErr         error
 	coOccurErr      error
@@ -32,6 +33,7 @@ type mockPluginStore struct {
 
 	setFlagCalls      int
 	setFlags          []uint8
+	checkDimCalls     int
 	updateEmbedCalls  int
 	hnswInsertCalls   int
 	autoLinkCalls     int
@@ -86,6 +88,11 @@ func (m *mockPluginStore) UpsertRelationship(_ context.Context, _ ULID, _ Extrac
 func (m *mockPluginStore) HNSWInsert(_ context.Context, _ ULID, _ []float32) error {
 	m.hnswInsertCalls++
 	return m.hnswInsertErr
+}
+
+func (m *mockPluginStore) CheckEmbedDim(_ context.Context, _ ULID, _ int) error {
+	m.checkDimCalls++
+	return m.checkDimErr
 }
 
 func (m *mockPluginStore) AutoLinkByEmbedding(_ context.Context, _ ULID, _ []float32) error {

--- a/internal/plugin/dim_guard_test.go
+++ b/internal/plugin/dim_guard_test.go
@@ -1,0 +1,166 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	hnswpkg "github.com/scrypster/muninndb/internal/index/hnsw"
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// openTestStoreWithHNSW returns a PebbleStore, an HNSW registry sharing the
+// same Pebble database (as wired in production by NewStoreAdapter), and that
+// database for building additional registries against the same storage.
+func openTestStoreWithHNSW(t *testing.T) (*storage.PebbleStore, *hnswpkg.Registry, *pebble.DB) {
+	t.Helper()
+	db, err := storage.OpenPebble(t.TempDir(), storage.DefaultOptions())
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 100})
+	t.Cleanup(func() { store.Close() })
+	return store, hnswpkg.NewRegistry(db), db
+}
+
+func guardTestVec(dim int) []float32 {
+	vec := make([]float32, dim)
+	for i := range vec {
+		vec[i] = float32(i%7) + 0.5
+	}
+	return vec
+}
+
+// TestStoreAdapter_UpdateEmbeddingDimGuard pins that a mismatched embedding is
+// refused BEFORE it is persisted (issue #582): no 0x18 key is written and the
+// HNSW backstop refuses it too.
+func TestStoreAdapter_UpdateEmbeddingDimGuard(t *testing.T) {
+	store, reg, storeDB := openTestStoreWithHNSW(t)
+	adapter := NewStoreAdapter(store, reg)
+	ctx := context.Background()
+	ws := store.VaultPrefix("dim-guard-vault")
+
+	id1, err := store.WriteEngram(ctx, ws, &storage.Engram{Concept: "a", Content: "a"})
+	if err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+	id2, err := store.WriteEngram(ctx, ws, &storage.Engram{Concept: "b", Content: "b"})
+	if err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+
+	// Establish the vault dimension at 384 through the normal embed sequence.
+	if err := adapter.UpdateEmbedding(ctx, ULID(id1), guardTestVec(384)); err != nil {
+		t.Fatalf("UpdateEmbedding (first, establishes dim): %v", err)
+	}
+	if err := adapter.HNSWInsert(ctx, ULID(id1), guardTestVec(384)); err != nil {
+		t.Fatalf("HNSWInsert: %v", err)
+	}
+
+	// A 768-dim embedding must now be refused with the typed error.
+	err = adapter.UpdateEmbedding(ctx, ULID(id2), guardTestVec(768))
+	var dimErr *hnswpkg.DimMismatchError
+	if !errors.As(err, &dimErr) {
+		t.Fatalf("expected *DimMismatchError from UpdateEmbedding, got %v", err)
+	}
+	if dimErr.Got != 768 || dimErr.Want != 384 {
+		t.Fatalf("DimMismatchError = got %d want %d; expected got 768 want 384", dimErr.Got, dimErr.Want)
+	}
+
+	// Nothing was persisted for id2.
+	if vec, err := store.GetEmbedding(ctx, ws, storage.ULID(id2)); err == nil && len(vec) > 0 {
+		t.Fatalf("refused embedding was persisted anyway (len %d)", len(vec))
+	}
+
+	// The HNSW backstop refuses the same vector as well.
+	err = adapter.HNSWInsert(ctx, ULID(id2), guardTestVec(768))
+	if !errors.As(err, &dimErr) {
+		t.Fatalf("expected *DimMismatchError from HNSWInsert, got %v", err)
+	}
+
+	// A matching embedding still goes through.
+	if err := adapter.UpdateEmbedding(ctx, ULID(id2), guardTestVec(384)); err != nil {
+		t.Fatalf("matching-dimension UpdateEmbedding: %v", err)
+	}
+
+	// The guard must also hold when the vault's HNSW index is NOT in memory:
+	// a fresh registry (cold cache) falls back to the on-disk dimension —
+	// one Pebble seek — without loading the graph.
+	coldAdapter := NewStoreAdapter(store, hnswpkg.NewRegistry(storeDB))
+	err = coldAdapter.UpdateEmbedding(ctx, ULID(id2), guardTestVec(768))
+	if !errors.As(err, &dimErr) {
+		t.Fatalf("expected *DimMismatchError from cold-cache UpdateEmbedding, got %v", err)
+	}
+}
+
+// TestRetroactiveProcessor_DimMismatchSkipsBeforeInference pins the #582
+// pre-scan contract: engrams of a vault whose dimension does not match the
+// active embedder are skipped BEFORE inference (Embed is never called), are
+// NOT failure-flagged (DigestEmbedFailed shares bit 0x80 with
+// DigestEnrichFailed and the condition is vault-level, resolved by `vault
+// reembed`), and remain pending for the next pass.
+func TestRetroactiveProcessor_DimMismatchSkipsBeforeInference(t *testing.T) {
+	eng := &Engram{Concept: "vec", Content: "data"}
+	iter := &mockIterator{engrams: []*Engram{eng}}
+
+	store := &mockPluginStore{
+		countResult: 1,
+		scanResult:  iter,
+		checkDimErr: &hnswpkg.DimMismatchError{Got: 384, Want: 1024},
+	}
+	embedPlugin := &mockEmbedPlugin{
+		mockPlugin: mockPlugin{name: "embed-dim", tier: TierEmbed},
+	}
+	rp := NewRetroactiveProcessor(store, embedPlugin, DigestEmbed)
+
+	if ok := rp.processBatch(context.Background()); !ok {
+		t.Error("processBatch should return true")
+	}
+
+	if store.checkDimCalls != 1 {
+		t.Errorf("expected 1 CheckEmbedDim call, got %d", store.checkDimCalls)
+	}
+	if embedPlugin.embedCalls != 0 {
+		t.Errorf("expected 0 Embed calls for a mismatched vault, got %d", embedPlugin.embedCalls)
+	}
+	if store.updateEmbedCalls != 0 || store.hnswInsertCalls != 0 {
+		t.Errorf("expected no embedding writes, got update=%d insert=%d", store.updateEmbedCalls, store.hnswInsertCalls)
+	}
+	if len(store.setFlags) != 0 {
+		t.Errorf("expected no digest flags on a dimension skip, flags set: %v", store.setFlags)
+	}
+}
+
+// TestRetroactiveProcessor_DimMismatchAtWriteLeftPending pins the backstop
+// behavior when the mismatch only surfaces at UpdateEmbedding (a race the
+// pre-scan cannot see): the engram is left pending — no DigestEmbedFailed,
+// no processed flag — and counted as an error.
+func TestRetroactiveProcessor_DimMismatchAtWriteLeftPending(t *testing.T) {
+	eng := &Engram{Concept: "vec", Content: "data"}
+	iter := &mockIterator{engrams: []*Engram{eng}}
+
+	store := &mockPluginStore{
+		countResult:    1,
+		scanResult:     iter,
+		updateEmbedErr: &hnswpkg.DimMismatchError{Got: 384, Want: 1024},
+	}
+	embedPlugin := &mockEmbedPlugin{
+		mockPlugin: mockPlugin{name: "embed-dim-race", tier: TierEmbed},
+	}
+	rp := NewRetroactiveProcessor(store, embedPlugin, DigestEmbed)
+
+	if ok := rp.processBatch(context.Background()); !ok {
+		t.Error("processBatch should return true")
+	}
+
+	if store.hnswInsertCalls != 0 {
+		t.Errorf("expected 0 HNSWInsert calls after refused embedding, got %d", store.hnswInsertCalls)
+	}
+	if len(store.setFlags) != 0 {
+		t.Errorf("expected no digest flags on a dimension refusal, flags set: %v", store.setFlags)
+	}
+	if stats := rp.Stats(); stats.Errors != 1 {
+		t.Errorf("expected Errors=1, got %d", stats.Errors)
+	}
+}

--- a/internal/plugin/embed/adapters.go
+++ b/internal/plugin/embed/adapters.go
@@ -25,3 +25,37 @@ func (a *embedServiceAdapter) Tokenize(text string) []string {
 func NewEmbedServiceAdapter(svc plugin.EmbedPlugin) activation.Embedder {
 	return &embedServiceAdapter{svc: svc}
 }
+
+// NewPrefixedEmbedPlugin wraps an EmbedPlugin so every embedded text carries
+// prefix — the passage side of instruction prefixes (e.g. "passage: " for the
+// e5 family, #583). An empty prefix returns the plugin unchanged.
+func NewPrefixedEmbedPlugin(svc plugin.EmbedPlugin, prefix string) plugin.EmbedPlugin {
+	if prefix == "" {
+		return svc
+	}
+	return &prefixedEmbedPlugin{EmbedPlugin: svc, prefix: prefix}
+}
+
+// prefixedEmbedPlugin forwards everything to the wrapped EmbedPlugin and
+// prepends a fixed prefix to every text passed to Embed.
+type prefixedEmbedPlugin struct {
+	plugin.EmbedPlugin
+	prefix string
+}
+
+func (p *prefixedEmbedPlugin) Embed(ctx context.Context, texts []string) ([]float32, error) {
+	prefixed := make([]string, len(texts))
+	for i, t := range texts {
+		prefixed[i] = p.prefix + t
+	}
+	return p.EmbedPlugin.Embed(ctx, prefixed)
+}
+
+// HardwareAccelerated forwards the wrapped plugin's hardware flag so the
+// wrapper does not hide plugin.HardwareAwarePlugin from type assertions.
+func (p *prefixedEmbedPlugin) HardwareAccelerated() bool {
+	if h, ok := p.EmbedPlugin.(plugin.HardwareAwarePlugin); ok {
+		return h.HardwareAccelerated()
+	}
+	return false
+}

--- a/internal/plugin/embed/adapters_test.go
+++ b/internal/plugin/embed/adapters_test.go
@@ -87,3 +87,56 @@ func TestEmbedServiceAdapter_Tokenize_Empty(t *testing.T) {
 		t.Errorf("expected 0 tokens for empty string, got %d", len(tokens))
 	}
 }
+
+// recordingEmbedPlugin captures the texts passed to Embed so prefix wrapping
+// can be asserted.
+type recordingEmbedPlugin struct {
+	stubEmbedPlugin
+	gotTexts []string
+	hardware bool
+}
+
+func (r *recordingEmbedPlugin) Embed(_ context.Context, texts []string) ([]float32, error) {
+	r.gotTexts = append([]string(nil), texts...)
+	return r.embedResult, r.embedErr
+}
+
+func (r *recordingEmbedPlugin) HardwareAccelerated() bool { return r.hardware }
+
+func TestNewPrefixedEmbedPlugin_EmptyPrefixReturnsUnwrapped(t *testing.T) {
+	stub := &recordingEmbedPlugin{}
+	if got := NewPrefixedEmbedPlugin(stub, ""); got != plugin.EmbedPlugin(stub) {
+		t.Fatal("empty prefix must return the plugin unchanged")
+	}
+}
+
+func TestNewPrefixedEmbedPlugin_PrependsPrefix(t *testing.T) {
+	stub := &recordingEmbedPlugin{}
+	wrapped := NewPrefixedEmbedPlugin(stub, "passage: ")
+
+	if _, err := wrapped.Embed(context.Background(), []string{"alpha", "beta"}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	want := []string{"passage: alpha", "passage: beta"}
+	if len(stub.gotTexts) != len(want) {
+		t.Fatalf("inner plugin saw %d texts, want %d", len(stub.gotTexts), len(want))
+	}
+	for i := range want {
+		if stub.gotTexts[i] != want[i] {
+			t.Errorf("text[%d] = %q, want %q", i, stub.gotTexts[i], want[i])
+		}
+	}
+}
+
+func TestPrefixedEmbedPlugin_ForwardsHardwareFlag(t *testing.T) {
+	stub := &recordingEmbedPlugin{hardware: true}
+	wrapped := NewPrefixedEmbedPlugin(stub, "query: ")
+
+	h, ok := wrapped.(plugin.HardwareAwarePlugin)
+	if !ok {
+		t.Fatal("prefixed plugin must still satisfy HardwareAwarePlugin")
+	}
+	if !h.HardwareAccelerated() {
+		t.Error("hardware flag not forwarded")
+	}
+}

--- a/internal/plugin/embed/embed.go
+++ b/internal/plugin/embed/embed.go
@@ -38,6 +38,12 @@ type ProviderHTTPConfig struct {
 	Model   string // "nomic-embed-text" or "text-embedding-3-small"
 	APIKey  string // empty for Ollama, required for cloud providers
 	DataDir string // local data directory for asset extraction (local provider only)
+
+	// User-supplied local ONNX model overrides (local provider only, #583).
+	LocalModelPath     string // path to a user-supplied .onnx model file
+	LocalTokenizerPath string // path to its HuggingFace tokenizer.json
+	LocalPooling       string // "cls" (default) or "mean"
+	LocalMaxTokens     int    // max sequence length; 0 = provider default
 }
 
 // EmbedService implements plugin.EmbedPlugin.
@@ -114,10 +120,14 @@ func (s *EmbedService) Init(ctx context.Context, cfg plugin.PluginConfig) error 
 	s.cfg = cfg
 
 	provHTTPCfg := ProviderHTTPConfig{
-		BaseURL: s.provCfg.BaseURL,
-		Model:   s.provCfg.Model,
-		APIKey:  cfg.APIKey,
-		DataDir: cfg.DataDir,
+		BaseURL:            s.provCfg.BaseURL,
+		Model:              s.provCfg.Model,
+		APIKey:             cfg.APIKey,
+		DataDir:            cfg.DataDir,
+		LocalModelPath:     cfg.LocalModelPath,
+		LocalTokenizerPath: cfg.LocalTokenizerPath,
+		LocalPooling:       cfg.LocalPooling,
+		LocalMaxTokens:     cfg.LocalMaxTokens,
 	}
 
 	slog.Info("initializing embed provider",

--- a/internal/plugin/embed/local.go
+++ b/internal/plugin/embed/local.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,9 +33,11 @@ var (
 	ortInitErr  error
 )
 
-// LocalProvider implements Provider using the bundled bge-small-en-v1.5 ONNX model.
-// No external process or network connection is required; all assets are embedded
-// in the binary and extracted to DataDir on first Init.
+// LocalProvider implements Provider using an in-process ONNX model: by default
+// the bundled bge-small-en-v1.5 (assets embedded in the binary, extracted to
+// DataDir on first Init), or a user-supplied model when
+// ProviderHTTPConfig.LocalModelPath/LocalTokenizerPath are set (issue #583).
+// No external process or network connection is required either way.
 //
 // Uses DynamicAdvancedSession so tensors are allocated per-call at the actual
 // batch size, supporting variable-sized batches up to localMaxBatch.
@@ -46,13 +49,24 @@ type LocalProvider struct {
 	session *ort.DynamicAdvancedSession
 	tok     *tokenizer.Tokenizer
 	dataDir string
+
+	// Model parameters, set at Init. The bundled model uses the package
+	// constants; a user-supplied model uses config values and a probed
+	// dimension.
+	dim        int
+	maxTokens  int
+	meanPool   bool
+	inputNames []string // the model's declared inputs, fed in this order
 }
 
 func (p *LocalProvider) Name() string { return "local" }
 
 func (p *LocalProvider) MaxBatchSize() int { return localMaxBatch }
 
-// Init extracts embedded assets to DataDir and initializes the ORT session.
+// Init initializes the ORT session — for the bundled model (assets extracted
+// to DataDir) or, when cfg.LocalModelPath/LocalTokenizerPath are set, for a
+// user-supplied model. The bundled ORT shared library serves both cases, so
+// embedded assets are extracted either way.
 func (p *LocalProvider) Init(ctx context.Context, cfg ProviderHTTPConfig) (int, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -61,6 +75,18 @@ func (p *LocalProvider) Init(ctx context.Context, cfg ProviderHTTPConfig) (int, 
 	if dataDir == "" {
 		// Fallback: use a directory next to the binary.
 		dataDir = "muninndb-data"
+	}
+
+	userModel := cfg.LocalModelPath != "" || cfg.LocalTokenizerPath != ""
+	if userModel {
+		// Validate the user configuration BEFORE any side effects (asset
+		// extraction, ORT library load): a broken configuration is a
+		// deterministic error and must not extract ~55 MB of assets or load
+		// the ORT shared library first — on Windows a loaded DLL cannot be
+		// deleted, which would also break temp-dir cleanup for any caller.
+		if _, _, err := validateUserModelConfig(cfg); err != nil {
+			return 0, err
+		}
 	}
 
 	modelDir := filepath.Join(dataDir, "models", "bge-small")
@@ -87,6 +113,53 @@ func (p *LocalProvider) Init(ctx context.Context, cfg ProviderHTTPConfig) (int, 
 		return 0, fmt.Errorf("local provider: ORT environment init: %w%s", ortInitErr, hint)
 	}
 
+	p.dataDir = dataDir
+
+	if userModel {
+		return p.initUserModelLocked(cfg)
+	}
+	return p.initBundledLocked(modelDir)
+}
+
+// validateUserModelConfig is the single owner of the user-model configuration
+// checks (issue #583): both paths present and readable, positive max tokens,
+// known pooling value. It is deliberately side-effect free so Init can run it
+// before extracting assets or loading the ORT library. Returns the resolved
+// max tokens and pooling mode.
+func validateUserModelConfig(cfg ProviderHTTPConfig) (maxTokens int, meanPool bool, err error) {
+	modelPath, tokPath := cfg.LocalModelPath, cfg.LocalTokenizerPath
+	if modelPath == "" || tokPath == "" {
+		return 0, false, fmt.Errorf("local provider: embed_model_path and embed_tokenizer_path must both be set (got model=%q tokenizer=%q)", modelPath, tokPath)
+	}
+	if _, statErr := os.Stat(modelPath); statErr != nil {
+		return 0, false, fmt.Errorf("local provider: user model: %w", statErr)
+	}
+	if _, statErr := os.Stat(tokPath); statErr != nil {
+		return 0, false, fmt.Errorf("local provider: user tokenizer: %w", statErr)
+	}
+
+	maxTokens = cfg.LocalMaxTokens
+	if maxTokens == 0 {
+		maxTokens = localMaxTokens
+	}
+	if maxTokens < 1 {
+		return 0, false, fmt.Errorf("local provider: embed_max_tokens must be positive, got %d", cfg.LocalMaxTokens)
+	}
+
+	switch cfg.LocalPooling {
+	case "", "cls":
+		meanPool = false
+	case "mean":
+		meanPool = true
+	default:
+		return 0, false, fmt.Errorf("local provider: unknown embed_pooling %q (want \"cls\" or \"mean\")", cfg.LocalPooling)
+	}
+	return maxTokens, meanPool, nil
+}
+
+// initBundledLocked sets up the bundled bge-small-en-v1.5 session.
+// Caller holds p.mu.
+func (p *LocalProvider) initBundledLocked(modelDir string) (int, error) {
 	// Load tokenizer.
 	tokPath := filepath.Join(modelDir, "tokenizer.json")
 	tok, err := pretrained.FromFile(tokPath)
@@ -94,14 +167,104 @@ func (p *LocalProvider) Init(ctx context.Context, cfg ProviderHTTPConfig) (int, 
 		return 0, fmt.Errorf("local provider: load tokenizer: %w", err)
 	}
 	p.tok = tok
-	p.dataDir = dataDir
 
-	// Create the ORT session. DynamicAdvancedSession does not bind tensors at
-	// init time — tensors are passed per Run() call at the actual batch size.
+	p.dim = localModelDim
+	p.maxTokens = localMaxTokens
+	p.meanPool = false // bge encodes sentence meaning into [CLS]
+	p.inputNames = []string{"input_ids", "attention_mask", "token_type_ids"}
+
 	modelPath := filepath.Join(modelDir, "model_int8.onnx")
+	session, err := p.newSession(modelPath, p.inputNames, "last_hidden_state")
+	if err != nil {
+		return 0, err
+	}
+	p.session = session
+
+	slog.Info("local embed provider initialized",
+		"model", "bge-small-en-v1.5",
+		"dimension", p.dim,
+		"model_dir", modelDir,
+	)
+
+	return p.dim, nil
+}
+
+// initUserModelLocked sets up a user-supplied ONNX model (issue #583).
+// Every failure is fatal to Init: an explicitly configured user model must
+// never fall back to the bundled one — the same principle #582 established
+// for explicitly configured network providers. Caller holds p.mu.
+func (p *LocalProvider) initUserModelLocked(cfg ProviderHTTPConfig) (int, error) {
+	modelPath, tokPath := cfg.LocalModelPath, cfg.LocalTokenizerPath
+	maxTokens, meanPool, err := validateUserModelConfig(cfg)
+	if err != nil {
+		return 0, err
+	}
+
+	tok, err := pretrained.FromFile(tokPath)
+	if err != nil {
+		return 0, fmt.Errorf("local provider: load user tokenizer %s: %w", tokPath, err)
+	}
+
+	// Read the model's declared inputs/outputs and feed exactly what it
+	// declares — XLM-R-family exports often omit token_type_ids.
+	inputs, outputs, err := ort.GetInputOutputInfo(modelPath)
+	if err != nil {
+		return 0, fmt.Errorf("local provider: read user model metadata %s: %w", modelPath, err)
+	}
+	inputNames, err := resolveModelInputs(inputs)
+	if err != nil {
+		return 0, fmt.Errorf("local provider: user model %s: %w", modelPath, err)
+	}
+	outputName, err := resolveModelOutput(outputs)
+	if err != nil {
+		return 0, fmt.Errorf("local provider: user model %s: %w", modelPath, err)
+	}
+
+	session, err := p.newSession(modelPath, inputNames, outputName)
+	if err != nil {
+		return 0, err
+	}
+
+	p.tok = tok
+	p.maxTokens = maxTokens
+	p.meanPool = meanPool
+	p.inputNames = inputNames
+	p.session = session
+
+	// Probe: the model's true output dimension comes from running one real
+	// inference — a user-declared number would be a second source of truth
+	// that can disagree with reality (#583).
+	dim, err := p.probeDimensionLocked()
+	if err != nil {
+		_ = session.Destroy()
+		p.session = nil
+		return 0, fmt.Errorf("local provider: user model probe failed for %s: %w", modelPath, err)
+	}
+	p.dim = dim
+
+	pooling := "cls"
+	if meanPool {
+		pooling = "mean"
+	}
+	slog.Info("local embed provider initialized",
+		"model", filepath.Base(modelPath),
+		"model_path", modelPath,
+		"dimension", p.dim,
+		"pooling", pooling,
+		"max_tokens", p.maxTokens,
+		"inputs", p.inputNames,
+	)
+
+	return p.dim, nil
+}
+
+// newSession creates the ORT session. DynamicAdvancedSession does not bind
+// tensors at init time — tensors are passed per Run() call at the actual
+// batch size.
+func (p *LocalProvider) newSession(modelPath string, inputNames []string, outputName string) (*ort.DynamicAdvancedSession, error) {
 	opts, err := ort.NewSessionOptions()
 	if err != nil {
-		return 0, fmt.Errorf("local provider: ORT session options: %w", err)
+		return nil, fmt.Errorf("local provider: ORT session options: %w", err)
 	}
 	defer opts.Destroy()
 
@@ -117,29 +280,191 @@ func (p *LocalProvider) Init(ctx context.Context, cfg ProviderHTTPConfig) (int, 
 	}
 	opts.SetIntraOpNumThreads(numThreads) //nolint:errcheck
 
-	session, err := ort.NewDynamicAdvancedSession(
-		modelPath,
-		[]string{"input_ids", "attention_mask", "token_type_ids"},
-		[]string{"last_hidden_state"},
-		opts,
-	)
+	session, err := ort.NewDynamicAdvancedSession(modelPath, inputNames, []string{outputName}, opts)
 	if err != nil {
-		return 0, fmt.Errorf("local provider: create ORT session: %w", err)
+		return nil, fmt.Errorf("local provider: create ORT session: %w", err)
 	}
-	p.session = session
+	return session, nil
+}
 
-	slog.Info("local embed provider initialized",
-		"model", "bge-small-en-v1.5",
-		"dimension", localModelDim,
-		"model_dir", modelDir,
-	)
+// resolveModelInputs returns the model's declared input names. A BERT-style
+// text encoder must declare input_ids and attention_mask; token_type_ids is
+// the only genuinely optional input (XLM-R-family exports omit it). Anything
+// else is refused.
+func resolveModelInputs(inputs []ort.InputOutputInfo) ([]string, error) {
+	known := map[string]bool{"input_ids": true, "attention_mask": true, "token_type_ids": true}
+	declared := make(map[string]bool, len(inputs))
+	names := make([]string, 0, len(inputs))
+	for _, in := range inputs {
+		if !known[in.Name] {
+			return nil, fmt.Errorf("model declares input %q, which this provider cannot produce (supported: input_ids, attention_mask, token_type_ids)", in.Name)
+		}
+		declared[in.Name] = true
+		names = append(names, in.Name)
+	}
+	if !declared["input_ids"] || !declared["attention_mask"] {
+		return nil, fmt.Errorf("model must declare input_ids and attention_mask inputs, got %v", names)
+	}
+	return names, nil
+}
 
-	return localModelDim, nil
+// resolveModelOutput picks the hidden-state output: "last_hidden_state" when
+// present, otherwise the model's single output. A configurable output tensor
+// name is deliberately deferred until a model actually needs it (#583).
+func resolveModelOutput(outputs []ort.InputOutputInfo) (string, error) {
+	for _, out := range outputs {
+		if out.Name == "last_hidden_state" {
+			return out.Name, nil
+		}
+	}
+	if len(outputs) == 1 {
+		return outputs[0].Name, nil
+	}
+	names := make([]string, len(outputs))
+	for i, out := range outputs {
+		names[i] = out.Name
+	}
+	return "", fmt.Errorf("cannot pick an output tensor: no \"last_hidden_state\" and %d outputs declared %v", len(outputs), names)
+}
+
+// probeDimensionLocked runs one real inference with an ORT-allocated output
+// tensor and derives the model's output dimension from the returned shape
+// [batch, sequence, dim]. It also validates that the probe vector is finite
+// and non-zero. Caller holds p.mu; p.session, p.tok, p.maxTokens and
+// p.inputNames must be set.
+func (p *LocalProvider) probeDimensionLocked() (int, error) {
+	inputs, _, cleanup, err := p.packBatchLocked([]string{"dimension probe"})
+	if err != nil {
+		return 0, err
+	}
+	defer cleanup()
+
+	// A nil output makes ORT allocate it, so the true output shape can be
+	// read back instead of being assumed.
+	outputs := []ort.Value{nil}
+	if err := p.session.Run(inputs, outputs); err != nil {
+		return 0, fmt.Errorf("probe inference: %w", err)
+	}
+	if outputs[0] == nil {
+		return 0, fmt.Errorf("probe inference returned no output")
+	}
+	defer outputs[0].Destroy()
+
+	tensor, ok := outputs[0].(*ort.Tensor[float32])
+	if !ok {
+		return 0, fmt.Errorf("probe output is not a float32 tensor")
+	}
+	shape := tensor.GetShape()
+	if len(shape) != 3 {
+		return 0, fmt.Errorf("probe output has rank %d, want 3 ([batch, sequence, dim])", len(shape))
+	}
+	// EmbedBatch pre-allocates its output as [batch, maxTokens, dim]; a model
+	// whose output sequence axis differs from the padded input length would
+	// pass a dim-only probe and then fail every real embedding call — reject
+	// it here, at init, instead (#583 fail-loud).
+	if int(shape[1]) != p.maxTokens {
+		return 0, fmt.Errorf("probe output sequence length %d does not match the padded input length %d — this model's output shape is unsupported", shape[1], p.maxTokens)
+	}
+	dim := int(shape[2])
+	if dim <= 0 {
+		return 0, fmt.Errorf("probe output reports non-positive dimension %d", dim)
+	}
+
+	// Validate the first token vector: all-zero or non-finite output means
+	// the model ran but produced garbage — fail now, not at recall time.
+	data := tensor.GetData()
+	if len(data) < dim {
+		return 0, fmt.Errorf("probe output holds %d floats, want at least %d", len(data), dim)
+	}
+	allZero := true
+	for _, v := range data[:dim] {
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			return 0, fmt.Errorf("probe output contains non-finite values")
+		}
+		if v != 0 {
+			allZero = false
+		}
+	}
+	if allZero {
+		return 0, fmt.Errorf("probe output is all zeros")
+	}
+
+	return dim, nil
+}
+
+// packBatchLocked tokenizes texts and packs them into one input tensor per
+// input the model declares, in p.inputNames order. It also returns the flat
+// attention-mask buffer ([len(texts) * p.maxTokens], shared with the
+// attention_mask tensor — valid until cleanup runs) for pooling, and a
+// cleanup that destroys the tensors. Caller holds p.mu.
+func (p *LocalProvider) packBatchLocked(texts []string) ([]ort.Value, []int64, func(), error) {
+	batchSize := len(texts)
+	inShape := ort.NewShape(int64(batchSize), int64(p.maxTokens))
+
+	values := make([]ort.Value, 0, len(p.inputNames))
+	cleanup := func() {
+		for _, v := range values {
+			_ = v.Destroy()
+		}
+	}
+
+	// resolveModelInputs guarantees input_ids and attention_mask are declared;
+	// only token_type_ids is optional (typeBuf stays nil when absent).
+	var idsBuf, maskBuf, typeBuf []int64
+	for _, name := range p.inputNames {
+		t, err := ort.NewEmptyTensor[int64](inShape)
+		if err != nil {
+			cleanup()
+			return nil, nil, nil, fmt.Errorf("local provider: alloc %s: %w", name, err)
+		}
+		values = append(values, t)
+		buf := t.GetData()
+		// Explicitly zero — the ORT allocator does not guarantee zeroed memory.
+		for i := range buf {
+			buf[i] = 0
+		}
+		switch name {
+		case "input_ids":
+			idsBuf = buf
+		case "attention_mask":
+			maskBuf = buf
+		case "token_type_ids":
+			typeBuf = buf
+		}
+	}
+
+	// Tokenize and pack each text into the batch tensors.
+	for i, text := range texts {
+		enc, encErr := p.tok.EncodeSingle(text, true)
+		if encErr != nil {
+			cleanup()
+			return nil, nil, nil, fmt.Errorf("local provider: tokenize text[%d]: %w", i, encErr)
+		}
+		ids := enc.GetIds()
+		mask := enc.GetAttentionMask()
+		typeIDs := enc.GetTypeIds()
+
+		seqLen := len(ids)
+		if seqLen > p.maxTokens {
+			seqLen = p.maxTokens
+		}
+		offset := i * p.maxTokens
+		for j := 0; j < seqLen; j++ {
+			idsBuf[offset+j] = int64(ids[j])
+			maskBuf[offset+j] = int64(mask[j])
+			if typeBuf != nil {
+				typeBuf[offset+j] = int64(typeIDs[j])
+			}
+		}
+	}
+
+	return values, maskBuf, cleanup, nil
 }
 
 // EmbedBatch tokenizes up to localMaxBatch texts, runs a single ORT inference
-// call for the whole batch, and returns the concatenated 384-dim embeddings.
-// The caller (BatchEmbedder) ensures len(texts) <= localMaxBatch.
+// call for the whole batch, and returns the concatenated embeddings
+// (len(texts) * dim floats). The caller (BatchEmbedder) ensures
+// len(texts) <= localMaxBatch.
 func (p *LocalProvider) EmbedBatch(ctx context.Context, texts []string) ([]float32, error) {
 	if len(texts) == 0 {
 		return nil, nil
@@ -156,84 +481,38 @@ func (p *LocalProvider) EmbedBatch(ctx context.Context, texts []string) ([]float
 	}
 
 	batchSize := len(texts)
-
-	// Allocate input tensors at actual batch size. Zeroed on allocation.
-	inShape := ort.NewShape(int64(batchSize), int64(localMaxTokens))
-	inputIDs, err := ort.NewEmptyTensor[int64](inShape)
+	inputs, poolMask, cleanup, err := p.packBatchLocked(texts)
 	if err != nil {
-		return nil, fmt.Errorf("local provider: alloc input_ids: %w", err)
+		return nil, err
 	}
-	defer inputIDs.Destroy()
+	defer cleanup()
 
-	attentionMask, err := ort.NewEmptyTensor[int64](inShape)
-	if err != nil {
-		return nil, fmt.Errorf("local provider: alloc attention_mask: %w", err)
-	}
-	defer attentionMask.Destroy()
-
-	tokenTypeIDs, err := ort.NewEmptyTensor[int64](inShape)
-	if err != nil {
-		return nil, fmt.Errorf("local provider: alloc token_type_ids: %w", err)
-	}
-	defer tokenTypeIDs.Destroy()
-
-	outShape := ort.NewShape(int64(batchSize), int64(localMaxTokens), int64(localModelDim))
+	outShape := ort.NewShape(int64(batchSize), int64(p.maxTokens), int64(p.dim))
 	outputTensor, err := ort.NewEmptyTensor[float32](outShape)
 	if err != nil {
 		return nil, fmt.Errorf("local provider: alloc output: %w", err)
 	}
 	defer outputTensor.Destroy()
 
-	inputBuf := inputIDs.GetData()
-	maskBuf := attentionMask.GetData()
-	typeBuf := tokenTypeIDs.GetData()
-
-	// Explicitly zero buffers — ORT allocator does not guarantee zeroed memory.
-	for i := range inputBuf {
-		inputBuf[i] = 0
-		maskBuf[i] = 0
-		typeBuf[i] = 0
-	}
-
-	// Tokenize and pack each text into the batch tensor.
-	for i, text := range texts {
-		enc, encErr := p.tok.EncodeSingle(text, true)
-		if encErr != nil {
-			return nil, fmt.Errorf("local provider: tokenize text[%d]: %w", i, encErr)
-		}
-		ids := enc.GetIds()
-		mask := enc.GetAttentionMask()
-		typeIDs := enc.GetTypeIds()
-
-		seqLen := len(ids)
-		if seqLen > localMaxTokens {
-			seqLen = localMaxTokens
-		}
-		offset := i * localMaxTokens
-		for j := 0; j < seqLen; j++ {
-			inputBuf[offset+j] = int64(ids[j])
-			maskBuf[offset+j] = int64(mask[j])
-			typeBuf[offset+j] = int64(typeIDs[j])
-		}
-	}
-
 	// Single ORT inference call for the entire batch.
-	if err := p.session.Run(
-		[]ort.Value{inputIDs, attentionMask, tokenTypeIDs},
-		[]ort.Value{outputTensor},
-	); err != nil {
+	if err := p.session.Run(inputs, []ort.Value{outputTensor}); err != nil {
 		return nil, fmt.Errorf("local provider: ORT run: %w", err)
 	}
 
-	// Unpack output shape [batchSize, localMaxTokens, localModelDim].
-	// For each sequence: extract the [CLS] token embedding (position 0), then L2-normalise.
-	// bge-small-en-v1.5 encodes sentence meaning into the [CLS] token, not mean-pooled tokens.
+	// Unpack output shape [batchSize, maxTokens, dim] and pool each sequence:
+	// the [CLS] token (position 0) for bge-family models, masked mean for
+	// mean-pooled families (e.g. e5); then L2-normalise.
 	hidden := outputTensor.GetData()
-	result := make([]float32, 0, batchSize*localModelDim)
-	seqStride := localMaxTokens * localModelDim
+	result := make([]float32, 0, batchSize*p.dim)
+	seqStride := p.maxTokens * p.dim
 	for i := 0; i < batchSize; i++ {
 		seqHidden := hidden[i*seqStride : (i+1)*seqStride]
-		vec := clsPool(seqHidden, localModelDim)
+		var vec []float32
+		if p.meanPool {
+			vec = meanPool(seqHidden, poolMask[i*p.maxTokens:(i+1)*p.maxTokens], p.maxTokens, p.dim)
+		} else {
+			vec = clsPool(seqHidden, p.dim)
+		}
 		l2Normalize(vec)
 		result = append(result, vec...)
 	}
@@ -241,7 +520,6 @@ func (p *LocalProvider) EmbedBatch(ctx context.Context, texts []string) ([]float
 	return result, nil
 }
 
-// clsPool extracts the [CLS] token embedding at position 0.
 // Close releases the ORT session.
 func (p *LocalProvider) Close() error {
 	p.mu.Lock()

--- a/internal/plugin/embed/local_assets_noembed.go
+++ b/internal/plugin/embed/local_assets_noembed.go
@@ -28,7 +28,12 @@ type LocalProvider struct{}
 
 func (p *LocalProvider) Name() string      { return "local" }
 func (p *LocalProvider) MaxBatchSize() int { return 0 }
-func (p *LocalProvider) Init(_ context.Context, _ ProviderHTTPConfig) (int, error) {
+func (p *LocalProvider) Init(_ context.Context, cfg ProviderHTTPConfig) (int, error) {
+	if cfg.LocalModelPath != "" || cfg.LocalTokenizerPath != "" {
+		// The ONNX runtime shared library ships with the embedded assets, so a
+		// user-supplied model (#583) needs a localassets build too.
+		return 0, fmt.Errorf("user-supplied local embed model requires a binary built with -tags localassets (this build has no ONNX runtime)")
+	}
 	return 0, errLocalUnavailable
 }
 func (p *LocalProvider) EmbedBatch(_ context.Context, _ []string) ([]float32, error) {

--- a/internal/plugin/embed/local_custom_test.go
+++ b/internal/plugin/embed/local_custom_test.go
@@ -1,0 +1,205 @@
+//go:build localassets
+
+package embed
+
+import (
+	"context"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	ort "github.com/yalue/onnxruntime_go"
+)
+
+// TestUserModel covers the user-supplied local model path (#583) with real
+// inference, using the bundled bge-small assets materialized as plain files —
+// a real model and tokenizer with no extra downloads. The main CI job runs
+// this (localassets tests execute with fetched assets); skipped under -short.
+func TestUserModel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real ORT inference")
+	}
+	if !LocalAvailable() {
+		t.Skip("assets not embedded — run `make fetch-assets` and rebuild with -tags localassets")
+	}
+
+	ctx := context.Background()
+
+	fixtureDir := t.TempDir()
+	modelPath := filepath.Join(fixtureDir, "user-model.onnx")
+	tokPath := filepath.Join(fixtureDir, "tokenizer.json")
+	if err := atomicWrite(modelPath, embeddedModel); err != nil {
+		t.Fatalf("write model fixture: %v", err)
+	}
+	if err := atomicWrite(tokPath, embeddedTokenizer); err != nil {
+		t.Fatalf("write tokenizer fixture: %v", err)
+	}
+
+	// Shared DataDir so the ORT shared library is extracted once.
+	dataDir := t.TempDir()
+
+	newUser := func(t *testing.T, pooling string, maxTokens int) *LocalProvider {
+		t.Helper()
+		p := &LocalProvider{}
+		dim, err := p.Init(ctx, ProviderHTTPConfig{
+			DataDir:            dataDir,
+			LocalModelPath:     modelPath,
+			LocalTokenizerPath: tokPath,
+			LocalPooling:       pooling,
+			LocalMaxTokens:     maxTokens,
+		})
+		if err != nil {
+			t.Fatalf("user model Init: %v", err)
+		}
+		t.Cleanup(func() { p.Close() })
+		if dim != localModelDim {
+			t.Fatalf("probed dimension = %d, want %d", dim, localModelDim)
+		}
+		return p
+	}
+
+	embedOne := func(t *testing.T, p *LocalProvider, text string) []float32 {
+		t.Helper()
+		vec, err := p.EmbedBatch(ctx, []string{text})
+		if err != nil {
+			t.Fatalf("EmbedBatch(%q): %v", text, err)
+		}
+		if len(vec) != localModelDim {
+			t.Fatalf("embedding has %d floats, want %d", len(vec), localModelDim)
+		}
+		var norm float64
+		for _, v := range vec {
+			norm += float64(v) * float64(v)
+		}
+		if diff := math.Abs(math.Sqrt(norm) - 1.0); diff > 1e-4 {
+			t.Fatalf("embedding norm = %f, want 1.0", math.Sqrt(norm))
+		}
+		return vec
+	}
+
+	const text = "The quick brown fox jumps over the lazy dog"
+
+	t.Run("ProbeDerivesDimensionAndClsMatchesBundled", func(t *testing.T) {
+		bundled := &LocalProvider{}
+		if _, err := bundled.Init(ctx, ProviderHTTPConfig{DataDir: dataDir}); err != nil {
+			t.Fatalf("bundled Init: %v", err)
+		}
+		t.Cleanup(func() { bundled.Close() })
+
+		user := newUser(t, "cls", 0)
+
+		vb := embedOne(t, bundled, text)
+		vu := embedOne(t, user, text)
+		for i := range vb {
+			if math.Abs(float64(vb[i]-vu[i])) > 1e-6 {
+				t.Fatalf("user[%d]=%f differs from bundled[%d]=%f — same model files must produce identical embeddings", i, vu[i], i, vb[i])
+			}
+		}
+	})
+
+	t.Run("MeanPoolingDiffersFromCls", func(t *testing.T) {
+		userCls := newUser(t, "cls", 0)
+		userMean := newUser(t, "mean", 0)
+
+		vc := embedOne(t, userCls, text)
+		vm := embedOne(t, userMean, text)
+		differs := false
+		for i := range vc {
+			if math.Abs(float64(vc[i]-vm[i])) > 1e-4 {
+				differs = true
+				break
+			}
+		}
+		if !differs {
+			t.Fatal("mean-pooled embedding equals CLS embedding — pooling config had no effect")
+		}
+	})
+
+	t.Run("FailLoud", func(t *testing.T) {
+		cases := []struct {
+			name string
+			cfg  ProviderHTTPConfig
+		}{
+			{"missing model file", ProviderHTTPConfig{DataDir: dataDir, LocalModelPath: filepath.Join(fixtureDir, "nope.onnx"), LocalTokenizerPath: tokPath}},
+			{"missing tokenizer file", ProviderHTTPConfig{DataDir: dataDir, LocalModelPath: modelPath, LocalTokenizerPath: filepath.Join(fixtureDir, "nope.json")}},
+			{"model path without tokenizer path", ProviderHTTPConfig{DataDir: dataDir, LocalModelPath: modelPath}},
+			{"unknown pooling", ProviderHTTPConfig{DataDir: dataDir, LocalModelPath: modelPath, LocalTokenizerPath: tokPath, LocalPooling: "max"}},
+			{"negative max tokens", ProviderHTTPConfig{DataDir: dataDir, LocalModelPath: modelPath, LocalTokenizerPath: tokPath, LocalMaxTokens: -1}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				p := &LocalProvider{}
+				if _, err := p.Init(ctx, tc.cfg); err == nil {
+					p.Close()
+					t.Fatal("Init succeeded, want a loud error")
+				}
+			})
+		}
+
+		t.Run("garbage model bytes", func(t *testing.T) {
+			garbagePath := filepath.Join(fixtureDir, "garbage.onnx")
+			if err := os.WriteFile(garbagePath, []byte("this is not an onnx model"), 0o600); err != nil {
+				t.Fatalf("write garbage: %v", err)
+			}
+			p := &LocalProvider{}
+			if _, err := p.Init(ctx, ProviderHTTPConfig{DataDir: dataDir, LocalModelPath: garbagePath, LocalTokenizerPath: tokPath}); err == nil {
+				p.Close()
+				t.Fatal("Init succeeded on a garbage model file, want a loud error")
+			}
+		})
+	})
+}
+
+func TestResolveModelInputs(t *testing.T) {
+	mk := func(names ...string) []ort.InputOutputInfo {
+		infos := make([]ort.InputOutputInfo, len(names))
+		for i, n := range names {
+			infos[i] = ort.InputOutputInfo{Name: n}
+		}
+		return infos
+	}
+
+	got, err := resolveModelInputs(mk("input_ids", "attention_mask", "token_type_ids"))
+	if err != nil || len(got) != 3 {
+		t.Fatalf("full BERT inputs: got %v, %v", got, err)
+	}
+
+	// XLM-R-style export without token_type_ids.
+	got, err = resolveModelInputs(mk("input_ids", "attention_mask"))
+	if err != nil || len(got) != 2 {
+		t.Fatalf("two-input model: got %v, %v", got, err)
+	}
+
+	if _, err = resolveModelInputs(mk("input_ids", "pixel_values")); err == nil {
+		t.Fatal("unknown input must be refused")
+	}
+	// input_ids and attention_mask are required — a model missing either is
+	// not a BERT-style text encoder this provider can serve.
+	if _, err = resolveModelInputs(mk("input_ids")); err == nil {
+		t.Fatal("model without attention_mask must be refused")
+	}
+	if _, err = resolveModelInputs(nil); err == nil {
+		t.Fatal("no inputs must be refused")
+	}
+}
+
+func TestResolveModelOutput(t *testing.T) {
+	mk := func(names ...string) []ort.InputOutputInfo {
+		infos := make([]ort.InputOutputInfo, len(names))
+		for i, n := range names {
+			infos[i] = ort.InputOutputInfo{Name: n}
+		}
+		return infos
+	}
+
+	if name, err := resolveModelOutput(mk("last_hidden_state", "pooler_output")); err != nil || name != "last_hidden_state" {
+		t.Fatalf("last_hidden_state preferred: got %q, %v", name, err)
+	}
+	if name, err := resolveModelOutput(mk("hidden")); err != nil || name != "hidden" {
+		t.Fatalf("single output used: got %q, %v", name, err)
+	}
+	if _, err := resolveModelOutput(mk("a", "b")); err == nil {
+		t.Fatal("ambiguous outputs must be refused")
+	}
+}

--- a/internal/plugin/enrich/entities_test.go
+++ b/internal/plugin/enrich/entities_test.go
@@ -68,6 +68,7 @@ func (m *mockPluginStore) UpdateDigest(context.Context, plugin.ULID, *plugin.Enr
 	return nil
 }
 func (m *mockPluginStore) HNSWInsert(context.Context, plugin.ULID, []float32) error { return nil }
+func (m *mockPluginStore) CheckEmbedDim(context.Context, plugin.ULID, int) error    { return nil }
 func (m *mockPluginStore) AutoLinkByEmbedding(context.Context, plugin.ULID, []float32) error {
 	return nil
 }

--- a/internal/plugin/registry_test.go
+++ b/internal/plugin/registry_test.go
@@ -21,9 +21,11 @@ func (m *mockPlugin) Close() error                                     { m.close
 // mockEmbedPlugin is a mock embed plugin
 type mockEmbedPlugin struct {
 	mockPlugin
+	embedCalls int
 }
 
 func (m *mockEmbedPlugin) Embed(ctx context.Context, texts []string) ([]float32, error) {
+	m.embedCalls++
 	return make([]float32, len(texts)*384), nil
 }
 func (m *mockEmbedPlugin) Dimension() int    { return 384 }

--- a/internal/plugin/retroactive.go
+++ b/internal/plugin/retroactive.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	"github.com/scrypster/muninndb/internal/engine/circuit"
+	hnswpkg "github.com/scrypster/muninndb/internal/index/hnsw"
 )
 
 // errLLMFailed is an unexported sentinel wrapping errors that originate from
@@ -285,6 +286,7 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 
 	startTime := time.Now()
 	batchCount := 0
+	dimSkipped := 0 // engrams skipped for a vault-dimension mismatch this pass (#582)
 
 	// For embed plugins, accumulate a micro-batch and embed in one ORT call.
 	// The batch size is determined by the plugin's MaxBatchSize() so the provider
@@ -332,14 +334,43 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 		for i, eng := range microEngrams {
 			vec := vecs[i*dim : (i+1)*dim]
 			if storeErr := rp.store.UpdateEmbedding(ctx, eng.ID, vec); storeErr != nil {
-				slog.Warn("retroactive processor: UpdateEmbedding failed",
-					"plugin", rp.plugin.Name(), "engram_id", eng.ID.String(), "error", storeErr)
+				var dimErr *hnswpkg.DimMismatchError
+				if errors.As(storeErr, &dimErr) {
+					// Vault-level condition (#582), not an engram failure: leave
+					// the engram pending — deliberately NO DigestEmbedFailed — so
+					// it embeds normally once the vault is re-embedded or the
+					// configuration is fixed. (DigestEmbedFailed shares bit 0x80
+					// with DigestEnrichFailed; stamping it here would also stop
+					// enrichment.) The pre-scan CheckEmbedDim makes this branch a
+					// rare race, not the steady state.
+					slog.Warn("retroactive processor: embedding dimension mismatch — engram left pending until the vault is re-embedded (`muninn vault reembed`)",
+						"plugin", rp.plugin.Name(), "engram_id", eng.ID.String(),
+						"embedder_dim", dimErr.Got, "vault_dim", dimErr.Want)
+				} else {
+					slog.Warn("retroactive processor: UpdateEmbedding failed",
+						"plugin", rp.plugin.Name(), "engram_id", eng.ID.String(), "error", storeErr)
+				}
 				rp.statsMu.Lock()
 				rp.stats.Errors++
 				rp.statsMu.Unlock()
 				continue
 			}
 			if storeErr := rp.store.HNSWInsert(ctx, eng.ID, vec); storeErr != nil {
+				var dimErr *hnswpkg.DimMismatchError
+				if errors.As(storeErr, &dimErr) {
+					// Refused by the registry's atomic guard (#582) — e.g. a
+					// concurrent first insert established a different dimension
+					// after the UpdateEmbedding pre-check passed. Leave the
+					// engram pending (no processed flag, no push notification):
+					// the next pass re-evaluates it against the settled vault.
+					slog.Warn("retroactive processor: HNSW refused embedding dimension — engram left pending",
+						"plugin", rp.plugin.Name(), "engram_id", eng.ID.String(),
+						"embedder_dim", dimErr.Got, "vault_dim", dimErr.Want)
+					rp.statsMu.Lock()
+					rp.stats.Errors++
+					rp.statsMu.Unlock()
+					continue
+				}
 				slog.Warn("retroactive processor: HNSWInsert failed",
 					"plugin", rp.plugin.Name(), "engram_id", eng.ID.String(), "error", storeErr)
 			} else if rp.onEmbed != nil {
@@ -419,6 +450,19 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 		}
 
 		if isEmbedPlugin {
+			// Skip engrams of a vault whose established dimension does not
+			// match the active embedder BEFORE paying for inference (#582).
+			// Deliberately no failure flag: the mismatch is a vault-level
+			// configuration condition (resolved by `muninn vault reembed` or
+			// a config fix), and skipped engrams embed normally afterwards.
+			// Skips do not count toward the per-pass cap — one cheap check
+			// per engram per pass, no inference, no hot re-notify loop.
+			if dim := embedPlugin.Dimension(); dim > 0 {
+				if dimErr := rp.store.CheckEmbedDim(ctx, eng.ID, dim); dimErr != nil {
+					dimSkipped++
+					continue
+				}
+			}
 			// Accumulate into micro-batch; flush when full.
 			microEngrams = append(microEngrams, eng)
 			microTexts = append(microTexts, eng.Concept+" "+eng.Content)
@@ -520,6 +564,13 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 
 	// Flush any remaining micro-batch at end of iterator.
 	flushMicroBatch()
+
+	// One summary line per pass instead of one per engram — a mismatched
+	// vault can hold thousands of pending engrams.
+	if dimSkipped > 0 {
+		slog.Warn("retroactive processor: engrams skipped — vault embedding dimension does not match the active embedder; run `muninn vault reembed` to re-embed them",
+			"plugin", rp.plugin.Name(), "skipped", dimSkipped)
+	}
 
 	rp.statsMu.Lock()
 	rp.stats.Status = "idle"

--- a/internal/plugin/store.go
+++ b/internal/plugin/store.go
@@ -52,6 +52,15 @@ type PluginStore interface {
 	// HNSWInsert inserts a vector into the HNSW index.
 	HNSWInsert(ctx context.Context, id ULID, vec []float32) error
 
+	// CheckEmbedDim reports whether an embedding of the given dimension would
+	// be accepted for the vault that contains the engram (issue #582). Returns
+	// nil when the vault has no established dimension yet. Used by the
+	// retroactive processor to skip engrams of a mismatched vault BEFORE
+	// paying for inference — the mismatch is a vault-level configuration
+	// condition, so the engrams stay pending (not failure-flagged) and embed
+	// normally once the configuration or the vault is fixed.
+	CheckEmbedDim(ctx context.Context, id ULID, dim int) error
+
 	// AutoLinkByEmbedding finds the top-K nearest neighbors by embedding and
 	// creates RELATES_TO associations with weight = similarity * 0.8.
 	// K = 5 (hardcoded, matching the design doc).

--- a/internal/plugin/store_adapter.go
+++ b/internal/plugin/store_adapter.go
@@ -47,7 +47,37 @@ func (a *pluginStoreAdapter) UpdateEmbedding(ctx context.Context, id ULID, vec [
 	if !ok {
 		return fmt.Errorf("UpdateEmbedding: engram %s not found", id.String())
 	}
+	// Refuse an embedding whose dimension differs from the vault's established
+	// dimension (issue #582) — checked before the embedding is persisted, so a
+	// mismatched vector is never stranded in storage. HNSWInsert has the same
+	// guard, but by then the 0x18 embedding key would already be written.
+	if err := a.checkVaultDim(ws, len(vec)); err != nil {
+		return err
+	}
 	return a.store.UpdateEmbedding(ctx, ws, storage.ULID(id), vec)
+}
+
+// CheckEmbedDim implements PluginStore (issue #582).
+func (a *pluginStoreAdapter) CheckEmbedDim(_ context.Context, id ULID, dim int) error {
+	ws, ok := a.store.FindVaultPrefix(storage.ULID(id))
+	if !ok {
+		return fmt.Errorf("CheckEmbedDim: engram %s not found", id.String())
+	}
+	return a.checkVaultDim(ws, dim)
+}
+
+// checkVaultDim compares dim against the vault's established dimension. The
+// peek deliberately avoids Registry.VaultEmbedDim: that would lazy-load and
+// pin the whole graph of a vault the caller may be about to refuse. Prefer
+// the cached index; fall back to one Pebble seek.
+func (a *pluginStoreAdapter) checkVaultDim(ws [8]byte, dim int) error {
+	want := a.hnsw.CachedVaultDim(ws)
+	if want == 0 {
+		// Best-effort: an error here just skips the pre-check; the
+		// Registry.Insert backstop still enforces the invariant.
+		want, _ = a.store.VaultEmbedDimOnDisk(ws)
+	}
+	return hnswpkg.CheckDim(want, dim)
 }
 
 func (a *pluginStoreAdapter) UpdateDigest(ctx context.Context, id ULID, result *EnrichmentResult) error {

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -19,6 +19,13 @@ type PluginConfig struct {
 	APIKey      string            // for cloud providers (OpenAI, Anthropic, Voyage)
 	Options     map[string]string // provider-specific options (e.g., "batch_size": "32")
 	DataDir     string            // plugin-specific data directory under the main data dir
+
+	// User-supplied local ONNX model overrides (local embed provider only,
+	// issue #583). Both paths set together; dimension is probed at init.
+	LocalModelPath     string // path to a user-supplied .onnx model file
+	LocalTokenizerPath string // path to its HuggingFace tokenizer.json
+	LocalPooling       string // "cls" (default) or "mean"
+	LocalMaxTokens     int    // max sequence length; 0 = provider default
 }
 
 // EnrichmentResult is what the enrich plugin returns for one engram.

--- a/internal/storage/embed_migration.go
+++ b/internal/storage/embed_migration.go
@@ -168,3 +168,44 @@ func (ps *PebbleStore) SetEmbedModel(ws [8]byte, model string) error {
 	}
 	return ps.db.Set(key, []byte(model), pebble.Sync)
 }
+
+// VaultEmbedDimOnDisk returns the embedding dimension established by a vault's
+// stored vectors, without loading its HNSW graph into memory: it reads the
+// first persisted embedding (0x18) key for the vault. The stored value is
+// 8 bytes of quantization parameters followed by one byte per vector component
+// (the same layout migration v1 derives dimensions from). Returns 0 when the
+// vault has no stored embeddings.
+func (ps *PebbleStore) VaultEmbedDimOnDisk(ws [8]byte) (int, error) {
+	wsPlus, err := keys.IncrementWSPrefix(ws)
+	if err != nil {
+		return 0, fmt.Errorf("vault embed dim: increment ws: %w", err)
+	}
+
+	lo := make([]byte, 9)
+	lo[0] = 0x18
+	copy(lo[1:], ws[:])
+	hi := make([]byte, 9)
+	hi[0] = 0x18
+	copy(hi[1:], wsPlus[:])
+
+	iter, err := ps.db.NewIter(&pebble.IterOptions{
+		LowerBound: lo,
+		UpperBound: hi,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("vault embed dim: create iter: %w", err)
+	}
+	defer iter.Close()
+
+	if !iter.First() {
+		return 0, nil
+	}
+	val, err := iter.ValueAndErr()
+	if err != nil {
+		return 0, fmt.Errorf("vault embed dim: read value: %w", err)
+	}
+	if len(val) <= 8 {
+		return 0, nil
+	}
+	return len(val) - 8, nil
+}

--- a/internal/storage/vault_embed_dim_test.go
+++ b/internal/storage/vault_embed_dim_test.go
@@ -1,0 +1,52 @@
+package storage
+
+import (
+	"context"
+	"testing"
+)
+
+func TestVaultEmbedDimOnDisk(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("embed-dim-on-disk")
+
+	// No stored embeddings → 0.
+	dim, err := store.VaultEmbedDimOnDisk(ws)
+	if err != nil {
+		t.Fatalf("VaultEmbedDimOnDisk (empty): %v", err)
+	}
+	if dim != 0 {
+		t.Fatalf("empty vault dim = %d, want 0", dim)
+	}
+
+	id, err := store.WriteEngram(ctx, ws, &Engram{Concept: "c", Content: "c"})
+	if err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+	vec := make([]float32, 384)
+	for i := range vec {
+		vec[i] = float32(i%7) + 0.5
+	}
+	if err := store.UpdateEmbedding(ctx, ws, id, vec); err != nil {
+		t.Fatalf("UpdateEmbedding: %v", err)
+	}
+
+	// The quantized on-disk layout (8 param bytes + 1 byte/component) must
+	// yield the original dimension.
+	dim, err = store.VaultEmbedDimOnDisk(ws)
+	if err != nil {
+		t.Fatalf("VaultEmbedDimOnDisk: %v", err)
+	}
+	if dim != 384 {
+		t.Fatalf("vault dim = %d, want 384", dim)
+	}
+
+	// Other vaults are unaffected.
+	other, err := store.VaultEmbedDimOnDisk(store.VaultPrefix("some-other-vault"))
+	if err != nil {
+		t.Fatalf("VaultEmbedDimOnDisk (other): %v", err)
+	}
+	if other != 0 {
+		t.Fatalf("other vault dim = %d, want 0", other)
+	}
+}


### PR DESCRIPTION
Implements the two halves agreed in #583's discussion: the dimension guard from
#582 direction (b) first, then the user-supplied local ONNX model built on top
of it. Two commits: the guard first, then the feature built on it — the
sequencing from the issue discussion.

## Part 1 — dimension guard (Refs #582)

The server-side embedder could still point a differently-dimensioned vector at
a populated vault (client-supplied embeddings were already checked at the MCP
layer with -32602, but no other path was). A mismatched vector inserts into
HNSW without error today, and CosineSimilarity's length check scores it 0
against everything — the silent split from #582. This PR makes the vault
dimension an explicit, enforced invariant:

- **One definition.** `hnsw.CheckDim` + an explicit per-index dimension,
  established atomically on first insert (two concurrent first inserts with
  different dimensions cannot both win) and derived deterministically from the
  smallest-ID vector on load — consistent with the storage layer's
  first-embedding-key derivation, instead of random map iteration on legacy
  mixed-dimension vaults.
- **Every write path refuses before persisting.** The engine validates
  client-supplied embeddings in Write/WriteBatch/Evolve/AddChild before
  anything is written (extending the MCP layer's -32602 contract to MBP,
  gRPC, SDKs, and the embedded library); the plugin store adapter refuses
  before the embedding key is written; `Registry.Insert` is the atomic
  backstop. The dimension peek never loads a graph (cached index or one
  Pebble seek).
- **Mismatch is a vault condition, not an engram failure.** The retroactive
  processor checks the vault's dimension against the embedder BEFORE paying
  for inference and skips mismatched engrams — no wasted ONNX/API spend, one
  summary log line per pass, and deliberately NO `DigestEmbedFailed`: that
  flag shares bit 0x80 with `DigestEnrichFailed` (stamping it would silently
  stop enrichment too), and the condition heals via `vault reembed` or a
  config fix, after which the still-pending engrams embed normally.
- **Fail closed on unknown state.** A vault whose graph failed to load
  refuses inserts (its real dimension is unknown; `Dim()==0` would accept
  anything and could recreate the split) — reads keep the degraded-empty
  contract from #499, and the insert retries next cycle.
- **Recall degrades, never breaks.** A mismatched query embedding returns a
  typed error from `Registry.Search`; activation's existing search-error path
  degrades to BM25-only (the #578 contract), logging both dimensions and the
  remedy.
- **Operators see it at boot.** Startup prints a per-vault advisory (one
  Pebble seek per vault, no graph loads). Deliberately not fatal: one legacy
  vault must not take down FTS recall for every other vault.
- The noop embedder now returns no embedding instead of a 384-dim zero
  vector: recalls take the existing FTS-only fast path, and the stub cannot
  trip the guard on non-384 vaults.

`vault reembed` composes unchanged (it clears vectors first ⇒ dimension
resets ⇒ the new model's dimension is accepted).

Stated limits (deliberate): a same-dimension model swap is invisible to any
dimension guard — that needs the vault-level model marker (0x1D, currently
write-only) as a follow-up. Cluster replication applies embeddings as raw KV
and bypasses engine-level guards — out of scope here.

Considered and rejected: merging UpdateEmbedding+HNSWInsert into one store
operation would remove the stranding hazard structurally, but changes the
PluginStore interface, the processor's flag handling, and every mock — wrong
size for this PR.

## Part 2 — user-supplied local ONNX model (Fixes #583)

Exactly the v1 scope from the issue discussion:

| Constraint (maintainer comment)            | Implementation |
|---|---|
| plugin_config.json keys, not embed_url/env | `embed_model_path` + `embed_tokenizer_path`, active when `embed_provider` is `"local"` |
| Probe-derived dimension, never declared    | init runs one real inference with an ORT-allocated output tensor and reads the true shape (incl. the sequence axis); validates finite, non-zero |
| Pooling enum                               | `embed_pooling`: `cls` (default) \| `mean` — reuses the existing pooling helpers |
| Fail-loud at init, never fall back to bge  | any failure (missing file, tokenizer, unknown pooling, probe, unsupported output shape) aborts startup with a clear error |
| Decide explicitly on instruction prefixes  | first-class config: `embed_query_prefix` / `embed_passage_prefix`, plus a warn when the filename looks like the e5 family and prefixes are unset or pooling ≠ mean |
| Max sequence length included               | `embed_max_tokens` (default 256) |
| Output tensor name deferred                | uses `last_hidden_state` or the single declared output; knob deferred until a model needs it |
| Dimension guard first or alongside         | Part 1 |

Mechanics: the provider reads the model's declared inputs and feeds exactly
those (`input_ids` + `attention_mask` required, `token_type_ids` optional —
XLM-R-family exports omit it). Prefixes wrap at the construction point in
buildEmbedder, where the query handle (activation embedder) and passage handle
(retroactive processor plugin) diverge — the provider stays role-agnostic, and
e5's asymmetric prefixes come for free. Requires a localassets build (all
release binaries): the bundled ORT shared library serves the user model too.

Config strictness, per the fail-loud principle: default behavior is
byte-identical when nothing is configured; user-model keys set while another
provider is selected warn as inactive; `MUNINN_LOCAL_EMBED=0` **or a leftover
provider env var** alongside a configured user model is a hard startup error —
env precedence would silently embed with a different model, the exact
substitution class of #582.

Decisions worth stating: typed fields through PluginConfig/ProviderHTTPConfig
rather than the `Options` map — compile-time safety and discoverability for a
four-field set, following the existing APIKey/DataDir plumbing. The prefix
decorator forwards `HardwareAccelerated`; any future optional interface on
EmbedPlugin needs the same forwarding (noted on the wrapper).

## Tests

- Full `-tags localassets ./... -race` suite green (the main CI
  configuration), plus the untagged suite for noembed builds.
- Real-inference user-model tests using the bundled assets materialized as
  plain files: probe-derived dimension; embeddings byte-identical to the
  bundled provider for the same model files; mean pooling verifiably differs;
  six fail-loud cases.
- Guard tests: atomic first-insert establishment under concurrency;
  fail-closed insert on load failure with recovery; registry insert/search
  refusal incl. persistence rollback and per-vault independence; engine-level
  client-embedding refusal; adapter refusal before the embedding write (warm
  and cold cache); processor skips before inference without flagging and
  leaves race-refused engrams pending; on-disk dimension derivation; noop
  contract.
- buildEmbedder branch/diagnostic tests in the #585 style (half-configured
  paths, env conflicts, broken paths never fall back, inactive keys), passing
  in both asset build variants.

## End-to-end validation (local test instance, real models)

Phase A: fresh vault embedded at 1024 dims via an external provider (bge-m3).
Phase B: switched the same vault to `Xenova/multilingual-e5-small` (quantized
ONNX, 384-dim, mean pooling, `query: `/`passage: ` prefixes):
- init probed 384 and logged pooling/inputs;
- the boot advisory named the vault and both dimensions;
- new memories were refused semantic indexing (left pending, exactly one log
  event — no retry loop) while FTS recall kept serving them;
- semantic recall degraded to BM25-only with both dims logged;
- `vault reembed` healed everything: all engrams re-embedded at 384, and a
  German-language paraphrase query sharing no keywords with the stored text
  returned the correct memory first (0.87) — the multilingual case the
  bundled English-only model cannot serve, per the docs self-test.

Phase C (pending-not-failed semantics): with a deliberately mismatched
provider (1024-dim) against the 384-dim vault, a new memory was skipped
before inference (one summary log line per pass, no failure flags, FTS
recall unaffected); after switching back to the matching model — no reembed,
no flag clearing — the pending memory embedded automatically on the next
scan and became the top semantic hit for a paraphrase query (0.86).

Refs #582
Fixes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)
