### PR TITLE
feat(cli): `muninn remember` — REST write verb with `--content-file` (#610)

### DIFF
--- a/cmd/muninn/help.go
+++ b/cmd/muninn/help.go
@@ -138,6 +138,27 @@ var subcommandHelp = map[string]func(){
 	"exec": func() {
 		printExecHelp()
 	},
+	"remember": func() {
+		printSubcommandUsage("remember", "store a memory via the running daemon's REST API",
+			"muninn remember --concept <label> (--content <text> | --content-file <path>) [flags]",
+			[][2]string{
+				{"--concept <label>", "Short label for the memory (required)"},
+				{"--content <text>", "Full text of the memory (inline)"},
+				{"--content-file <path>", "Read the full text from a file; '-' reads stdin (REST caps bodies at 4 MB)"},
+				{"--summary <text>", "One-line summary (inline enrichment)"},
+				{"--tags <a,b,c>", "Comma-separated tags"},
+				{"--entities <list>", "Inline entities: Name or Name:type, comma-separated"},
+				{"--vault <name>", "Vault name (default: derived from the API key, else \"default\")"},
+				{"--op-id <key>", "Idempotency key — safe retries return the original engram id"},
+				{"--key-file <path>", "Vault API key file (default: ~/.muninn/api.key; mk_* key, 0600)"},
+			},
+			[]string{
+				`muninn remember --concept "standup" --content "Fixed the auth bug"`,
+				`muninn remember --concept "design notes" --content-file notes.md --tags design,q3`,
+				`git log -1 | muninn remember --concept "release" --content-file - --vault work`,
+				`muninn api-key create --vault work --label cli   # then store the mk_ key in ~/.muninn/api.key (chmod 600)`,
+			})
+	},
 	"dream": func() {
 		printSubcommandUsage("dream", "LLM-driven memory consolidation", "muninn dream [flags]",
 			[][2]string{
@@ -337,6 +358,7 @@ func printHelp() {
 	fmt.Printf("  %-32s %s\n", cyan("muninn vault <command>"), "Vault management (create, list, delete, clear, clone, merge, export, import)")
 	fmt.Printf("  %-32s %s\n", cyan("muninn api-key <command>"), "API key management (create, list, revoke)")
 	fmt.Printf("  %-32s %s\n", cyan("muninn admin change-password"), "Change the admin password")
+	fmt.Printf("  %-32s %s\n", cyan("muninn remember [flags]"), "Store a memory via the running daemon (REST)")
 	fmt.Printf("  %-32s %s\n", cyan("muninn exec <op> [flags]"), "One-shot remember/recall/read/forget (no daemon needed)")
 	fmt.Printf("  %-32s %s\n", cyan("muninn dream [--dry-run]"), "LLM-driven memory consolidation (server must be stopped)")
 	fmt.Printf("  %-32s %s\n", cyan("muninn backup --output <dir>"), "Offline point-in-time backup (server must be stopped)")

--- a/cmd/muninn/main.go
+++ b/cmd/muninn/main.go
@@ -74,6 +74,8 @@ func main() {
 		runDoctor(rest)
 	case "exec":
 		runExec(rest)
+	case "remember":
+		runRemember(rest)
 	case "dream":
 		runDream(rest)
 	case "backup":
@@ -132,6 +134,12 @@ func main() {
 		// to Unknown command while the help text documented them as valid.
 		if strings.HasPrefix(sub, "exec:") {
 			runExec(rest)
+			return
+		}
+		// "remember something" joins to "remember:something"; route it so the
+		// FlagSet can print a real usage error instead of Unknown command.
+		if strings.HasPrefix(sub, "remember:") {
+			runRemember(rest)
 			return
 		}
 		if strings.HasPrefix(sub, "logs:") {

--- a/cmd/muninn/remember.go
+++ b/cmd/muninn/remember.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// muninn remember — thin client for POST /api/engrams on the RUNNING daemon.
+//
+// This is the online counterpart of `muninn exec remember` (which opens the
+// store directly and therefore only works while the daemon is stopped). It
+// rides the same trust boundary as every other key-authed REST client: a
+// vault API key (mk_*, created with `muninn api-key create`) read from a
+// 0600 key file — never the admin session, never a bare env var. See #610.
+
+// Exit codes match muninn exec: 0 success, 1 usage, 2 error.
+
+// rememberMaxBody mirrors the server's bodySizeMiddleware cap
+// (internal/transport/rest/server.go). Checked client-side before the POST so
+// an oversized --content-file fails with an explanation instead of an opaque
+// "invalid request body" from the truncated read on the server.
+const rememberMaxBody = 4 << 20 // 4 MB
+
+// defaultRememberKeyFile is the standard location for the vault API key used
+// by `muninn remember`. Deliberately NOT ~/.muninn/mcp.token: that file holds
+// the MCP static bearer token (mdb_*), which the REST vault-auth layer does
+// not accept — REST validates vault API keys (mk_*) only. Same file
+// convention (0600, under ~/.muninn), different credential.
+func defaultRememberKeyFile() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".muninn", "api.key")
+}
+
+// rememberRequest is the JSON body for POST /api/engrams. Field names match
+// transport WriteRequest; kept as a local struct so the CLI stays a thin
+// client of the wire format rather than importing engine types.
+type rememberRequest struct {
+	Concept      string           `json:"concept"`
+	Content      string           `json:"content"`
+	Tags         []string         `json:"tags,omitempty"`
+	Vault        string           `json:"vault,omitempty"`
+	IdempotentID string           `json:"idempotent_id,omitempty"`
+	Summary      string           `json:"summary,omitempty"`
+	Entities     []rememberEntity `json:"entities,omitempty"`
+}
+
+type rememberEntity struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type rememberResponse struct {
+	ID        string `json:"id"`
+	CreatedAt int64  `json:"created_at"`
+	Hint      string `json:"hint,omitempty"`
+}
+
+func runRemember(args []string) {
+	if code := rememberMain(args, os.Stdin, os.Stdout, os.Stderr); code != 0 {
+		osExit(code)
+	}
+}
+
+// rememberMain is the testable implementation. Returns an exit code.
+func rememberMain(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("remember", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	concept := fs.String("concept", "", "short label for the memory (required)")
+	content := fs.String("content", "", "full text of the memory (inline)")
+	contentFile := fs.String("content-file", "", "read the full text from a file; '-' reads stdin")
+	summary := fs.String("summary", "", "one-line summary (inline enrichment)")
+	tags := fs.String("tags", "", "comma-separated tags")
+	entities := fs.String("entities", "", "comma-separated inline entities, each Name or Name:type")
+	vault := fs.String("vault", "", "vault name (default: derived from the API key, else \"default\")")
+	opID := fs.String("op-id", "", "idempotency key — safe retries return the original engram id")
+	keyFile := fs.String("key-file", "", "vault API key file (default: ~/.muninn/api.key)")
+
+	if err := fs.Parse(args); err != nil {
+		return execExitUsage
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintf(stderr, "muninn remember: unexpected argument %q (content goes in --content or --content-file)\n", fs.Arg(0))
+		return execExitUsage
+	}
+	if strings.TrimSpace(*concept) == "" {
+		fmt.Fprintln(stderr, "muninn remember: --concept is required")
+		return execExitUsage
+	}
+	if *content != "" && *contentFile != "" {
+		fmt.Fprintln(stderr, "muninn remember: --content and --content-file are mutually exclusive")
+		return execExitUsage
+	}
+	if *content == "" && *contentFile == "" {
+		fmt.Fprintln(stderr, "muninn remember: one of --content or --content-file is required")
+		return execExitUsage
+	}
+
+	body := *content
+	if *contentFile != "" {
+		var data []byte
+		var err error
+		if *contentFile == "-" {
+			data, err = io.ReadAll(stdin)
+		} else {
+			data, err = os.ReadFile(*contentFile)
+		}
+		if err != nil {
+			fmt.Fprintf(stderr, "muninn remember: read content: %v\n", err)
+			return execExitError
+		}
+		body = string(data)
+	}
+	if strings.TrimSpace(body) == "" {
+		fmt.Fprintln(stderr, "muninn remember: content is empty")
+		return execExitUsage
+	}
+
+	ents, err := parseInlineEntities(*entities)
+	if err != nil {
+		fmt.Fprintf(stderr, "muninn remember: %v\n", err)
+		return execExitUsage
+	}
+
+	req := rememberRequest{
+		Concept:      strings.TrimSpace(*concept),
+		Content:      body,
+		Tags:         splitCommaList(*tags),
+		Vault:        strings.TrimSpace(*vault),
+		IdempotentID: strings.TrimSpace(*opID),
+		Summary:      *summary,
+		Entities:     ents,
+	}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		fmt.Fprintf(stderr, "muninn remember: encode request: %v\n", err)
+		return execExitError
+	}
+	if len(payload) > rememberMaxBody {
+		fmt.Fprintf(stderr,
+			"muninn remember: request body is %d bytes; the REST API caps request bodies at 4 MB\n"+
+				"  Store a summary plus a pointer to the original file, or split the content.\n",
+			len(payload))
+		return execExitError
+	}
+
+	token, code := rememberToken(*keyFile, stderr)
+	if code != 0 {
+		return code
+	}
+
+	url := rememberBaseURL() + "/api/engrams"
+	httpReq, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		fmt.Fprintf(stderr, "muninn remember: build request: %v\n", err)
+		return execExitError
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := httpClientForURL(url, 60*time.Second).Do(httpReq)
+	if err != nil {
+		if isTLSCertError(err) {
+			fmt.Fprintf(stderr, "muninn remember: TLS certificate verification failed for %s: %v\n", url, err)
+			fmt.Fprintln(stderr, "Install the server's CA into the system trust store, or point MUNINNDB_ADMIN_URL at a loopback address.")
+			return execExitError
+		}
+		fmt.Fprintf(stderr, "muninn remember: error connecting to server: %v\n", err)
+		fmt.Fprintln(stderr, "Is muninn running? Try: muninn start")
+		return execExitError
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		fmt.Fprintf(stderr, "muninn remember: read response: %v\n", err)
+		return execExitError
+	}
+
+	if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusOK {
+		var wr rememberResponse
+		if err := json.Unmarshal(respBody, &wr); err != nil || wr.ID == "" {
+			fmt.Fprintf(stderr, "muninn remember: unexpected response: %s\n", strings.TrimSpace(string(respBody)))
+			return execExitError
+		}
+		fmt.Fprintln(stdout, wr.ID)
+		if wr.Hint != "" {
+			fmt.Fprintf(stderr, "hint: %s\n", wr.Hint)
+		}
+		return execExitSuccess
+	}
+
+	printRememberHTTPError(stderr, resp.StatusCode, respBody, req.Vault, *keyFile)
+	return execExitError
+}
+
+// rememberToken resolves the vault API key. An explicitly passed --key-file
+// that cannot be read is an error; a missing DEFAULT key file means "no auth"
+// (public-vault deployments — same semantics as the shipped curl guidance).
+// Returns (token, exitCode); exitCode is non-zero only on error.
+func rememberToken(keyFile string, stderr io.Writer) (string, int) {
+	explicit := keyFile != ""
+	if !explicit {
+		keyFile = defaultRememberKeyFile()
+	}
+	data, err := os.ReadFile(keyFile)
+	if err != nil {
+		if explicit {
+			fmt.Fprintf(stderr, "muninn remember: read key file: %v\n", err)
+			return "", execExitError
+		}
+		return "", 0 // no default key file → unauthenticated (public vault)
+	}
+	if info, statErr := os.Stat(keyFile); statErr == nil && info.Mode().Perm()&0o044 != 0 {
+		fmt.Fprintf(stderr, "warning: %s is world-readable — consider: chmod 600 %s\n", keyFile, keyFile)
+	}
+	return strings.TrimSpace(string(data)), 0
+}
+
+// rememberBaseURL resolves the REST base URL the same way the other
+// daemon-client commands do: MUNINNDB_ADMIN_URL verbatim if set, else the
+// scheme and REST port advertised by the running daemon's addrs file.
+func rememberBaseURL() string {
+	addrs, _ := readAddrsFile(defaultDataDir())
+	restPort := defaultRESTPort
+	if addrs.RestAddr != "" {
+		if _, p, err := net.SplitHostPort(addrs.RestAddr); err == nil && p != "" {
+			restPort = p
+		}
+	}
+	return healthURL("MUNINNDB_ADMIN_URL", addrs.Scheme, restPort)
+}
+
+// printRememberHTTPError renders a non-2xx response with actionable hints.
+// The REST API uses two error shapes — auth middleware returns a flat
+// {"error":"...","code":"..."} while handlers return a nested
+// {"error":{"code":4003,"message":"..."}} — so try both before falling back
+// to the raw body.
+func printRememberHTTPError(stderr io.Writer, status int, respBody []byte, vault, keyFile string) {
+	var flat struct {
+		Error json.RawMessage `json:"error"`
+	}
+	var msg string
+	if json.Unmarshal(respBody, &flat) == nil && len(flat.Error) > 0 {
+		var s string
+		var nested struct {
+			Message string `json:"message"`
+		}
+		switch {
+		case json.Unmarshal(flat.Error, &s) == nil:
+			msg = s
+		case json.Unmarshal(flat.Error, &nested) == nil && nested.Message != "":
+			msg = nested.Message
+		}
+	}
+	if msg == "" {
+		msg = strings.TrimSpace(string(respBody))
+	}
+	fmt.Fprintf(stderr, "muninn remember: HTTP %d — %s\n", status, msg)
+
+	switch {
+	case status == http.StatusUnauthorized:
+		if vault == "" {
+			vault = "default"
+		}
+		if keyFile == "" {
+			keyFile = defaultRememberKeyFile()
+		}
+		fmt.Fprintf(stderr, "  The REST API authenticates with a vault API key (mk_*), not the MCP token.\n")
+		fmt.Fprintf(stderr, "  Create one:  muninn api-key create --vault %s --label cli\n", vault)
+		fmt.Fprintf(stderr, "  Store it:    printf '%%s\\n' 'mk_...' > %s && chmod 600 %s\n", keyFile, keyFile)
+	case status == http.StatusRequestEntityTooLarge:
+		fmt.Fprintln(stderr, "  The REST API caps request bodies at 4 MB.")
+	}
+}
+
+// splitCommaList splits a comma-separated flag value, trimming whitespace and
+// dropping empty items. Returns nil for an empty input so the JSON field is
+// omitted entirely.
+func splitCommaList(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// parseInlineEntities parses --entities "Name,Other Name:type" into inline
+// entity records. The type after the LAST colon is optional; names may not be
+// empty.
+func parseInlineEntities(s string) ([]rememberEntity, error) {
+	items := splitCommaList(s)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	out := make([]rememberEntity, 0, len(items))
+	for _, item := range items {
+		name, typ := item, ""
+		if i := strings.LastIndex(item, ":"); i >= 0 {
+			name, typ = strings.TrimSpace(item[:i]), strings.TrimSpace(item[i+1:])
+		}
+		if name == "" {
+			return nil, fmt.Errorf("invalid --entities item %q (want Name or Name:type)", item)
+		}
+		out = append(out, rememberEntity{Name: name, Type: typ})
+	}
+	return out, nil
+}

--- a/cmd/muninn/remember_test.go
+++ b/cmd/muninn/remember_test.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// rememberTestServer records the last request it saw and replies with the
+// configured status and body.
+type rememberTestServer struct {
+	*httptest.Server
+	lastMethod string
+	lastPath   string
+	lastAuth   string
+	lastCT     string
+	lastBody   []byte
+}
+
+func newRememberTestServer(t *testing.T, status int, respBody string) *rememberTestServer {
+	t.Helper()
+	rts := &rememberTestServer{}
+	rts.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rts.lastMethod = r.Method
+		rts.lastPath = r.URL.Path
+		rts.lastAuth = r.Header.Get("Authorization")
+		rts.lastCT = r.Header.Get("Content-Type")
+		body := new(bytes.Buffer)
+		body.ReadFrom(r.Body) //nolint:errcheck
+		rts.lastBody = body.Bytes()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		w.Write([]byte(respBody)) //nolint:errcheck
+	}))
+	t.Cleanup(rts.Server.Close)
+	return rts
+}
+
+// isolateRememberEnv points the verb at srv and gives the test an empty HOME
+// so the default key file lookup cannot see a developer's real ~/.muninn.
+func isolateRememberEnv(t *testing.T, srv *rememberTestServer) {
+	t.Helper()
+	t.Setenv("MUNINNDB_ADMIN_URL", srv.URL)
+	t.Setenv("HOME", t.TempDir())
+}
+
+func writeKeyFile(t *testing.T, mode os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "api.key")
+	if err := os.WriteFile(path, []byte("mk_testtoken\n"), mode); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestRememberPostsEngram(t *testing.T) {
+	srv := newRememberTestServer(t, http.StatusCreated,
+		`{"id":"01TESTULID","created_at":123,"hint":"linked to 2 memories"}`)
+	isolateRememberEnv(t, srv)
+
+	contentPath := filepath.Join(t.TempDir(), "notes.md")
+	if err := os.WriteFile(contentPath, []byte("full text of the memory\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := rememberMain([]string{
+		"--concept", "test concept",
+		"--content-file", contentPath,
+		"--summary", "a summary",
+		"--tags", "one, two",
+		"--entities", "Alice:person,Widget",
+		"--vault", "work",
+		"--op-id", "retry-key-1",
+		"--key-file", writeKeyFile(t, 0600),
+	}, strings.NewReader(""), &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr: %s", code, stderr.String())
+	}
+	if got := stdout.String(); got != "01TESTULID\n" {
+		t.Errorf("stdout = %q, want engram id line", got)
+	}
+	if !strings.Contains(stderr.String(), "linked to 2 memories") {
+		t.Errorf("hint not surfaced on stderr: %q", stderr.String())
+	}
+	if srv.lastMethod != http.MethodPost || srv.lastPath != "/api/engrams" {
+		t.Errorf("request = %s %s, want POST /api/engrams", srv.lastMethod, srv.lastPath)
+	}
+	if srv.lastAuth != "Bearer mk_testtoken" {
+		t.Errorf("Authorization = %q", srv.lastAuth)
+	}
+	if !strings.HasPrefix(srv.lastCT, "application/json") {
+		t.Errorf("Content-Type = %q", srv.lastCT)
+	}
+
+	var req rememberRequest
+	if err := json.Unmarshal(srv.lastBody, &req); err != nil {
+		t.Fatalf("request body: %v", err)
+	}
+	if req.Concept != "test concept" || req.Content != "full text of the memory\n" {
+		t.Errorf("concept/content = %q / %q", req.Concept, req.Content)
+	}
+	if req.Summary != "a summary" || req.Vault != "work" || req.IdempotentID != "retry-key-1" {
+		t.Errorf("summary/vault/op-id = %q / %q / %q", req.Summary, req.Vault, req.IdempotentID)
+	}
+	if len(req.Tags) != 2 || req.Tags[0] != "one" || req.Tags[1] != "two" {
+		t.Errorf("tags = %v", req.Tags)
+	}
+	if len(req.Entities) != 2 || req.Entities[0] != (rememberEntity{Name: "Alice", Type: "person"}) ||
+		req.Entities[1] != (rememberEntity{Name: "Widget"}) {
+		t.Errorf("entities = %v", req.Entities)
+	}
+}
+
+func TestRememberStdinContent(t *testing.T) {
+	srv := newRememberTestServer(t, http.StatusCreated, `{"id":"01FROMSTDIN","created_at":1}`)
+	isolateRememberEnv(t, srv)
+
+	var stdout, stderr bytes.Buffer
+	code := rememberMain(
+		[]string{"--concept", "piped", "--content-file", "-"},
+		strings.NewReader("piped content"), &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr: %s", code, stderr.String())
+	}
+	var req rememberRequest
+	if err := json.Unmarshal(srv.lastBody, &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.Content != "piped content" {
+		t.Errorf("content = %q", req.Content)
+	}
+	if srv.lastAuth != "" {
+		t.Errorf("expected unauthenticated request without a key file, got Authorization %q", srv.lastAuth)
+	}
+}
+
+func TestRememberUsageErrors(t *testing.T) {
+	srv := newRememberTestServer(t, http.StatusCreated, `{"id":"01X","created_at":1}`)
+	isolateRememberEnv(t, srv)
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing concept", []string{"--content", "x"}, "--concept is required"},
+		{"no content source", []string{"--concept", "c"}, "one of --content or --content-file"},
+		{"both content sources", []string{"--concept", "c", "--content", "x", "--content-file", "y"}, "mutually exclusive"},
+		{"positional arg", []string{"--concept", "c", "--content", "x", "stray"}, "unexpected argument"},
+		{"empty entity name", []string{"--concept", "c", "--content", "x", "--entities", ":person"}, "invalid --entities"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := rememberMain(tc.args, strings.NewReader(""), &stdout, &stderr)
+			if code != execExitUsage {
+				t.Fatalf("exit code = %d, want %d (stderr: %s)", code, execExitUsage, stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Errorf("stderr = %q, want substring %q", stderr.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestRememberEmptyContentRejected(t *testing.T) {
+	srv := newRememberTestServer(t, http.StatusCreated, `{"id":"01X","created_at":1}`)
+	isolateRememberEnv(t, srv)
+
+	path := filepath.Join(t.TempDir(), "empty.md")
+	if err := os.WriteFile(path, []byte("  \n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := rememberMain([]string{"--concept", "c", "--content-file", path},
+		strings.NewReader(""), &stdout, &stderr)
+	if code != execExitUsage || !strings.Contains(stderr.String(), "content is empty") {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+}
+
+func TestRememberBodyCap(t *testing.T) {
+	srv := newRememberTestServer(t, http.StatusCreated, `{"id":"01X","created_at":1}`)
+	isolateRememberEnv(t, srv)
+
+	var stdout, stderr bytes.Buffer
+	code := rememberMain(
+		[]string{"--concept", "big", "--content", strings.Repeat("a", rememberMaxBody+1)},
+		strings.NewReader(""), &stdout, &stderr)
+	if code != execExitError {
+		t.Fatalf("exit code = %d, want %d", code, execExitError)
+	}
+	if !strings.Contains(stderr.String(), "4 MB") {
+		t.Errorf("stderr should name the 4 MB cap: %q", stderr.String())
+	}
+	if srv.lastMethod != "" {
+		t.Error("oversized body must be rejected before any request is sent")
+	}
+}
+
+func TestRememberUnauthorizedHint(t *testing.T) {
+	srv := newRememberTestServer(t, http.StatusUnauthorized, `{"error":"invalid api key"}`)
+	isolateRememberEnv(t, srv)
+
+	var stdout, stderr bytes.Buffer
+	code := rememberMain(
+		[]string{"--concept", "c", "--content", "x", "--key-file", writeKeyFile(t, 0600)},
+		strings.NewReader(""), &stdout, &stderr)
+	if code != execExitError {
+		t.Fatalf("exit code = %d, want %d", code, execExitError)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "invalid api key") || !strings.Contains(out, "api-key create") {
+		t.Errorf("401 output should surface the server error and the key-creation hint: %q", out)
+	}
+}
+
+func TestRememberNestedErrorShapeSurfaced(t *testing.T) {
+	// Handlers (as opposed to auth middleware) return the nested error shape.
+	srv := newRememberTestServer(t, http.StatusBadRequest,
+		`{"error":{"code":4003,"message":"vault must match the authenticated request vault","request_id":"x"}}`)
+	isolateRememberEnv(t, srv)
+
+	var stdout, stderr bytes.Buffer
+	code := rememberMain([]string{"--concept", "c", "--content", "x", "--vault", "other"},
+		strings.NewReader(""), &stdout, &stderr)
+	if code != execExitError {
+		t.Fatalf("exit code = %d, want %d", code, execExitError)
+	}
+	if !strings.Contains(stderr.String(), "vault must match the authenticated request vault") {
+		t.Errorf("nested error message not extracted: %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "request_id") {
+		t.Errorf("raw JSON leaked into the rendered error: %q", stderr.String())
+	}
+}
+
+func TestRememberExplicitKeyFileMissing(t *testing.T) {
+	srv := newRememberTestServer(t, http.StatusCreated, `{"id":"01X","created_at":1}`)
+	isolateRememberEnv(t, srv)
+
+	var stdout, stderr bytes.Buffer
+	code := rememberMain(
+		[]string{"--concept", "c", "--content", "x", "--key-file", filepath.Join(t.TempDir(), "absent.key")},
+		strings.NewReader(""), &stdout, &stderr)
+	if code != execExitError || !strings.Contains(stderr.String(), "read key file") {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	if srv.lastMethod != "" {
+		t.Error("missing explicit key file must fail before any request is sent")
+	}
+}
+
+func TestRememberWorldReadableKeyWarns(t *testing.T) {
+	srv := newRememberTestServer(t, http.StatusCreated, `{"id":"01X","created_at":1}`)
+	isolateRememberEnv(t, srv)
+
+	var stdout, stderr bytes.Buffer
+	code := rememberMain(
+		[]string{"--concept", "c", "--content", "x", "--key-file", writeKeyFile(t, 0644)},
+		strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "world-readable") {
+		t.Errorf("expected world-readable warning, stderr = %q", stderr.String())
+	}
+}
+
+func TestParseInlineEntities(t *testing.T) {
+	got, err := parseInlineEntities("Alice:person, Bob ,  Muninn DB : project ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []rememberEntity{
+		{Name: "Alice", Type: "person"},
+		{Name: "Bob"},
+		{Name: "Muninn DB", Type: "project"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entity %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Implements the `remember --content-file` proposal green-lit in #610. No server-side changes — this is purely the thin client described there, shaped by both review notes.

## Shape

```
muninn remember --concept "..." (--content "..." | --content-file <path>)
    [--summary ...] [--tags a,b] [--entities "Name:type,..."]
    [--vault NAME] [--op-id KEY] [--key-file PATH]
```

Prints the engram id alone on stdout (script-friendly); hints and warnings go to stderr; exit codes match `muninn exec` (0 / 1 usage / 2 error). `--content-file -` reads stdin, so `git log -1 | muninn remember --concept release --content-file -` works. `--op-id` maps to `idempotent_id` (#560) — a retry prints the original id and surfaces the server's `idempotent` hint on stderr.

## Your two notes, and how they landed

**1. Token-file auth, not admin-session.** The verb reads an `mk_*` vault API key from a 0600 key file, re-read at use, world-readable-warns — the `mcp_stdio.go`/`setup_ai.go` file handling exactly. One deliberate deviation to flag: the default path is `~/.muninn/api.key`, **not** `~/.muninn/mcp.token` — because `mcp.token` holds the MCP static bearer (`mdb_*`), which the REST vault-auth layer doesn't accept (`VaultAuthMiddleware` validates `mk_*` vault keys only). Defaulting to `mcp.token` would send a token the server is guaranteed to 401, and would also break open deployments (a present-but-wrong Bearer fails where *no* Bearer would have passed the public-vault path). So: same convention, sibling file. The 401 hint text spells out the mdb_/mk_ distinction and gives the two commands to fix it. A missing *default* key file degrades to an unauthenticated request (public-vault deployments keep working — same semantics as the shipped curl guidance); a missing *explicit* `--key-file` is an error. `--key-file` override included per your nice-to-have.

**2. 4 MB cap documented.** In the subcommand help (`--content-file` flag text), and enforced client-side before the POST: an oversized payload fails with the byte count, the cap, and a suggestion — instead of the opaque decode error the truncated server read would produce. A server 413 is also mapped, should the cap ever move.

## Tests

11 tests in `cmd/muninn/remember_test.go` against an httptest server: request shape (all fields incl. entities/op-id/vault), Bearer header from key file, stdin form, unauthenticated-when-no-default-key, usage errors, empty content, 4 MB pre-flight (asserts no request is sent), 401 hint, explicit-key-file-missing, world-readable warning, nested-vs-flat error shape rendering. `gofmt`/`go vet` clean; full `./cmd/muninn` suite passes.

Also exercised end-to-end against a fresh daemon (first-run, public default vault): happy path → ULID; same `--op-id` retry → same ULID + `hint: idempotent`; stdin form; keyed write via the default key file; cross-vault body write with a pinned key → your 400/4003 (`vault must match the authenticated request vault`) rendered as a one-liner; bogus key → 401 with the creation hint.

One incidental finding while wiring errors: the REST API emits two error shapes — flat `{"error":"...","code":"..."}` from the auth middleware, nested `{"error":{"code":4003,"message":"..."}}` from handlers. The verb renders both; noting it in case unifying them upstream is ever on the table.

If you'd rather the default key file be literally `~/.muninn/mcp.token` despite the mdb_/mk_ mismatch, say the word and I'll change it — the rest stands either way.

— Cairn (context in #609)


Closes #610
