### PR TITLE
fix(mcp): expose stored memory type on read/recall/where_left_off/find_by_entity

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2158,6 +2158,8 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 			Relevance:   scored.Engram.Relevance,
 			State:       uint8(scored.Engram.State),
 			Trust:       uint8(scored.Engram.Trust),
+			MemoryType:  uint8(scored.Engram.MemoryType),
+			TypeLabel:   scored.Engram.TypeLabel,
 		}
 
 		items[i].ScoreComponents = mbp.ScoreComponents{

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -2425,3 +2425,46 @@ func TestEngineWriteBatch_CreatedAtValid(t *testing.T) {
 		t.Errorf("expected no error for valid past CreatedAt in batch, got: %v", errs[0])
 	}
 }
+
+// TestActivateCarriesMemoryType verifies that recall results carry the stored
+// memory type end to end: write with an explicit type, activate, and the
+// ActivationItem must expose MemoryType and TypeLabel. Before this field
+// existed on ActivationItem, recall was the only read surface that dropped
+// type at the wire rather than in presentation.
+func TestActivateCarriesMemoryType(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:      "test",
+		Concept:    "Migration decision for the storage layer",
+		Content:    "We decided to migrate the storage layer to Pebble for compaction control.",
+		MemoryType: uint8(storage.TypeDecision),
+		TypeLabel:  "architectural_decision",
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	awaitFTS(t, eng)
+
+	resp, err := eng.Activate(ctx, &mbp.ActivateRequest{
+		Vault:      "test",
+		Context:    []string{"storage layer migration"},
+		MaxResults: 10,
+		Threshold:  0.01,
+	})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if len(resp.Activations) == 0 {
+		t.Fatal("Activate returned 0 results, want >= 1")
+	}
+	top := resp.Activations[0]
+	if top.MemoryType != uint8(storage.TypeDecision) {
+		t.Errorf("MemoryType = %d, want %d (decision)", top.MemoryType, uint8(storage.TypeDecision))
+	}
+	if top.TypeLabel != "architectural_decision" {
+		t.Errorf("TypeLabel = %q, want %q", top.TypeLabel, "architectural_decision")
+	}
+}

--- a/internal/mcp/convert.go
+++ b/internal/mcp/convert.go
@@ -38,7 +38,10 @@ func activationToMemory(item *mbp.ActivationItem) Memory {
 		Confidence:  item.Confidence,
 		Why:         item.Why,
 		// Map the lifecycle state label the same way the read path does (#502).
-		State:       storage.LifecycleState(item.State).String(),
+		State: storage.LifecycleState(item.State).String(),
+		// Type mirrors the vocabulary muninn_remember accepts (storage.ParseMemoryType).
+		Type:        storage.MemoryType(item.MemoryType).String(),
+		TypeLabel:   item.TypeLabel,
 		CreatedAt:   time.Unix(0, item.CreatedAt).UTC(),
 		LastAccess:  time.Unix(0, item.LastAccess).UTC(),
 		AccessCount: item.AccessCount,
@@ -60,6 +63,8 @@ func readResponseToMemory(r *mbp.ReadResponse) Memory {
 		Confidence:  r.Confidence,
 		Tags:        r.Tags,
 		State:       storage.LifecycleState(r.State).String(),
+		Type:        storage.MemoryType(r.MemoryType).String(),
+		TypeLabel:   r.TypeLabel,
 		CreatedAt:   time.Unix(0, r.CreatedAt).UTC(),
 		LastAccess:  time.Unix(0, r.LastAccess).UTC(),
 		AccessCount: r.AccessCount,

--- a/internal/mcp/convert_test.go
+++ b/internal/mcp/convert_test.go
@@ -393,3 +393,50 @@ func TestActivationToMemory_FallsBackToTruncated(t *testing.T) {
 		t.Error("truncated content must end with '...'")
 	}
 }
+
+// TestActivationToMemoryMapsType verifies muninn_recall exposes the stored
+// memory type as its canonical label plus the writer's free-form type_label.
+func TestActivationToMemoryMapsType(t *testing.T) {
+	item := &mbp.ActivationItem{
+		ID:         "typed-recall",
+		MemoryType: uint8(storage.TypeDecision),
+		TypeLabel:  "architectural_decision",
+	}
+	m := activationToMemory(item)
+	if m.Type != "decision" {
+		t.Errorf("Type = %q, want %q", m.Type, "decision")
+	}
+	if m.TypeLabel != "architectural_decision" {
+		t.Errorf("TypeLabel = %q, want %q", m.TypeLabel, "architectural_decision")
+	}
+}
+
+// TestActivationToMemoryTypeZeroValueIsFact pins the zero-value story: an
+// engram stored without an explicit type (MemoryType 0) presents as "fact",
+// so the field is always present and never reads as "type not exposed".
+func TestActivationToMemoryTypeZeroValueIsFact(t *testing.T) {
+	m := activationToMemory(&mbp.ActivationItem{ID: "untyped-recall"})
+	if m.Type != "fact" {
+		t.Errorf("Type = %q, want %q", m.Type, "fact")
+	}
+	if m.TypeLabel != "" {
+		t.Errorf("TypeLabel = %q, want empty", m.TypeLabel)
+	}
+}
+
+// TestReadResponseToMemoryMapsType verifies muninn_read maps MemoryType and
+// TypeLabel from the wire response (which has always carried them).
+func TestReadResponseToMemoryMapsType(t *testing.T) {
+	r := &mbp.ReadResponse{
+		ID:         "typed-read",
+		MemoryType: uint8(storage.TypeProcedure),
+		TypeLabel:  "runbook",
+	}
+	m := readResponseToMemory(r)
+	if m.Type != "procedure" {
+		t.Errorf("Type = %q, want %q", m.Type, "procedure")
+	}
+	if m.TypeLabel != "runbook" {
+		t.Errorf("TypeLabel = %q, want %q", m.TypeLabel, "runbook")
+	}
+}

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -382,15 +382,23 @@ func (a *mcpEngineAdapter) WhereLeftOff(ctx context.Context, vault string, limit
 		if eng == nil {
 			continue
 		}
-		entries = append(entries, WhereLeftOffEntry{
-			ID:         eng.ID.String(),
-			Concept:    eng.Concept,
-			Summary:    eng.Summary,
-			LastAccess: eng.LastAccess,
-			State:      lifecycleStateLabel(eng.State),
-		})
+		entries = append(entries, whereLeftOffEntryFromEngram(eng))
 	}
 	return entries, nil
+}
+
+// whereLeftOffEntryFromEngram projects a stored engram onto the
+// muninn_where_left_off result shape.
+func whereLeftOffEntryFromEngram(eng *storage.Engram) WhereLeftOffEntry {
+	return WhereLeftOffEntry{
+		ID:         eng.ID.String(),
+		Concept:    eng.Concept,
+		Summary:    eng.Summary,
+		LastAccess: eng.LastAccess,
+		State:      lifecycleStateLabel(eng.State),
+		Type:       eng.MemoryType.String(),
+		TypeLabel:  eng.TypeLabel,
+	}
 }
 
 // lifecycleStateLabel converts a storage.LifecycleState to a display string.

--- a/internal/mcp/engine_adapter_test.go
+++ b/internal/mcp/engine_adapter_test.go
@@ -309,3 +309,27 @@ func TestRelTypeToString_ZeroValueEmpty(t *testing.T) {
 		t.Errorf("relTypeToString(0) = %q, want empty string", got)
 	}
 }
+
+// TestWhereLeftOffEntryFromEngramMapsType verifies the muninn_where_left_off
+// projection carries the stored memory type — previously this surface dropped
+// it even though the engine hands the adapter full engrams.
+func TestWhereLeftOffEntryFromEngramMapsType(t *testing.T) {
+	eng := &storage.Engram{
+		ID:         storage.ULID{7},
+		Concept:    "typed entry",
+		MemoryType: storage.TypeGoal,
+		TypeLabel:  "quarterly_objective",
+	}
+	entry := whereLeftOffEntryFromEngram(eng)
+	if entry.Type != "goal" {
+		t.Errorf("Type = %q, want %q", entry.Type, "goal")
+	}
+	if entry.TypeLabel != "quarterly_objective" {
+		t.Errorf("TypeLabel = %q, want %q", entry.TypeLabel, "quarterly_objective")
+	}
+	// Zero value presents as "fact" — the field is always present.
+	plain := whereLeftOffEntryFromEngram(&storage.Engram{ID: storage.ULID{8}})
+	if plain.Type != "fact" {
+		t.Errorf("zero-value Type = %q, want %q", plain.Type, "fact")
+	}
+}

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1018,18 +1018,22 @@ func (s *MCPServer) handleFindByEntity(ctx context.Context, w http.ResponseWrite
 	}
 	engrams := res.Engrams
 	type engramEntry struct {
-		ID      string `json:"id"`
-		Concept string `json:"concept"`
-		Summary string `json:"summary,omitempty"`
-		State   string `json:"state"`
+		ID        string `json:"id"`
+		Concept   string `json:"concept"`
+		Summary   string `json:"summary,omitempty"`
+		State     string `json:"state"`
+		Type      string `json:"type"`
+		TypeLabel string `json:"type_label,omitempty"`
 	}
 	entries := make([]engramEntry, 0, len(engrams))
 	for _, e := range engrams {
 		entries = append(entries, engramEntry{
-			ID:      e.ID.String(),
-			Concept: e.Concept,
-			Summary: e.Summary,
-			State:   lifecycleStateLabel(e.State),
+			ID:        e.ID.String(),
+			Concept:   e.Concept,
+			Summary:   e.Summary,
+			State:     lifecycleStateLabel(e.State),
+			Type:      e.MemoryType.String(),
+			TypeLabel: e.TypeLabel,
 		})
 	}
 	payload := map[string]any{

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -1391,6 +1391,8 @@ func (e *whereLeftOffEngine) WhereLeftOff(_ context.Context, _ string, _ int) ([
 			Summary:    "working on feature X",
 			LastAccess: time.Now().Add(-5 * time.Minute),
 			State:      "active",
+			Type:       "task",
+			TypeLabel:  "feature_work",
 		},
 		{
 			ID:         "entry-2",
@@ -1454,10 +1456,16 @@ func TestHandleWhereLeftOff_ResponseShape(t *testing.T) {
 	if !ok {
 		t.Fatal("memories[0] is not an object")
 	}
-	for _, field := range []string{"id", "concept", "last_access", "state"} {
+	for _, field := range []string{"id", "concept", "last_access", "state", "type"} {
 		if _, ok := entry[field]; !ok {
 			t.Errorf("memory entry missing field: %q", field)
 		}
+	}
+	if entry["type"] != "task" {
+		t.Errorf("entry type = %v, want %q", entry["type"], "task")
+	}
+	if entry["type_label"] != "feature_work" {
+		t.Errorf("entry type_label = %v, want %q", entry["type_label"], "feature_work")
 	}
 
 	count, ok := content["count"].(float64)

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -74,6 +74,8 @@ type Memory struct {
 	Why         string    `json:"why,omitempty"`
 	Tags        []string  `json:"tags,omitempty"`
 	State       string    `json:"state,omitempty"`
+	Type        string    `json:"type"`                 // canonical MemoryType label ("fact", "decision", ...); always present
+	TypeLabel   string    `json:"type_label,omitempty"` // writer-supplied free-form label, e.g. "architectural_decision"
 	CreatedAt   time.Time `json:"created_at"`
 	LastAccess  time.Time `json:"last_access"`
 	AccessCount uint32    `json:"access_count,omitempty"`
@@ -365,6 +367,8 @@ type WhereLeftOffEntry struct {
 	Summary    string    `json:"summary,omitempty"`
 	LastAccess time.Time `json:"last_access"`
 	State      string    `json:"state"`
+	Type       string    `json:"type"`                 // canonical MemoryType label; always present
+	TypeLabel  string    `json:"type_label,omitempty"` // writer-supplied free-form label
 }
 
 // EntityClusterResult is one entity co-occurrence pair returned by muninn_entity_clusters.

--- a/internal/transport/mbp/types.go
+++ b/internal/transport/mbp/types.go
@@ -235,6 +235,11 @@ type ActivationItem struct {
 	State uint8 `msgpack:"state,omitempty" json:"state,omitempty"`
 	// Trust is the TrustLevel uint8. omitempty intentional — see ReadResponse.Trust comment.
 	Trust uint8 `msgpack:"trust,omitempty" json:"trust,omitempty"`
+	// MemoryType is the stored MemoryType uint8 (see storage.MemoryType).
+	// omitempty intentional — absent means TypeFact (0), the zero value.
+	MemoryType uint8 `msgpack:"memory_type,omitempty" json:"memory_type,omitempty"`
+	// TypeLabel is the writer's free-form type label; empty when none was stored.
+	TypeLabel string `msgpack:"type_label,omitempty" json:"type_label,omitempty"`
 }
 
 // ScoreComponents breaks down the activation score.

--- a/internal/transport/rest/openapi.yaml
+++ b/internal/transport/rest/openapi.yaml
@@ -318,6 +318,8 @@ components:
           type: string
         content:
           type: string
+        summary:
+          type: string
         score:
           type: number
           format: float
@@ -334,6 +336,31 @@ components:
             type: string
         dormant:
           type: boolean
+        created_at:
+          type: integer
+          format: int64
+        last_access:
+          type: integer
+          format: int64
+        access_count:
+          type: integer
+          format: int64
+        relevance:
+          type: number
+          format: float
+        source_type:
+          type: string
+        state:
+          type: integer
+          format: uint8
+        trust:
+          type: integer
+          format: uint8
+        memory_type:
+          type: integer
+          format: uint8
+        type_label:
+          type: string
 
     BriefSentence:
       type: object


### PR DESCRIPTION
## What

`MemoryType`/`TypeLabel` are stored with every engram and bindable on write (`muninn_remember`'s `type`), but no MCP read surface returned them — stored type was effectively write-only for MCP clients:

- **`muninn_read`**: `ReadResponse` carries `memory_type` + `type_label` on the wire, but the `mcp.Memory` struct had no type field, so `readResponseToMemory` dropped them at presentation.
- **`muninn_recall`**: lost a layer earlier — `mbp.ActivationItem` never carried type at all, even though the engine has the full engram in hand when it builds activations.
- **`muninn_where_left_off`** and **`muninn_find_by_entity`**: their projections drop type the same way, despite the engine handing them full engrams.

We noticed when trying to audit whether `type` binds correctly on our own writes: the stored value is unreachable through MCP, so every written specimen was unreadable.

## Fix

- `mbp.ActivationItem`: add `memory_type` + `type_label`. Additive and `omitempty` — absent means `TypeFact(0)`, the same convention as the late `state`/`trust` additions on this struct. msgpack/JSON compatible both directions.
- Engine: populate both fields from `scored.Engram` when converting activations.
- `mcp.Memory`, `WhereLeftOffEntry`, and the `find_by_entity` projection: add `type` (canonical `MemoryType` label, **always present**, symmetric with the vocabulary `ParseMemoryType` accepts on write) and `type_label` (writer's free-form label, omitted when empty).

`type` is deliberately not `omitempty`: the zero value presents as `"fact"`, and an always-present field lets a client distinguish "this memory is a fact" from "this server doesn't expose type".

## Tests

- Converter mapping in both directions, plus a pin on the zero-value→`"fact"` story
- `where_left_off` projection unit test (mapping extracted to a small helper for testability)
- Handler shape test extended to assert `type`/`type_label` serialize
- End-to-end engine test: write a typed engram → `Activate` → the wire item carries `MemoryType`+`TypeLabel`

All new tests verified to fail with the mapping reverted (engine population and presentation mapping each reverted separately). Full `./internal/...` green (47 packages).

## Not covered (follow-up candidates)

`recall_tree`, `traverse`, and `list_deleted` serialize their own shapes and remain type-blind. Happy to follow up on those if you want them in the same shape — kept this PR to the primary read surfaces.

One thing to be aware of rather than a change: `MemoryType.String()` maps out-of-range bytes to `"fact"` (its default arm), so the label alone can't distinguish a corrupt stored byte from a genuine fact. The raw `memory_type` uint8 stays available on the wire structs for anyone who needs to verify the stored byte itself.