### PR TITLE
feat(mcp): toolset profiles for tools/list — env default + per-connection header override (#588)

### DIFF
--- a/cmd/muninn/mcp_stdio.go
+++ b/cmd/muninn/mcp_stdio.go
@@ -22,6 +22,16 @@ var mcpProxyURL = "http://127.0.0.1:" + defaultMCPPort + "/mcp"
 // tests can redirect it without forking a process.
 var mcpStderr io.Writer = os.Stderr
 
+// mcpToolset is the toolset preference forwarded to the daemon as the
+// X-Muninn-Toolset header on every outbound request. Stdio clients cannot set
+// HTTP headers themselves, so the proxy is their only channel: set
+// MUNINN_MCP_TOOLSET in the client's env block for the `muninn mcp` command.
+// Empty means no header — the daemon falls back to its own default. The value
+// is forwarded as-is: the daemon owns validation and fails open on unknown
+// values, so the proxy stays a dumb pipe. Overridable in tests via direct
+// assignment.
+var mcpToolset string
+
 // jsonRPCErrorResponse is a JSON-RPC 2.0 error response structure.
 type jsonRPCErrorResponse struct {
 	JSONRPC string          `json:"jsonrpc"`
@@ -87,6 +97,11 @@ func httpStatusToRPCError(status int) (code int, msg string) {
 // MUNINN_MCP_URL overrides the target endpoint for non-default port or TLS setups:
 //
 //	MUNINN_MCP_URL=https://127.0.0.1:8750/mcp muninn mcp
+//
+// MUNINN_MCP_TOOLSET selects the toolset tools/list advertises for this client;
+// the proxy forwards it as the X-Muninn-Toolset header on every request:
+//
+//	MUNINN_MCP_TOOLSET=core muninn mcp
 func runMCPStdio() {
 	loadEnvFile()
 
@@ -95,6 +110,7 @@ func runMCPStdio() {
 	} else {
 		mcpProxyURL = defaultMCPProxyURL()
 	}
+	mcpToolset = strings.TrimSpace(os.Getenv("MUNINN_MCP_TOOLSET"))
 	runMCPStdioWith(os.Stdin, os.Stdout)
 }
 
@@ -142,6 +158,10 @@ func runMCPStdioWith(in io.Reader, out io.Writer) {
 		req.Header.Set("Content-Type", "application/json")
 		if token != "" {
 			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		// Forward the client's toolset preference; see mcpToolset.
+		if mcpToolset != "" {
+			req.Header.Set("X-Muninn-Toolset", mcpToolset)
 		}
 		// Forward the MCP session ID on all requests after initialize.
 		if sessionID != "" {

--- a/cmd/muninn/mcp_stdio_test.go
+++ b/cmd/muninn/mcp_stdio_test.go
@@ -283,6 +283,55 @@ func TestRunMCPStdioWith_ContentTypeHeader(t *testing.T) {
 	}
 }
 
+// TestRunMCPStdioWith_ToolsetHeaderForwarded verifies the proxy forwards the
+// client-side toolset preference as X-Muninn-Toolset — stdio clients have no
+// other channel to reach the daemon's per-client toolset switch.
+func TestRunMCPStdioWith_ToolsetHeaderForwarded(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("X-Muninn-Toolset")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+
+	orig := mcpToolset
+	mcpToolset = "core"
+	t.Cleanup(func() { mcpToolset = orig })
+
+	in := strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n")
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	if got != "core" {
+		t.Errorf("X-Muninn-Toolset = %q, want \"core\"", got)
+	}
+}
+
+// TestRunMCPStdioWith_NoToolsetHeaderWhenUnset verifies no header is sent when
+// the client sets no preference, leaving the daemon's own default in charge.
+func TestRunMCPStdioWith_NoToolsetHeaderWhenUnset(t *testing.T) {
+	var present bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, present = r.Header["X-Muninn-Toolset"]
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	withMCPProxyURL(t, srv.URL)
+
+	orig := mcpToolset
+	mcpToolset = ""
+	t.Cleanup(func() { mcpToolset = orig })
+
+	in := strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n")
+	var out bytes.Buffer
+	runMCPStdioWith(in, &out)
+
+	if present {
+		t.Error("X-Muninn-Toolset header sent despite no client preference")
+	}
+}
+
 func TestRunMCPStdioWith_MultipleRequests(t *testing.T) {
 	responses := []string{
 		`{"jsonrpc":"2.0","id":1,"result":{"pong":true}}`,

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -247,6 +247,26 @@ To override the daemon endpoint (non-default port, TLS):
 MUNINN_MCP_URL=https://my-server:8750/mcp muninn mcp
 ```
 
+To advertise the lean `core` toolset to this client only (trims the schema
+overhead in the client's context window; every tool remains callable), set
+`MUNINN_MCP_TOOLSET` in the client's env block — the proxy forwards it as the
+`X-Muninn-Toolset` header:
+```json
+{
+  "mcpServers": {
+    "muninn": {
+      "command": "muninn",
+      "args": ["mcp"],
+      "transport": "stdio",
+      "env": { "MUNINN_MCP_TOOLSET": "core" }
+    }
+  }
+}
+```
+
+HTTP-transport clients that support custom headers can set `X-Muninn-Toolset`
+directly in their MCP config instead.
+
 **Windsurf** — `~/.codeium/windsurf/mcp_config.json`
 ```json
 {
@@ -299,6 +319,7 @@ curl http://127.0.0.1:8750/mcp/health
 | `MUNINN_GC_PERCENT` | `200` | GOGC tuning |
 | `MUNINN_CORS_ORIGINS` | `""` | Comma-separated allowed CORS origins |
 | `MUNINN_MCP_URL` | `http://127.0.0.1:8750/mcp` | Override MCP endpoint used by `muninn mcp` proxy (OpenClaw) |
+| `MUNINN_MCP_TOOLSET` | `full` | Toolset advertised by MCP `tools/list`: `full` or `core` (every tool stays callable either way). On the daemon: the default for all clients. On the `muninn mcp` proxy: forwarded per-client as the `X-Muninn-Toolset` request header, which takes precedence over the daemon default. Unknown values fall back to the next layer with a logged warning |
 | `MUNINNDB_ADMIN_URL` | auto-detected | Override the REST/admin base URL probed by `muninn status` & admin CLI (TLS deployments) |
 | `MUNINNDB_UI_URL` | auto-detected | Override the Web UI base URL probed by `muninn status` (TLS deployments) |
 | `MUNINNDB_MCP_URL` | auto-detected | Override the MCP base URL probed by `muninn status` / `muninn start` (TLS deployments) |

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -161,7 +161,7 @@ func (s *MCPServer) handleRPC(w http.ResponseWriter, r *http.Request) {
 	case req.Method == "ping":
 		sendResult(w, req.ID, map[string]any{})
 	case req.Method == "tools/list":
-		sendResult(w, req.ID, map[string]any{"tools": allToolDefinitions()})
+		sendResult(w, req.ID, map[string]any{"tools": exposedToolDefinitions(r)})
 	case req.Method == "tools/call":
 		s.dispatchToolCall(ctx, w, &req, a)
 	case req.Method == "":
@@ -509,7 +509,7 @@ func (s *MCPServer) processAndPushSSE(w http.ResponseWriter, r *http.Request, ch
 	case req.Method == "ping":
 		sendResult(recorder, req.ID, map[string]any{})
 	case req.Method == "tools/list":
-		sendResult(recorder, req.ID, map[string]any{"tools": allToolDefinitions()})
+		sendResult(recorder, req.ID, map[string]any{"tools": exposedToolDefinitions(r)})
 	case req.Method == "tools/call":
 		s.dispatchToolCall(ctx, recorder, &req, authFromContext(r.Context()))
 	case req.Method == "":
@@ -599,7 +599,7 @@ func (s *MCPServer) handleInitialize(w http.ResponseWriter, req *JSONRPCRequest)
 
 func (s *MCPServer) handleListTools(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"tools": allToolDefinitions()})
+	json.NewEncoder(w).Encode(map[string]any{"tools": exposedToolDefinitions(r)})
 }
 
 func (s *MCPServer) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/internal/mcp/toolset.go
+++ b/internal/mcp/toolset.go
@@ -28,7 +28,19 @@ var coreToolNames = map[string]bool{
 	"muninn_guide":          true,
 }
 
-var toolsetWarnOnce sync.Once
+// toolsetWarned tracks which unknown toolset values have already been logged,
+// keyed by (source, value), so each distinct typo warns exactly once per
+// process — not only the first one ever (a second client's different typo
+// must not go silent).
+var toolsetWarned sync.Map
+
+// warnUnknownToolset logs one warning per distinct (source, value) pair.
+func warnUnknownToolset(source, value, fallback string) {
+	if _, seen := toolsetWarned.LoadOrStore(source+"\x00"+value, true); !seen {
+		slog.Warn("mcp: unknown toolset value, falling back",
+			"source", source, "value", value, "fallback", fallback)
+	}
+}
 
 // resolveToolset picks the toolset for one request. Precedence: the
 // X-Muninn-Toolset request header (lets each client choose in its own MCP
@@ -43,9 +55,7 @@ func resolveToolset(r *http.Request) string {
 		case "":
 			// no header — fall through to env
 		default:
-			toolsetWarnOnce.Do(func() {
-				slog.Warn("mcp: unknown X-Muninn-Toolset header, falling back to daemon default", "value", v)
-			})
+			warnUnknownToolset("X-Muninn-Toolset header", v, "daemon default")
 		}
 	}
 	switch v := strings.ToLower(strings.TrimSpace(os.Getenv("MUNINN_MCP_TOOLSET"))); v {
@@ -54,9 +64,7 @@ func resolveToolset(r *http.Request) string {
 	case "":
 		return "full"
 	default:
-		toolsetWarnOnce.Do(func() {
-			slog.Warn("mcp: unknown MUNINN_MCP_TOOLSET value, serving full toolset", "value", v)
-		})
+		warnUnknownToolset("MUNINN_MCP_TOOLSET env", v, "full")
 		return "full"
 	}
 }

--- a/internal/mcp/toolset.go
+++ b/internal/mcp/toolset.go
@@ -1,0 +1,79 @@
+package mcp
+
+import (
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+)
+
+// coreToolNames is the day-to-day working set: session boot, recall, the
+// write/evolve path, and health. Everything else (enrichment admin, graph
+// export, entity surgery, tree memory, consolidation, ...) remains fully
+// callable via tools/call — the toolset only filters what tools/list
+// ADVERTISES, because advertised schemas ride in every MCP client's context
+// window whether or not they are used (~41KB / ~10k tokens for the full
+// 39-tool surface, vs ~1/4 of that for this set).
+var coreToolNames = map[string]bool{
+	"muninn_recall":         true,
+	"muninn_remember":       true,
+	"muninn_remember_batch": true,
+	"muninn_read":           true,
+	"muninn_evolve":         true,
+	"muninn_link":           true,
+	"muninn_where_left_off": true,
+	"muninn_find_by_entity": true,
+	"muninn_status":         true,
+	"muninn_guide":          true,
+}
+
+var toolsetWarnOnce sync.Once
+
+// resolveToolset picks the toolset for one request. Precedence: the
+// X-Muninn-Toolset request header (lets each client choose in its own MCP
+// config, no daemon restart), then the MUNINN_MCP_TOOLSET env var (daemon
+// default), then "full". Unknown values fall through to the next layer —
+// a typo in a header or env file must never cost a seat its memory tools.
+func resolveToolset(r *http.Request) string {
+	if r != nil {
+		switch v := strings.ToLower(strings.TrimSpace(r.Header.Get("X-Muninn-Toolset"))); v {
+		case "core", "full":
+			return v
+		case "":
+			// no header — fall through to env
+		default:
+			toolsetWarnOnce.Do(func() {
+				slog.Warn("mcp: unknown X-Muninn-Toolset header, falling back to daemon default", "value", v)
+			})
+		}
+	}
+	switch v := strings.ToLower(strings.TrimSpace(os.Getenv("MUNINN_MCP_TOOLSET"))); v {
+	case "core", "full":
+		return v
+	case "":
+		return "full"
+	default:
+		toolsetWarnOnce.Do(func() {
+			slog.Warn("mcp: unknown MUNINN_MCP_TOOLSET value, serving full toolset", "value", v)
+		})
+		return "full"
+	}
+}
+
+// exposedToolDefinitions returns the tool definitions tools/list advertises
+// for this request. Filtering happens at advertisement time only; dispatch
+// (tools/call) is by name and never consults this list.
+func exposedToolDefinitions(r *http.Request) []ToolDefinition {
+	all := allToolDefinitions()
+	if resolveToolset(r) != "core" {
+		return all
+	}
+	out := make([]ToolDefinition, 0, len(coreToolNames))
+	for _, t := range all {
+		if coreToolNames[t.Name] {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/mcp/toolset_test.go
+++ b/internal/mcp/toolset_test.go
@@ -1,0 +1,99 @@
+package mcp
+
+import (
+	"net/http"
+	"testing"
+)
+
+func reqWithToolsetHeader(t *testing.T, v string) *http.Request {
+	t.Helper()
+	r, err := http.NewRequest(http.MethodPost, "/mcp", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != "" {
+		r.Header.Set("X-Muninn-Toolset", v)
+	}
+	return r
+}
+
+func TestExposedToolDefinitions(t *testing.T) {
+	all := allToolDefinitions()
+
+	t.Run("core names all exist in the full list", func(t *testing.T) {
+		names := map[string]bool{}
+		for _, td := range all {
+			names[td.Name] = true
+		}
+		for n := range coreToolNames {
+			if !names[n] {
+				t.Errorf("core tool %q not present in allToolDefinitions — rename drift", n)
+			}
+		}
+	})
+
+	t.Run("unset env, no header serves full", func(t *testing.T) {
+		t.Setenv("MUNINN_MCP_TOOLSET", "")
+		if got := len(exposedToolDefinitions(nil)); got != len(all) {
+			t.Fatalf("got %d tools, want %d", got, len(all))
+		}
+	})
+
+	t.Run("env full serves full", func(t *testing.T) {
+		t.Setenv("MUNINN_MCP_TOOLSET", "full")
+		if got := len(exposedToolDefinitions(nil)); got != len(all) {
+			t.Fatalf("got %d tools, want %d", got, len(all))
+		}
+	})
+
+	t.Run("env core serves exactly the core set", func(t *testing.T) {
+		t.Setenv("MUNINN_MCP_TOOLSET", "core")
+		got := exposedToolDefinitions(nil)
+		if len(got) != len(coreToolNames) {
+			t.Fatalf("got %d tools, want %d", len(got), len(coreToolNames))
+		}
+		for _, td := range got {
+			if !coreToolNames[td.Name] {
+				t.Errorf("non-core tool %q leaked into core toolset", td.Name)
+			}
+		}
+	})
+
+	t.Run("env case and whitespace tolerated", func(t *testing.T) {
+		t.Setenv("MUNINN_MCP_TOOLSET", "  CORE  ")
+		if got := len(exposedToolDefinitions(nil)); got != len(coreToolNames) {
+			t.Fatalf("got %d tools, want %d", got, len(coreToolNames))
+		}
+	})
+
+	t.Run("unknown env fails open to full", func(t *testing.T) {
+		t.Setenv("MUNINN_MCP_TOOLSET", "cor")
+		if got := len(exposedToolDefinitions(nil)); got != len(all) {
+			t.Fatalf("got %d tools, want %d (fail-open)", got, len(all))
+		}
+	})
+
+	t.Run("header core overrides env full", func(t *testing.T) {
+		t.Setenv("MUNINN_MCP_TOOLSET", "full")
+		r := reqWithToolsetHeader(t, "core")
+		if got := len(exposedToolDefinitions(r)); got != len(coreToolNames) {
+			t.Fatalf("got %d tools, want %d", got, len(coreToolNames))
+		}
+	})
+
+	t.Run("header full overrides env core", func(t *testing.T) {
+		t.Setenv("MUNINN_MCP_TOOLSET", "core")
+		r := reqWithToolsetHeader(t, "FULL")
+		if got := len(exposedToolDefinitions(r)); got != len(all) {
+			t.Fatalf("got %d tools, want %d", got, len(all))
+		}
+	})
+
+	t.Run("unknown header falls back to env", func(t *testing.T) {
+		t.Setenv("MUNINN_MCP_TOOLSET", "core")
+		r := reqWithToolsetHeader(t, "corre")
+		if got := len(exposedToolDefinitions(r)); got != len(coreToolNames) {
+			t.Fatalf("got %d tools, want %d (fall back to env)", got, len(coreToolNames))
+		}
+	})
+}

--- a/internal/mcp/toolset_test.go
+++ b/internal/mcp/toolset_test.go
@@ -1,7 +1,10 @@
 package mcp
 
 import (
+	"bytes"
+	"log/slog"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -96,4 +99,28 @@ func TestExposedToolDefinitions(t *testing.T) {
 			t.Fatalf("got %d tools, want %d (fall back to env)", got, len(coreToolNames))
 		}
 	})
+}
+
+// TestWarnUnknownToolset_PerDistinctValue guards that each distinct unknown
+// toolset value logs its own warning — a second client's different typo must
+// not be swallowed by a process-lifetime Once — while repeats stay silent.
+func TestWarnUnknownToolset_PerDistinctValue(t *testing.T) {
+	var buf bytes.Buffer
+	orig := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	t.Setenv("MUNINN_MCP_TOOLSET", "")
+
+	resolveToolset(reqWithToolsetHeader(t, "typo-alpha"))
+	resolveToolset(reqWithToolsetHeader(t, "typo-beta"))
+	resolveToolset(reqWithToolsetHeader(t, "typo-alpha")) // repeat: must stay silent
+
+	logs := buf.String()
+	if got := strings.Count(logs, "typo-alpha"); got != 1 {
+		t.Errorf("typo-alpha warned %d times, want exactly 1\nlogs:\n%s", got, logs)
+	}
+	if got := strings.Count(logs, "typo-beta"); got != 1 {
+		t.Errorf("typo-beta warned %d times, want exactly 1\nlogs:\n%s", got, logs)
+	}
 }


### PR DESCRIPTION
Implements #588 — working code for the design discussion there, running in production in our multi-agent deployment since 2026-07-12 (on v0.7.0; rebased cleanly onto develop for this PR).

## What it does

- `MUNINN_MCP_TOOLSET=core|full` — server default via env. `core` advertises a 10-tool hot-path set; `full` (and unset) is exactly today's behaviour.
- `X-Muninn-Toolset: core|full` request header — per-connection override, beats the env. MCP clients that let users set custom headers in client config (Claude Code, most SDK clients — the same place the Authorization header already lives) get the connect-time win with one config line and no server restart.
- **Advertisement-only**, exactly as #588 frames it: dispatch is by name and never consults the list, so every tool stays callable under any profile. Orthogonal to the key-mode security gate.
- **Fail-open**: an unknown value in header or env falls through (header → env → full) with one logged warning. A typo must never hide a client's memory tools.

## On the selection-mechanism question (A/B/C)

We shipped what amounts to **server default + per-connection override**, without touching the key model. The header reaches the same end as (B)/(C) — per-client choice, one key — while dodging (B)'s weakness: standard clients call `tools/list` with no parameters, but they *do* attach configured headers to every request, so the connect-time saving is realized today. If you'd rather carry the profile as a per-key attribute (A), happy to rework — the filter core, fail-open semantics, and tests all carry over unchanged; only `resolveToolset` moves.

## Numbers (measured on our live instance)

| | tools | bytes | ~tokens |
|---|---|---|---|
| full | 39 | 41,063 | ~10.3k |
| core | 10 | 16,600 | ~4.2k |

In a bounded-context harness this measured as 23% of a typical session's context before, and the schemas outweighed the actual memory content a session read.

## Membership (maintainer's call, happy to adjust)

Your proposed lite set +`remember_batch` (the atomicity guidance in `muninn_remember`'s own description steers clients toward batch), +`find_by_entity` (documented first step for named-entity lookup), +`status` (health checks), +`guide` (the discovery pointer for everything unlisted — feels load-bearing once tools are hidden), −`session` (kept out of our set; no strong opinion). Rename `core`→`lite` is a trivial change if you prefer the issue's naming.

Default stays `full`, so existing keys, clients, and the registry-parity smoke check are unaffected. 9 focused tests in `toolset_test.go`; `go test ./internal/mcp/` green on develop with the 1.26.5 toolchain.
