### PR TITLE
feat(auth): add working plasticity preset (RFC #597)

### DIFF
--- a/cmd/muninn/vault.go
+++ b/cmd/muninn/vault.go
@@ -1432,7 +1432,7 @@ func applyPlasticitySet(kv string, kinds map[string]reflect.Kind, changes map[st
 		return fmt.Errorf("unknown plasticity field %q", key)
 	}
 	if key == "preset" && !auth.ValidPlasticityPreset(val) {
-		return fmt.Errorf("unknown preset %q (valid: default, reference, scratchpad, knowledge-graph)", val)
+		return fmt.Errorf("unknown preset %q (valid: default, reference, scratchpad, knowledge-graph, working)", val)
 	}
 	coerced, err := coercePlasticityValue(kind, val)
 	if err != nil {
@@ -1454,7 +1454,7 @@ func runVaultPlasticity(args []string) {
 		fmt.Println("Usage: muninn vault plasticity <vault> [--preset <name>] [--set <key>=<value>]...")
 		fmt.Println()
 		fmt.Println("  With no flags, prints the vault's resolved plasticity config.")
-		fmt.Println("  --preset <name>     Set the preset: default, reference, scratchpad, knowledge-graph")
+		fmt.Println("  --preset <name>     Set the preset: default, reference, scratchpad, knowledge-graph, working")
 		fmt.Println("  --set <key>=<value> Set an individual override field (repeatable).")
 		fmt.Println()
 		fmt.Println("  Example: muninn vault plasticity research --preset knowledge-graph")

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -168,7 +168,7 @@ curl -X PUT http://127.0.0.1:8475/api/admin/vaults/config \
 
 Plasticity controls the cognitive pipeline for a vault — how it learns, forgets, and traverses connections between engrams. Each vault can have its own plasticity settings independent of others.
 
-**Four preset profiles** are available: `default` (balanced Hebbian + temporal), `reference` (preserves with strong Hebbian bonds), `scratchpad` (rapid fading, minimal history), and `knowledge-graph` (rich traversal, strong associative learning).
+**Five preset profiles** are available: `default` (balanced Hebbian + temporal), `reference` (preserves with strong Hebbian bonds), `scratchpad` (rapid fading, minimal history), `knowledge-graph` (rich traversal, strong associative learning), and `working` (default cognition with 7-day auto-eviction for shared workflow scratch vaults; pair with `multi_user` per RFC #597).
 
 Get the current plasticity configuration for a vault:
 
@@ -219,7 +219,7 @@ curl -X PUT "http://127.0.0.1:8475/api/admin/vault/default/plasticity" \
 
 | Field | Type | Range | Purpose |
 |-------|------|-------|---------|
-| `preset` | string | `default` \| `reference` \| `scratchpad` \| `knowledge-graph` | Base cognitive profile; overrides applied on top |
+| `preset` | string | `default` \| `reference` \| `scratchpad` \| `knowledge-graph` \| `working` | Base cognitive profile; overrides applied on top |
 | `hebbian_enabled` | bool | — | Enable/disable Hebbian weight updates (coactivation learning) |
 | `temporal_enabled` | bool | — | Enable/disable time-based temporal scoring |
 | `multi_user` | bool | — | Vault shared by multiple users/agents: guide + recall hints steer clients to per-user scoped recall; `where_left_off`/`session` flagged vault-global |

--- a/docs/feature-reference.md
+++ b/docs/feature-reference.md
@@ -324,7 +324,7 @@ Every cognitive behavior is tunable per vault:
 
 | Setting | Default | Range | Description |
 |---------|---------|-------|-------------|
-| `preset` | `"default"` | default/reference/scratchpad/knowledge-graph | Base behavior template |
+| `preset` | `"default"` | default/reference/scratchpad/knowledge-graph/working | Base behavior template |
 | `hebbian_enabled` | true | bool | Hebbian co-activation learning |
 | `temporal_enabled` | true | bool | Temporal decay scoring |
 | `auto_link_neighbors` | true | bool | Semantic neighbor auto-linking on write |
@@ -351,6 +351,7 @@ Every cognitive behavior is tunable per vault:
 - **default** — balanced, all features on, autonomous behavior
 - **reference** — long-term knowledge, minimal decay, strong Hebbian, autonomous behavior
 - **scratchpad** — short-lived, high recency bias, no Hebbian, PAS off, selective behavior
+- **working** — default cognition (Hebbian + PAS on) with 7-day auto-eviction and selective behavior; for shared workflow scratch vaults (RFC #597)
 - **knowledge-graph** — deep traversal (4 hops), strong Hebbian (8.0 scale), autonomous behavior
 
 ### Behavior Modes (How the AI Uses Memory)

--- a/docs/feature-reference.md
+++ b/docs/feature-reference.md
@@ -351,7 +351,7 @@ Every cognitive behavior is tunable per vault:
 - **default** — balanced, all features on, autonomous behavior
 - **reference** — long-term knowledge, minimal decay, strong Hebbian, autonomous behavior
 - **scratchpad** — short-lived, high recency bias, no Hebbian, PAS off, selective behavior
-- **working** — default cognition (Hebbian + PAS on) with 7-day auto-eviction and selective behavior; for shared workflow scratch vaults (RFC #597)
+- **working** — default cognition (Hebbian + PAS on) with 7-day auto-eviction and selective behavior; for shared workflow scratch vaults, pair with `multi_user` (RFC #597)
 - **knowledge-graph** — deep traversal (4 hops), strong Hebbian (8.0 scale), autonomous behavior
 
 ### Behavior Modes (How the AI Uses Memory)

--- a/internal/auth/plasticity.go
+++ b/internal/auth/plasticity.go
@@ -5,7 +5,7 @@ package auth
 // Non-nil pointer fields override the chosen preset value.
 type PlasticityConfig struct {
 	Version int    `json:"version,omitempty"` // schema version, currently 1
-	Preset  string `json:"preset,omitempty"`  // "default" | "reference" | "scratchpad" | "knowledge-graph"
+	Preset  string `json:"preset,omitempty"`  // "default" | "reference" | "scratchpad" | "knowledge-graph" | "working"
 
 	// Optional overrides (nil = use preset value)
 	HebbianEnabled    *bool    `json:"hebbian_enabled,omitempty"`

--- a/internal/auth/plasticity.go
+++ b/internal/auth/plasticity.go
@@ -267,6 +267,35 @@ var plasticityPresets = map[string]plasticityPreset{
 		EnrichmentEnabled:    true,
 		RecallMode:           "balanced",
 	},
+	"working": {
+		// default-derived cognition (Hebbian + PAS on) for a shared workflow
+		// vault, with two changes: scratch auto-evaporates, and agents get
+		// "selective" persistence guidance. See RFC #597.
+		HebbianEnabled:       true,
+		TemporalEnabled:      true,
+		AutoLinkNeighbors:    true,
+		HopDepth:             2,
+		SemanticWeight:       0.6,
+		FTSWeight:            0.3,
+		RelevanceFloor:       0.05,
+		TemporalHalflife:     30,
+		HebbianWeight:        0.5,
+		TemporalWeight:       0.4,
+		RecencyWeight:        0.3,
+		ACTRDecay:            0.5,
+		ACTRHebScale:         4.0,
+		PredictiveActivation: true,
+		PASMaxInjections:     5,
+		MaxEngrams:           0,
+		RetentionDays:        7,
+		AssocDecayFactor:     0.95,
+		AssocMinWeight:       0.05,
+		ArchiveThreshold:     0.05,
+		BehaviorMode:         "selective",
+		InlineEnrichment:     "caller_preferred",
+		EnrichmentEnabled:    true,
+		RecallMode:           "balanced",
+	},
 }
 
 // ResolvePlasticity merges cfg (which may be nil) atop its chosen preset,

--- a/internal/auth/plasticity_ltp_test.go
+++ b/internal/auth/plasticity_ltp_test.go
@@ -75,7 +75,7 @@ func TestPlasticity_LTP_Clamping(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPlasticity_LTP_PresetsHaveZeroDefaults(t *testing.T) {
-	for _, preset := range []string{"default", "reference", "scratchpad", "knowledge-graph"} {
+	for _, preset := range []string{"default", "reference", "scratchpad", "knowledge-graph", "working"} {
 		cfg := &PlasticityConfig{Preset: preset}
 		r := ResolvePlasticity(cfg)
 

--- a/internal/auth/plasticity_test.go
+++ b/internal/auth/plasticity_test.go
@@ -1,6 +1,9 @@
 package auth
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestResolvePlasticity_NilUsesDefault(t *testing.T) {
 	r := ResolvePlasticity(nil)
@@ -565,5 +568,16 @@ func TestMultiUser_Override(t *testing.T) {
 	r := ResolvePlasticity(&PlasticityConfig{MultiUser: &on})
 	if !r.MultiUser {
 		t.Error("override: want MultiUser=true")
+	}
+}
+
+func TestResolvePlasticity_WorkingEqualsDefaultPlusTwoDeltas(t *testing.T) {
+	d := ResolvePlasticity(&PlasticityConfig{Preset: "default"})
+	w := ResolvePlasticity(&PlasticityConfig{Preset: "working"})
+	// working is defined as default + exactly these two deltas.
+	d.RetentionDays = 7
+	d.BehaviorMode = "selective"
+	if !reflect.DeepEqual(d, w) {
+		t.Errorf("working must equal default + {RetentionDays:7, BehaviorMode:selective}\ndefault+δ: %+v\nworking:   %+v", d, w)
 	}
 }

--- a/internal/auth/plasticity_test.go
+++ b/internal/auth/plasticity_test.go
@@ -45,6 +45,32 @@ func TestResolvePlasticity_KnowledgeGraphPreset(t *testing.T) {
 	}
 }
 
+func TestResolvePlasticity_WorkingPreset(t *testing.T) {
+	r := ResolvePlasticity(&PlasticityConfig{Preset: "working"})
+	// Keystone: scratch actually evaporates.
+	if r.RetentionDays != 7 {
+		t.Errorf("working RetentionDays want 7, got %v", r.RetentionDays)
+	}
+	// Workspace-style: Hebbian + PAS stay ON (not scratchpad-derived).
+	if !r.HebbianEnabled {
+		t.Error("working: want HebbianEnabled=true")
+	}
+	if !r.PredictiveActivation {
+		t.Error("working: want PredictiveActivation=true")
+	}
+	if r.HopDepth != 2 {
+		t.Errorf("working HopDepth want 2 (default-derived), got %d", r.HopDepth)
+	}
+	// Transient-vault guidance signal (engine-neutral).
+	if r.BehaviorMode != "selective" {
+		t.Errorf("working BehaviorMode want %q, got %q", "selective", r.BehaviorMode)
+	}
+	// Guards against silent drift if default is later edited.
+	if r.ACTRDecay != 0.5 {
+		t.Errorf("working ACTRDecay want 0.5 (default-derived), got %v", r.ACTRDecay)
+	}
+}
+
 func TestResolvePlasticity_PointerOverride(t *testing.T) {
 	hd := 5
 	r := ResolvePlasticity(&PlasticityConfig{
@@ -89,6 +115,9 @@ func TestValidPlasticityPreset(t *testing.T) {
 	}
 	if !ValidPlasticityPreset("knowledge-graph") {
 		t.Error("knowledge-graph should be valid")
+	}
+	if !ValidPlasticityPreset("working") {
+		t.Error("working should be valid")
 	}
 	if ValidPlasticityPreset("bogus") {
 		t.Error("bogus should not be valid")
@@ -259,7 +288,7 @@ func TestBehaviorMode_CustomWithInstructions(t *testing.T) {
 }
 
 func TestBehaviorMode_AllPresetsHaveMode(t *testing.T) {
-	presets := []string{"default", "reference", "scratchpad", "knowledge-graph"}
+	presets := []string{"default", "reference", "scratchpad", "knowledge-graph", "working"}
 	for _, preset := range presets {
 		t.Run(preset, func(t *testing.T) {
 			r := ResolvePlasticity(&PlasticityConfig{Preset: preset})
@@ -280,7 +309,7 @@ func TestInlineEnrichment_DefaultPreset(t *testing.T) {
 }
 
 func TestInlineEnrichment_AllPresetsHaveValue(t *testing.T) {
-	presets := []string{"default", "reference", "scratchpad", "knowledge-graph"}
+	presets := []string{"default", "reference", "scratchpad", "knowledge-graph", "working"}
 	for _, preset := range presets {
 		t.Run(preset, func(t *testing.T) {
 			r := ResolvePlasticity(&PlasticityConfig{Preset: preset})
@@ -355,7 +384,7 @@ func TestEnrichmentEnabled_ExplicitTrue(t *testing.T) {
 }
 
 func TestEnrichmentEnabled_AllPresetsDefaultTrue(t *testing.T) {
-	presets := []string{"default", "reference", "scratchpad", "knowledge-graph"}
+	presets := []string{"default", "reference", "scratchpad", "knowledge-graph", "working"}
 	for _, name := range presets {
 		r := ResolvePlasticity(&PlasticityConfig{Preset: name})
 		if !r.EnrichmentEnabled {
@@ -383,7 +412,7 @@ func TestValidRecallMode_Invalid(t *testing.T) {
 }
 
 func TestRecallMode_AllPresetsDefaultBalanced(t *testing.T) {
-	presets := []string{"default", "reference", "scratchpad", "knowledge-graph"}
+	presets := []string{"default", "reference", "scratchpad", "knowledge-graph", "working"}
 	for _, name := range presets {
 		r := ResolvePlasticity(&PlasticityConfig{Preset: name})
 		if r.RecallMode != "balanced" {

--- a/internal/auth/rrf_plasticity_test.go
+++ b/internal/auth/rrf_plasticity_test.go
@@ -14,7 +14,7 @@ func TestScoringFusion_DefaultEmpty(t *testing.T) {
 }
 
 func TestScoringFusion_AllPresetsDefaultEmpty(t *testing.T) {
-	presets := []string{"default", "reference", "scratchpad", "knowledge-graph"}
+	presets := []string{"default", "reference", "scratchpad", "knowledge-graph", "working"}
 	for _, name := range presets {
 		r := ResolvePlasticity(&PlasticityConfig{Preset: name})
 		if r.ScoringFusion != "" {

--- a/internal/mcp/guide_test.go
+++ b/internal/mcp/guide_test.go
@@ -108,6 +108,24 @@ func TestGenerateGuide_ScratchpadConfig(t *testing.T) {
 	}
 }
 
+func TestGenerateGuide_WorkingConfig(t *testing.T) {
+	r := auth.ResolvePlasticity(&auth.PlasticityConfig{Preset: "working"})
+	guide := generateGuide("wf", r, engineStats{})
+
+	if !strings.Contains(guide, "Hebbian learning: enabled") {
+		t.Error("working should show Hebbian enabled")
+	}
+	if !strings.Contains(guide, "Predictive activation (PAS): enabled") {
+		t.Error("working should show PAS enabled")
+	}
+	if !strings.Contains(guide, "Behavior mode: selective") {
+		t.Error("working preset should show selective behavior mode")
+	}
+	if !strings.Contains(guide, "Retention: 7 days") {
+		t.Error("working should surface its 7-day retention")
+	}
+}
+
 func TestGenerateGuide_TipsSection(t *testing.T) {
 	r := auth.ResolvePlasticity(nil)
 	guide := generateGuide("default", r, engineStats{})

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -2006,12 +2006,14 @@ document.addEventListener('alpine:init', () => {
         'reference':       [1.00, 0.35, 0.375, 0.80, 0.70],
         'scratchpad':      [0.05, 0.00, 0.00, 0.70, 0.60],
         'knowledge-graph': [0.70, 1.00, 1.00, 0.75, 0.50],
+        'working':         [0.30, 0.40, 0.50, 0.70, 0.60],
     },
     _plasticityColors: {
         'default':         { border: '#6366f1', bg: 'rgba(99,102,241,0.35)' },
         'reference':       { border: '#10b981', bg: 'rgba(16,185,129,0.35)' },
         'scratchpad':      { border: '#f59e0b', bg: 'rgba(245,158,11,0.35)' },
         'knowledge-graph': { border: '#ec4899', bg: 'rgba(236,72,153,0.35)' },
+        'working':         { border: '#14b8a6', bg: 'rgba(20,184,166,0.35)' },
     },
     initPlasticityChart() {
         const canvas = document.getElementById('plasticityChart');
@@ -2088,6 +2090,7 @@ document.addEventListener('alpine:init', () => {
             'reference':       'Documentation and facts. Temporal scoring OFF — memories persist indefinitely.',
             'scratchpad':      'Ephemeral drafts. Aggressive fading (7-day halflife, 0.01 floor). No Hebbian, no hops.',
             'knowledge-graph': 'Dense interlinked concepts. 4-hop BFS, slow fading (60-day halflife).',
+            'working':         'Shared workflow scratch. Default cognition (Hebbian + PAS, 2-hop) with 7-day auto-eviction. Pair with multi_user for multi-agent workflows.',
         };
         return d[preset] || '';
     },

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1353,6 +1353,18 @@
                     <span :style="'font-size:0.65rem;background:rgba(236,72,153,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#f9a8d4' : '#be185d')">Slow fading</span>
                   </div>
                 </div>
+
+                <!-- Working -->
+                <div @click="plasticityForm.showAdvanced=false; plasticityForm.preset='working'; onPlasticityPresetChange()"
+                     :style="'border-radius:0.625rem;cursor:pointer;transition:all 0.15s;' + (plasticityForm.preset==='working' && !plasticityForm.showAdvanced ? 'border:2px solid #14b8a6;background:rgba(20,184,166,0.12);padding:calc(1.25rem - 1px);' : 'border:1px solid var(--border);background:var(--bg-elevated);padding:1.25rem;')">
+                  <div style="font-weight:600;font-size:0.875rem;margin-bottom:0.25rem;">Working</div>
+                  <div style="font-size:0.75rem;color:var(--text-muted);margin-bottom:0.5rem;">Shared workflow scratch</div>
+                  <div style="display:flex;gap:0.3rem;flex-wrap:wrap;">
+                    <span :style="'font-size:0.65rem;background:rgba(20,184,166,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#5eead4' : '#0f766e')">2-hop</span>
+                    <span :style="'font-size:0.65rem;background:rgba(20,184,166,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#5eead4' : '#0f766e')">Hebbian</span>
+                    <span :style="'font-size:0.65rem;background:rgba(20,184,166,0.2);border-radius:9999px;padding:0.1rem 0.4rem;color:' + (isDarkMode ? '#5eead4' : '#0f766e')">7-day evap.</span>
+                  </div>
+                </div>
               </div>
 
               <!-- Default Recall Mode -->


### PR DESCRIPTION
## Summary

Implements the first increment of RFC #597 — a `working` plasticity preset that gives a shared workflow vault full default cognition (Hebbian + PAS) **plus** automatic eviction, so scratch actually behaves like scratch.

Complementary to #376 (cross-vault recall), not a duplicate: #376 fuses **reads** across isolated vaults (preserves boundaries, defers cross-vault Hebbian); `working` is one **writable** shared space that erases boundaries inside the workflow and gains cross-agent Hebbian for free — then evaporates.

## The gap this closes

All four existing presets ship `RetentionDays: 0`. The engine already has a background pruner (runs every 60s ±5s, `internal/engine/engine.go`) that hard-deletes engrams older than the retention threshold — but it is inert for every preset. A "working vault" that never forgets is permanent clutter, not scratch. `working` turns the pruner on.

## The preset

`working` is the `default` preset with exactly two fields changed:

| field | `default` | `working` | why |
|---|---|---|---|
| `RetentionDays` | `0` | `7` | activates the 60s pruner; engrams older than 7 days are hard-deleted |
| `BehaviorMode` | `"autonomous"` | `"selective"` | guide-text only (engine-neutral); signals "transient, persist selectively" |

Everything else is identical to `default` (Hebbian on, HopDepth 2, PAS on). A `reflect.DeepEqual` test pins the "default + exactly two deltas" invariant, so a future edit to `default` can't silently drift `working`.

`MultiUser` is deliberately **not** baked into the preset — it stays a per-vault override. Presets tune cognition/decay; `MultiUser` is a social/guidance flag. The shared-working-vault recipe is the two-knob `--preset working --set multi_user=true`.

## Changes

- `internal/auth/plasticity.go` — the `working` preset entry + `Preset` field doc comment.
- `internal/auth/plasticity_test.go` — pinning test + `reflect.DeepEqual` invariant test + `working` added to the four preset-invariant suites.
- `internal/auth/plasticity_ltp_test.go`, `internal/auth/rrf_plasticity_test.go` — `working` added to the LTP / ScoringFusion preset suites.
- `internal/mcp/guide_test.go` — guide-render test (confirms `guide.go` needs no change — the `selective` BehaviorMode branch and the generic Retention printer already cover `working`).
- `cmd/muninn/vault.go` — CLI plasticity help + validation-error strings.
- `docs/feature-reference.md`, `docs/auth.md` — user-facing preset reference.
- `web/templates/index.html`, `web/static/js/app.js` — management-console preset card + radar/color/description.

## Testing

- `go test -race ./...` green; `go vet ./...` clean; `gofmt -l` empty.
- The `reflect.DeepEqual` invariant test was RED-sanity-checked (mutating any shared field fails it with a readable `%+v` diff).
- Purely additive — no struct, engine, or on-disk-format change; the four existing presets resolve identically.

## Out of scope (tracked in #597 as follow-up increments)

Deliberately deferred to keep this PR minimal and reviewable:
- MCP-surface vault lifecycle (`muninn_create_workflow_vault`) so agents self-serve a workflow vault.
- Revive the dead `session.go` for connect-once session-default vault binding.
- Concurrency hardening (write-path lease enforcement, single-batch CAS atomicity, fencing token), plus a doc note on the pruner↔replication cluster behavior for retention-configured vaults (pre-existing property, surfaces more now that retention is a one-line default rather than an opt-in override).

Refs #597.
