### PR TITLE
fix(activation): preserve explicit search threshold under RRF + expose Search Scoring setting

### DIFF
--- a/internal/engine/activation/activation_test.go
+++ b/internal/engine/activation/activation_test.go
@@ -1378,6 +1378,65 @@ func TestRRF_ReturnsResultsWithDefaultThreshold(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Test: Run() applies a mode-appropriate DEFAULT threshold only when the caller
+// leaves Threshold <= 0, and never overrides an explicit user-set value.
+//
+// Regression for the threshold-preservation bug: previously any explicit
+// threshold >= 0.01 was silently trampled down to 0.001 whenever RRF was on,
+// which made the API's threshold parameter meaningless under RRF.
+//
+// Run() mutates req.Threshold in place, so we assert on it after the call.
+// ---------------------------------------------------------------------------
+
+func TestRun_ThresholdDefaulting(t *testing.T) {
+	store := newStubStore()
+	eng1 := &storage.Engram{
+		Concept:    "threshold defaulting",
+		Content:    "engram for threshold defaulting behavior",
+		Confidence: 1.0,
+		Stability:  30.0,
+		Relevance:  0.8,
+	}
+	store.writeEngram(eng1)
+	ftsResults := []activation.ScoredID{{ID: eng1.ID, Score: 0.8}}
+
+	cases := []struct {
+		name      string
+		threshold float64
+		rrf       bool
+		want      float64
+	}{
+		{"explicit value preserved under RRF", 0.02, true, 0.02},
+		{"explicit value preserved without RRF", 0.02, false, 0.02},
+		{"no threshold defaults to 0.001 under RRF", 0, true, 0.001},
+		{"no threshold defaults to 0.05 without RRF", 0, false, 0.05},
+		{"negative threshold defaults to 0.001 under RRF", -1, true, 0.001},
+		{"negative threshold defaults to 0.05 without RRF", -1, false, 0.05},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			eng := newTestEngine(store, &stubFTS{results: ftsResults}, nil)
+			req := &activation.ActivateRequest{
+				Context:    []string{"threshold"},
+				Threshold:  tc.threshold,
+				MaxResults: 10,
+				Weights: &activation.Weights{
+					UseRRFFusion: tc.rrf,
+					DisableACTR:  tc.rrf,
+				},
+			}
+			if _, err := eng.Run(context.Background(), req); err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if req.Threshold != tc.want {
+				t.Errorf("Threshold = %v, want %v", req.Threshold, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Test: When both UseRRFFusion and UseCGDN are enabled, RRF takes precedence
 // and CGDN is silently disabled. The guard in phase6Score logs a warning and
 // clears UseCGDN so the RRF path executes.

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -372,16 +372,15 @@ func (e *ActivationEngine) Run(ctx context.Context, req *ActivateRequest) (*Acti
 	if req.MaxResults <= 0 {
 		req.MaxResults = 10
 	}
-	if req.Threshold <= 0 {
-		req.Threshold = 0.05
-	}
-
-	// After threshold default is set, adjust for RRF mode.
-	// RRF scores are typically in [0, 0.05] range -- much lower than ACT-R.
-	// Apply an RRF-appropriate threshold to avoid filtering all results.
 	w := resolveWeights(req.Weights, e.weights)
-	if w.UseRRFFusion && req.Threshold >= 0.01 {
-		req.Threshold = 0.001
+	if req.Threshold <= 0 {
+		// No explicit threshold: pick a mode-appropriate default.
+		// RRF scores are rank-based, typically in [0, 0.05] -- far lower than ACT-R.
+		if w.UseRRFFusion {
+			req.Threshold = 0.001
+		} else {
+			req.Threshold = 0.05
+		}
 	}
 
 	// Phase 1: embed + tokenize

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -204,6 +204,7 @@ document.addEventListener('alpine:init', () => {
       relevanceFloor: null,
       temporalHalflife: null,
       recallMode: 'balanced',
+      scoringFusion: '',
     },
     plasticitySaving: false,
     plasticitySaveOk: false,
@@ -1986,6 +1987,7 @@ document.addEventListener('alpine:init', () => {
             this.plasticityForm.relevanceFloor     = cfg.relevance_floor     ?? null;
             this.plasticityForm.temporalHalflife = cfg.temporal_halflife ?? null;
             this.plasticityForm.recallMode = cfg.recall_mode || data.resolved?.recall_mode || 'balanced';
+            this.plasticityForm.scoringFusion = cfg.scoring_fusion ?? data.resolved?.scoring_fusion ?? '';
         } catch (err) {
             console.error('loadPlasticity error:', err);
             this.plasticitySaveErr = 'Failed to load Plasticity settings';
@@ -1999,6 +2001,7 @@ document.addEventListener('alpine:init', () => {
         this.plasticityForm.temporalHalflife = null;
         this.plasticityForm.hebbianEnabled = true;
         this.plasticityForm.temporalEnabled   = true;
+        this.plasticityForm.scoringFusion = '';
         this._updatePlasticityChart();
     },
     _plasticityData: {
@@ -2098,6 +2101,7 @@ document.addEventListener('alpine:init', () => {
         try {
             const payload = { ...(this.plasticityRawConfig || {}), version: 1, preset: this.plasticityForm.preset };
             payload.recall_mode = this.plasticityForm.recallMode;
+            payload.scoring_fusion = this.plasticityForm.scoringFusion;
             if (this.plasticityForm.showAdvanced) {
                 if (this.plasticityForm.hopDepth       !== null) payload.hop_depth       = this.plasticityForm.hopDepth;
                 if (this.plasticityForm.semanticWeight !== null) payload.semantic_weight = this.plasticityForm.semanticWeight;

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1372,6 +1372,22 @@
                 </template>
               </div>
 
+              <!-- Search Scoring -->
+              <p style="font-size:0.8125rem;font-weight:600;color:var(--text-secondary);margin:0 0 0.75rem;text-transform:uppercase;letter-spacing:0.05em;">Search Scoring</p>
+              <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.625rem;margin-bottom:1.25rem;">
+                <template x-for="sf in [
+                  {id:'',             label:'ACT-R (default)', desc:'Cognitive decay + Hebbian'},
+                  {id:'rrf',          label:'RRF',             desc:'Reciprocal rank fusion'},
+                  {id:'weighted_sum', label:'Weighted Sum',    desc:'Linear blend of signals'}
+                ]" :key="sf.id">
+                  <div @click="plasticityForm.scoringFusion = sf.id"
+                       :style="'border-radius:0.625rem;cursor:pointer;transition:all 0.15s;' + (plasticityForm.scoringFusion === sf.id ? 'border:2px solid var(--accent);background:rgba(99,102,241,0.12);padding:calc(1.25rem - 1px);' : 'border:1px solid var(--border);background:var(--bg-elevated);padding:1.25rem;')">
+                    <div style="font-weight:600;font-size:0.875rem;margin-bottom:0.25rem;" x-text="sf.label"></div>
+                    <div style="font-size:0.75rem;color:var(--text-muted);" x-text="sf.desc"></div>
+                  </div>
+                </template>
+              </div>
+
               <!-- Advanced overrides -->
               <div style="margin-bottom:1.25rem;">
                 <label style="font-size:0.8125rem;font-weight:500;cursor:pointer;display:flex;align-items:center;gap:0.5rem;">


### PR DESCRIPTION
Split out of #431 per maintainer request — this is the focused RRF/threshold change, with no bleve/FAISS backend and zero new dependencies. Based on current `develop`.

## 1. Threshold preservation fix

`ActivationEngine.Run` silently overrode any user-set threshold ≥ 0.01 down to 0.001 whenever RRF was active, trampling explicit user config. Now the RRF-appropriate default (0.001) is applied **only** on the no-threshold path (`req.Threshold <= 0`); explicit user values are respected under both ACT-R and RRF.

Covered by a new table test `TestRun_ThresholdDefaulting` (RED confirmed before the fix, GREEN after).

## 2. Search Scoring UI

Surfaces the existing `scoring_fusion` plasticity config as a first-class "Search Scoring" card selector in vault settings, mirroring the existing "Default Recall Mode" pattern, with plain-English labels:
- **ACT-R (default)** — cognitive decay + Hebbian scoring (unchanged default)
- **RRF** — reciprocal rank fusion; better recall on small corpora
- **Weighted Sum** — linear blend of signals

ACT-R remains the default; RRF stays an explicit opt-in.

## Notes
- Zero new go.mod / JS dependencies; no `internal/search/**` or Dockerfile changes.
- `go build ./...` clean, `go test ./internal/engine/... ./internal/auth/...` pass.
- The bleve/FAISS backend from #431 will be discussed separately in an architecture issue before any further code.
