### PR TITLE
chore(deps): bump Go toolchain to 1.26.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Bump Go toolchain to 1.26.5, fixing [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856)
+  (Encrypted Client Hello privacy leak in `crypto/tls`), reachable via the gRPC server,
+  MCP server, WAL recovery, `doctor` cert dial, and plugin transport.
+
 ---
 
 ## [0.7.0] - 2026-06-12

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scrypster/muninndb
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/bits-and-blooms/bloom/v3 v3.7.1


### PR DESCRIPTION
## What

Bumps `go.mod`'s `go` directive from 1.26.4 to 1.26.5.

## Why

The Vulnerability scan CI check started failing on `develop` after #576 merged, flagging **GO-2026-5856** (Encrypted Client Hello privacy leak in `crypto/tls`), a newly-disclosed stdlib CVE — not something introduced by any recent PR. `govulncheck` traced real reachable call paths: gRPC server (`internal/transport/grpc/server.go`), MCP server (`internal/mcp/server.go`), WAL recovery (`internal/wal/mol.go`), `doctor` cert dial (`cmd/muninn/doctor.go`), and the plugin transport (`internal/plugin/transport.go`). Fixed upstream in go1.26.5.

This is blocking release readiness — the release workflow builds with `go-version-file: go.mod`, so cutting a release right now would ship binaries carrying the vulnerability.

## Verification

- `go build ./...` — clean (toolchain auto-upgrades to 1.26.5 per `GOTOOLCHAIN=auto`)
- `govulncheck ./...` — 0 vulnerabilities (previously 1, GO-2026-5856)
- Full suite: `go test ./...` — 49/49 packages pass, no failures
- No other hardcoded Go version pins found in CI workflows/Dockerfiles — all reference `go-version-file: go.mod`, so this is the only change needed