### PR TITLE
ci: rename stale 'minilm-v2' embed-asset cache keys to bge-small-en-v1.5 (#601)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: internal/plugin/embed/assets
-          key: embed-assets-ort-1.24.2-minilm-v2-linux
+          key: embed-assets-ort-1.24.2-bge-small-en-v1.5-linux
 
       # Only fetch if the cache missed — saves ~2 min and 130MB on cache hits.
       - name: Fetch embed assets (linux/amd64 only)
@@ -96,7 +96,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: internal/plugin/embed/assets
-          key: embed-assets-ort-1.24.2-minilm-v2-linux
+          key: embed-assets-ort-1.24.2-bge-small-en-v1.5-linux
 
       # Fetch if cache missed (e.g. first run after cache key changes)
       - name: Fetch embed assets if needed
@@ -233,7 +233,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: internal/plugin/embed/assets
-          key: embed-assets-ort-1.24.2-minilm-v2-linux
+          key: embed-assets-ort-1.24.2-bge-small-en-v1.5-linux
 
       # Fetch if cache missed (e.g. first run after cache key changes)
       - name: Fetch embed assets if needed
@@ -322,7 +322,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: internal/plugin/embed/assets
-          key: embed-assets-ort-1.24.2-minilm-v2-linux
+          key: embed-assets-ort-1.24.2-bge-small-en-v1.5-linux
 
       - name: Fetch embed assets if needed
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             goos: darwin
             goarch: arm64
             ort_target: _ort-darwin-arm64
-            cache_key: embed-assets-ort-1.24.2-minilm-v2-darwin-arm64
+            cache_key: embed-assets-ort-1.24.2-bge-small-en-v1.5-darwin-arm64
             cc: ""
 
           - runner: macos-14         # Cross-compile Intel from arm64 runner
@@ -29,21 +29,21 @@ jobs:
             goarch: amd64
             ort_target: _ort-darwin-amd64
             # ORT dropped Intel Mac support after v1.23.2; this pin is intentional.
-            cache_key: embed-assets-ort-1.23.2-minilm-v2-darwin-amd64
+            cache_key: embed-assets-ort-1.23.2-bge-small-en-v1.5-darwin-amd64
             cc: "clang -arch x86_64"
 
           - runner: ubuntu-latest    # Linux x86-64
             goos: linux
             goarch: amd64
             ort_target: _ort-linux-amd64
-            cache_key: embed-assets-ort-1.24.2-minilm-v2-linux-amd64
+            cache_key: embed-assets-ort-1.24.2-bge-small-en-v1.5-linux-amd64
             cc: ""
 
           - runner: ubuntu-24.04-arm  # Native linux/arm64 runner
             goos: linux
             goarch: arm64
             ort_target: _ort-linux-arm64
-            cache_key: embed-assets-ort-1.24.2-minilm-v2-linux-arm64
+            cache_key: embed-assets-ort-1.24.2-bge-small-en-v1.5-linux-arm64
             cc: ""
 
     steps:


### PR DESCRIPTION
## Summary

Fixes the `minilm-v2` half of #601: eight embed-asset cache keys (the four darwin/linux matrix keys in `release.yml` and the four linux job keys in `ci.yml`) still name `minilm-v2`, but `make fetch-model` has cached **bge-small-en-v1.5** under those keys since the model swap. `release.yml`'s Windows job already uses the correct pattern; this brings the rest in line.

Label-only change — the cached bytes were always the right ones. The point is future-proofing: the next model change that forgets the manual key bump would silently restore a cache entry named after the wrong model. Cost of the rename: one cold re-download per key on the next run (~56 MB per platform in `release.yml`, per its own comment).

Deliberately untouched:
- the darwin-amd64 `ort-1.23.2` version segment — intentional pin (last ORT with Intel-Mac support, per the adjacent comment and `ORT_VERSION_DARWIN_AMD64` in the Makefile; see the correction comment on #601);
- `ci.yml`'s Windows key — that job genuinely downloads all-MiniLM-L6-v2, so its label matches its bytes (the model difference itself is a separate concern from key naming).

## Changes

- `.github/workflows/release.yml`: 4 matrix `cache_key` literals `-minilm-v2-` → `-bge-small-en-v1.5-` (ORT-version and platform segments unchanged)
- `.github/workflows/ci.yml`: the same rename on the 4 linux job keys

The keys are consumed only via `${{ matrix.cache_key }}` / literal `key:` fields; there are no `restore-keys` or cross-workflow references, so the rename cannot silently break cache restore — a miss just re-runs `make fetch-model`.

## Release Checklist

- [ ] ~~`CHANGELOG.md`~~ — maintainers update this at release time, no action needed
- [ ] ~~OpenAPI spec~~ — no API changes (CI-only)
- [ ] ~~SDK types~~ — no schema changes
- [ ] ~~`docs/`~~ — no user-facing behavior change
- [x] `go build ./...` clean — no Go changes; YAML parse-checked
- [x] `go vet ./...` clean — no Go changes
- [x] `go test ./...` passes — no Go changes; note `release.yml` is tag-triggered and not exercised by PR CI, so this PR is inspection-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
