### PR TITLE
feat(mcp): capability tokens + muninn_create_workflow_vault (RFC #597)

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -1500,7 +1500,11 @@ func runServer() {
 
 	// Build MCP server
 	mcpAdapter := mcp.NewEngineAdapter(eng, enrichPlugin, pStore)
-	mcpServer := mcp.New(*mcpAddr, mcpAdapter, *mcpToken, authStore, clientTLS)
+	// capAuth is nil for now (RFC #597 Task 2): cap_ capability tokens are
+	// recognized by authFromRequest but not yet minted or wired to the live
+	// store. Task 4 flips this to authStore once muninn_create_workflow_vault
+	// ships.
+	mcpServer := mcp.New(*mcpAddr, mcpAdapter, *mcpToken, authStore, nil, clientTLS)
 
 	// Build gRPC server
 	grpcAdapter := grpcpkg.NewEngineAdapter(eng)

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -1500,11 +1500,12 @@ func runServer() {
 
 	// Build MCP server
 	mcpAdapter := mcp.NewEngineAdapter(eng, enrichPlugin, pStore)
-	// capAuth is nil for now (RFC #597 Task 2): cap_ capability tokens are
-	// recognized by authFromRequest but not yet minted or wired to the live
-	// store. Task 4 flips this to authStore once muninn_create_workflow_vault
-	// ships.
-	mcpServer := mcp.New(*mcpAddr, mcpAdapter, *mcpToken, authStore, nil, clientTLS)
+	// capAuth wires the live *auth.Store as the cap_ capability validator AND
+	// (via type assertion inside mcp.New) the create-workflow-vault handler's
+	// store for SetVaultConfig + GenerateCapability. With this, cap_ tokens
+	// authenticate on every transport and muninn_create_workflow_vault (opt-in
+	// via MUNINN_AGENT_VAULT_CREATE) can mint workflow capabilities (RFC #597).
+	mcpServer := mcp.New(*mcpAddr, mcpAdapter, *mcpToken, authStore, authStore, clientTLS)
 
 	// Build gRPC server
 	grpcAdapter := grpcpkg.NewEngineAdapter(eng)

--- a/cmd/muninn/smoke_exhaustive_test.go
+++ b/cmd/muninn/smoke_exhaustive_test.go
@@ -51,6 +51,7 @@ var allMCPTools = []string{
 	"muninn_add_child",
 	"muninn_similar_entities",
 	"muninn_merge_entity",
+	"muninn_create_workflow_vault",
 	"muninn_replay_enrichment",
 	"muninn_provenance",
 	"muninn_entity_timeline",
@@ -952,6 +953,20 @@ func TestSmoke_AllMCPTools(t *testing.T) {
 		})
 		if errVal, hasErr := result["error"]; hasErr {
 			t.Errorf("muninn_entities returned error field: %v", errVal)
+		}
+	})
+
+	t.Run("muninn_create_workflow_vault", func(t *testing.T) {
+		// Privileged tool: requires opt-in (MUNINN_AGENT_VAULT_CREATE) + a full-mode
+		// mk_ key. The smoke daemon uses a static token with opt-in off, so the guard
+		// must reject this call — the error is expected (it proves the gate fires).
+		result := mcpTool(t, tok, "muninn_create_workflow_vault", map[string]any{
+			"name": "wf-smoke",
+		})
+		if errVal, hasErr := result["error"]; !hasErr {
+			t.Errorf("muninn_create_workflow_vault: expected guard rejection (static token, opt-in off), got: %v", result)
+		} else {
+			t.Logf("muninn_create_workflow_vault rejected as expected: %v", errVal)
 		}
 	})
 }

--- a/cmd/muninn/smoke_exhaustive_test.go
+++ b/cmd/muninn/smoke_exhaustive_test.go
@@ -959,14 +959,16 @@ func TestSmoke_AllMCPTools(t *testing.T) {
 	t.Run("muninn_create_workflow_vault", func(t *testing.T) {
 		// Privileged tool: requires opt-in (MUNINN_AGENT_VAULT_CREATE) + a full-mode
 		// mk_ key. The smoke daemon uses a static token with opt-in off, so the guard
-		// must reject this call — the error is expected (it proves the gate fires).
-		result := mcpTool(t, tok, "muninn_create_workflow_vault", map[string]any{
+		// must reject this call. Use mcpToolNoFail (the tool legitimately errors here)
+		// and assert the opt-in-disabled rejection fired — proves the gate works.
+		_, err := mcpToolNoFail(t, tok, "muninn_create_workflow_vault", map[string]any{
 			"name": "wf-smoke",
 		})
-		if errVal, hasErr := result["error"]; !hasErr {
-			t.Errorf("muninn_create_workflow_vault: expected guard rejection (static token, opt-in off), got: %v", result)
-		} else {
-			t.Logf("muninn_create_workflow_vault rejected as expected: %v", errVal)
+		if err == nil {
+			t.Fatalf("muninn_create_workflow_vault: expected guard rejection (static token, opt-in off), got success")
+		}
+		if !strings.Contains(err.Error(), "disabled") {
+			t.Errorf("muninn_create_workflow_vault: unexpected error %q (want the opt-in-disabled rejection)", err)
 		}
 	})
 }

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -123,10 +123,7 @@ A `cap_` token resolves to `IsCapability=true`, distinct from `IsAPIKey`. This d
 - **Mode-enforced identically.** A `full` cap can mutate cognitive state; an `observe` cap cannot — the same `ReadOnlyGuard` / `denyReadOnlyMutation` paths apply.
 - **Rejected at the privileged tool boundary.** `muninn_create_workflow_vault` requires `IsAPIKey && full`. Because capabilities authenticate as `IsCapability`, they are rejected at dispatch. Recursion is structurally impossible, not merely policy.
 
-```bash
-curl http://127.0.0.1:8475/api/engrams?vault=wf-acme12 \
-  -H "Authorization: Bearer cap_xK9m..."
-```
+**MCP-only authentication.** `cap_` tokens are resolved on **MCP transports only** (stdio, SSE, HTTP-streamable). The REST (port 8475) and gRPC transports call only `ValidateAPIKey`, so they accept `mk_` keys but **not** `cap_` tokens — a `cap_` bearer on REST/gRPC is rejected as an invalid key. Use `mk_` keys to drive those transports, or reach the vault over MCP with the `cap_` token.
 
 ### Minting capabilities — `muninn_create_workflow_vault`
 
@@ -175,7 +172,7 @@ The vault is created with the `working` preset (default cognition + 7-day auto-e
 ### TTL configuration
 
 - **Per-call:** the `ttl_hours` arg (default `168`).
-- **Operator-wide clamp:** `MUNINN_WORKFLOW_CAP_TTL_HOURS` overrides the default when set, letting operators pin a fleet-wide ceiling that individual calls cannot exceed.
+- **Operator-wide ceiling:** `MUNINN_WORKFLOW_CAP_TTL_HOURS` clamps the per-call value — when set, a caller's `ttl_hours` is honored only up to this fleet-wide maximum, and any larger request is capped.
 
 ### Security notes
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -94,6 +94,97 @@ For body-based REST routes, the vault must be supplied as `?vault=`. Some routes
 
 ---
 
+## Workflow capabilities (`cap_`)
+
+Capabilities are a second vault credential type, designed for **short-lived, scoped access** in agentic workflows. Where an `mk_` key is a long-lived integration credential you create and rotate by hand, a `cap_` token is minted programmatically, carries a mandatory expiry, and cannot escalate its own privileges.
+
+| | `mk_` API key | `cap_` capability |
+|---|---|---|
+| Lifetime | Long-lived, until revoked | **TTL-bound** (default 168h / 7d) |
+| Created by | Admin, via the admin API | `muninn_create_workflow_vault` tool, programmatically |
+| Can mint vaults? | Yes (with `full` mode + opt-in) | **No** — structural recursion guard |
+| Auth identity | `IsAPIKey` | `IsCapability` |
+| Mode-enforced | Yes (`full` / `observe` / `write`) | Yes — same guards |
+
+### Capability format
+
+```
+cap_xK9mP2nQ4rT7wY1aZb3cD5eF6gH7iJ8kL9m
+│   └─────────────────────────────────── 32 random bytes, base64url encoded
+└── prefix identifies MuninnDB capabilities
+```
+
+Like `mk_` keys, the raw bytes are generated with `crypto/rand` and only a SHA-256 hash is persisted — the token itself is the credential. The defining difference is the mandatory `ExpiresAt`: a capability with no TTL is refused at mint time.
+
+### How capabilities authenticate
+
+A `cap_` token resolves to `IsCapability=true`, distinct from `IsAPIKey`. This distinction is load-bearing:
+
+- **Mode-enforced identically.** A `full` cap can mutate cognitive state; an `observe` cap cannot — the same `ReadOnlyGuard` / `denyReadOnlyMutation` paths apply.
+- **Rejected at the privileged tool boundary.** `muninn_create_workflow_vault` requires `IsAPIKey && full`. Because capabilities authenticate as `IsCapability`, they are rejected at dispatch. Recursion is structurally impossible, not merely policy.
+
+```bash
+curl http://127.0.0.1:8475/api/engrams?vault=wf-acme12 \
+  -H "Authorization: Bearer cap_xK9m..."
+```
+
+### Minting capabilities — `muninn_create_workflow_vault`
+
+The MCP tool `muninn_create_workflow_vault` creates a workflow vault and mints a full-mode capability for it in one call. It is **opt-in and off by default**.
+
+**Opt-in (operator):**
+
+```bash
+export MUNINN_AGENT_VAULT_CREATE=1
+```
+
+When unset (or any value other than `1`), the tool returns `forbidden: agent vault creation disabled` even if the caller holds a valid full-mode `mk_` key. The caller must also be an `mk_` key in `full` mode — a `cap_` bearer is rejected by the recursion guard.
+
+**Call (MCP):**
+
+```json
+{
+  "name": "wf-acme-sprint",
+  "label": "acme-worker",
+  "ttl_hours": 168
+}
+```
+
+| Arg | Default | Notes |
+|-----|---------|-------|
+| `name` | auto `wf-<8hex>` | 1-64 lowercase alphanumeric / hyphen / underscore |
+| `label` | `agent-minted` | Stamped on the capability for audit and listing |
+| `ttl_hours` | `168` (7 days) | Matches the `working` preset's 7-day retention |
+
+**Response:**
+
+```json
+{
+  "vault": "wf-acme-sprint",
+  "capability_id": "A1B2C3D4",
+  "capability_secret": "cap_xK9m...",
+  "mode": "full",
+  "expires_at": "2026-07-23T12:19:21Z",
+  "auto_evap_days": 7,
+  "warning": "capability_secret is shown once; distribute it to worker agents. The vault auto-evaporates engrams after 7 days."
+}
+```
+
+The vault is created with the `working` preset (default cognition + 7-day auto-evaporation) and `multi_user` enabled, so the agent guide steers worker agents toward per-user-scoped recall. `capability_secret` is returned **once** — distribute it to worker agents out-of-band.
+
+### TTL configuration
+
+- **Per-call:** the `ttl_hours` arg (default `168`).
+- **Operator-wide clamp:** `MUNINN_WORKFLOW_CAP_TTL_HOURS` overrides the default when set, letting operators pin a fleet-wide ceiling that individual calls cannot exceed.
+
+### Security notes
+
+- **Bearer token.** A `cap_` is a bearer credential — anyone holding it can access the vault at its mode until it expires or is revoked. The TTL bounds exposure if a token leaks via logs or transcripts; it does not prevent the leak. Distribute secrets out-of-band and never log them.
+- **Shown once.** `capability_secret` appears in the MCP response and never again. The store holds only a SHA-256 hash.
+- **Recursion-proof by construction.** The privileged tool checks `IsAPIKey && full` at dispatch. Capabilities authenticate as `IsCapability` and cannot satisfy that check, so no capability can mint another capability — a leaked `cap_` cannot spiral into unauthorized vault creation.
+
+---
+
 ## Managing keys
 
 ### Create a key (admin only)
@@ -259,6 +350,7 @@ If each user had their own relevance weights, the vault would have N brains inst
 | Key revocation | Immediate, no grace period |
 | Observe isolation | Enforced at both the transport layer (`ReadOnlyGuard` on REST, `denyReadOnlyMutation` on gRPC) and the engine activation layer — not just an honor system |
 | Encryption at rest | Not built-in — use OS/volume encryption; see [self-hosting guide](self-hosting.md#encryption-at-rest) |
+| Capability tokens | TTL-bound bearer; SHA-256 hash only (plaintext never persisted); recursion-guarded at dispatch — `IsAPIKey` is required to mint, so no `cap_` can mint another |
 
 ---
 

--- a/internal/auth/capability.go
+++ b/internal/auth/capability.go
@@ -1,0 +1,19 @@
+package auth
+
+import "time"
+
+// Capability is a scoped, revocable, TTL'd credential distinct from an APIKey.
+// It authenticates via the "cap_" token prefix and resolves to {Vault, Mode}.
+// Capabilities are minted by muninn_create_workflow_vault so worker agents can
+// access a workflow vault without holding an mk_ key (which would let it mint
+// more vaults). See RFC #597.
+type Capability struct {
+	ID          string     `json:"id"`
+	Vault       string     `json:"vault"`
+	Mode        string     `json:"mode"` // ModeFull | ModeObserve | ModeWrite
+	Label       string     `json:"label"`
+	Origin      string     `json:"origin"` // provenance, e.g. "workflow_vault"
+	CreatedAt   time.Time  `json:"created_at"`
+	StorageHash []byte     `json:"storage_hash"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+}

--- a/internal/auth/capability_store.go
+++ b/internal/auth/capability_store.go
@@ -1,0 +1,159 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+)
+
+// ErrCapabilityNotFound is returned by RevokeCapability when the cap is absent.
+var ErrCapabilityNotFound = errors.New("capability not found")
+
+// errCapabilityNoExpiry enforces that workflow capabilities always carry a TTL
+// (part of the RedTeam mitigation: bounded credential lifetime).
+var errCapabilityNoExpiry = errors.New("capability requires an ExpiresAt (nil forbidden)")
+
+// GenerateCapability creates a new cap_ token for the given vault.
+// ttl is required (pass a non-nil ExpiresAt); returns the raw token (shown once) and metadata.
+func (s *Store) GenerateCapability(vault, label, mode, origin string, expiresAt *time.Time) (token string, cap Capability, err error) {
+	if mode != ModeFull && mode != ModeObserve && mode != ModeWrite {
+		err = fmt.Errorf("mode must be %q, %q, or %q", ModeFull, ModeObserve, ModeWrite)
+		return
+	}
+	if expiresAt == nil {
+		err = errCapabilityNoExpiry
+		return
+	}
+
+	raw := make([]byte, 32)
+	if _, err = rand.Read(raw); err != nil {
+		err = fmt.Errorf("generate random bytes: %w", err)
+		return
+	}
+	token = "cap_" + base64.RawURLEncoding.EncodeToString(raw)
+
+	h := sha256.Sum256(raw)
+	storageHash := h[:16]
+	capID := h[:8]
+
+	cap = Capability{
+		ID:          base64.RawURLEncoding.EncodeToString(capID),
+		Vault:       vault,
+		Label:       label,
+		Mode:        mode,
+		Origin:      origin,
+		CreatedAt:   time.Now(),
+		StorageHash: storageHash,
+		ExpiresAt:   expiresAt,
+	}
+
+	data, marshalErr := json.Marshal(cap)
+	if marshalErr != nil {
+		err = fmt.Errorf("marshal capability: %w", marshalErr)
+		return
+	}
+
+	batch := s.db.NewBatch()
+	if setErr := batch.Set(capabilityStorageKey(storageHash), data, nil); setErr != nil {
+		batch.Close()
+		err = setErr
+		return
+	}
+	if setErr := batch.Set(capabilityVaultIdxKey(vault, capID), storageHash, nil); setErr != nil {
+		batch.Close()
+		err = setErr
+		return
+	}
+	err = batch.Commit(pebble.Sync)
+	return
+}
+
+// ValidateCapability parses the cap_ token and returns its metadata.
+func (s *Store) ValidateCapability(token string) (Capability, error) {
+	const pfx = "cap_"
+	if len(token) <= len(pfx) || token[:len(pfx)] != pfx {
+		return Capability{}, fmt.Errorf("invalid token format")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(token[len(pfx):])
+	if err != nil || len(raw) != 32 {
+		return Capability{}, fmt.Errorf("invalid token encoding")
+	}
+	h := sha256.Sum256(raw)
+	data, closer, err := s.db.Get(capabilityStorageKey(h[:16]))
+	if err != nil {
+		return Capability{}, fmt.Errorf("invalid capability")
+	}
+	defer closer.Close()
+
+	var cap Capability
+	if err := json.Unmarshal(data, &cap); err != nil {
+		return Capability{}, fmt.Errorf("corrupt capability record: %w", err)
+	}
+	if cap.ExpiresAt == nil || time.Now().After(*cap.ExpiresAt) {
+		return Capability{}, fmt.Errorf("capability has expired")
+	}
+	return cap, nil
+}
+
+// ListCapabilities returns all capability metadata for a vault (tokens not included).
+func (s *Store) ListCapabilities(vault string) ([]Capability, error) {
+	prefix := capabilityVaultIdxPrefix(vault)
+	upper := make([]byte, len(prefix))
+	copy(upper, prefix)
+	upper[len(upper)-1]++
+
+	iter, err := s.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		return nil, fmt.Errorf("new iter: %w", err)
+	}
+	defer iter.Close()
+
+	var caps []Capability
+	for iter.First(); iter.Valid(); iter.Next() {
+		storageHash := make([]byte, 16)
+		copy(storageHash, iter.Value())
+		data, closer, err := s.db.Get(capabilityStorageKey(storageHash))
+		if err != nil {
+			continue
+		}
+		var cap Capability
+		if jsonErr := json.Unmarshal(data, &cap); jsonErr == nil {
+			caps = append(caps, cap)
+		}
+		closer.Close()
+	}
+	return caps, iter.Error()
+}
+
+// RevokeCapability removes the capability with the given display ID from the vault.
+func (s *Store) RevokeCapability(vault, capID string) error {
+	idBytes, err := base64.RawURLEncoding.DecodeString(capID)
+	if err != nil || len(idBytes) != 8 {
+		return ErrCapabilityNotFound
+	}
+	idxKey := capabilityVaultIdxKey(vault, idBytes)
+	storageHash, closer, err := s.db.Get(idxKey)
+	if err != nil {
+		return ErrCapabilityNotFound
+	}
+	hash := make([]byte, 16)
+	copy(hash, storageHash)
+	closer.Close()
+
+	batch := s.db.NewBatch()
+	if err := batch.Delete(capabilityStorageKey(hash), nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Delete(idxKey, nil); err != nil {
+		batch.Close()
+		return err
+	}
+	return batch.Commit(pebble.Sync)
+}

--- a/internal/auth/capability_store_test.go
+++ b/internal/auth/capability_store_test.go
@@ -1,0 +1,63 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCapability_GenerateValidateRoundtrip(t *testing.T) {
+	db := openAuthTestDB(t)
+	store := NewStore(db)
+	exp := time.Now().Add(time.Hour)
+	token, cap, err := store.GenerateCapability("wf-x", "agent", ModeFull, "workflow_vault", &exp)
+	if err != nil {
+		t.Fatalf("GenerateCapability: %v", err)
+	}
+	if token[:4] != "cap_" {
+		t.Errorf("token prefix want cap_, got %q", token[:4])
+	}
+	got, err := store.ValidateCapability(token)
+	if err != nil {
+		t.Fatalf("ValidateCapability: %v", err)
+	}
+	if got.Vault != "wf-x" || got.Mode != ModeFull || got.Origin != "workflow_vault" {
+		t.Errorf("resolved cap = %+v", got)
+	}
+	if cap.ID != got.ID {
+		t.Error("ID mismatch between generate and validate")
+	}
+}
+
+func TestCapability_ExpiredRejected(t *testing.T) {
+	db := openAuthTestDB(t)
+	store := NewStore(db)
+	past := time.Now().Add(-time.Minute)
+	token, _, err := store.GenerateCapability("wf-x", "agent", ModeFull, "workflow_vault", &past)
+	if err != nil {
+		t.Fatalf("GenerateCapability: %v", err)
+	}
+	if _, err := store.ValidateCapability(token); err == nil {
+		t.Error("expired capability should fail validation")
+	}
+}
+
+func TestCapability_Revoke(t *testing.T) {
+	db := openAuthTestDB(t)
+	store := NewStore(db)
+	exp := time.Now().Add(time.Hour)
+	token, cap, _ := store.GenerateCapability("wf-x", "agent", ModeFull, "workflow_vault", &exp)
+	if err := store.RevokeCapability("wf-x", cap.ID); err != nil {
+		t.Fatalf("RevokeCapability: %v", err)
+	}
+	if _, err := store.ValidateCapability(token); err == nil {
+		t.Error("revoked capability should fail validation")
+	}
+}
+
+func TestCapability_NilExpiryForbidden(t *testing.T) {
+	db := openAuthTestDB(t)
+	store := NewStore(db)
+	if _, _, err := store.GenerateCapability("wf-x", "agent", ModeFull, "workflow_vault", nil); err == nil {
+		t.Error("workflow capabilities must have an expiry (nil ExpiresAt forbidden)")
+	}
+}

--- a/internal/auth/keys.go
+++ b/internal/auth/keys.go
@@ -1,10 +1,12 @@
 package auth
 
 const (
-	prefixAdminUser  byte = 0x11
-	prefixAPIKey     byte = 0x12
-	prefixAPIKeyVIdx byte = 0x13
-	prefixVaultCfg   byte = 0x14
+	prefixAdminUser      byte = 0x11
+	prefixAPIKey         byte = 0x12
+	prefixAPIKeyVIdx     byte = 0x13
+	prefixVaultCfg       byte = 0x14
+	prefixCapability     byte = 0x15
+	prefixCapabilityVIdx byte = 0x16
 )
 
 func adminUserKey(username string) []byte {
@@ -35,6 +37,32 @@ func apiKeyVaultIdxKey(vault string, keyID []byte) []byte {
 func apiKeyVaultIdxPrefix(vault string) []byte {
 	key := make([]byte, 1+len(vault)+1)
 	key[0] = prefixAPIKeyVIdx
+	copy(key[1:], vault)
+	key[1+len(vault)] = 0x00
+	return key
+}
+
+func capabilityStorageKey(hash16 []byte) []byte {
+	key := make([]byte, 1+16)
+	key[0] = prefixCapability
+	copy(key[1:], hash16)
+	return key
+}
+
+// capabilityVaultIdxKey indexes capabilities by vault for listing/revocation.
+func capabilityVaultIdxKey(vault string, capID []byte) []byte {
+	key := make([]byte, 1+len(vault)+1+8)
+	key[0] = prefixCapabilityVIdx
+	copy(key[1:], vault)
+	key[1+len(vault)] = 0x00
+	copy(key[1+len(vault)+1:], capID[:8])
+	return key
+}
+
+// capabilityVaultIdxPrefix returns the scan prefix for all capabilities in a vault.
+func capabilityVaultIdxPrefix(vault string) []byte {
+	key := make([]byte, 1+len(vault)+1)
+	key[0] = prefixCapabilityVIdx
 	copy(key[1:], vault)
 	key[1+len(vault)] = 0x00
 	return key

--- a/internal/auth/keys.go
+++ b/internal/auth/keys.go
@@ -5,8 +5,8 @@ const (
 	prefixAPIKey         byte = 0x12
 	prefixAPIKeyVIdx     byte = 0x13
 	prefixVaultCfg       byte = 0x14
-	prefixCapability     byte = 0x15
-	prefixCapabilityVIdx byte = 0x16
+	prefixCapability     byte = 0x40
+	prefixCapabilityVIdx byte = 0x41
 )
 
 func adminUserKey(username string) []byte {

--- a/internal/auth/keys_test.go
+++ b/internal/auth/keys_test.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"testing"
+)
+
+// TestCapabilityPrefixesNoCollision (RedTeam NOTABLE #5 regression guard):
+// the 0x40/0x41 capability prefixes were relocated off storage's 0x15/0x16
+// keyspace (commit 0553a07). This test asserts the prefixes don't collide
+// with the storage layer's range (0x01–0x2A) or auth's own range
+// (0x11–0x14). Reverting 0x40→0x15 (or any value in either range) would
+// fail this test, catching the regression before it ships.
+//
+// The storage prefix range is sourced from the keys package; we hard-code
+// the known bounds here so this test stays in the auth package without an
+// import cycle. If storage extends past 0x2A, update storageMaxPrefix.
+func TestCapabilityPrefixesNoCollision(t *testing.T) {
+	// Known storage prefix bounds (internal/storage/keys/keys.go).
+	// As of this writing, the highest storage prefix is 0x2A (LeaseKey).
+	const storageMinPrefix = 0x01
+	const storageMaxPrefix = 0x2A
+
+	// Auth's own non-capability prefixes (admin user, API key, API key vIdx,
+	// vault config).
+	const authOwnMin = 0x11
+	const authOwnMax = 0x14
+
+	capPrefixes := []struct {
+		name string
+		val  byte
+	}{
+		{"prefixCapability", prefixCapability},         // 0x40
+		{"prefixCapabilityVIdx", prefixCapabilityVIdx}, // 0x41
+	}
+
+	for _, p := range capPrefixes {
+		// Must be ABOVE both ranges — not inside storage's, not inside auth's own.
+		if p.val >= storageMinPrefix && p.val <= storageMaxPrefix {
+			t.Errorf("%s = 0x%02X collides with storage prefix range [0x%02X, 0x%02X] — capabilities would corrupt storage keys",
+				p.name, p.val, storageMinPrefix, storageMaxPrefix)
+		}
+		if p.val >= authOwnMin && p.val <= authOwnMax {
+			t.Errorf("%s = 0x%02X collides with auth's own prefix range [0x%02X, 0x%02X] — capabilities would corrupt API key or vault config records",
+				p.name, p.val, authOwnMin, authOwnMax)
+		}
+	}
+
+	// The capability prefixes must also be distinct from each other.
+	if prefixCapability == prefixCapabilityVIdx {
+		t.Errorf("prefixCapability == prefixCapabilityVIdx (both 0x%02X) — storage and vault index keys would collide", prefixCapability)
+	}
+}

--- a/internal/engine/engine_vault.go
+++ b/internal/engine/engine_vault.go
@@ -245,6 +245,14 @@ func (e *Engine) RegisterVaultName(name string) error {
 	return e.store.WriteVaultName(ws, name)
 }
 
+// VaultNameExists reports whether a vault with the given name is registered.
+// Delegates to PebbleStore.VaultNameExists (0x0F name→prefix index lookup).
+// Used by muninn_create_workflow_vault to reject names that already exist,
+// preventing cross-vault config clobber (RFC #597 RedTeam finding).
+func (e *Engine) VaultNameExists(name string) bool {
+	return e.store.VaultNameExists(name)
+}
+
 // RenameVault atomically renames a vault. This is a metadata-only operation —
 // no engram data is moved or modified. Returns ErrVaultNotFound if oldName
 // doesn't exist, ErrVaultJobActive if a clone/merge job targets the vault,

--- a/internal/mcp/auth_mk_test.go
+++ b/internal/mcp/auth_mk_test.go
@@ -800,6 +800,14 @@ func TestDispatch_WriteMode_AllMutatingToolsAllowed(t *testing.T) {
 		if !isMutatingTool(name) {
 			continue
 		}
+		// muninn_create_workflow_vault is a privileged mutating tool: although
+		// classified mutating (so observe-mode keys are blocked by mode
+		// enforcement), it additionally requires a full-mode mk_ key via the
+		// recursion guard. Write-mode is correctly rejected. See
+		// TestCreateWorkflowVault_NonFullKeyRejected.
+		if name == "muninn_create_workflow_vault" {
+			continue
+		}
 		body := mkToolCallBody(name, map[string]any{"vault": "v", "concept": "x", "content": "y", "id": "x", "ids": []string{"x"}, "merged_content": "y", "decision": "x", "rationale": "y"})
 		w := doAuthenticatedPost(srv, "mk_wrt-all", body)
 		var resp JSONRPCResponse

--- a/internal/mcp/auth_mk_test.go
+++ b/internal/mcp/auth_mk_test.go
@@ -64,7 +64,7 @@ func TestAuthFromRequest_MkToken_ValidFullMode(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer mk_abc123")
 
-	a := authFromRequest(req, "mdb_statictoken", store)
+	a := authFromRequest(req, "mdb_statictoken", store, nil)
 
 	if !a.Authorized {
 		t.Fatal("expected Authorized=true for valid mk_ key")
@@ -92,7 +92,7 @@ func TestAuthFromRequest_MkToken_ObserveMode(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer mk_obs999")
 
-	a := authFromRequest(req, "mdb_x", store)
+	a := authFromRequest(req, "mdb_x", store, nil)
 
 	if !a.Authorized {
 		t.Fatal("expected Authorized=true")
@@ -111,7 +111,7 @@ func TestAuthFromRequest_MkToken_WriteMode(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer mk_wrt777")
 
-	a := authFromRequest(req, "mdb_x", store)
+	a := authFromRequest(req, "mdb_x", store, nil)
 
 	if a.Mode != auth.ModeWrite {
 		t.Errorf("expected write mode, got %q", a.Mode)
@@ -123,7 +123,7 @@ func TestAuthFromRequest_MkToken_Expired(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer mk_expired")
 
-	a := authFromRequest(req, "mdb_x", store)
+	a := authFromRequest(req, "mdb_x", store, nil)
 
 	if a.Authorized {
 		t.Error("expected Authorized=false for expired/revoked key")
@@ -135,7 +135,7 @@ func TestAuthFromRequest_MkToken_NilStore(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer mk_somekey")
 
-	a := authFromRequest(req, "mdb_static", nil)
+	a := authFromRequest(req, "mdb_static", nil, nil)
 
 	if a.Authorized {
 		t.Error("expected Authorized=false when apiKeyStore is nil")
@@ -146,7 +146,7 @@ func TestAuthFromRequest_StaticToken_BackwardCompat(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer mdb_mytoken")
 
-	a := authFromRequest(req, "mdb_mytoken", nil)
+	a := authFromRequest(req, "mdb_mytoken", nil, nil)
 
 	if !a.Authorized {
 		t.Fatal("static mdb_ token must still work")
@@ -163,7 +163,7 @@ func TestAuthFromRequest_StaticToken_WrongValue(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer mdb_wrong")
 
-	a := authFromRequest(req, "mdb_correct", nil)
+	a := authFromRequest(req, "mdb_correct", nil, nil)
 
 	if a.Authorized {
 		t.Error("wrong static token must be rejected")
@@ -173,7 +173,7 @@ func TestAuthFromRequest_StaticToken_WrongValue(t *testing.T) {
 func TestAuthFromRequest_NoToken(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 
-	a := authFromRequest(req, "mdb_x", nil)
+	a := authFromRequest(req, "mdb_x", nil, nil)
 
 	if a.Authorized {
 		t.Error("missing token must be rejected")
@@ -184,7 +184,7 @@ func TestAuthFromRequest_EmptyRequiredToken(t *testing.T) {
 	// Server started with no token = open access.
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 
-	a := authFromRequest(req, "", nil)
+	a := authFromRequest(req, "", nil, nil)
 
 	if !a.Authorized {
 		t.Error("no required token = should always authorize")
@@ -203,7 +203,7 @@ func TestAuthFromRequest_OpenServer_ValidMkKey(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer mk_vaultkey1")
 
-	a := authFromRequest(req, "", store) // no static token = open-server mode
+	a := authFromRequest(req, "", store, nil) // no static token = open-server mode
 
 	if !a.Authorized {
 		t.Fatal("valid mk_ key must be authorized in open-server mode")
@@ -223,7 +223,7 @@ func TestAuthFromRequest_OpenServer_InvalidMkKey(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer mk_badkey")
 
-	a := authFromRequest(req, "", store) // no static token = open-server mode
+	a := authFromRequest(req, "", store, nil) // no static token = open-server mode
 
 	if a.Authorized {
 		t.Error("invalid mk_ key must not fall through to open access")
@@ -237,7 +237,7 @@ func TestAuthFromRequest_OpenServer_NoKey(t *testing.T) {
 	store := newMockKeyStore()
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 
-	a := authFromRequest(req, "", store)
+	a := authFromRequest(req, "", store, nil)
 
 	if !a.Authorized {
 		t.Error("no key presented in open-server mode must still authorize")
@@ -350,7 +350,7 @@ func mkToolCallBody(toolName string, args map[string]any) []byte {
 // testServer wraps MCPServer with a mock engine and key store for integration tests.
 func newAuthTestServer(keyStore apiKeyValidator) *MCPServer {
 	eng := &fakeEngine{}
-	return New(":0", eng, "mdb_static", keyStore, nil)
+	return New(":0", eng, "mdb_static", keyStore, nil, nil)
 }
 
 func doAuthenticatedPost(srv *MCPServer, token string, body []byte) *httptest.ResponseRecorder {
@@ -358,7 +358,7 @@ func doAuthenticatedPost(srv *MCPServer, token string, body []byte) *httptest.Re
 	r.Header.Set("Authorization", "Bearer "+token)
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	srv.handleRPC(w, r.WithContext(contextWithAuth(r.Context(), authFromRequest(r, srv.token, srv.authKeys))))
+	srv.handleRPC(w, r.WithContext(contextWithAuth(r.Context(), authFromRequest(r, srv.token, srv.authKeys, nil))))
 	return w
 }
 
@@ -514,7 +514,7 @@ func TestDispatch_StaticToken_FullAccess_AnyVault(t *testing.T) {
 		})
 		r := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(body))
 		r.Header.Set("Authorization", "Bearer mdb_static")
-		a := authFromRequest(r, srv.token, srv.authKeys)
+		a := authFromRequest(r, srv.token, srv.authKeys, nil)
 		w := httptest.NewRecorder()
 		srv.handleRPC(w, r.WithContext(contextWithAuth(r.Context(), a)))
 
@@ -564,14 +564,14 @@ func TestSSESession_StoresFullAuthContext(t *testing.T) {
 		Vault: "sse-vault",
 		Mode:  auth.ModeObserve,
 	})
-	srv := New(":0", &fakeEngine{}, "mdb_static", store, nil)
+	srv := New(":0", &fakeEngine{}, "mdb_static", store, nil, nil)
 
 	// Manually insert a session as handleSSE would after auth
 	a := authFromRequest(func() *http.Request {
 		r := httptest.NewRequest(http.MethodGet, "/mcp", nil)
 		r.Header.Set("Authorization", "Bearer mk_sse001")
 		return r
-	}(), "mdb_static", store)
+	}(), "mdb_static", store, nil)
 
 	srv.sseSessionsMu.Lock()
 	srv.sseSessions["test-session"] = &sseSession{
@@ -637,7 +637,7 @@ func TestAuthFromRequest_BearerOnly_NoToken(t *testing.T) {
 	// "Bearer " with trailing space but no actual token value.
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer ")
-	a := authFromRequest(req, "mdb_x", nil)
+	a := authFromRequest(req, "mdb_x", nil, nil)
 	if a.Authorized {
 		t.Error("'Bearer ' with empty token must be rejected")
 	}
@@ -647,7 +647,7 @@ func TestAuthFromRequest_LowercaseBearer(t *testing.T) {
 	// "bearer token" (lowercase) — Go's net/http does case-sensitive header values.
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "bearer mdb_x")
-	a := authFromRequest(req, "mdb_x", nil)
+	a := authFromRequest(req, "mdb_x", nil, nil)
 	if a.Authorized {
 		t.Error("lowercase 'bearer' prefix should be rejected (spec requires 'Bearer')")
 	}
@@ -656,7 +656,7 @@ func TestAuthFromRequest_LowercaseBearer(t *testing.T) {
 func TestAuthFromRequest_BasicScheme(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
-	a := authFromRequest(req, "mdb_x", nil)
+	a := authFromRequest(req, "mdb_x", nil, nil)
 	if a.Authorized {
 		t.Error("Basic auth scheme must be rejected")
 	}
@@ -667,7 +667,7 @@ func TestAuthFromRequest_BearerWithExtraSpaces(t *testing.T) {
 	// CutPrefix("Bearer ") leaves " tok" which is a different token.
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer  mdb_x")
-	a := authFromRequest(req, "mdb_x", nil)
+	a := authFromRequest(req, "mdb_x", nil, nil)
 	if a.Authorized {
 		t.Error("token with leading space should not match (timing-safe compare)")
 	}
@@ -677,7 +677,7 @@ func TestAuthFromRequest_BearerWithMultipleTokens(t *testing.T) {
 	// "Bearer tok1 tok2" — extra data after the token.
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer mdb_x extra_data")
-	a := authFromRequest(req, "mdb_x", nil)
+	a := authFromRequest(req, "mdb_x", nil, nil)
 	if a.Authorized {
 		t.Error("token with extra data after space must be rejected")
 	}
@@ -688,7 +688,7 @@ func TestAuthFromRequest_HugeToken_Rejected(t *testing.T) {
 	huge := "Bearer " + strings.Repeat("x", 10000)
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", huge)
-	a := authFromRequest(req, "mdb_x", nil)
+	a := authFromRequest(req, "mdb_x", nil, nil)
 	if a.Authorized {
 		t.Error("absurdly long token must be rejected")
 	}
@@ -699,7 +699,7 @@ func TestAuthFromRequest_MkPrefix_EmptySuffix(t *testing.T) {
 	store := newMockKeyStore() // empty store
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer mk_")
-	a := authFromRequest(req, "mdb_x", store)
+	a := authFromRequest(req, "mdb_x", store, nil)
 	if a.Authorized {
 		t.Error("'mk_' with empty suffix must be rejected")
 	}
@@ -849,7 +849,7 @@ func TestDispatch_UnknownMode_Rejected(t *testing.T) {
 // --- SSE message auth re-validation ---
 
 func TestSSEMessage_RequiresAuth_WhenServerHasToken(t *testing.T) {
-	srv := New(":0", &fakeEngine{}, "mdb_secret", nil, nil)
+	srv := New(":0", &fakeEngine{}, "mdb_secret", nil, nil, nil)
 
 	// Insert a fake SSE session
 	srv.sseSessionsMu.Lock()
@@ -874,7 +874,7 @@ func TestSSEMessage_RequiresAuth_WhenServerHasToken(t *testing.T) {
 // --- findSSEChannelsByToken with empty token ---
 
 func TestFindSSEChannelsByToken_EmptyToken_ReturnsNil(t *testing.T) {
-	srv := New(":0", &fakeEngine{}, "", nil, nil)
+	srv := New(":0", &fakeEngine{}, "", nil, nil, nil)
 
 	srv.sseSessionsMu.Lock()
 	srv.sseSessions["s1"] = &sseSession{ch: make(chan []byte, 4), auth: AuthContext{Token: ""}}

--- a/internal/mcp/auth_mk_test.go
+++ b/internal/mcp/auth_mk_test.go
@@ -358,7 +358,7 @@ func doAuthenticatedPost(srv *MCPServer, token string, body []byte) *httptest.Re
 	r.Header.Set("Authorization", "Bearer "+token)
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	srv.handleRPC(w, r.WithContext(contextWithAuth(r.Context(), authFromRequest(r, srv.token, srv.authKeys, nil))))
+	srv.handleRPC(w, r.WithContext(contextWithAuth(r.Context(), authFromRequest(r, srv.token, srv.authKeys, srv.capKeys))))
 	return w
 }
 

--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -28,6 +28,13 @@ type apiKeyValidator interface {
 	ValidateAPIKey(token string) (auth.APIKey, error)
 }
 
+// capabilityValidator is the subset of auth.Store used by MCP for cap_ token
+// auth (RFC #597). Kept as an interface so the mcp package remains testable
+// without a live Pebble store; the real implementation is *auth.Store.
+type capabilityValidator interface {
+	ValidateCapability(token string) (auth.Capability, error)
+}
+
 // mcpAuthContextKey is the unexported key used to store AuthContext in request context.
 type mcpAuthContextKey struct{}
 
@@ -52,7 +59,10 @@ func authFromContext(ctx context.Context) AuthContext {
 //  3. Open-server mode — if no static token configured and no mk_ key present, allow.
 //
 // apiKeyStore may be nil to disable mk_ key auth (legacy mode).
-func authFromRequest(r *http.Request, requiredToken string, apiKeyStore apiKeyValidator) AuthContext {
+// capStore may be nil to disable cap_ capability auth (pre-RFC #597 mode);
+// when non-nil, an invalid or expired cap_ token fails closed (never falls
+// through to open-server), mirroring the mk_ posture.
+func authFromRequest(r *http.Request, requiredToken string, apiKeyStore apiKeyValidator, capStore capabilityValidator) AuthContext {
 	token, found := auth.ParseBearerToken(r.Header.Get("Authorization"))
 
 	// 1. mk_ vault API key — always checked first, regardless of whether a static
@@ -69,6 +79,24 @@ func authFromRequest(r *http.Request, requiredToken string, apiKeyStore apiKeyVa
 			}
 		}
 		// Invalid mk_ key: fail-closed. Do not fall through to open-server mode.
+		return AuthContext{Authorized: false}
+	}
+
+	// 1b. cap_ capability token — vault-pinned, mode-enforced, TTL'd (RFC #597).
+	// Checked before the open-server fallthrough: an invalid or expired cap_
+	// token must NOT drop into open-server mode. When capStore is nil, cap_
+	// auth is disabled and the branch is skipped (backward-compatible).
+	if found && len(token) > 4 && token[:4] == "cap_" && capStore != nil {
+		if cap, err := capStore.ValidateCapability(token); err == nil {
+			return AuthContext{
+				Token:        token,
+				Authorized:   true,
+				Vault:        cap.Vault,
+				Mode:         cap.Mode,
+				IsCapability: true,
+			}
+		}
+		// Invalid cap_ token: fail-closed.
 		return AuthContext{Authorized: false}
 	}
 

--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -206,7 +206,8 @@ func isMutatingTool(name string) bool {
 		"muninn_trust",
 		"muninn_compare_and_set",
 		"muninn_claim",
-		"muninn_release":
+		"muninn_release",
+		"muninn_create_workflow_vault":
 		return true
 	}
 	return false

--- a/internal/mcp/context_capability_test.go
+++ b/internal/mcp/context_capability_test.go
@@ -1,0 +1,42 @@
+package mcp
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/auth"
+)
+
+// stubCapStore satisfies capabilityValidator without a live Pebble store.
+type stubCapStore struct {
+	cap auth.Capability
+	err error
+}
+
+func (s stubCapStore) ValidateCapability(token string) (auth.Capability, error) {
+	return s.cap, s.err
+}
+
+func TestAuthFromRequest_CapToken(t *testing.T) {
+	exp := time.Now().Add(time.Hour)
+	stub := stubCapStore{cap: auth.Capability{Vault: "wf-x", Mode: auth.ModeFull, ExpiresAt: &exp}}
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer cap_abc")
+	a := authFromRequest(req, "", nil, stub)
+	if !a.Authorized || !a.IsCapability || a.IsAPIKey || a.Vault != "wf-x" || a.Mode != auth.ModeFull {
+		t.Errorf("cap auth resolved wrong: %+v", a)
+	}
+}
+
+func TestAuthFromRequest_InvalidCapFailClosed(t *testing.T) {
+	stub := stubCapStore{err: errors.New("nope")}
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer cap_abc")
+	a := authFromRequest(req, "", nil, stub)
+	if a.Authorized {
+		t.Error("invalid cap_ token must not fall through to open-server mode")
+	}
+}

--- a/internal/mcp/context_capability_test.go
+++ b/internal/mcp/context_capability_test.go
@@ -1,9 +1,11 @@
 package mcp
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,5 +40,35 @@ func TestAuthFromRequest_InvalidCapFailClosed(t *testing.T) {
 	a := authFromRequest(req, "", nil, stub)
 	if a.Authorized {
 		t.Error("invalid cap_ token must not fall through to open-server mode")
+	}
+}
+
+// TestDispatch_ObserveModeCapability_BlocksMutatingTool mirrors
+// TestDispatch_ObserveMode_BlocksMutatingTool (the mk_ variant in
+// auth_mk_test.go) but authenticates with a cap_ capability token
+// (IsCapability=true, IsAPIKey=false). It pins down that mode enforcement in
+// dispatchToolCall fires for capability bearers, not just mk_ API keys.
+func TestDispatch_ObserveModeCapability_BlocksMutatingTool(t *testing.T) {
+	exp := time.Now().Add(time.Hour)
+	stub := stubCapStore{cap: auth.Capability{
+		Vault:     "wf-x",
+		Mode:      auth.ModeObserve,
+		ExpiresAt: &exp,
+	}}
+	eng := &fakeEngine{}
+	srv := New(":0", eng, "", nil, stub, nil)
+
+	body := mkToolCallBody("muninn_remember", map[string]any{"vault": "wf-x", "concept": "x", "content": "y"})
+	w := doAuthenticatedPost(srv, "cap_obs-block", body)
+
+	var resp JSONRPCResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error response for observe-mode capability calling mutating tool")
+	}
+	if !strings.Contains(resp.Error.Message, "forbidden") {
+		t.Errorf("expected 'forbidden' in error, got: %s", resp.Error.Message)
 	}
 }

--- a/internal/mcp/create_workflow_vault_test.go
+++ b/internal/mcp/create_workflow_vault_test.go
@@ -1,0 +1,238 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/scrypster/muninndb/internal/auth"
+)
+
+// newWorkflowTestStore builds an *auth.Store over an in-memory Pebble DB for
+// create-workflow-vault tests. The store satisfies both apiKeyValidator and
+// capabilityValidator (and is the concrete type the handler needs for
+// SetVaultConfig + GenerateCapability).
+func newWorkflowTestStore(t *testing.T) *auth.Store {
+	t.Helper()
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return auth.NewStore(db)
+}
+
+// decodeRPCResult decodes a successful JSON-RPC response's result map.
+func decodeRPCResult(t *testing.T, w *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var resp JSONRPCResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v\nbody: %s", err, w.Body.String())
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: code=%d msg=%s", resp.Error.Code, resp.Error.Message)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result is not a map: %T", resp.Result)
+	}
+	return m
+}
+
+// assertRPCError asserts the response is a JSON-RPC error with wantCode and a
+// message containing wantMsgContains. A non-empty wantMsgContains distinguishes
+// a guard-layer rejection from an auth-layer "unauthorized" — critical for the
+// recursion-guard proof.
+func assertRPCError(t *testing.T, w *httptest.ResponseRecorder, wantCode int, wantMsgContains string) {
+	t.Helper()
+	var resp JSONRPCResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v\nbody: %s", err, w.Body.String())
+	}
+	if resp.Error == nil {
+		t.Fatalf("expected error code %d, got success result: %v", wantCode, resp.Result)
+	}
+	if resp.Error.Code != wantCode {
+		t.Errorf("error code = %d, want %d (msg: %s)", resp.Error.Code, wantCode, resp.Error.Message)
+	}
+	if wantMsgContains != "" && !strings.Contains(resp.Error.Message, wantMsgContains) {
+		t.Errorf("error message %q does not contain %q", resp.Error.Message, wantMsgContains)
+	}
+}
+
+// TestCreateWorkflowVault_OptInOff verifies the tool is disabled when
+// MUNINN_AGENT_VAULT_CREATE is unset (secure-by-default). Even a full-mode mk_
+// key caller is rejected with -32001 "disabled".
+func TestCreateWorkflowVault_OptInOff(t *testing.T) {
+	store := newWorkflowTestStore(t)
+	mkToken, _, err := store.GenerateAPIKey("admin", "admin", auth.ModeFull, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := New(":0", &fakeEngine{}, "", store, store, nil)
+	srv.agentVaultCreate = false // opt-in OFF (also the default)
+
+	body := mkToolCallBody("muninn_create_workflow_vault", map[string]any{})
+	w := doAuthenticatedPost(srv, mkToken, body)
+	assertRPCError(t, w, -32001, "disabled")
+}
+
+// TestCreateWorkflowVault_RecursionGuard_CapCallerRejected is the CRITICAL
+// security test for RFC #597. A legitimate cap_ capability token — exactly the
+// kind the tool itself mints — authenticates successfully (IsCapability=true,
+// IsAPIKey=false) yet MUST be rejected by the recursion guard. This proves the
+// structural fix: no capability can mint further vaults/capabilities, because
+// the guard gates on IsAPIKey, which capabilities never satisfy.
+//
+// The assertion on the guard's specific message ("full-mode mk_ key") — rather
+// than a generic "unauthorized" — proves the cap_ token passed authentication
+// and was rejected by the privileged-tool guard, not the auth layer.
+func TestCreateWorkflowVault_RecursionGuard_CapCallerRejected(t *testing.T) {
+	store := newWorkflowTestStore(t)
+	// Mint a real, valid, full-mode cap_ token against an existing workflow vault.
+	exp := time.Now().Add(time.Hour)
+	capToken, _, err := store.GenerateCapability("wf-existing", "worker", auth.ModeFull, "workflow_vault", &exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := New(":0", &fakeEngine{}, "", store, store, nil)
+	srv.agentVaultCreate = true // opt-in ON so the ONLY gate is the IsAPIKey check
+
+	body := mkToolCallBody("muninn_create_workflow_vault", map[string]any{})
+	w := doAuthenticatedPost(srv, capToken, body)
+	assertRPCError(t, w, -32001, "full-mode mk_ key")
+}
+
+// TestCreateWorkflowVault_NonFullKeyRejected verifies that a write-mode mk_
+// key — which passes mode enforcement (the tool is mutating) — is still
+// rejected by the recursion guard because it requires full-mode specifically.
+func TestCreateWorkflowVault_NonFullKeyRejected(t *testing.T) {
+	store := newWorkflowTestStore(t)
+	wrToken, _, err := store.GenerateAPIKey("admin", "writer", auth.ModeWrite, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := New(":0", &fakeEngine{}, "", store, store, nil)
+	srv.agentVaultCreate = true
+
+	body := mkToolCallBody("muninn_create_workflow_vault", map[string]any{})
+	w := doAuthenticatedPost(srv, wrToken, body)
+	assertRPCError(t, w, -32001, "full-mode mk_ key")
+}
+
+// TestCreateWorkflowVault_HappyPath verifies the end-to-end flow: a full-mode
+// mk_ key creates a named workflow vault, the vault is configured with the
+// working preset + multi_user, and the returned cap_ token validates as
+// full-mode against the new vault.
+func TestCreateWorkflowVault_HappyPath(t *testing.T) {
+	store := newWorkflowTestStore(t)
+	mkToken, _, err := store.GenerateAPIKey("admin", "admin", auth.ModeFull, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := New(":0", &fakeEngine{}, "", store, store, nil)
+	srv.agentVaultCreate = true
+	t.Setenv("MUNINN_WORKFLOW_CAP_TTL_HOURS", "") // no env override
+
+	body := mkToolCallBody("muninn_create_workflow_vault", map[string]any{"name": "wf-happy"})
+	w := doAuthenticatedPost(srv, mkToken, body)
+	result := decodeRPCResult(t, w)
+
+	if result["vault"] != "wf-happy" {
+		t.Errorf("vault = %v, want wf-happy", result["vault"])
+	}
+	capSecret, _ := result["capability_secret"].(string)
+	if capSecret == "" {
+		t.Fatal("capability_secret empty — must be shown once")
+	}
+	if !strings.HasPrefix(capSecret, "cap_") {
+		t.Errorf("capability_secret = %q, want cap_ prefix", capSecret)
+	}
+
+	// The minted token validates against the same store (full-mode, new vault).
+	cap, err := store.ValidateCapability(capSecret)
+	if err != nil {
+		t.Fatalf("minted cap_ token failed validation: %v", err)
+	}
+	if cap.Vault != "wf-happy" {
+		t.Errorf("cap vault = %s, want wf-happy", cap.Vault)
+	}
+	if cap.Mode != auth.ModeFull {
+		t.Errorf("cap mode = %s, want %s", cap.Mode, auth.ModeFull)
+	}
+
+	// Vault config: working preset + multi_user enabled.
+	cfg, err := store.GetVaultConfig("wf-happy")
+	if err != nil {
+		t.Fatalf("get vault config: %v", err)
+	}
+	if cfg.Plasticity == nil || cfg.Plasticity.Preset != "working" {
+		t.Errorf("preset = %v, want working", cfg.Plasticity)
+	}
+	if cfg.Plasticity == nil || cfg.Plasticity.MultiUser == nil || !*cfg.Plasticity.MultiUser {
+		t.Errorf("multi_user not enabled: %+v", cfg.Plasticity)
+	}
+}
+
+// TestCreateWorkflowVault_TTLHonored verifies the ttl_hours arg flows through
+// to the minted capability's ExpiresAt. With ttl_hours=1 and no env override,
+// the cap expires ~1h from now and validates successfully (not yet expired).
+func TestCreateWorkflowVault_TTLHonored(t *testing.T) {
+	store := newWorkflowTestStore(t)
+	mkToken, _, err := store.GenerateAPIKey("admin", "admin", auth.ModeFull, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := New(":0", &fakeEngine{}, "", store, store, nil)
+	srv.agentVaultCreate = true
+	t.Setenv("MUNINN_WORKFLOW_CAP_TTL_HOURS", "") // arg, not env, drives the TTL
+
+	before := time.Now()
+	body := mkToolCallBody("muninn_create_workflow_vault", map[string]any{
+		"name":      "wf-ttl",
+		"ttl_hours": float64(1), // JSON numbers arrive as float64
+	})
+	w := doAuthenticatedPost(srv, mkToken, body)
+	result := decodeRPCResult(t, w)
+
+	capSecret, _ := result["capability_secret"].(string)
+	cap, err := store.ValidateCapability(capSecret)
+	if err != nil {
+		t.Fatalf("validate cap: %v", err)
+	}
+	if cap.ExpiresAt == nil {
+		t.Fatal("minted cap has nil ExpiresAt — TTL not applied")
+	}
+	want := before.Add(time.Hour)
+	got := *cap.ExpiresAt
+	if tol := 5 * time.Minute; got.Sub(want).Abs() > tol {
+		t.Errorf("ttl expiry = %v, want ~%v (tol %v)", got, want, tol)
+	}
+}
+
+// TestCreateWorkflowVault_AutoName verifies that omitting "name" auto-generates
+// a wf-<8hex> vault name and the flow still succeeds.
+func TestCreateWorkflowVault_AutoName(t *testing.T) {
+	store := newWorkflowTestStore(t)
+	mkToken, _, err := store.GenerateAPIKey("admin", "admin", auth.ModeFull, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := New(":0", &fakeEngine{}, "", store, store, nil)
+	srv.agentVaultCreate = true
+	t.Setenv("MUNINN_WORKFLOW_CAP_TTL_HOURS", "")
+
+	body := mkToolCallBody("muninn_create_workflow_vault", map[string]any{})
+	w := doAuthenticatedPost(srv, mkToken, body)
+	result := decodeRPCResult(t, w)
+
+	name, _ := result["vault"].(string)
+	if !strings.HasPrefix(name, "wf-") || len(name) != len("wf-")+8 {
+		t.Errorf("auto-name = %q, want wf-<8hex>", name)
+	}
+}

--- a/internal/mcp/create_workflow_vault_test.go
+++ b/internal/mcp/create_workflow_vault_test.go
@@ -1,7 +1,9 @@
 package mcp
 
 import (
+	"bytes"
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -234,5 +236,141 @@ func TestCreateWorkflowVault_AutoName(t *testing.T) {
 	name, _ := result["vault"].(string)
 	if !strings.HasPrefix(name, "wf-") || len(name) != len("wf-")+8 {
 		t.Errorf("auto-name = %q, want wf-<8hex>", name)
+	}
+}
+
+// TestCreateWorkflowVault_Namespace_RejectsOperatorVault (RedTeam CRITICAL #1):
+// a caller-supplied name without the wf- prefix must be rejected even when
+// otherwise well-formed. This proves the structural anti-clobber guard: a
+// full-mode key scoped to one vault cannot pass name="default" or
+// name="production" to overwrite an operator vault's config.
+func TestCreateWorkflowVault_Namespace_RejectsOperatorVault(t *testing.T) {
+	store := newWorkflowTestStore(t)
+	mkToken, _, err := store.GenerateAPIKey("admin", "admin", auth.ModeFull, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := New(":0", &fakeEngine{}, "", store, store, nil)
+	srv.agentVaultCreate = true
+
+	cases := []struct {
+		name  string
+		vault string
+	}{
+		{"default", "default"},
+		{"production", "production"},
+		{"missing-prefix", "my-vault"},
+		{"prefix-only", "wf-"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := mkToolCallBody("muninn_create_workflow_vault", map[string]any{"name": tc.vault})
+			w := doAuthenticatedPost(srv, mkToken, body)
+			assertRPCError(t, w, -32602, "wf-")
+		})
+	}
+}
+
+// TestCreateWorkflowVault_RecursionGuard_ViaSSEPost (RedTeam NOTABLE #5):
+// exercises the recursion guard through the SSE message path
+// (handleSSEMessage → processAndPushSSE → dispatchToolCall), a different
+// production dispatch route than doAuthenticatedPost (which hits handleRPC).
+// A cap_ bearer opening an SSE session and then POSTing
+// muninn_create_workflow_vault must be rejected by the IsAPIKey guard inside
+// dispatchToolCall — proving the guard fires in real SSE routing.
+func TestCreateWorkflowVault_RecursionGuard_ViaSSEPost(t *testing.T) {
+	store := newWorkflowTestStore(t)
+	exp := time.Now().Add(time.Hour)
+	capToken, _, err := store.GenerateCapability("wf-existing", "worker", auth.ModeFull, "workflow_vault", &exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := New(":0", &fakeEngine{}, "", store, store, nil)
+	srv.agentVaultCreate = true
+
+	// Simulate an SSE session opened with the cap_ token: register the session
+	// the way handleSSE does, caching the cap_ auth context.
+	srv.sseSessionsMu.Lock()
+	srv.sseSessions["sess-cap"] = &sseSession{
+		ch:   make(chan []byte, 4),
+		auth: AuthContext{Token: capToken, Authorized: true, Vault: "wf-existing", Mode: auth.ModeFull, IsCapability: true},
+	}
+	srv.sseSessionsMu.Unlock()
+
+	body := mkToolCallBody("muninn_create_workflow_vault", map[string]any{})
+	r := httptest.NewRequest(http.MethodPost, "/mcp/message?sessionId=sess-cap", bytes.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+capToken)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleSSEMessage(w, r)
+
+	// The SSE POST writes the JSON-RPC response into both the POST body and the
+	// SSE channel. The POST body carries the dispatch result — assert the
+	// recursion guard fired with the IsAPIKey-specific message.
+	var resp JSONRPCResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v\nbody: %s", err, w.Body.String())
+	}
+	if resp.Error == nil {
+		t.Fatalf("expected recursion-guard rejection, got success result: %v", resp.Result)
+	}
+	if resp.Error.Code != -32001 {
+		t.Errorf("error code = %d, want -32001 (msg: %s)", resp.Error.Code, resp.Error.Message)
+	}
+	if !strings.Contains(resp.Error.Message, "full-mode mk_ key") {
+		t.Errorf("error message %q does not contain 'full-mode mk_ key' — guard may not have fired", resp.Error.Message)
+	}
+}
+
+// TestSSEMessage_CapRevokedMidSession_RejectedOnPost (RedTeam CRITICAL #2 + #5):
+// proves the per-POST re-validation of cached SSE credentials. Opens an SSE
+// session with a valid cap_, then revokes the cap_ mid-session, then POSTs
+// WITHOUT re-sending the bearer token — simulating the MCP SSE client pattern
+// where the bearer is sent only on the GET (SSE open) and subsequent POSTs
+// rely on the session ID. Without Fix 2 the POST passes (authFromRequest
+// falls through to open-server mode because there's no static token and no
+// bearer on the POST) and dispatches on the cached, now-revoked sess.auth;
+// with Fix 2 the POST is rejected because ValidateCapability(sess.auth.Token)
+// catches the revocation. This is the RED-sanity test for Fix 2.
+func TestSSEMessage_CapRevokedMidSession_RejectedOnPost(t *testing.T) {
+	store := newWorkflowTestStore(t)
+	exp := time.Now().Add(time.Hour)
+	capToken, cap, err := store.GenerateCapability("wf-session", "worker", auth.ModeFull, "workflow_vault", &exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Server has NO static token (""), only cap_ auth. This is the deployment
+	// shape where the confused-deputy is exploitable without Fix 2: a POST
+	// without a bearer falls through authFromRequest to open-server mode.
+	srv := New(":0", &fakeEngine{}, "", store, store, nil)
+	srv.agentVaultCreate = true
+
+	// Open SSE session with the cap_ token (valid at open time).
+	srv.sseSessionsMu.Lock()
+	srv.sseSessions["sess-revoke"] = &sseSession{
+		ch:   make(chan []byte, 4),
+		auth: AuthContext{Token: capToken, Authorized: true, Vault: "wf-session", Mode: auth.ModeFull, IsCapability: true},
+	}
+	srv.sseSessionsMu.Unlock()
+
+	// Revoke the capability mid-session.
+	if err := store.RevokeCapability("wf-session", cap.ID); err != nil {
+		t.Fatalf("revoke capability: %v", err)
+	}
+
+	// POST WITHOUT Authorization header — simulates the client pattern where
+	// the bearer is sent only on the GET. The POST auth check falls through to
+	// open-server mode (no static token, no bearer), so only Fix 2's
+	// sess.auth re-validation catches the revoked cap_.
+	body := mkToolCallBody("muninn_recall", map[string]any{"context": []string{"x"}})
+	r := httptest.NewRequest(http.MethodPost, "/mcp/message?sessionId=sess-revoke", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleSSEMessage(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 after cap_ revoked mid-session (POST without bearer), got %d (body: %s)", w.Code, w.Body.String())
 	}
 }

--- a/internal/mcp/decide_test.go
+++ b/internal/mcp/decide_test.go
@@ -102,7 +102,7 @@ func TestAuthFromRequest_ValidToken(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer "+requiredToken)
 
-	ctx := authFromRequest(req, requiredToken, nil)
+	ctx := authFromRequest(req, requiredToken, nil, nil)
 	if !ctx.Authorized {
 		t.Error("expected Authorized=true for matching token")
 	}
@@ -116,7 +116,7 @@ func TestAuthFromRequest_MissingHeader(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPost, "/mcp", nil)
 	// No Authorization header.
 
-	ctx := authFromRequest(req, requiredToken, nil)
+	ctx := authFromRequest(req, requiredToken, nil, nil)
 	if ctx.Authorized {
 		t.Error("expected Authorized=false when Authorization header is absent")
 	}
@@ -127,7 +127,7 @@ func TestAuthFromRequest_WrongToken(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer wrong-token")
 
-	ctx := authFromRequest(req, requiredToken, nil)
+	ctx := authFromRequest(req, requiredToken, nil, nil)
 	if ctx.Authorized {
 		t.Error("expected Authorized=false for wrong token")
 	}
@@ -138,7 +138,7 @@ func TestAuthFromRequest_NoTokenRequired(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPost, "/mcp", nil)
 	// No Authorization header.
 
-	ctx := authFromRequest(req, "", nil)
+	ctx := authFromRequest(req, "", nil, nil)
 	if !ctx.Authorized {
 		t.Error("expected Authorized=true when no token is required")
 	}
@@ -150,7 +150,7 @@ func TestAuthFromRequest_MalformedHeader(t *testing.T) {
 	// Missing "Bearer " prefix.
 	req.Header.Set("Authorization", "Token secret-token")
 
-	ctx := authFromRequest(req, requiredToken, nil)
+	ctx := authFromRequest(req, requiredToken, nil, nil)
 	if ctx.Authorized {
 		t.Error("expected Authorized=false when Authorization header lacks 'Bearer ' prefix")
 	}

--- a/internal/mcp/engine.go
+++ b/internal/mcp/engine.go
@@ -195,4 +195,10 @@ type EngineInterface interface {
 	// RegisterVaultName registers a vault name in the engine's vault registry
 	// (idempotent 2-key write). Used by muninn_create_workflow_vault (RFC #597).
 	RegisterVaultName(name string) error
+
+	// VaultNameExists reports whether a vault with the given name is registered
+	// (i.e. has a 0x0F name→prefix index key). Used by muninn_create_workflow_vault
+	// to reject caller-supplied names that collide with an existing vault
+	// (operator or workflow-scoped), preventing cross-vault config clobber.
+	VaultNameExists(name string) bool
 }

--- a/internal/mcp/engine.go
+++ b/internal/mcp/engine.go
@@ -191,4 +191,8 @@ type EngineInterface interface {
 	// Used to populate muninn_recall annotation objects when annotate=true.
 	// Returns a non-nil *engine.AnnotationData (possibly with empty fields) on success.
 	GetAnnotations(ctx context.Context, vault, id string) (*engine.AnnotationData, error)
+
+	// RegisterVaultName registers a vault name in the engine's vault registry
+	// (idempotent 2-key write). Used by muninn_create_workflow_vault (RFC #597).
+	RegisterVaultName(name string) error
 }

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -29,6 +29,13 @@ func (a *mcpEngineAdapter) RegisterVaultName(name string) error {
 	return a.eng.RegisterVaultName(name)
 }
 
+// VaultNameExists reports whether a vault name is already registered.
+// Delegates to engine.Engine.VaultNameExists (RFC #597 RedTeam fix:
+// existence-check before minting into a caller-supplied name).
+func (a *mcpEngineAdapter) VaultNameExists(name string) bool {
+	return a.eng.VaultNameExists(name)
+}
+
 // NewEngineAdapter returns an EngineInterface backed by eng with optional enricher.
 // pStore is used by RetryEnrich to persist entity and relationship data; pass nil when
 // no enrichment plugin is configured (RetryEnrich will error before using pStore).

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -23,6 +23,12 @@ type mcpEngineAdapter struct {
 	pStore   plugin.PluginStore // needed by RetryEnrich to persist entities/relationships
 }
 
+// RegisterVaultName registers a vault name (idempotent 2-key write).
+// Delegates to engine.Engine.RegisterVaultName (RFC #597: muninn_create_workflow_vault).
+func (a *mcpEngineAdapter) RegisterVaultName(name string) error {
+	return a.eng.RegisterVaultName(name)
+}
+
 // NewEngineAdapter returns an EngineInterface backed by eng with optional enricher.
 // pStore is used by RetryEnrich to persist entity and relationship data; pass nil when
 // no enrichment plugin is configured (RetryEnrich will error before using pStore).

--- a/internal/mcp/guide.go
+++ b/internal/mcp/guide.go
@@ -105,6 +105,7 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 	b.WriteString("- **muninn_remember_tree** — Store a nested engram tree in one call\n")
 	b.WriteString("- **muninn_recall_tree** — Retrieve the complete ordered tree from a root ID\n")
 	b.WriteString("- **muninn_add_child** — Append or insert a child node under a parent\n")
+	b.WriteString("- **muninn_create_workflow_vault** — Create a shared working vault + mint a TTL'd cap_ capability (requires operator opt-in `MUNINN_AGENT_VAULT_CREATE` and a full-mode mk_ key; off by default)\n")
 
 	// Vault Configuration Summary
 	b.WriteString("\n## Vault Configuration\n\n")

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -2020,8 +2020,8 @@ func (s *MCPServer) handleCreateWorkflowVault(ctx context.Context, w http.Respon
 		ttlHours = int(v) // JSON numbers arrive as float64
 	}
 	if ev := os.Getenv("MUNINN_WORKFLOW_CAP_TTL_HOURS"); ev != "" {
-		if n, err := strconv.Atoi(ev); err == nil && n > 0 {
-			ttlHours = n // env override (operators can clamp fleet-wide)
+		if n, err := strconv.Atoi(ev); err == nil && n > 0 && n < ttlHours {
+			ttlHours = n // env is a fleet-wide ceiling; a smaller caller ttl_hours is honored
 		}
 	}
 

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -2049,9 +2049,21 @@ func (s *MCPServer) handleCreateWorkflowVault(ctx context.Context, w http.Respon
 		label = "agent-minted"
 	}
 
-	ttlHours := 168
-	if v, ok := args["ttl_hours"].(float64); ok && v > 0 && v <= 24*365 {
+	// TTL floor + cap (RedTeam finding NOTABLE #4): floor sub-hour fractions
+	// (0.5h → int(0)=0 → born-expired) to 1h; cap at 168h (7 days, the working
+	// preset retention) — minting a cap that outlives the vault's data is
+	// pointless and the prior 24*365 ceiling contradicted the documented 168h
+	// default.
+	const ttlCeiling = 168
+	ttlHours := ttlCeiling
+	if v, ok := args["ttl_hours"].(float64); ok && v > 0 {
 		ttlHours = int(v) // JSON numbers arrive as float64
+		if ttlHours < 1 {
+			ttlHours = 1 // floor: reject sub-hour truncation to zero
+		}
+		if ttlHours > ttlCeiling {
+			ttlHours = ttlCeiling // cap: don't outlive the vault's 7-day retention
+		}
 	}
 	if ev := os.Getenv("MUNINN_WORKFLOW_CAP_TTL_HOURS"); ev != "" {
 		if n, err := strconv.Atoi(ev); err == nil && n > 0 && n < ttlHours {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1985,6 +1985,23 @@ func (s *MCPServer) handleRelease(ctx context.Context, w http.ResponseWriter, id
 	})))
 }
 
+// isWorkflowVaultName reports whether name is a valid workflow-vault identifier:
+// it MUST start with the "wf-" namespace prefix and satisfy the general vault
+// name format (1-64 chars, lowercase alphanumeric, hyphen, underscore).
+// This is the structural anti-clobber guard (RedTeam finding CRITICAL #1):
+// it makes muninn_create_workflow_vault incapable of targeting an operator
+// vault such as "default" or "production", because those names lack the prefix.
+func isWorkflowVaultName(name string) bool {
+	const prefix = "wf-"
+	if !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	if len(name) <= len(prefix) {
+		return false // "wf-" alone has no body
+	}
+	return auth.IsValidVaultName(name)
+}
+
 // handleCreateWorkflowVault implements muninn_create_workflow_vault (RFC #597).
 // It creates a shared working vault and mints a scoped, TTL'd cap_ capability
 // token for worker agents. The tool is privileged: dispatchToolCall's recursion
@@ -2005,8 +2022,25 @@ func (s *MCPServer) handleCreateWorkflowVault(ctx context.Context, w http.Respon
 			return
 		}
 		name = "wf-" + hex.EncodeToString(rb)
-	} else if !auth.IsValidVaultName(name) {
-		sendError(w, id, -32602, "invalid vault name: must be 1-64 lowercase alphanumeric, hyphen, or underscore")
+	} else if !isWorkflowVaultName(name) {
+		// Structural anti-clobber guard (RedTeam finding CRITICAL #1): a caller-
+		// supplied name MUST be namespaced to workflow vaults (wf-*). This makes
+		// the tool structurally incapable of targeting an operator vault
+		// (default, production, etc.) — IsValidVaultName alone was format-only
+		// and allowed any well-formed name, so SetVaultConfig could overwrite
+		// an existing vault's config and mint a cap_ against it.
+		sendError(w, id, -32602, "invalid vault name: must start with 'wf-' and be workflow-scoped (1-64 lowercase alphanumeric or hyphen)")
+		return
+	}
+
+	// Existence check (RedTeam finding CRITICAL #1): reject if the vault is
+	// already registered. RegisterVaultName is idempotent and SetVaultConfig is
+	// a destructive overwrite, so without this gate a second call against an
+	// existing wf-* vault would silently clobber its config + mint a fresh cap.
+	// Auto-generated names should not collide in practice (4 bytes of entropy)
+	// but are checked anyway — cheap and fails-closed.
+	if s.engine.VaultNameExists(name) {
+		sendError(w, id, -32602, "vault already exists: "+name)
 		return
 	}
 

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -2,12 +2,16 @@ package mcp
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"math"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1979,4 +1983,80 @@ func (s *MCPServer) handleRelease(ctx context.Context, w http.ResponseWriter, id
 		"released": released,
 		"owner":    curOwner,
 	})))
+}
+
+// handleCreateWorkflowVault implements muninn_create_workflow_vault (RFC #597).
+// It creates a shared working vault and mints a scoped, TTL'd cap_ capability
+// token for worker agents. The tool is privileged: dispatchToolCall's recursion
+// guard verifies an mk_ full-mode key BEFORE this handler runs, so capabilities
+// (IsCapability, not IsAPIKey) can never reach it — structural recursion
+// prevention. The capability_secret is shown ONCE.
+func (s *MCPServer) handleCreateWorkflowVault(ctx context.Context, w http.ResponseWriter, id json.RawMessage, _ string, args map[string]any) {
+	if s.authStore == nil {
+		sendError(w, id, -32603, "vault creation unavailable: auth store not configured on this server")
+		return
+	}
+
+	name, _ := args["name"].(string)
+	if name == "" {
+		rb := make([]byte, 4)
+		if _, err := rand.Read(rb); err != nil {
+			sendError(w, id, -32603, "generate vault name: "+err.Error())
+			return
+		}
+		name = "wf-" + hex.EncodeToString(rb)
+	} else if !auth.IsValidVaultName(name) {
+		sendError(w, id, -32602, "invalid vault name: must be 1-64 lowercase alphanumeric, hyphen, or underscore")
+		return
+	}
+
+	label, _ := args["label"].(string)
+	if label == "" {
+		label = "agent-minted"
+	}
+
+	ttlHours := 168
+	if v, ok := args["ttl_hours"].(float64); ok && v > 0 && v <= 24*365 {
+		ttlHours = int(v) // JSON numbers arrive as float64
+	}
+	if ev := os.Getenv("MUNINN_WORKFLOW_CAP_TTL_HOURS"); ev != "" {
+		if n, err := strconv.Atoi(ev); err == nil && n > 0 {
+			ttlHours = n // env override (operators can clamp fleet-wide)
+		}
+	}
+
+	// 1. Register vault name (idempotent 2-key write in the engine's vault registry).
+	if err := s.engine.RegisterVaultName(name); err != nil {
+		sendError(w, id, -32603, "register vault: "+err.Error())
+		return
+	}
+
+	// 2. Configure the vault: working preset (default cognition + 7-day
+	// auto-evaporation) + multi_user (guidance steers toward per-user recall).
+	mu := true
+	if err := s.authStore.SetVaultConfig(auth.VaultConfig{
+		Name:       name,
+		Plasticity: &auth.PlasticityConfig{Preset: "working", MultiUser: &mu},
+	}); err != nil {
+		sendError(w, id, -32603, "set vault config: "+err.Error())
+		return
+	}
+
+	// 3. Mint a full-mode capability with the TTL. The token is shown once.
+	expiresAt := time.Now().Add(time.Duration(ttlHours) * time.Hour)
+	token, cap, err := s.authStore.GenerateCapability(name, label, auth.ModeFull, "workflow_vault", &expiresAt)
+	if err != nil {
+		sendError(w, id, -32603, "mint capability: "+err.Error())
+		return
+	}
+
+	sendResult(w, id, map[string]any{
+		"vault":             name,
+		"capability_id":     cap.ID,
+		"capability_secret": token, // shown once
+		"mode":              auth.ModeFull,
+		"expires_at":        expiresAt.Format(time.RFC3339),
+		"auto_evap_days":    7,
+		"warning":           "capability_secret is shown once; distribute it to worker agents. The vault auto-evaporates engrams after 7 days.",
+	})
 }

--- a/internal/mcp/handlers_entity_rel_test.go
+++ b/internal/mcp/handlers_entity_rel_test.go
@@ -21,7 +21,7 @@ func (e *captureEntityRelEngine) Write(_ context.Context, req *mbp.WriteRequest)
 
 func TestHandleRemember_EntityRelationships_Parsed(t *testing.T) {
 	eng := &captureEntityRelEngine{}
-	srv := New(":0", eng, "", nil, nil)
+	srv := New(":0", eng, "", nil, nil, nil)
 	w := postRPC(t, srv, `{
         "jsonrpc":"2.0","id":1,"method":"tools/call",
         "params":{"name":"muninn_remember","arguments":{
@@ -56,7 +56,7 @@ func TestHandleRemember_EntityRelationships_Parsed(t *testing.T) {
 
 func TestHandleRemember_EntityRelationships_DefaultWeight(t *testing.T) {
 	eng := &captureEntityRelEngine{}
-	srv := New(":0", eng, "", nil, nil)
+	srv := New(":0", eng, "", nil, nil, nil)
 	w := postRPC(t, srv, `{
         "jsonrpc":"2.0","id":1,"method":"tools/call",
         "params":{"name":"muninn_remember","arguments":{
@@ -76,7 +76,7 @@ func TestHandleRemember_EntityRelationships_DefaultWeight(t *testing.T) {
 
 func TestHandleRemember_EntityRelationships_SkipsInvalid(t *testing.T) {
 	eng := &captureEntityRelEngine{}
-	srv := New(":0", eng, "", nil, nil)
+	srv := New(":0", eng, "", nil, nil, nil)
 	w := postRPC(t, srv, `{
         "jsonrpc":"2.0","id":1,"method":"tools/call",
         "params":{"name":"muninn_remember","arguments":{

--- a/internal/mcp/handlers_entity_test.go
+++ b/internal/mcp/handlers_entity_test.go
@@ -28,7 +28,7 @@ func (e *entityAggEngine) ListEntities(_ context.Context, _ string, _ int, _ str
 }
 
 func TestHandleEntity_HappyPath(t *testing.T) {
-	srv := New(":0", &entityAggEngine{}, "", nil, nil)
+	srv := New(":0", &entityAggEngine{}, "", nil, nil, nil)
 	w := postRPC(t, srv, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"muninn_entity","arguments":{"vault":"default","name":"PostgreSQL"}}}`)
 	if w.Code != 200 {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
@@ -66,7 +66,7 @@ func TestHandleEntity_MissingName(t *testing.T) {
 }
 
 func TestHandleEntities_HappyPath(t *testing.T) {
-	srv := New(":0", &entityAggEngine{}, "", nil, nil)
+	srv := New(":0", &entityAggEngine{}, "", nil, nil, nil)
 	w := postRPC(t, srv, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"muninn_entities","arguments":{"vault":"default"}}}`)
 	if w.Code != 200 {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
@@ -100,7 +100,7 @@ func TestHandleEntities_HappyPath(t *testing.T) {
 
 func TestHandleEntities_NoVaultDefaultsToDefault(t *testing.T) {
 	// When vault is omitted, the server defaults to "default" — no error expected.
-	srv := New(":0", &entityAggEngine{}, "", nil, nil)
+	srv := New(":0", &entityAggEngine{}, "", nil, nil, nil)
 	w := postRPC(t, srv, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"muninn_entities","arguments":{}}}`)
 	if w.Code != 200 {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())

--- a/internal/mcp/handlers_feedback_test.go
+++ b/internal/mcp/handlers_feedback_test.go
@@ -13,7 +13,7 @@ func (e *feedbackEngine) RecordFeedback(_ context.Context, _, _ string, _ bool) 
 }
 
 func TestHandleFeedback_HappyPath(t *testing.T) {
-	srv := New(":0", &feedbackEngine{}, "", nil, nil)
+	srv := New(":0", &feedbackEngine{}, "", nil, nil, nil)
 	w := postRPC(t, srv, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"muninn_feedback","arguments":{"vault":"default","engram_id":"01HXYZ","useful":false}}}`)
 	if w.Code != 200 {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
@@ -36,7 +36,7 @@ func TestHandleFeedback_HappyPath(t *testing.T) {
 
 func TestHandleFeedback_DefaultVault(t *testing.T) {
 	// Vault is optional — omitting it defaults to "default".
-	srv := New(":0", &feedbackEngine{}, "", nil, nil)
+	srv := New(":0", &feedbackEngine{}, "", nil, nil, nil)
 	w := postRPC(t, srv, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"muninn_feedback","arguments":{"engram_id":"01HXYZ"}}}`)
 	if w.Code != 200 {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())

--- a/internal/mcp/handlers_provenance_test.go
+++ b/internal/mcp/handlers_provenance_test.go
@@ -17,7 +17,7 @@ func (e *provenanceEngine) GetProvenance(_ context.Context, _, _ string) ([]Prov
 }
 
 func TestHandleProvenance_HappyPath(t *testing.T) {
-	srv := New(":0", &provenanceEngine{}, "", nil, nil)
+	srv := New(":0", &provenanceEngine{}, "", nil, nil, nil)
 	w := postRPC(t, srv, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"muninn_provenance","arguments":{"vault":"default","id":"01HXYZ"}}}`)
 	if w.Code != 200 {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
@@ -80,7 +80,7 @@ func (e *provenanceErrEngine) GetProvenance(_ context.Context, _, _ string) ([]P
 }
 
 func TestHandleProvenance_EngineError(t *testing.T) {
-	srv := New(":0", &provenanceErrEngine{}, "", nil, nil)
+	srv := New(":0", &provenanceErrEngine{}, "", nil, nil, nil)
 	w := postRPC(t, srv, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"muninn_provenance","arguments":{"vault":"default","id":"01HXYZ"}}}`)
 	var resp JSONRPCResponse
 	json.NewDecoder(w.Body).Decode(&resp)

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -21,7 +21,7 @@ import (
 
 // newTestServerWith creates a server backed by the supplied engine.
 func newTestServerWith(eng EngineInterface) *MCPServer {
-	return New(":0", eng, "", nil, nil)
+	return New(":0", eng, "", nil, nil, nil)
 }
 
 // extractInnerJSON decodes the MCP textContent envelope and returns the inner

--- a/internal/mcp/handlers_tree_test.go
+++ b/internal/mcp/handlers_tree_test.go
@@ -359,7 +359,7 @@ func TestHandleRememberTree_DuplicateConcept(t *testing.T) {
 	eng := &fakeEngineRememberTreeErr{
 		rememberTreeErr: fmt.Errorf("RememberTree: duplicate concept %q at depth 1", "Phase 1"),
 	}
-	srv := New(":0", eng, "", nil, nil)
+	srv := New(":0", eng, "", nil, nil, nil)
 
 	body := `{
 		"jsonrpc":"2.0","method":"tools/call","id":1,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -21,8 +21,9 @@ import (
 // MCPServer serves the MCP JSON-RPC 2.0 protocol on a single HTTP mux.
 type MCPServer struct {
 	engine    EngineInterface
-	token     string          // required Bearer token (mdb_ static token); empty = no auth
-	authKeys  apiKeyValidator // optional: enables mk_ vault API key auth; nil = disabled
+	token     string              // required Bearer token (mdb_ static token); empty = no auth
+	authKeys  apiKeyValidator     // optional: enables mk_ vault API key auth; nil = disabled
+	capKeys   capabilityValidator // optional: enables cap_ capability auth (RFC #597); nil = disabled
 	srv       *http.Server
 	tlsConfig *tls.Config // nil = plain TCP
 
@@ -55,12 +56,14 @@ type sseSession struct {
 // New creates an MCPServer. addr is the listen address (e.g., ":8750").
 // token is the required static Bearer token (mdb_ style); pass "" to disable auth.
 // keyAuth, if non-nil, enables mk_ vault API key authentication with automatic vault pinning.
+// capAuth, if non-nil, enables cap_ capability token authentication (RFC #597).
 // tlsConfig, if non-nil, enables TLS on the listener.
-func New(addr string, eng EngineInterface, token string, keyAuth apiKeyValidator, tlsConfig *tls.Config) *MCPServer {
+func New(addr string, eng EngineInterface, token string, keyAuth apiKeyValidator, capAuth capabilityValidator, tlsConfig *tls.Config) *MCPServer {
 	s := &MCPServer{
 		engine:      eng,
 		token:       token,
 		authKeys:    keyAuth,
+		capKeys:     capAuth,
 		sseSessions: make(map[string]*sseSession),
 		tlsConfig:   tlsConfig,
 	}
@@ -125,7 +128,7 @@ func (s *MCPServer) withMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		}
 		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 
-		a := authFromRequest(r, s.token, s.authKeys)
+		a := authFromRequest(r, s.token, s.authKeys, s.capKeys)
 		if !a.Authorized {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
@@ -325,7 +328,7 @@ func (s *MCPServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Auth check
-	a := authFromRequest(r, s.token, s.authKeys)
+	a := authFromRequest(r, s.token, s.authKeys, s.capKeys)
 	if !a.Authorized {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
@@ -394,7 +397,7 @@ func (s *MCPServer) handleSSEMessage(w http.ResponseWriter, r *http.Request) {
 	// Run whenever any auth mechanism is active (static token or mk_ key store),
 	// not just when a static token is configured.
 	if s.token != "" || s.authKeys != nil {
-		a := authFromRequest(r, s.token, s.authKeys)
+		a := authFromRequest(r, s.token, s.authKeys, s.capKeys)
 		if !a.Authorized {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
@@ -430,7 +433,7 @@ func (s *MCPServer) handleStreamablePost(w http.ResponseWriter, r *http.Request)
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 
-	a := authFromRequest(r, s.token, s.authKeys)
+	a := authFromRequest(r, s.token, s.authKeys, s.capKeys)
 	if !a.Authorized {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -192,10 +192,12 @@ func (s *MCPServer) dispatchToolCall(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 
-	// Mode enforcement for mk_ vault keys.
+	// Mode enforcement for mk_ vault keys and cap_ capability tokens (RFC #597).
 	// Fail-closed: unknown tools (not in either classification list) are blocked
-	// for both observe and write modes. Only full-mode keys bypass this check.
-	if a.IsAPIKey {
+	// for both observe and write modes. Only full-mode credentials bypass this
+	// check. The body switches on a.Mode, which is populated for both credential
+	// types, so only the guard condition needed to include capabilities.
+	if a.IsAPIKey || a.IsCapability {
 		toolName := req.Params.Name
 		switch a.Mode {
 		case auth.ModeObserve:

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -455,6 +455,23 @@ func (s *MCPServer) handleSSEMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Re-validate the cached session credential before dispatch (RedTeam finding
+	// CRITICAL #2). The POST's authFromRequest above only checks .Authorized; the
+	// dispatch context below is set to sess.auth (cached at SSE-open). Without
+	// this re-validation, a cap_ token's TTL expiry or revocation is NEVER
+	// re-checked for an active SSE session — the TTL/revocation mitigation is
+	// defeated on /mcp/message. We keep dispatching on sess.auth (the SSE session
+	// model depends on it for vault pinning) — we just refuse to dispatch if the
+	// cached credential is no longer valid.
+	if sess.auth.IsCapability && s.capKeys != nil {
+		if _, err := s.capKeys.ValidateCapability(sess.auth.Token); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"jsonrpc":"2.0","error":{"code":-32001,"message":"session credential no longer valid (expired or revoked)"}}`))
+			return
+		}
+	}
+
 	// Thread the auth context established at SSE stream open time into the request.
 	// The session auth is authoritative for vault pinning and mode enforcement;
 	// the POST auth check above ensures the caller is still authenticated.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -20,12 +21,14 @@ import (
 
 // MCPServer serves the MCP JSON-RPC 2.0 protocol on a single HTTP mux.
 type MCPServer struct {
-	engine    EngineInterface
-	token     string              // required Bearer token (mdb_ static token); empty = no auth
-	authKeys  apiKeyValidator     // optional: enables mk_ vault API key auth; nil = disabled
-	capKeys   capabilityValidator // optional: enables cap_ capability auth (RFC #597); nil = disabled
-	srv       *http.Server
-	tlsConfig *tls.Config // nil = plain TCP
+	engine           EngineInterface
+	token            string              // required Bearer token (mdb_ static token); empty = no auth
+	authKeys         apiKeyValidator     // optional: enables mk_ vault API key auth; nil = disabled
+	capKeys          capabilityValidator // optional: enables cap_ capability auth (RFC #597); nil = disabled
+	authStore        *auth.Store         // privileged: SetVaultConfig + GenerateCapability (create-workflow-vault); nil = tool disabled
+	agentVaultCreate bool                // opt-in: MUNINN_AGENT_VAULT_CREATE (default off, secure-by-default)
+	srv              *http.Server
+	tlsConfig        *tls.Config // nil = plain TCP
 
 	sseSessionsMu sync.RWMutex
 	sseSessions   map[string]*sseSession // sessionID → session
@@ -59,13 +62,25 @@ type sseSession struct {
 // capAuth, if non-nil, enables cap_ capability token authentication (RFC #597).
 // tlsConfig, if non-nil, enables TLS on the listener.
 func New(addr string, eng EngineInterface, token string, keyAuth apiKeyValidator, capAuth capabilityValidator, tlsConfig *tls.Config) *MCPServer {
+	// muninn_create_workflow_vault opt-in: default off (secure-by-default).
+	agentVaultCreate := os.Getenv("MUNINN_AGENT_VAULT_CREATE") == "1"
 	s := &MCPServer{
-		engine:      eng,
-		token:       token,
-		authKeys:    keyAuth,
-		capKeys:     capAuth,
-		sseSessions: make(map[string]*sseSession),
-		tlsConfig:   tlsConfig,
+		engine:           eng,
+		token:            token,
+		authKeys:         keyAuth,
+		capKeys:          capAuth,
+		agentVaultCreate: agentVaultCreate,
+		sseSessions:      make(map[string]*sseSession),
+		tlsConfig:        tlsConfig,
+	}
+	// The create-workflow-vault handler needs the concrete *auth.Store for
+	// SetVaultConfig + GenerateCapability. capAuth is typed capabilityValidator
+	// for testability (stub cap_ stores in tests), but in production it holds a
+	// real *auth.Store. Derive authStore via type assertion so the constructor
+	// signature stays unchanged; stub-based tests get authStore == nil (the
+	// recursion guard still fires, the handler returns "not configured").
+	if as, ok := capAuth.(*auth.Store); ok {
+		s.authStore = as
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
@@ -219,6 +234,26 @@ func (s *MCPServer) dispatchToolCall(ctx context.Context, w http.ResponseWriter,
 		}
 	}
 
+	// muninn_create_workflow_vault is privileged: it requires an mk_ full-mode
+	// key AND the opt-in flag. A cap_ bearer (IsCapability, not IsAPIKey) is
+	// rejected here — this is the structural recursion guard. No capability can
+	// mint further capabilities, because capabilities do not satisfy IsAPIKey.
+	// This check runs BEFORE handler dispatch (handlers do not receive
+	// AuthContext) and AFTER mode enforcement. Write-mode keys pass mode
+	// enforcement (the tool is mutating) but fail here because Mode != ModeFull.
+	// NOTE: the guard deliberately checks IsAPIKey, NOT IsCapability — this is
+	// the security-critical invariant (see TestCreateWorkflowVault_RecursionGuard).
+	if req.Params.Name == "muninn_create_workflow_vault" {
+		if !s.agentVaultCreate {
+			sendError(w, req.ID, -32001, "forbidden: agent vault creation disabled (set MUNINN_AGENT_VAULT_CREATE=1)")
+			return
+		}
+		if !(a.IsAPIKey && a.Mode == auth.ModeFull) {
+			sendError(w, req.ID, -32001, "forbidden: muninn_create_workflow_vault requires a full-mode mk_ key")
+			return
+		}
+	}
+
 	handlers := map[string]func(context.Context, http.ResponseWriter, json.RawMessage, string, map[string]any){
 		"muninn_remember":       s.handleRemember,
 		"muninn_remember_batch": s.handleRememberBatch,
@@ -287,6 +322,9 @@ func (s *MCPServer) dispatchToolCall(ctx context.Context, w http.ResponseWriter,
 
 		// Trust label
 		"muninn_trust": s.handleSetTrust,
+
+		// RFC #597: privileged workflow-vault creation (recursion-guarded above).
+		"muninn_create_workflow_vault": s.handleCreateWorkflowVault,
 	}
 
 	handler, found := handlers[req.Params.Name]
@@ -317,6 +355,7 @@ func registeredToolNames() []string {
 		"muninn_entity", "muninn_entities",
 		"muninn_trust",
 		"muninn_compare_and_set", "muninn_claim", "muninn_release",
+		"muninn_create_workflow_vault",
 	}
 }
 
@@ -396,9 +435,9 @@ func (s *MCPServer) handleSSEMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Re-validate auth on every POST — defense in depth against session ID leakage.
-	// Run whenever any auth mechanism is active (static token or mk_ key store),
-	// not just when a static token is configured.
-	if s.token != "" || s.authKeys != nil {
+	// Run whenever any auth mechanism is active (static token, mk_ key store, or
+	// cap_ capability store), not just when a static token is configured.
+	if s.token != "" || s.authKeys != nil || s.capKeys != nil {
 		a := authFromRequest(r, s.token, s.authKeys, s.capKeys)
 		if !a.Authorized {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/mcp/server_coverage_test.go
+++ b/internal/mcp/server_coverage_test.go
@@ -124,7 +124,7 @@ func TestDispatchToolCall_InvalidVaultReturnsError(t *testing.T) {
 
 func TestWithMiddleware_UnauthorizedRequest(t *testing.T) {
 	// Server with a required token — a request without the Bearer token must get 401.
-	srv := New(":0", &fakeEngine{}, "secret", nil, nil)
+	srv := New(":0", &fakeEngine{}, "secret", nil, nil, nil)
 	req := httptest.NewRequest("GET", "/mcp/tools", nil)
 	// No Authorization header.
 	w := httptest.NewRecorder()
@@ -136,7 +136,7 @@ func TestWithMiddleware_UnauthorizedRequest(t *testing.T) {
 
 func TestWithMiddleware_AuthorizedRequest(t *testing.T) {
 	// Correct Bearer token must succeed.
-	srv := New(":0", &fakeEngine{}, "secret", nil, nil)
+	srv := New(":0", &fakeEngine{}, "secret", nil, nil, nil)
 	req := httptest.NewRequest("GET", "/mcp/tools", nil)
 	req.Header.Set("Authorization", "Bearer secret")
 	w := httptest.NewRecorder()
@@ -160,7 +160,7 @@ func TestWithMiddleware_ContentLengthTooLarge(t *testing.T) {
 // ── handleStreamablePost: auth failure ───────────────────────────────────────
 
 func TestHandleStreamablePost_Unauthorized(t *testing.T) {
-	srv := New(":0", &fakeEngine{}, "secret", nil, nil)
+	srv := New(":0", &fakeEngine{}, "secret", nil, nil, nil)
 	body := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"muninn_status","arguments":{"vault":"default"}}}`
 	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -20,6 +20,8 @@ import (
 // fakeEngine implements EngineInterface for tests.
 type fakeEngine struct{}
 
+func (f *fakeEngine) RegisterVaultName(name string) error { return nil }
+
 func (f *fakeEngine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteResponse, error) {
 	return &mbp.WriteResponse{ID: "fake-id"}, nil
 }
@@ -299,8 +301,8 @@ func TestListTools(t *testing.T) {
 	var result map[string]any
 	json.NewDecoder(w.Body).Decode(&result)
 	tools, _ := result["tools"].([]any)
-	if len(tools) != 42 {
-		t.Errorf("expected 42 tools, got %d", len(tools))
+	if len(tools) != 43 {
+		t.Errorf("expected 43 tools, got %d", len(tools))
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,6 +22,10 @@ type fakeEngine struct{}
 
 func (f *fakeEngine) RegisterVaultName(name string) error { return nil }
 
+// VaultNameExists defaults to false (no pre-existing vault) so workflow-vault
+// creation tests proceed. Tests needing collision behaviour wrap a real engine.
+func (f *fakeEngine) VaultNameExists(name string) bool { return false }
+
 func (f *fakeEngine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteResponse, error) {
 	return &mbp.WriteResponse{ID: "fake-id"}, nil
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -203,7 +203,7 @@ func (f *fakeEngine) GetAnnotations(_ context.Context, _, _ string) (*engine.Ann
 }
 
 func newTestServer() *MCPServer {
-	return New(":0", &fakeEngine{}, "", nil, nil)
+	return New(":0", &fakeEngine{}, "", nil, nil, nil)
 }
 
 func postRPC(t *testing.T, srv *MCPServer, body string) *httptest.ResponseRecorder {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -921,7 +921,7 @@ func allToolDefinitions() []ToolDefinition {
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"name":      map[string]any{"type": "string", "description": "Vault name (optional; auto-generates wf-<8hex> if omitted). 1-64 lowercase alphanum/hyphen/underscore."},
+					"name":      map[string]any{"type": "string", "description": "Vault name (optional; auto-generates wf-<8hex> if omitted). MUST start with 'wf-' and be 1-64 lowercase alphanum/hyphen/underscore. Names lacking the wf- prefix are rejected (prevents cross-vault clobber)."},
 					"label":     map[string]any{"type": "string", "default": "agent-minted", "description": "Label stamped on the minted capability (for audit/listing)."},
 					"ttl_hours": map[string]any{"type": "integer", "default": 168, "description": "Capability lifetime in hours (default 168 = 7d, matching the working preset retention)."},
 				},

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -923,7 +923,7 @@ func allToolDefinitions() []ToolDefinition {
 				"properties": map[string]any{
 					"name":      map[string]any{"type": "string", "description": "Vault name (optional; auto-generates wf-<8hex> if omitted). MUST start with 'wf-' and be 1-64 lowercase alphanum/hyphen/underscore. Names lacking the wf- prefix are rejected (prevents cross-vault clobber)."},
 					"label":     map[string]any{"type": "string", "default": "agent-minted", "description": "Label stamped on the minted capability (for audit/listing)."},
-					"ttl_hours": map[string]any{"type": "integer", "default": 168, "description": "Capability lifetime in hours (default 168 = 7d, matching the working preset retention)."},
+					"ttl_hours": map[string]any{"type": "integer", "default": 168, "minimum": float64(1), "maximum": float64(168), "description": "Capability lifetime in hours (1-168; default 168 = 7d, matching the working preset retention). Sub-hour values floor to 1; values above 168 clamp to 168."},
 				},
 			},
 		},

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -914,5 +914,18 @@ func allToolDefinitions() []ToolDefinition {
 				"required": []string{"id", "trust"},
 			},
 		},
+		// RFC #597: privileged workflow-vault creation (recursion-guarded in dispatchToolCall).
+		{
+			Name:        "muninn_create_workflow_vault",
+			Description: "Create a shared working vault for an agentic workflow and mint a scoped, TTL'd capability token a worker agent can use to access it. The vault uses the `working` preset (default cognition + 7-day auto-evaporation) with multi_user enabled. Requires a full-mode mk_ key and the MUNINN_AGENT_VAULT_CREATE opt-in. The returned capability_secret is shown once — distribute it to worker agents out-of-band. Recursion-safe: a capability cannot call this tool.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name":      map[string]any{"type": "string", "description": "Vault name (optional; auto-generates wf-<8hex> if omitted). 1-64 lowercase alphanum/hyphen/underscore."},
+					"label":     map[string]any{"type": "string", "default": "agent-minted", "description": "Label stamped on the minted capability (for audit/listing)."},
+					"ttl_hours": map[string]any{"type": "integer", "default": 168, "description": "Capability lifetime in hours (default 168 = 7d, matching the working preset retention)."},
+				},
+			},
+		},
 	}
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestAllToolDefinitionsCount(t *testing.T) {
 	tools := allToolDefinitions()
-	if len(tools) != 42 {
-		t.Errorf("expected 42 tools, got %d", len(tools))
+	if len(tools) != 43 {
+		t.Errorf("expected 43 tools, got %d", len(tools))
 	}
 }
 
@@ -38,7 +38,15 @@ func TestAllToolNamesUnique(t *testing.T) {
 
 func TestAllToolsHaveVaultParam(t *testing.T) {
 	tools := allToolDefinitions()
+	// Privileged meta-tools that operate above vault scoping — e.g. one that
+	// creates new vaults — legitimately omit the vault parameter.
+	noVaultParam := map[string]bool{
+		"muninn_create_workflow_vault": true,
+	}
 	for _, tool := range tools {
+		if noVaultParam[tool.Name] {
+			continue
+		}
 		schema, ok := tool.InputSchema.(map[string]any)
 		if !ok {
 			t.Errorf("tool %s: inputSchema is not a map", tool.Name)

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -40,6 +40,11 @@ type AuthContext struct {
 	Vault    string // vault the key is scoped to; empty for static-token auth
 	Mode     string // "full", "observe", or "write"; empty for static-token auth
 	IsAPIKey bool   // true when authed via an mk_ vault API key
+	// IsCapability is true when authed via a cap_ capability token (RFC #597).
+	// Capabilities are distinct from mk_ API keys: they cannot mint further
+	// vaults, so the recursion guard in dispatchToolCall (Task 4) gates
+	// muninn_create_workflow_vault on IsAPIKey, not merely Authorized.
+	IsCapability bool // true when authed via a cap_ capability token
 }
 
 // ToolDefinition is one entry in the tools/list response.

--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -227,6 +227,67 @@ func (s *Server) handleRevokeAPIKey(authStore *auth.Store) http.HandlerFunc {
 	}
 }
 
+// handleListCapabilities lists cap_ capabilities for a vault (RedTeam finding
+// SIGNIFICANT #3). Mirrors handleListAPIKeys: admin-gated, StorageHash stripped.
+// GET /api/admin/vaults/{name}/capabilities
+func (s *Server) handleListCapabilities(authStore *auth.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vault := r.PathValue("name")
+		if vault == "" {
+			vault = r.URL.Query().Get("vault")
+		}
+		if vault == "" {
+			vault = "default"
+		}
+		if !isValidVaultName(vault) {
+			s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "invalid vault name")
+			return
+		}
+		caps, err := authStore.ListCapabilities(vault)
+		if err != nil {
+			s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, "failed to list capabilities")
+			return
+		}
+		// Never leak the storage hash to API consumers (matches handleListAPIKeys posture).
+		for i := range caps {
+			caps[i].StorageHash = nil
+		}
+		s.sendJSON(w, http.StatusOK, map[string]interface{}{"capabilities": caps})
+	}
+}
+
+// handleRevokeCapability revokes a cap_ capability by its display ID (RedTeam
+// finding SIGNIFICANT #3). Mirrors handleRevokeAPIKey: admin-gated.
+// DELETE /api/admin/vaults/{name}/capabilities/{capID}
+func (s *Server) handleRevokeCapability(authStore *auth.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vault := r.PathValue("name")
+		capID := r.PathValue("capID")
+		if vault == "" {
+			s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "vault name required")
+			return
+		}
+		if !isValidVaultName(vault) {
+			s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "invalid vault name")
+			return
+		}
+		if capID == "" {
+			s.sendError(r, w, http.StatusBadRequest, ErrInvalidEngram, "capability id required")
+			return
+		}
+		if err := authStore.RevokeCapability(vault, capID); err != nil {
+			if errors.Is(err, auth.ErrCapabilityNotFound) {
+				s.sendError(r, w, http.StatusNotFound, ErrEngramNotFound, err.Error())
+				return
+			}
+			s.sendError(r, w, http.StatusInternalServerError, ErrStorageError, err.Error())
+			return
+		}
+		s.sendJSON(w, http.StatusOK, map[string]interface{}{"revoked": capID})
+		s.EmitAudit(r, "capability.revoke", "capability", capID, "ok", nil)
+	}
+}
+
 func (s *Server) handleChangeAdminPassword(authStore *auth.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req struct {

--- a/internal/transport/rest/server.go
+++ b/internal/transport/rest/server.go
@@ -247,6 +247,8 @@ func NewServer(addr string, engine EngineAPI, authStore *auth.Store, sessionSecr
 	mux.HandleFunc("GET /api/admin/plugins", s.withAdminMiddleware(s.handlePlugins))
 	mux.HandleFunc("GET /api/admin/vault/{name}/plasticity", s.withAdminMiddleware(s.handleGetVaultPlasticity(authStore)))
 	mux.HandleFunc("PUT /api/admin/vault/{name}/plasticity", s.withAdminMiddleware(s.handlePutVaultPlasticity(authStore)))
+	mux.HandleFunc("GET /api/admin/vaults/{name}/capabilities", s.withAdminMiddleware(s.handleListCapabilities(authStore)))
+	mux.HandleFunc("DELETE /api/admin/vaults/{name}/capabilities/{capID}", s.withAdminMiddleware(s.handleRevokeCapability(authStore)))
 	mux.HandleFunc("GET /api/admin/plugin-config", s.withAdminMiddleware(s.handleGetPluginConfig))
 	mux.HandleFunc("PUT /api/admin/plugin-config", s.withAdminMiddleware(s.handlePutPluginConfig))
 	mux.HandleFunc("DELETE /api/admin/vaults/{name}", s.withAdminMiddleware(s.handleDeleteVault))


### PR DESCRIPTION
## Summary

Implements increment 2 of RFC #597: a `cap_` **capability-token** credential primitive + a `muninn_create_workflow_vault` MCP tool that lets an autonomous agent self-provision a shared working vault for a fleet of worker agents. Complementary to #376 (cross-vault recall).

Refs #597 (not `Closes` — the RFC has further increments). Builds on #599 (the `working` preset, merged).

## Framing note (how this evolved past the #597 comment)

The #597 progress comment framed this as "an MCP-surface vault lifecycle tool." A 32-agent RedTeam review of the obvious design (mint a full-mode `mk_` key for the new vault) found two **critical** flaws: (1) **recursive credential minting** — a minted full-mode key satisfies the gate and can mint more, indefinitely; (2) **immortal orphan keys** — `RetentionDays` evaporates engrams but never keys. This PR replaces "mint a key" with "mint a capability" — a distinct, scoped, TTL'd credential type — which closes both flaws **by construction**. A second 32-agent RedTeam on the implemented code then surfaced two more criticals (cross-vault config clobber; an SSE confused-deputy), both fixed before this PR (details under Security).

## What ships

- **Capability primitive** (`internal/auth/capability.go`, `capability_store.go`) — a new `cap_` credential type mirroring `mk_` API keys (SHA-256-hashed secret, shown once, revocable), at Pebble prefixes `0x40`/`0x41` (off both storage's `0x01`–`0x2A` and auth's `0x11`–`0x14` ranges).
- **`cap_` auth branch** (`internal/mcp/context.go`) — `authFromRequest` resolves `cap_` tokens to `AuthContext{IsCapability:true, IsAPIKey:false}`; fail-closed, like `mk_`. Mode enforcement extended to capabilities.
- **`muninn_create_workflow_vault` MCP tool** (`internal/mcp/handlers.go`) — creates a `wf-*` workflow vault (`working` preset + `multi_user`), mints a TTL'd full-mode `cap_` for it, returns the token once. Opt-in (`MUNINN_AGENT_VAULT_CREATE`, **default off**). TTL default 168h, configurable via `ttl_hours` (1–168) + `MUNINN_WORKFLOW_CAP_TTL_HOURS` (operator ceiling).
- **REST admin revocation/listing** (`internal/transport/rest/admin_handlers.go`) — `GET`/`DELETE /api/admin/vaults/{name}/capabilities[/...]`, admin-gated.
- **Docs** (`docs/auth.md`) + agent guide pointer.

## Security posture (hardened after two 32-agent RedTeam passes)

- **Recursion impossible by construction.** The create tool requires `a.IsAPIKey && Mode==Full && opt-in`. Capabilities authenticate as `IsCapability` (never `IsAPIKey`), so a `cap_` cannot call the tool — no capability can mint another. Verified by `TestCreateWorkflowVault_RecursionGuard_CapCallerRejected` (via production dispatch).
- **Cross-vault clobber prevented.** Vault names are namespaced to `wf-*` (operator vaults like `default`/`production` are unreachable) AND rejected if the vault already exists (`VaultNameExists`).
- **No immortal caps.** `GenerateCapability` rejects `nil` expiry; every cap carries a TTL; SSE sessions re-validate the cached cap_ on each POST (expiry + revocation).
- **Secure-by-default.** Opt-in flag defaults off; `cap_` is MCP-transport-only (REST/gRPC accept `mk_` keys, documented).
- **Accepted residual (documented):** the `capability_secret` is returned in the MCP response (autonomy requirement). Mitigated by TTL + structural recursion + audit; the binding-based full close is deferred.

## Testing

- `go test -race ./...` green (40 packages); `go vet`/`gofmt` clean.
- Capability store roundtrip/expiry/revoke/nil-expiry-forbidden; `cap_` auth fail-closed; mode enforcement on caps; recursion guard (production dispatch + via SSE); namespace rejection (`default`/`production`/existing); SSE mid-session revocation; TTL floor/ceiling; prefix-collision regression.

## Out of scope (follow-up increments on the same primitive)

- **Phase 2b hardening:** per-caller rate-limit + active-vault quota; pruner auto-revoke of a working vault's caps when its engrams hit zero; single-batch atomicity for register+config+mint.
- **Capability binding** (parent-key/session), fine-grained scopes, delegation — the long-term authz payoff.
- **One small known gap (flagged for transparency):** SSE per-POST re-validation currently covers `IsCapability` only, not `IsAPIKey` (a revoked `mk_` key on a bearerless POST against an open-static-token server could ride a cached session). Narrow pre-existing edge; symmetric fix is small; happy to follow up.
- Toolset-profile visibility for the create tool once #604 lands.

## Relation to #611

While relocating the capability prefixes off storage's keyspace, this work surfaced a **pre-existing** overlap: auth's `0x11`–`0x14` and storage's `0x11`–`0x14` share the same Pebble DB. Reported separately as #611; unrelated to this PR's additive `0x40`/`0x41` allocation.

Refs #597.
