### PR TITLE
fix(storage/auth): relocate auth prefixes + prefix registry + v3 migration (#611)

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -953,6 +953,7 @@ func runServer() {
 	uiAddr := flag.String("ui-addr", uiAddrDefault, "Web UI HTTP listen address")
 	mcpToken := flag.String("mcp-token", "", "Bearer token override for MCP auth (leave empty to read from MUNINN_MCP_TOKEN env var or ~/.muninn/mcp.token)")
 	dev := flag.Bool("dev", false, "serve web assets from ./web directory (development mode)")
+	forceMigrationRerun := flag.Bool("force-migration-rerun", false, "Reset the stored migration version to 0 and exit without starting the server. The next normal start re-applies every registered migration (all are idempotent). Operator recovery path for a wedged/partial migration (#611). Always back up the DB before a migration-bearing upgrade; use this flag to recover from a wedged/partial migration.")
 	backupInterval := flag.String("backup-interval", "", "Automated backup interval (e.g. 6h, 30m); empty = disabled")
 	backupDir := flag.String("backup-dir", "", "Directory to write automated backups into")
 	backupRetain := flag.Int("backup-retain", 5, "Number of automated backups to keep")
@@ -1152,6 +1153,27 @@ func runServer() {
 	// NOTE: db.Close() is NOT deferred here because store.Close() (called
 	// during the ordered shutdown sequence) internally closes the Pebble DB
 	// after flushing its own background workers.
+
+	// --force-migration-rerun: reset the stored migration version to 0 and
+	// exit. The next normal start re-applies every registered migration.
+	// This is the operator recovery path for a wedged/partial migration
+	// (#611, Task 7b / RT5): if a version was stamped but the operator needs
+	// to force a re-run (e.g. recover from a partial state), this resets
+	// the marker so the existing Runner re-applies the migrations on the
+	// next Open. It does NOT run migrations itself — that keeps the path
+	// simple and reuses the hardened Runner's fail-loud semantics.
+	if *forceMigrationRerun {
+		if err := migrate.ForceRerunMigrations(db); err != nil {
+			slog.Error("force-migration-rerun failed", "err", err)
+			_ = db.Close()
+			os.Exit(1)
+		}
+		slog.Info("migration version reset to 0; all registered migrations will re-run on next start",
+			"data_dir", *dataDir)
+		fmt.Fprintln(os.Stderr, "migration version reset to 0; re-run on next start. Re-run `muninn start` (without this flag) to apply.")
+		_ = db.Close()
+		os.Exit(0)
+	}
 
 	if err := replication.CheckAndSetSchemaVersion(db); err != nil {
 		slog.Error("schema version check", "err", err)

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -1182,16 +1182,7 @@ func runServer() {
 
 	// Run versioned schema migrations before the storage layer is built.
 	migRunner := migrate.NewRunner(db)
-	migRunner.Register(migrate.Migration{
-		Version:     1,
-		Description: "backfill embed_dim in ERF records for existing embeddings",
-		Up:          migrate.BackfillEmbedDim,
-	})
-	migRunner.Register(migrate.Migration{
-		Version:     2,
-		Description: "backfill relationship entity index (0x26) for GetEntityAggregate optimisation",
-		Up:          migrate.BackfillRelEntityIndex,
-	})
+	migrate.RegisterMigrations(migRunner)
 	if applied, err := migRunner.Run(); err != nil {
 		slog.Error("migration failed", "err", err)
 		db.Close()

--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -953,7 +953,7 @@ func runServer() {
 	uiAddr := flag.String("ui-addr", uiAddrDefault, "Web UI HTTP listen address")
 	mcpToken := flag.String("mcp-token", "", "Bearer token override for MCP auth (leave empty to read from MUNINN_MCP_TOKEN env var or ~/.muninn/mcp.token)")
 	dev := flag.Bool("dev", false, "serve web assets from ./web directory (development mode)")
-	forceMigrationRerun := flag.Bool("force-migration-rerun", false, "Reset the stored migration version to 0 and exit without starting the server. The next normal start re-applies every registered migration (all are idempotent). Operator recovery path for a wedged/partial migration (#611). Always back up the DB before a migration-bearing upgrade; use this flag to recover from a wedged/partial migration.")
+	forceMigrationRerun := flag.Bool("force-migration-rerun", false, "Reset the stored migration version to 0 and exit without starting the server. The next normal start re-applies every registered migration. Re-running only re-applies migrations THIS binary knows about — if the DB was last written by a NEWER binary, do NOT use this flag; upgrade instead (the helper refuses a stored version newer than this binary's max). Operator recovery path for a wedged/partial migration (#611). Always back up the DB before a migration-bearing upgrade; use this flag to recover from a wedged/partial migration — not to downgrade.")
 	backupInterval := flag.String("backup-interval", "", "Automated backup interval (e.g. 6h, 30m); empty = disabled")
 	backupDir := flag.String("backup-dir", "", "Directory to write automated backups into")
 	backupRetain := flag.Int("backup-retain", 5, "Number of automated backups to keep")
@@ -1162,6 +1162,12 @@ func runServer() {
 	// the marker so the existing Runner re-applies the migrations on the
 	// next Open. It does NOT run migrations itself — that keeps the path
 	// simple and reuses the hardened Runner's fail-loud semantics.
+	//
+	// Refuse-newer guard (RT6): ForceRerunMigrations reads the stored version
+	// and refuses if it exceeds this binary's MaxRegisteredVersion — resetting
+	// to 0 would let an older binary re-apply only its own (smaller) migration
+	// set against a newer schema, a downgrade-bypass surface. The operator
+	// must upgrade the binary, not recover with an older one.
 	if *forceMigrationRerun {
 		if err := migrate.ForceRerunMigrations(db); err != nil {
 			slog.Error("force-migration-rerun failed", "err", err)

--- a/internal/auth/keys.go
+++ b/internal/auth/keys.go
@@ -1,12 +1,14 @@
 package auth
 
+import "github.com/scrypster/muninndb/internal/prefix"
+
 const (
-	prefixAdminUser      byte = 0x11
-	prefixAPIKey         byte = 0x12
-	prefixAPIKeyVIdx     byte = 0x13
-	prefixVaultCfg       byte = 0x14
-	prefixCapability     byte = 0x40
-	prefixCapabilityVIdx byte = 0x41
+	prefixAdminUser      = prefix.AdminUser
+	prefixAPIKey         = prefix.APIKey
+	prefixAPIKeyVIdx     = prefix.APIKeyVaultIdx
+	prefixVaultCfg       = prefix.VaultConfig
+	prefixCapability     = prefix.Capability
+	prefixCapabilityVIdx = prefix.CapabilityVaultIdx
 )
 
 func adminUserKey(username string) []byte {

--- a/internal/auth/keys_test.go
+++ b/internal/auth/keys_test.go
@@ -2,30 +2,30 @@ package auth
 
 import (
 	"testing"
+
+	"github.com/scrypster/muninndb/internal/prefix"
 )
 
 // TestCapabilityPrefixesNoCollision (RedTeam NOTABLE #5 regression guard):
 // the 0x40/0x41 capability prefixes were relocated off storage's 0x15/0x16
 // keyspace (commit 0553a07). This test asserts the prefixes don't collide
-// with the storage layer's range (0x01–0x2A) or auth's own range
-// (0x42–0x45, relocated from 0x11–0x14 by #611). Reverting 0x40→0x15 (or
-// any value in either range) would fail this test, catching the regression
-// before it ships.
-//
-// The storage prefix range is sourced from the keys package; we hard-code
-// the known bounds here so this test stays in the auth package without an
-// import cycle. If storage extends past 0x2A, update storageMaxPrefix.
-// Task 5 will refine both ranges to source from prefix.All().
+// with any storage or auth-own prefix registered in prefix.All(). Reverting
+// 0x40→0x15 (or any value already claimed by another owner) would fail this
+// test, catching the regression before it ships.
 func TestCapabilityPrefixesNoCollision(t *testing.T) {
-	// Known storage prefix bounds (internal/storage/keys/keys.go).
-	// As of this writing, the highest storage prefix is 0x2A (LeaseKey).
-	const storageMinPrefix = 0x01
-	const storageMaxPrefix = 0x2A
-
-	// Auth's own non-capability prefixes (admin user, API key, API key vIdx,
-	// vault config) — relocated to 0x42–0x45 by #611.
-	const authOwnMin = 0x42
-	const authOwnMax = 0x45
+	// Build the set of every registered prefix byte grouped by owner, sourced
+	// from the registry (prefix.All()). Task 5 dropped the hardcoded bounds
+	// (0x01–0x2A storage / 0x42–0x45 auth) in favour of the registry so that
+	// adding a new prefix anywhere in the range automatically tightens this
+	// guard.
+	type owner struct {
+		name string
+		cat  string
+	}
+	owners := make(map[byte]owner, len(prefix.All()))
+	for _, e := range prefix.All() {
+		owners[e.Byte] = owner{name: e.Owner + "/" + e.Name, cat: e.Cat}
+	}
 
 	capPrefixes := []struct {
 		name string
@@ -36,14 +36,15 @@ func TestCapabilityPrefixesNoCollision(t *testing.T) {
 	}
 
 	for _, p := range capPrefixes {
-		// Must be ABOVE both ranges — not inside storage's, not inside auth's own.
-		if p.val >= storageMinPrefix && p.val <= storageMaxPrefix {
-			t.Errorf("%s = 0x%02X collides with storage prefix range [0x%02X, 0x%02X] — capabilities would corrupt storage keys",
-				p.name, p.val, storageMinPrefix, storageMaxPrefix)
-		}
-		if p.val >= authOwnMin && p.val <= authOwnMax {
-			t.Errorf("%s = 0x%02X collides with auth's own prefix range [0x%02X, 0x%02X] — capabilities would corrupt API key or vault config records",
-				p.name, p.val, authOwnMin, authOwnMax)
+		// Must not collide with any NON-capability registered prefix. The
+		// capability entries themselves (capability/Capability,
+		// capability/CapabilityVaultIdx) are expected to match their own
+		// byte — that's the registry recording the allocation, not a
+		// collision.
+		if existing, ok := owners[p.val]; ok && existing.name != "capability/Capability" && existing.name != "capability/CapabilityVaultIdx" {
+			t.Errorf("%s = 0x%02X collides with already-registered prefix %s — "+
+				"two keyspaces would overlap",
+				p.name, p.val, existing.name)
 		}
 	}
 

--- a/internal/auth/keys_test.go
+++ b/internal/auth/keys_test.go
@@ -8,12 +8,14 @@ import (
 // the 0x40/0x41 capability prefixes were relocated off storage's 0x15/0x16
 // keyspace (commit 0553a07). This test asserts the prefixes don't collide
 // with the storage layer's range (0x01–0x2A) or auth's own range
-// (0x11–0x14). Reverting 0x40→0x15 (or any value in either range) would
-// fail this test, catching the regression before it ships.
+// (0x42–0x45, relocated from 0x11–0x14 by #611). Reverting 0x40→0x15 (or
+// any value in either range) would fail this test, catching the regression
+// before it ships.
 //
 // The storage prefix range is sourced from the keys package; we hard-code
 // the known bounds here so this test stays in the auth package without an
 // import cycle. If storage extends past 0x2A, update storageMaxPrefix.
+// Task 5 will refine both ranges to source from prefix.All().
 func TestCapabilityPrefixesNoCollision(t *testing.T) {
 	// Known storage prefix bounds (internal/storage/keys/keys.go).
 	// As of this writing, the highest storage prefix is 0x2A (LeaseKey).
@@ -21,9 +23,9 @@ func TestCapabilityPrefixesNoCollision(t *testing.T) {
 	const storageMaxPrefix = 0x2A
 
 	// Auth's own non-capability prefixes (admin user, API key, API key vIdx,
-	// vault config).
-	const authOwnMin = 0x11
-	const authOwnMax = 0x14
+	// vault config) — relocated to 0x42–0x45 by #611.
+	const authOwnMin = 0x42
+	const authOwnMax = 0x45
 
 	capPrefixes := []struct {
 		name string

--- a/internal/auth/lockout_regression_test.go
+++ b/internal/auth/lockout_regression_test.go
@@ -1,0 +1,143 @@
+package auth_test
+
+import (
+	"context"
+	"encoding/binary"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/scrypster/muninndb/internal/auth"
+	"github.com/scrypster/muninndb/internal/prefix"
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// TestLockoutRegression_AllThreeBugsClosed proves the #611 prefix-relocation
+// fix (auth: 0x11–0x14 → 0x42–0x45) closes all three live bugs end-to-end over
+// a real in-mem Pebble DB shared between auth.Store and storage.PebbleStore:
+//
+//  1. Lockout  — AdminExists (scanning 0x42) is NOT fooled by storage
+//     DigestFlags records at 0x11 that used to collide with auth's pre-relocation
+//     AdminUser prefix and falsely trip AdminExists, short-circuiting Bootstrap.
+//  2. Real admin — Bootstrap creates root whose password actually validates
+//     (not a false-positive AdminExists return that skips CreateAdmin).
+//  3. Symmetric miscount — CountWithFlag over [0x11,0x12) returns exactly N,
+//     not N+admin (admin JSON at 0x42 is outside the DigestFlags range).
+//
+// The test FAILS if anyone reverts auth back to 0x11–0x14: AdminExists would
+// see the 0x11 DigestFlags records, return true, and Bootstrap would skip
+// CreateAdmin — failing assertion (3); CountWithFlag would also walk the admin
+// JSON, failing assertion (4).
+func TestLockoutRegression_AllThreeBugsClosed(t *testing.T) {
+	db, store, pebbleStore := setupLockoutRegressionDB(t)
+
+	// Seed 3 DigestFlags records at 0x11 (the storage key space that used to
+	// collide with auth's pre-relocation AdminUser prefix and falsely trip
+	// AdminExists). Key: 0x11 | id(16) = 17 bytes; value: 1-byte flag.
+	const numDigestFlags = 3
+	const flag = uint8(0x01)
+	for i := 0; i < numDigestFlags; i++ {
+		var id [16]byte
+		id[15] = byte(i)
+		key := make([]byte, 1+16)
+		key[0] = prefix.DigestFlags
+		copy(key[1:], id[:])
+		if err := db.Set(key, []byte{flag}, pebble.Sync); err != nil {
+			t.Fatalf("seed DigestFlags[%d]: %v", i, err)
+		}
+	}
+
+	// (1) AdminExists == false despite 3 records at 0x11 — the lockout bug.
+	// Pre-relocation, AdminUser was at 0x11 and AdminExists scanned [0x11,0x12),
+	// finding the digest-flag records and wrongly concluding an admin existed.
+	if store.AdminExists() {
+		t.Fatal("AdminExists=true with only 0x11 digest-flag records — lockout regression (#611)")
+	}
+
+	// (2) Bootstrap creates root — must succeed because AdminExists correctly
+	// reports false. Pre-relocation, Bootstrap would skip CreateAdmin here.
+	secretPath := filepath.Join(t.TempDir(), "auth_secret")
+	if _, err := auth.Bootstrap(store, secretPath); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if !store.AdminExists() {
+		t.Fatal("AdminExists=false after Bootstrap — root admin was not created")
+	}
+
+	// (3) ValidateAdmin("root", "password") — a real admin whose password
+	// validates, proving Bootstrap actually invoked CreateAdmin (default
+	// password "password") rather than no-oping on a false positive.
+	if err := store.ValidateAdmin("root", "password"); err != nil {
+		t.Fatalf("ValidateAdmin(root, default password) failed: %v — admin was not really created", err)
+	}
+
+	// (4) CountWithFlag over [0x11,0x12) returns exactly N — the symmetric-
+	// miscount guard. Pre-relocation, admin JSON under 0x11 was incorrectly
+	// walked by CountWithFlag, inflating the count.
+	got, err := pebbleStore.CountWithFlag(context.Background(), flag)
+	if err != nil {
+		t.Fatalf("CountWithFlag: %v", err)
+	}
+	if got != int64(numDigestFlags) {
+		t.Errorf("CountWithFlag = %d, want %d (admin JSON at 0x42 must not be counted as a digest flag)",
+			got, numDigestFlags)
+	}
+}
+
+// TestLockoutRegression_ListVaultConfigsPerfCliff proves that ListVaultConfigs
+// (scanning [0x45,0x46)) no longer reads the AssocWeightIndex at 0x14 — the
+// perf-cliff collision source. Pre-relocation, VaultConfig lived at 0x14 and
+// every association-weight row was misread as vault-config JSON, blowing up
+// json.Unmarshal and degrading list-vault operations to a full scan of the
+// association index.
+func TestLockoutRegression_ListVaultConfigsPerfCliff(t *testing.T) {
+	db, store, _ := setupLockoutRegressionDB(t)
+	_ = db
+
+	// Seed 50 AssocWeightIndex records at 0x14 — the perf-cliff collision
+	// source. Key: 0x14 | ws(8) | src(16) | dst(16) = 41 bytes; value: 4-byte
+	// float32 weight.
+	const numAssocWeightRows = 50
+	for i := 0; i < numAssocWeightRows; i++ {
+		key := make([]byte, 1+8+16+16)
+		key[0] = prefix.AssocWeightIndex
+		binary.BigEndian.PutUint64(key[1:9], uint64(i))
+		// src[9:25] and dst[25:41] left zero — uniqueness comes from the ws slot.
+		if err := db.Set(key, make([]byte, 4), pebble.Sync); err != nil {
+			t.Fatalf("seed AssocWeightIndex[%d]: %v", i, err)
+		}
+	}
+
+	// ListVaultConfigs must return an empty slice — 0x14 records must NOT
+	// be read as VaultConfig JSON. Pre-relocation this returned 50 garbage
+	// entries (or errored on json.Unmarshal of a 4-byte float32).
+	cfgs, err := store.ListVaultConfigs()
+	if err != nil {
+		t.Fatalf("ListVaultConfigs: %v", err)
+	}
+	if len(cfgs) != 0 {
+		t.Errorf("ListVaultConfigs = %d configs, want 0 (AssocWeightIndex at 0x14 must not be read as vault configs)",
+			len(cfgs))
+	}
+}
+
+// setupLockoutRegressionDB opens an in-mem Pebble DB and wraps it with both
+// auth.Store and storage.PebbleStore so the test can drive the REAL production
+// code paths for AdminExists/Bootstrap/ValidateAdmin (auth) and CountWithFlag
+// (storage) over the same key space. The PebbleStore owns db.Close via
+// t.Cleanup; auth.Store has no Close of its own.
+func setupLockoutRegressionDB(t *testing.T) (*pebble.DB, *auth.Store, *storage.PebbleStore) {
+	t.Helper()
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("open in-mem pebble: %v", err)
+	}
+	authStore := auth.NewStore(db)
+	pebbleStore := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 100})
+	// PebbleStore.Close drains background goroutines (walSync, counterFlush,
+	// provWork, transCache) AND closes the shared db via closeOnce — single
+	// Close path, no double-close.
+	t.Cleanup(func() { _ = pebbleStore.Close() })
+	return db, authStore, pebbleStore
+}

--- a/internal/prefix/prefix.go
+++ b/internal/prefix/prefix.go
@@ -11,47 +11,47 @@ package prefix
 // Source-of-truth prefix bytes. Storage unchanged; auth RELOCATED 0x11–0x14 → 0x42–0x45.
 const (
 	// Storage (0x01–0x2A)
-	Engram byte = 0x01
-	Meta   byte = 0x02
-	AssocFwd          byte = 0x03
-	AssocRev          byte = 0x04
-	FTSPosting        byte = 0x05
-	Trigram           byte = 0x06
-	HNSWNode          byte = 0x07
-	FTSStats          byte = 0x08
-	TermStats         byte = 0x09
-	Contradiction     byte = 0x0A
-	StateIndex        byte = 0x0B
-	TagIndex          byte = 0x0C
-	CreatorIndex      byte = 0x0D
-	VaultMeta         byte = 0x0E
-	VaultNameIndex    byte = 0x0F
-	RelevanceBucket   byte = 0x10
-	DigestFlags       byte = 0x11
-	Coherence         byte = 0x12
-	VaultWeights      byte = 0x13
-	AssocWeightIndex  byte = 0x14
-	VaultCount        byte = 0x15
-	Provenance        byte = 0x16
-	BucketMigration   byte = 0x17
-	Embedding         byte = 0x18
-	Idempotency       byte = 0x19
-	Episode           byte = 0x1A
-	FTSVersion        byte = 0x1B
-	Transition        byte = 0x1C
-	EmbedModel        byte = 0x1D
-	Ordinal           byte = 0x1E
-	Entity            byte = 0x1F
-	EntityEngramLink  byte = 0x20
-	Relationship      byte = 0x21
-	LastAccess        byte = 0x22
+	Engram             byte = 0x01
+	Meta               byte = 0x02
+	AssocFwd           byte = 0x03
+	AssocRev           byte = 0x04
+	FTSPosting         byte = 0x05
+	Trigram            byte = 0x06
+	HNSWNode           byte = 0x07
+	FTSStats           byte = 0x08
+	TermStats          byte = 0x09
+	Contradiction      byte = 0x0A
+	StateIndex         byte = 0x0B
+	TagIndex           byte = 0x0C
+	CreatorIndex       byte = 0x0D
+	VaultMeta          byte = 0x0E
+	VaultNameIndex     byte = 0x0F
+	RelevanceBucket    byte = 0x10
+	DigestFlags        byte = 0x11
+	Coherence          byte = 0x12
+	VaultWeights       byte = 0x13
+	AssocWeightIndex   byte = 0x14
+	VaultCount         byte = 0x15
+	Provenance         byte = 0x16
+	BucketMigration    byte = 0x17
+	Embedding          byte = 0x18
+	Idempotency        byte = 0x19
+	Episode            byte = 0x1A
+	FTSVersion         byte = 0x1B
+	Transition         byte = 0x1C
+	EmbedModel         byte = 0x1D
+	Ordinal            byte = 0x1E
+	Entity             byte = 0x1F
+	EntityEngramLink   byte = 0x20
+	Relationship       byte = 0x21
+	LastAccess         byte = 0x22
 	EntityReverseIndex byte = 0x23
-	CoOccurrence      byte = 0x24
-	ArchiveAssoc      byte = 0x25
-	RelEntityIndex    byte = 0x26
-	DreamState        byte = 0x27
-	ContentHash       byte = 0x28
-	Lease             byte = 0x2A
+	CoOccurrence       byte = 0x24
+	ArchiveAssoc       byte = 0x25
+	RelEntityIndex     byte = 0x26
+	DreamState         byte = 0x27
+	ContentHash        byte = 0x28
+	Lease              byte = 0x2A
 	// Capability (0x40/0x41 — clean since #612)
 	Capability         byte = 0x40
 	CapabilityVaultIdx byte = 0x41
@@ -79,7 +79,9 @@ func All() []Entry { return registry }
 // Category returns the partition category for a prefix (Task 5's per-list guards).
 func Category(b byte) string {
 	for _, e := range registry {
-		if e.Byte == b { return e.Cat }
+		if e.Byte == b {
+			return e.Cat
+		}
 	}
 	return ""
 }

--- a/internal/prefix/prefix.go
+++ b/internal/prefix/prefix.go
@@ -1,0 +1,135 @@
+// Package prefix is the single source of truth for Pebble key-prefix byte
+// allocations across storage, auth, and capability. Every key constructor in
+// internal/storage/keys and internal/auth MUST reference these constants;
+// never inline a raw byte. [RT-FIX RT3] The length invariants below are load-
+// bearing for the v3 migration discriminator. NOTE: replication's schemaVersionKey
+// (0x19,0x03,... in internal/replication/schema_version.go) bypasses this registry
+// and overlaps storage's 0x19 Idempotency — a pre-existing instance of the same
+// bug class, flagged as a follow-up (NOT fixed here).
+package prefix
+
+// Source-of-truth prefix bytes. Storage unchanged; auth RELOCATED 0x11–0x14 → 0x42–0x45.
+const (
+	// Storage (0x01–0x2A)
+	Engram byte = 0x01
+	Meta   byte = 0x02
+	AssocFwd          byte = 0x03
+	AssocRev          byte = 0x04
+	FTSPosting        byte = 0x05
+	Trigram           byte = 0x06
+	HNSWNode          byte = 0x07
+	FTSStats          byte = 0x08
+	TermStats         byte = 0x09
+	Contradiction     byte = 0x0A
+	StateIndex        byte = 0x0B
+	TagIndex          byte = 0x0C
+	CreatorIndex      byte = 0x0D
+	VaultMeta         byte = 0x0E
+	VaultNameIndex    byte = 0x0F
+	RelevanceBucket   byte = 0x10
+	DigestFlags       byte = 0x11
+	Coherence         byte = 0x12
+	VaultWeights      byte = 0x13
+	AssocWeightIndex  byte = 0x14
+	VaultCount        byte = 0x15
+	Provenance        byte = 0x16
+	BucketMigration   byte = 0x17
+	Embedding         byte = 0x18
+	Idempotency       byte = 0x19
+	Episode           byte = 0x1A
+	FTSVersion        byte = 0x1B
+	Transition        byte = 0x1C
+	EmbedModel        byte = 0x1D
+	Ordinal           byte = 0x1E
+	Entity            byte = 0x1F
+	EntityEngramLink  byte = 0x20
+	Relationship      byte = 0x21
+	LastAccess        byte = 0x22
+	EntityReverseIndex byte = 0x23
+	CoOccurrence      byte = 0x24
+	ArchiveAssoc      byte = 0x25
+	RelEntityIndex    byte = 0x26
+	DreamState        byte = 0x27
+	ContentHash       byte = 0x28
+	Lease             byte = 0x2A
+	// Capability (0x40/0x41 — clean since #612)
+	Capability         byte = 0x40
+	CapabilityVaultIdx byte = 0x41
+	// Auth (RELOCATED 0x42–0x45 by #611)
+	AdminUser      byte = 0x42
+	APIKey         byte = 0x43
+	APIKeyVaultIdx byte = 0x44
+	VaultConfig    byte = 0x45
+
+	// [RT-FIX RT3] length invariants the v3 discriminator depends on (no magic numbers).
+	MinAPIKeyLen     = 17 // APIKey key = 1 + 16-byte hash
+	MinAPIKeyVIdxLen = 10 // APIKeyVaultIdx key = 1 + vault + 0x00 + 8 (>= 10)
+	CoherenceKeyLen  = 9  // Coherence/VaultWeights key = 1 + 8-byte wsPrefix
+)
+
+type Entry struct {
+	Byte  byte
+	Owner string // "storage" | "auth" | "capability"
+	Name  string
+	Cat   string // category for the per-list partition guards (Task 5)
+}
+
+func All() []Entry { return registry }
+
+// Category returns the partition category for a prefix (Task 5's per-list guards).
+func Category(b byte) string {
+	for _, e := range registry {
+		if e.Byte == b { return e.Cat }
+	}
+	return ""
+}
+
+var registry = []Entry{
+	{Engram, "storage", "Engram", "vault-scoped-data"},
+	{Meta, "storage", "Meta", "vault-scoped-data"},
+	{AssocFwd, "storage", "AssocFwd", "vault-scoped-data"},
+	{AssocRev, "storage", "AssocRev", "vault-scoped-data"},
+	{FTSPosting, "storage", "FTSPosting", "vault-scoped-data"},
+	{Trigram, "storage", "Trigram", "vault-scoped-data"},
+	{HNSWNode, "storage", "HNSWNode", "vault-scoped-data"},
+	{FTSStats, "storage", "FTSStats", "vault-scoped-data"},
+	{TermStats, "storage", "TermStats", "vault-scoped-data"},
+	{Contradiction, "storage", "Contradiction", "vault-scoped-data"},
+	{StateIndex, "storage", "StateIndex", "vault-scoped-data"},
+	{TagIndex, "storage", "TagIndex", "vault-scoped-data"},
+	{CreatorIndex, "storage", "CreatorIndex", "vault-scoped-data"},
+	{VaultMeta, "storage", "VaultMeta", "name-key"},
+	{VaultNameIndex, "storage", "VaultNameIndex", "name-key"},
+	{RelevanceBucket, "storage", "RelevanceBucket", "vault-scoped-data"},
+	{DigestFlags, "storage", "DigestFlags", "global-by-ulid"},
+	{Coherence, "storage", "Coherence", "vault-scoped-data"},
+	{VaultWeights, "storage", "VaultWeights", "vault-scoped-data"},
+	{AssocWeightIndex, "storage", "AssocWeightIndex", "vault-scoped-data"},
+	{VaultCount, "storage", "VaultCount", "vault-scoped-data"},
+	{Provenance, "storage", "Provenance", "vault-scoped-data"},
+	{BucketMigration, "storage", "BucketMigration", "vault-scoped-data"},
+	{Embedding, "storage", "Embedding", "vault-scoped-data"},
+	{Idempotency, "storage", "Idempotency", "global-by-ulid"},
+	{Episode, "storage", "Episode", "vault-scoped-data"},
+	{FTSVersion, "storage", "FTSVersion", "vault-scoped-data"},
+	{Transition, "storage", "Transition", "vault-scoped-data"},
+	{EmbedModel, "storage", "EmbedModel", "vault-scoped-data"},
+	{Ordinal, "storage", "Ordinal", "vault-scoped-data"},
+	{Entity, "storage", "Entity", "global-by-ulid"},
+	{EntityEngramLink, "storage", "EntityEngramLink", "vault-scoped-data"},
+	{Relationship, "storage", "Relationship", "vault-scoped-data"},
+	{LastAccess, "storage", "LastAccess", "vault-scoped-data"},
+	{EntityReverseIndex, "storage", "EntityReverseIndex", "global-by-ulid"},
+	{CoOccurrence, "storage", "CoOccurrence", "vault-scoped-data"},
+	{ArchiveAssoc, "storage", "ArchiveAssoc", "vault-scoped-data"},
+	{RelEntityIndex, "storage", "RelEntityIndex", "vault-scoped-data"},
+	{DreamState, "storage", "DreamState", "vault-scoped-data"},
+	{ContentHash, "storage", "ContentHash", "vault-scoped-data"},
+	{Lease, "storage", "Lease", "lease"},
+	{Capability, "capability", "Capability", "capability"},
+	{CapabilityVaultIdx, "capability", "CapabilityVaultIdx", "capability"},
+	{AdminUser, "auth", "AdminUser", "auth"},
+	{APIKey, "auth", "APIKey", "auth"},
+	{APIKeyVaultIdx, "auth", "APIKeyVaultIdx", "auth"},
+	{VaultConfig, "auth", "VaultConfig", "auth"},
+}

--- a/internal/prefix/prefix_test.go
+++ b/internal/prefix/prefix_test.go
@@ -1,0 +1,154 @@
+package prefix
+
+import (
+	"testing"
+)
+
+// TestAll_NoDuplicateBytes asserts no two registry entries share the same
+// prefix byte. This is the foundational invariant of the #611 fix — the
+// storage/auth/capability keyspaces must be byte-disjoint.
+func TestAll_NoDuplicateBytes(t *testing.T) {
+	seen := make(map[byte]string, len(All())) // byte -> first Name seen
+	for _, e := range All() {
+		if prev, ok := seen[e.Byte]; ok {
+			t.Errorf("prefix byte 0x%02X duplicated: %q and %q both claim it", e.Byte, prev, e.Name)
+		}
+		seen[e.Byte] = e.Name
+	}
+}
+
+// TestAll_OwnerGroupsPairwiseDisjoint asserts the three owner groups
+// (storage, auth, capability) hold pairwise-disjoint byte sets. This is
+// stronger than NoDuplicateBytes scoped across owners — it catches the
+// specific class of bug #611 fixes (e.g. auth 0x11 colliding with storage
+// DigestFlags 0x11 pre-relocation).
+func TestAll_OwnerGroupsPairwiseDisjoint(t *testing.T) {
+	groups := map[string]map[byte]string{} // owner -> byte -> name
+	for _, e := range All() {
+		if groups[e.Owner] == nil {
+			groups[e.Owner] = map[byte]string{}
+		}
+		groups[e.Owner][e.Byte] = e.Name
+	}
+	// Pairwise check across every distinct pair of owners.
+	owners := []string{"storage", "auth", "capability"}
+	for i := 0; i < len(owners); i++ {
+		for j := i + 1; j < len(owners); j++ {
+			a, b := owners[i], owners[j]
+			for byteVal, aName := range groups[a] {
+				if bName, ok := groups[b][byteVal]; ok {
+					t.Errorf("owner %q and %q share byte 0x%02X (%q vs %q)", a, b, byteVal, aName, bName)
+				}
+			}
+		}
+	}
+}
+
+// TestCategory_KnownPrefixes verifies Category() resolves each named prefix
+// to the Cat value recorded in the registry. Category() is the lookup Task
+// 5's per-list partition guards depend on.
+func TestCategory_KnownPrefixes(t *testing.T) {
+	for _, e := range All() {
+		got := Category(e.Byte)
+		if got != e.Cat {
+			t.Errorf("Category(0x%02X) = %q; want %q (entry %q)", e.Byte, got, e.Cat, e.Name)
+		}
+	}
+	// Unknown prefix must return "" (the zero value), not a stale match.
+	if got := Category(0x00); got != "" {
+		t.Errorf("Category(0x00) = %q; want empty for unallocated byte", got)
+	}
+}
+
+// TestAll_ConstSliceComplete is the [RT-FIX RT3] completeness guard: every
+// exported prefix-byte const must appear in All(), and every All() entry
+// must correspond to a named const. Catches add-const-forget-slice drift
+// (and the inverse — a registry entry with no backing const).
+func TestAll_ConstSliceComplete(t *testing.T) {
+	// Named prefix-byte consts (the source of truth the rest of the codebase
+	// references via prefix.X). Update this list when adding a const; the
+	// bidirectional check below catches omissions in either direction.
+	named := []struct {
+		name string
+		b    byte
+	}{
+		// Storage (0x01–0x2A)
+		{"Engram", Engram},
+		{"Meta", Meta},
+		{"AssocFwd", AssocFwd},
+		{"AssocRev", AssocRev},
+		{"FTSPosting", FTSPosting},
+		{"Trigram", Trigram},
+		{"HNSWNode", HNSWNode},
+		{"FTSStats", FTSStats},
+		{"TermStats", TermStats},
+		{"Contradiction", Contradiction},
+		{"StateIndex", StateIndex},
+		{"TagIndex", TagIndex},
+		{"CreatorIndex", CreatorIndex},
+		{"VaultMeta", VaultMeta},
+		{"VaultNameIndex", VaultNameIndex},
+		{"RelevanceBucket", RelevanceBucket},
+		{"DigestFlags", DigestFlags},
+		{"Coherence", Coherence},
+		{"VaultWeights", VaultWeights},
+		{"AssocWeightIndex", AssocWeightIndex},
+		{"VaultCount", VaultCount},
+		{"Provenance", Provenance},
+		{"BucketMigration", BucketMigration},
+		{"Embedding", Embedding},
+		{"Idempotency", Idempotency},
+		{"Episode", Episode},
+		{"FTSVersion", FTSVersion},
+		{"Transition", Transition},
+		{"EmbedModel", EmbedModel},
+		{"Ordinal", Ordinal},
+		{"Entity", Entity},
+		{"EntityEngramLink", EntityEngramLink},
+		{"Relationship", Relationship},
+		{"LastAccess", LastAccess},
+		{"EntityReverseIndex", EntityReverseIndex},
+		{"CoOccurrence", CoOccurrence},
+		{"ArchiveAssoc", ArchiveAssoc},
+		{"RelEntityIndex", RelEntityIndex},
+		{"DreamState", DreamState},
+		{"ContentHash", ContentHash},
+		{"Lease", Lease},
+		// Capability (0x40/0x41)
+		{"Capability", Capability},
+		{"CapabilityVaultIdx", CapabilityVaultIdx},
+		// Auth (RELOCATED 0x42–0x45 by #611)
+		{"AdminUser", AdminUser},
+		{"APIKey", APIKey},
+		{"APIKeyVaultIdx", APIKeyVaultIdx},
+		{"VaultConfig", VaultConfig},
+	}
+
+	// Build a set of bytes that appear in All() for the forward direction.
+	inAll := make(map[byte]bool, len(All()))
+	for _, e := range All() {
+		inAll[e.Byte] = true
+	}
+
+	// Forward: every named const must be in All().
+	for _, n := range named {
+		if !inAll[n.b] {
+			t.Errorf("named const %s (0x%02X) not present in All()", n.name, n.b)
+		}
+	}
+	// Reverse: every All() entry must be one of the named consts.
+	namedSet := make(map[byte]bool, len(named))
+	for _, n := range named {
+		namedSet[n.b] = true
+	}
+	for _, e := range All() {
+		if !namedSet[e.Byte] {
+			t.Errorf("All() entry 0x%02X (%q) has no backing named const", e.Byte, e.Name)
+		}
+	}
+
+	// Count check — catches accidental duplication in either list.
+	if got, want := len(All()), len(named); got != want {
+		t.Errorf("len(All()) = %d; want %d (named consts)", got, want)
+	}
+}

--- a/internal/storage/archive_bloom.go
+++ b/internal/storage/archive_bloom.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/prefix"
 )
 
 // archiveBloom is an in-memory Bloom filter over src engram IDs that have
@@ -38,8 +39,8 @@ func (b *archiveBloom) MayContain(id [16]byte) bool {
 // Called on startup and after GC runs.
 func (ps *PebbleStore) RebuildArchiveBloom() *archiveBloom {
 	// Scan 0x25 | * (all vaults).
-	startKey := []byte{0x25}
-	endKey := []byte{0x26} // exclusive upper bound for prefix 0x25
+	startKey := []byte{prefix.ArchiveAssoc}
+	endKey := []byte{prefix.RelEntityIndex} // exclusive upper bound for prefix 0x25
 
 	iterOpts := &pebble.IterOptions{
 		LowerBound: startKey,

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/prefix"
 	"github.com/scrypster/muninndb/internal/storage/keys"
 )
 
@@ -522,7 +523,7 @@ const assocDecayGraceWindow = 5 * time.Minute
 func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, decayFactor float64, minWeight float32, archiveThreshold float64) (int, error) {
 	// Build scan prefix: 0x03 | wsPrefix (9 bytes).
 	scanPrefix := make([]byte, 9)
-	scanPrefix[0] = 0x03
+	scanPrefix[0] = prefix.AssocFwd
 	copy(scanPrefix[1:9], wsPrefix[:])
 
 	// The iterator snapshot is fixed at creation time — mutations committed in

--- a/internal/storage/clone.go
+++ b/internal/storage/clone.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/prefix"
 	"github.com/scrypster/muninndb/internal/storage/erf"
 	"github.com/scrypster/muninndb/internal/storage/keys"
 )
@@ -43,10 +44,11 @@ func incrementWS(ws [8]byte) ([8]byte, error) {
 // 0x13 (VaultWeightsKey) is intentionally omitted — weights are vault-specific
 // and must not be inherited from the source.
 var vaultScopedSwapPrefixes = []byte{
-	0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-	0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x10, 0x14,
-	0x15, 0x16, 0x17,
-	0x28, // content-hash dedup index
+	prefix.Meta, prefix.AssocFwd, prefix.AssocRev, prefix.FTSPosting,
+	prefix.Trigram, prefix.HNSWNode, prefix.FTSStats, prefix.TermStats,
+	prefix.Contradiction, prefix.StateIndex, prefix.TagIndex, prefix.CreatorIndex,
+	prefix.RelevanceBucket, prefix.AssocWeightIndex, prefix.VaultCount, prefix.Provenance,
+	prefix.BucketMigration, prefix.ContentHash,
 }
 
 const cloneBatchSize = 512
@@ -84,10 +86,10 @@ func (ps *PebbleStore) CloneVaultData(
 	// ---- Phase 1: Copy engrams (0x01) with ERF decode → reset → re-encode ----
 	{
 		lo := make([]byte, 9)
-		lo[0] = 0x01
+		lo[0] = prefix.Engram
 		copy(lo[1:], wsSource[:])
 		hi := make([]byte, 9)
-		hi[0] = 0x01
+		hi[0] = prefix.Engram
 		copy(hi[1:], wsSourceNext[:])
 
 		iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: lo, UpperBound: hi})
@@ -290,10 +292,10 @@ func (ps *PebbleStore) MergeVaultData(
 	// ---- Phase 1: Merge engrams (0x01) with collision detection ----
 	{
 		lo := make([]byte, 9)
-		lo[0] = 0x01
+		lo[0] = prefix.Engram
 		copy(lo[1:], wsSource[:])
 		hi := make([]byte, 9)
-		hi[0] = 0x01
+		hi[0] = prefix.Engram
 		copy(hi[1:], wsSourceNext[:])
 
 		iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: lo, UpperBound: hi})

--- a/internal/storage/clone.go
+++ b/internal/storage/clone.go
@@ -202,8 +202,8 @@ func (ps *PebbleStore) CloneVaultData(
 
 			k := iter.Key()
 
-			// Skip the 9-byte VaultCountKey (0x15 | ws[8]) — written separately.
-			if p == 0x15 && len(k) == 9 {
+			// Skip the 9-byte VaultCountKey (prefix.VaultCount | ws[8]) — written separately.
+			if p == prefix.VaultCount && len(k) == 9 {
 				continue
 			}
 
@@ -397,13 +397,13 @@ func (ps *PebbleStore) MergeVaultData(
 	for _, p := range vaultScopedSwapPrefixes {
 		// Prefix-level skip: FTS stats and keeper-target prefixes.
 		switch p {
-		case 0x08, 0x09:
+		case prefix.FTSStats, prefix.TermStats:
 			// FTS global stats / per-term stats — rebuilt by reindexVault after merge.
 			continue
-		case 0x13:
+		case prefix.VaultWeights:
 			// Vault scoring weights — keep target's weights, don't overwrite with source.
 			continue
-		case 0x17:
+		case prefix.BucketMigration:
 			// Bucket migration state — keep target state, don't overwrite.
 			continue
 		}
@@ -443,7 +443,7 @@ func (ps *PebbleStore) MergeVaultData(
 
 			// Per-key strategy based on prefix.
 			switch p {
-			case 0x15:
+			case prefix.VaultCount:
 				// VaultCountKey (9 bytes): skip — recomputed in Phase 4.
 				// Episode keys (>9 bytes): UNION.
 				if len(k) == 9 {

--- a/internal/storage/embed_migration.go
+++ b/internal/storage/embed_migration.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/prefix"
 	"github.com/scrypster/muninndb/internal/storage/keys"
 )
 
@@ -31,10 +32,10 @@ func (ps *PebbleStore) ClearEmbedFlagsForVault(ctx context.Context, ws [8]byte) 
 
 	// Step 1: Range-delete all 0x18 embedding keys for this vault.
 	lo := make([]byte, 9)
-	lo[0] = 0x18
+	lo[0] = prefix.Embedding
 	copy(lo[1:], ws[:])
 	hi := make([]byte, 9)
-	hi[0] = 0x18
+	hi[0] = prefix.Embedding
 	copy(hi[1:], wsPlus[:])
 
 	if err := ps.db.DeleteRange(lo, hi, pebble.Sync); err != nil {
@@ -45,10 +46,10 @@ func (ps *PebbleStore) ClearEmbedFlagsForVault(ctx context.Context, ws [8]byte) 
 	// digest flag, clear bit 0x02, and write back. Skip engrams where the bit is
 	// already cleared.
 	engramLo := make([]byte, 9)
-	engramLo[0] = 0x01
+	engramLo[0] = prefix.Engram
 	copy(engramLo[1:], ws[:])
 	engramHi := make([]byte, 9)
-	engramHi[0] = 0x01
+	engramHi[0] = prefix.Engram
 	copy(engramHi[1:], wsPlus[:])
 
 	iter, err := ps.db.NewIter(&pebble.IterOptions{
@@ -132,10 +133,10 @@ func (ps *PebbleStore) ClearHNSWForVault(ws [8]byte) error {
 	}
 
 	lo := make([]byte, 9)
-	lo[0] = 0x07
+	lo[0] = prefix.HNSWNode
 	copy(lo[1:], ws[:])
 	hi := make([]byte, 9)
-	hi[0] = 0x07
+	hi[0] = prefix.HNSWNode
 	copy(hi[1:], wsPlus[:])
 
 	if err := ps.db.DeleteRange(lo, hi, pebble.Sync); err != nil {
@@ -182,10 +183,10 @@ func (ps *PebbleStore) VaultEmbedDimOnDisk(ws [8]byte) (int, error) {
 	}
 
 	lo := make([]byte, 9)
-	lo[0] = 0x18
+	lo[0] = prefix.Embedding
 	copy(lo[1:], ws[:])
 	hi := make([]byte, 9)
-	hi[0] = 0x18
+	hi[0] = prefix.Embedding
 	copy(hi[1:], wsPlus[:])
 
 	iter, err := ps.db.NewIter(&pebble.IterOptions{

--- a/internal/storage/engram.go
+++ b/internal/storage/engram.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/prefix"
 	"github.com/scrypster/muninndb/internal/provenance"
 	"github.com/scrypster/muninndb/internal/storage/erf"
 	"github.com/scrypster/muninndb/internal/storage/keys"
@@ -922,10 +923,10 @@ func (ps *PebbleStore) ScanEngrams(ctx context.Context, ws [8]byte, fn func(*Eng
 	}
 
 	lo := make([]byte, 9)
-	lo[0] = 0x01
+	lo[0] = prefix.Engram
 	copy(lo[1:], ws[:])
 	hi := make([]byte, 9)
-	hi[0] = 0x01
+	hi[0] = prefix.Engram
 	copy(hi[1:], wsNext[:])
 
 	iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: lo, UpperBound: hi})
@@ -936,10 +937,10 @@ func (ps *PebbleStore) ScanEngrams(ctx context.Context, ws [8]byte, fn func(*Eng
 
 	// Second iterator for 0x18 embedding keys — sorted by ws|id, same order as 0x01.
 	eLo := make([]byte, 9)
-	eLo[0] = 0x18
+	eLo[0] = prefix.Embedding
 	copy(eLo[1:], ws[:])
 	eHi := make([]byte, 9)
-	eHi[0] = 0x18
+	eHi[0] = prefix.Embedding
 	copy(eHi[1:], wsNext[:])
 
 	embedIter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: eLo, UpperBound: eHi})

--- a/internal/storage/entity.go
+++ b/internal/storage/entity.go
@@ -62,6 +62,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/prefix"
 	"github.com/scrypster/muninndb/internal/storage/erf"
 	"github.com/scrypster/muninndb/internal/storage/keys"
 	"github.com/vmihailenco/msgpack/v5"
@@ -1047,12 +1048,12 @@ func (ps *PebbleStore) deleteEntityLinks(ws [8]byte, engramID [16]byte, batch *p
 // FindSimilarEntities). fn is called exactly once per identity, with the first-seen
 // casing as the representative name.
 func (ps *PebbleStore) ScanVaultEntityNames(ctx context.Context, ws [8]byte, fn func(name string) error) error {
-	prefix := make([]byte, 1+8)
-	prefix[0] = 0x20
-	copy(prefix[1:9], ws[:])
+	prefixPre := make([]byte, 1+8)
+	prefixPre[0] = prefix.EntityEngramLink
+	copy(prefixPre[1:9], ws[:])
 
-	upperBound := make([]byte, len(prefix))
-	copy(upperBound, prefix)
+	upperBound := make([]byte, len(prefixPre))
+	copy(upperBound, prefixPre)
 	for i := len(upperBound) - 1; i >= 0; i-- {
 		upperBound[i]++
 		if upperBound[i] != 0 {
@@ -1060,7 +1061,7 @@ func (ps *PebbleStore) ScanVaultEntityNames(ctx context.Context, ws [8]byte, fn 
 		}
 	}
 
-	iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upperBound})
+	iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: prefixPre, UpperBound: upperBound})
 	if err != nil {
 		return fmt.Errorf("scan vault entity names: iter: %w", err)
 	}

--- a/internal/storage/export.go
+++ b/internal/storage/export.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/prefix"
 )
 
 // vaultScopedExportPrefixes lists every prefix scoped by a vault workspace
@@ -23,30 +24,12 @@ import (
 // global/name keys excluded from the data stream (written by WriteVaultName
 // on import). 0x11 (DigestFlagsKey) is globally keyed by ULID — excluded.
 var vaultScopedExportPrefixes = []byte{
-	0x01, // engrams (full record)
-	0x02, // metadata-only
-	0x03, // forward associations
-	0x04, // reverse associations
-	0x05, // FTS posting lists
-	0x06, // trigrams
-	0x07, // HNSW node neighbors
-	0x08, // FTS global stats
-	0x09, // per-term FTS stats
-	0x0A, // contradictions
-	0x0B, // state secondary index
-	0x0C, // tag secondary index
-	0x0D, // creator secondary index
-	0x10, // relevance bucket index
-	0x12, // coherence counters
-	0x13, // vault scoring weights
-	0x14, // association weight index
-	0x15, // vault count key
-	0x16, // provenance
-	0x17, // bucket migration state
-	0x18, // standalone embeddings (ERF v2 EmbeddingKey)
-	0x1A, // episode keys (EpisodeKey + EpisodeFrameKey)
-	0x1B, // FTS schema version marker
-	0x28, // content-hash dedup index
+	prefix.Engram, prefix.Meta, prefix.AssocFwd, prefix.AssocRev,
+	prefix.FTSPosting, prefix.Trigram, prefix.HNSWNode, prefix.FTSStats,
+	prefix.TermStats, prefix.Contradiction, prefix.StateIndex, prefix.TagIndex,
+	prefix.CreatorIndex, prefix.RelevanceBucket, prefix.Coherence, prefix.VaultWeights,
+	prefix.AssocWeightIndex, prefix.VaultCount, prefix.Provenance, prefix.BucketMigration,
+	prefix.Embedding, prefix.Episode, prefix.FTSVersion, prefix.ContentHash,
 }
 
 const exportBatchSize = 512

--- a/internal/storage/export.go
+++ b/internal/storage/export.go
@@ -94,7 +94,7 @@ func (ps *PebbleStore) ExportVaultData(
 			// byte size: 4 (key_len) + strippedLen + 4 (val_len) + len(v)
 			kvSize += int64(4 + strippedLen + 4 + len(v))
 
-			if p == 0x01 {
+			if p == prefix.Engram {
 				engramCount++
 			}
 			totalKeys++
@@ -382,12 +382,12 @@ func (ps *PebbleStore) ImportVaultData(
 				copy(fullKey[1:9], wsTarget[:])
 				copy(fullKey[9:], strippedKey[1:])
 
-				prefix := strippedKey[0]
+				prefixByte := strippedKey[0]
 
-				// Deduplication: for EngramKey (0x01), check if this engram already exists
+				// Deduplication: for EngramKey (prefix.Engram), check if this engram already exists
 				// in the target vault. If it does, record its ID in skipIDs so that all
 				// related keys are also skipped.
-				if prefix == 0x01 {
+				if prefixByte == prefix.Engram {
 					if len(strippedKey) >= 17 {
 						existing, closer, getErr := ps.db.Get(fullKey)
 						if getErr == nil {
@@ -409,8 +409,8 @@ func (ps *PebbleStore) ImportVaultData(
 				// Skip keys whose engram ID is in skipIDs.
 				// Each key type has the engram ID at a specific offset in the stripped key.
 				if len(skipIDs) > 0 {
-					switch prefix {
-					case 0x02, 0x07, 0x16, 0x18:
+					switch prefixByte {
+					case prefix.Meta, prefix.HNSWNode, prefix.Provenance, prefix.Embedding:
 						// MetaKey, HNSWNodeKey, ProvenanceKey, EmbeddingKey:
 						// stripped layout: [prefix(1)][id(16)]...  — ID at bytes 1:17
 						if len(strippedKey) >= 17 {
@@ -420,8 +420,8 @@ func (ps *PebbleStore) ImportVaultData(
 								continue
 							}
 						}
-					case 0x03:
-						// AssocFwdKey: stripped = [0x03][src(16)][weight(4)][dst(16)]
+					case prefix.AssocFwd:
+						// AssocFwdKey: stripped = [prefix.AssocFwd][src(16)][weight(4)][dst(16)]
 						// src ID at bytes 1:17
 						if len(strippedKey) >= 17 {
 							var id [16]byte
@@ -430,8 +430,8 @@ func (ps *PebbleStore) ImportVaultData(
 								continue
 							}
 						}
-					case 0x04:
-						// AssocRevKey: stripped = [0x04][dst(16)][weight(4)][src(16)]
+					case prefix.AssocRev:
+						// AssocRevKey: stripped = [prefix.AssocRev][dst(16)][weight(4)][src(16)]
 						// src ID at bytes 21:37
 						if len(strippedKey) >= 37 {
 							var id [16]byte
@@ -440,8 +440,8 @@ func (ps *PebbleStore) ImportVaultData(
 								continue
 							}
 						}
-					case 0x10:
-						// RelevanceBucketKey: stripped = [0x10][bucket(1)][id(16)]
+					case prefix.RelevanceBucket:
+						// RelevanceBucketKey: stripped = [prefix.RelevanceBucket][bucket(1)][id(16)]
 						// ID at bytes 2:18
 						if len(strippedKey) >= 18 {
 							var id [16]byte
@@ -454,7 +454,7 @@ func (ps *PebbleStore) ImportVaultData(
 				}
 
 				batch.Set(fullKey, val, nil)
-				if strippedKey[0] == 0x01 {
+				if strippedKey[0] == prefix.Engram {
 					engramCount++
 				}
 				totalKeys++

--- a/internal/storage/idempotency.go
+++ b/internal/storage/idempotency.go
@@ -73,7 +73,7 @@ func (ps *PebbleStore) PurgeExpiredIdempotency(ctx context.Context, maxAge time.
 	var toDelete [][]byte
 	for iter.SeekGE(lower); iter.Valid(); iter.Next() {
 		k := iter.Key()
-		if len(k) == 0 || k[0] != 0x19 {
+		if len(k) == 0 || k[0] != prefix.Idempotency {
 			break
 		}
 		val := iter.Value()

--- a/internal/storage/idempotency.go
+++ b/internal/storage/idempotency.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/prefix"
 	"github.com/scrypster/muninndb/internal/storage/keys"
 )
 
@@ -57,7 +58,7 @@ func (ps *PebbleStore) WriteIdempotency(ctx context.Context, opID, engramID stri
 func (ps *PebbleStore) PurgeExpiredIdempotency(ctx context.Context, maxAge time.Duration) (int, error) {
 	cutoff := time.Now().Add(-maxAge).UnixNano()
 
-	lower := []byte{0x19}
+	lower := []byte{prefix.Idempotency}
 	upper := keys.PrefixUpperBound(lower)
 
 	iter, err := ps.db.NewIter(&pebble.IterOptions{

--- a/internal/storage/impl.go
+++ b/internal/storage/impl.go
@@ -635,11 +635,18 @@ func (ps *PebbleStore) ProvenanceStore() *provenance.Store {
 	return ps.provenance
 }
 
+// clearFTSKeysPrefixes lists every FTS-index prefix that ClearFTSKeys deletes
+// via range tombstones. Hoisted to package scope so the per-list partition
+// guard (TestClearFTSKeysPrefixes_Scope) can pin its membership directly.
+var clearFTSKeysPrefixes = []byte{
+	prefix.FTSPosting, prefix.Trigram, prefix.FTSStats, prefix.TermStats,
+}
+
 // ClearFTSKeys deletes all FTS index keys for the given vault workspace prefix via
 // range tombstones. Prefixes cleared: 0x05 (posting lists), 0x06 (trigrams),
 // 0x08 (FTS global stats), 0x09 (per-term stats).
 func (ps *PebbleStore) ClearFTSKeys(ws, wsPlus [8]byte) error {
-	ftsPrefixes := []byte{prefix.FTSPosting, prefix.Trigram, prefix.FTSStats, prefix.TermStats}
+	ftsPrefixes := clearFTSKeysPrefixes
 	batch := ps.db.NewBatch()
 	for _, p := range ftsPrefixes {
 		lo := make([]byte, 9)

--- a/internal/storage/impl.go
+++ b/internal/storage/impl.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/scrypster/muninndb/internal/prefix"
 	"github.com/scrypster/muninndb/internal/provenance"
 	"github.com/scrypster/muninndb/internal/scoring"
 	"github.com/scrypster/muninndb/internal/storage/erf"
@@ -157,7 +158,7 @@ func (ps *PebbleStore) countEngramsForVault(ctx context.Context, wsPrefix [8]byt
 		}
 	}
 	upper := make([]byte, 1+8)
-	upper[0] = 0x01
+	upper[0] = prefix.Engram
 	copy(upper[1:9], upperWS[:])
 	iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
 	if err != nil {
@@ -638,7 +639,7 @@ func (ps *PebbleStore) ProvenanceStore() *provenance.Store {
 // range tombstones. Prefixes cleared: 0x05 (posting lists), 0x06 (trigrams),
 // 0x08 (FTS global stats), 0x09 (per-term stats).
 func (ps *PebbleStore) ClearFTSKeys(ws, wsPlus [8]byte) error {
-	ftsPrefixes := []byte{0x05, 0x06, 0x08, 0x09}
+	ftsPrefixes := []byte{prefix.FTSPosting, prefix.Trigram, prefix.FTSStats, prefix.TermStats}
 	batch := ps.db.NewBatch()
 	for _, p := range ftsPrefixes {
 		lo := make([]byte, 9)

--- a/internal/storage/keys/keys.go
+++ b/internal/storage/keys/keys.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/dchest/siphash"
 	"golang.org/x/text/unicode/norm"
+
+	"github.com/scrypster/muninndb/internal/prefix"
 )
 
 // SipHash keys for vault prefix computation
@@ -28,7 +30,7 @@ func VaultPrefix(vault string) [8]byte {
 // Key: 0x01 | wsPrefix(8) | ulid(16) = 25 bytes
 func EngramKey(ws [8]byte, id [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x01
+	key[0] = prefix.Engram
 	copy(key[1:9], ws[:])
 	copy(key[9:25], id[:])
 	return key
@@ -37,7 +39,7 @@ func EngramKey(ws [8]byte, id [16]byte) []byte {
 // MetaKey constructs the key for metadata-only record (0x02 prefix).
 func MetaKey(ws [8]byte, id [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x02
+	key[0] = prefix.Meta
 	copy(key[1:9], ws[:])
 	copy(key[9:25], id[:])
 	return key
@@ -46,7 +48,7 @@ func MetaKey(ws [8]byte, id [16]byte) []byte {
 // AssocFwdKey constructs the forward association key (0x03 prefix).
 func AssocFwdKey(ws [8]byte, src [16]byte, weight float32, dst [16]byte) []byte {
 	key := make([]byte, 1+8+16+4+16)
-	key[0] = 0x03
+	key[0] = prefix.AssocFwd
 	copy(key[1:9], ws[:])
 	copy(key[9:25], src[:])
 	wc := WeightComplement(weight)
@@ -58,7 +60,7 @@ func AssocFwdKey(ws [8]byte, src [16]byte, weight float32, dst [16]byte) []byte 
 // AssocRevKey constructs the reverse association key (0x04 prefix).
 func AssocRevKey(ws [8]byte, dst [16]byte, weight float32, src [16]byte) []byte {
 	key := make([]byte, 1+8+16+4+16)
-	key[0] = 0x04
+	key[0] = prefix.AssocRev
 	copy(key[1:9], ws[:])
 	copy(key[9:25], dst[:])
 	wc := WeightComplement(weight)
@@ -74,7 +76,7 @@ func AssocRevKey(ws [8]byte, dst [16]byte, weight float32, src [16]byte) []byte 
 func FTSPostingKey(ws [8]byte, term string, field uint8, id [16]byte) []byte {
 	termBytes := []byte(term)
 	key := make([]byte, 1+8+len(termBytes)+1+1+16)
-	key[0] = 0x05
+	key[0] = prefix.FTSPosting
 	copy(key[1:9], ws[:])
 	copy(key[9:9+len(termBytes)], termBytes)
 	key[9+len(termBytes)] = 0x00 // separator
@@ -86,7 +88,7 @@ func FTSPostingKey(ws [8]byte, term string, field uint8, id [16]byte) []byte {
 // TrigramKey constructs the trigram index key (0x06 prefix).
 func TrigramKey(ws [8]byte, trigram [3]byte, id [16]byte) []byte {
 	key := make([]byte, 1+8+3+16)
-	key[0] = 0x06
+	key[0] = prefix.Trigram
 	copy(key[1:9], ws[:])
 	copy(key[9:12], trigram[:])
 	copy(key[12:28], id[:])
@@ -96,7 +98,7 @@ func TrigramKey(ws [8]byte, trigram [3]byte, id [16]byte) []byte {
 // HNSWNodeKey constructs the HNSW node neighbor list key (0x07 prefix).
 func HNSWNodeKey(ws [8]byte, id [16]byte, layer uint8) []byte {
 	key := make([]byte, 1+8+16+1)
-	key[0] = 0x07
+	key[0] = prefix.HNSWNode
 	copy(key[1:9], ws[:])
 	copy(key[9:25], id[:])
 	key[25] = layer
@@ -106,7 +108,7 @@ func HNSWNodeKey(ws [8]byte, id [16]byte, layer uint8) []byte {
 // FTSStatsKey constructs the global FTS stats key (0x08 prefix).
 func FTSStatsKey(ws [8]byte) []byte {
 	key := make([]byte, 1+8+5)
-	key[0] = 0x08
+	key[0] = prefix.FTSStats
 	copy(key[1:9], ws[:])
 	copy(key[9:14], []byte("stats"))
 	return key
@@ -116,7 +118,7 @@ func FTSStatsKey(ws [8]byte) []byte {
 func TermStatsKey(ws [8]byte, term string) []byte {
 	termBytes := []byte(term)
 	key := make([]byte, 1+8+len(termBytes))
-	key[0] = 0x09
+	key[0] = prefix.TermStats
 	copy(key[1:9], ws[:])
 	copy(key[9:], termBytes)
 	return key
@@ -125,7 +127,7 @@ func TermStatsKey(ws [8]byte, term string) []byte {
 // ContradictionKeyPrefix returns the 9-byte scan prefix for all contradictions in a vault.
 func ContradictionKeyPrefix(ws [8]byte) []byte {
 	key := make([]byte, 9)
-	key[0] = 0x0A
+	key[0] = prefix.Contradiction
 	copy(key[1:9], ws[:])
 	return key
 }
@@ -133,7 +135,7 @@ func ContradictionKeyPrefix(ws [8]byte) []byte {
 // ContradictionKey constructs the contradiction index key (0x0A prefix).
 func ContradictionKey(ws [8]byte, conceptHash uint32, relType uint16, id [16]byte) []byte {
 	key := make([]byte, 1+8+4+2+16)
-	key[0] = 0x0A
+	key[0] = prefix.Contradiction
 	copy(key[1:9], ws[:])
 	binary.BigEndian.PutUint32(key[9:13], conceptHash)
 	binary.BigEndian.PutUint16(key[13:15], relType)
@@ -144,7 +146,7 @@ func ContradictionKey(ws [8]byte, conceptHash uint32, relType uint16, id [16]byt
 // StateIndexKey constructs the state secondary index key (0x0B prefix).
 func StateIndexKey(ws [8]byte, state uint8, id [16]byte) []byte {
 	key := make([]byte, 1+8+1+16)
-	key[0] = 0x0B
+	key[0] = prefix.StateIndex
 	copy(key[1:9], ws[:])
 	key[9] = state
 	copy(key[10:26], id[:])
@@ -154,7 +156,7 @@ func StateIndexKey(ws [8]byte, state uint8, id [16]byte) []byte {
 // TagIndexKey constructs the tag secondary index key (0x0C prefix).
 func TagIndexKey(ws [8]byte, tagHash uint32, id [16]byte) []byte {
 	key := make([]byte, 1+8+4+16)
-	key[0] = 0x0C
+	key[0] = prefix.TagIndex
 	copy(key[1:9], ws[:])
 	binary.BigEndian.PutUint32(key[9:13], tagHash)
 	copy(key[13:29], id[:])
@@ -164,7 +166,7 @@ func TagIndexKey(ws [8]byte, tagHash uint32, id [16]byte) []byte {
 // CreatorIndexKey constructs the creator secondary index key (0x0D prefix).
 func CreatorIndexKey(ws [8]byte, creatorHash uint32, id [16]byte) []byte {
 	key := make([]byte, 1+8+4+16)
-	key[0] = 0x0D
+	key[0] = prefix.CreatorIndex
 	copy(key[1:9], ws[:])
 	binary.BigEndian.PutUint32(key[9:13], creatorHash)
 	copy(key[13:29], id[:])
@@ -176,7 +178,7 @@ func CreatorIndexKey(ws [8]byte, creatorHash uint32, id [16]byte) []byte {
 // Key: 0x0E | wsPrefix(8) = 9 bytes
 func VaultMetaKey(ws [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x0E
+	key[0] = prefix.VaultMeta
 	copy(key[1:9], ws[:])
 	return key
 }
@@ -189,7 +191,7 @@ func VaultMetaKey(ws [8]byte) []byte {
 func VaultNameIndexKey(name string) []byte {
 	nameHash := siphash.Hash(sipKey0, sipKey1, []byte(name))
 	key := make([]byte, 1+8)
-	key[0] = 0x0F
+	key[0] = prefix.VaultNameIndex
 	binary.BigEndian.PutUint64(key[1:], nameHash)
 	return key
 }
@@ -200,7 +202,7 @@ func VaultNameIndexKey(name string) []byte {
 // Higher relevance values produce lower bucket numbers (sort first in ascending scan).
 func RelevanceBucketKey(ws [8]byte, relevance float32, id [16]byte) []byte {
 	key := make([]byte, 1+8+1+16)
-	key[0] = 0x10
+	key[0] = prefix.RelevanceBucket
 	copy(key[1:9], ws[:])
 
 	// Calculate storedBucket
@@ -227,7 +229,7 @@ func RelevanceBucketKey(ws [8]byte, relevance float32, id [16]byte) []byte {
 // Key: 0x11 | id(16) = 17 bytes (global — no vault scope needed since ULIDs are globally unique)
 func DigestFlagsKey(id [16]byte) []byte {
 	key := make([]byte, 1+16)
-	key[0] = 0x11
+	key[0] = prefix.DigestFlags
 	copy(key[1:17], id[:])
 	return key
 }
@@ -237,7 +239,7 @@ func DigestFlagsKey(id [16]byte) []byte {
 // Value layout: 56 bytes (7 × BigEndian int64)
 func CoherenceKey(vaultPrefix [8]byte) []byte {
 	key := make([]byte, 9)
-	key[0] = 0x12
+	key[0] = prefix.Coherence
 	copy(key[1:], vaultPrefix[:])
 	return key
 }
@@ -246,7 +248,7 @@ func CoherenceKey(vaultPrefix [8]byte) []byte {
 // Key: 0x13 | wsPrefix(8) = 9 bytes
 func VaultWeightsKey(ws [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x13
+	key[0] = prefix.VaultWeights
 	copy(key[1:9], ws[:])
 	return key
 }
@@ -257,7 +259,7 @@ func VaultWeightsKey(ws [8]byte) []byte {
 // Key: 0x14 | wsPrefix(8) | src(16) | dst(16) = 41 bytes
 func AssocWeightIndexKey(ws [8]byte, src [16]byte, dst [16]byte) []byte {
 	key := make([]byte, 1+8+16+16)
-	key[0] = 0x14
+	key[0] = prefix.AssocWeightIndex
 	copy(key[1:9], ws[:])
 	copy(key[9:25], src[:])
 	copy(key[25:41], dst[:])
@@ -268,7 +270,7 @@ func AssocWeightIndexKey(ws [8]byte, src [16]byte, dst [16]byte) []byte {
 // associations within a vault (0x03 prefix scan lower bound).
 func AssocFwdRangeStart(ws [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x03
+	key[0] = prefix.AssocFwd
 	copy(key[1:9], ws[:])
 	return key
 }
@@ -278,7 +280,7 @@ func AssocFwdRangeStart(ws [8]byte) []byte {
 // last byte, standard Pebble upper-bound idiom).
 func AssocFwdRangeEnd(ws [8]byte) []byte {
 	end := make([]byte, 1+8)
-	end[0] = 0x03
+	end[0] = prefix.AssocFwd
 	copy(end[1:9], ws[:])
 	// Increment the last byte of ws portion in the key to get exclusive upper bound.
 	for i := len(end) - 1; i >= 1; i-- {
@@ -294,7 +296,7 @@ func AssocFwdRangeEnd(ws [8]byte) []byte {
 // associations from a given source engram (0x03 | ws(8) | src(16)).
 func AssocFwdPrefixForID(ws [8]byte, id [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x03
+	key[0] = prefix.AssocFwd
 	copy(key[1:9], ws[:])
 	copy(key[9:25], id[:])
 	return key
@@ -305,7 +307,7 @@ func AssocFwdPrefixForID(ws [8]byte, id [16]byte) []byte {
 // (0x04 | ws(8) | dstID(16)).
 func AssocRevPrefixForID(ws [8]byte, id [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x04
+	key[0] = prefix.AssocRev
 	copy(key[1:9], ws[:])
 	copy(key[9:25], id[:])
 	return key
@@ -318,7 +320,7 @@ func AssocRevPrefixForID(ws [8]byte, id [16]byte) []byte {
 // 0x15 is the sole user of this prefix. EpisodeKey uses 0x1A.
 func VaultCountKey(ws [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x15
+	key[0] = prefix.VaultCount
 	copy(key[1:9], ws[:])
 	return key
 }
@@ -329,7 +331,7 @@ func VaultCountKey(ws [8]byte) []byte {
 // for a given engram.
 func ProvenanceKey(ws [8]byte, id [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x16
+	key[0] = prefix.Provenance
 	copy(key[1:9], ws[:])
 	copy(key[9:25], id[:])
 	return key
@@ -364,7 +366,7 @@ func ProvenanceKeyUpperBound(ws [8]byte, id [16]byte) []byte {
 // The BigEndian timestamp ensures chronological scan order.
 func ProvenanceSuffixKey(ws [8]byte, id [16]byte, ts uint64, seq uint32) []byte {
 	key := make([]byte, 1+8+16+8+4)
-	key[0] = 0x16
+	key[0] = prefix.Provenance
 	copy(key[1:9], ws[:])
 	copy(key[9:25], id[:])
 	binary.BigEndian.PutUint64(key[25:33], ts)
@@ -376,7 +378,7 @@ func ProvenanceSuffixKey(ws [8]byte, id [16]byte, ts uint64, seq uint32) []byte 
 // Key: 0x1A | wsPrefix(8) | episodeID(16) = 25 bytes
 func EpisodeKey(ws [8]byte, id [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x1A
+	key[0] = prefix.Episode
 	copy(key[1:9], ws[:])
 	copy(key[9:25], id[:])
 	return key
@@ -386,7 +388,7 @@ func EpisodeKey(ws [8]byte, id [16]byte) []byte {
 // Key: 0x1A | wsPrefix(8) | episodeID(16) | 0xFF | position(4) = 30 bytes
 func EpisodeFrameKey(ws [8]byte, episodeID [16]byte, position uint32) []byte {
 	key := make([]byte, 1+8+16+1+4)
-	key[0] = 0x1A
+	key[0] = prefix.Episode
 	copy(key[1:9], ws[:])
 	copy(key[9:25], episodeID[:])
 	key[25] = 0xFF
@@ -399,7 +401,7 @@ func EpisodeFrameKey(ws [8]byte, episodeID [16]byte, position uint32) []byte {
 // Value: [version uint8][optional cursor [16]byte] — used by MigrateBuckets.
 func BucketMigrationKey(ws [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x17
+	key[0] = prefix.BucketMigration
 	copy(key[1:9], ws[:])
 	return key
 }
@@ -409,7 +411,7 @@ func BucketMigrationKey(ws [8]byte) []byte {
 // Key: 0x18 | wsPrefix(8) | ulid(16) = 25 bytes
 func EmbeddingKey(ws [8]byte, id [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x18
+	key[0] = prefix.Embedding
 	copy(key[1:9], ws[:])
 	copy(key[9:25], id[:])
 	return key
@@ -421,7 +423,7 @@ func EmbeddingKey(ws [8]byte, id [16]byte) []byte {
 // Once set to 1, dual-path query fallback is skipped (all tokens are stemmed).
 func FTSVersionKey(ws [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x1B
+	key[0] = prefix.FTSVersion
 	copy(key[1:9], ws[:])
 	return key
 }
@@ -430,7 +432,7 @@ func FTSVersionKey(ws [8]byte) []byte {
 // Key: 0x1C | wsPrefix(8) | srcID(16) | dstID(16) = 41 bytes
 func TransitionKey(ws [8]byte, src [16]byte, dst [16]byte) []byte {
 	key := make([]byte, 1+8+16+16)
-	key[0] = 0x1C
+	key[0] = prefix.Transition
 	copy(key[1:9], ws[:])
 	copy(key[9:25], src[:])
 	copy(key[25:41], dst[:])
@@ -441,7 +443,7 @@ func TransitionKey(ws [8]byte, src [16]byte, dst [16]byte) []byte {
 // targets from a given source engram (0x1C | ws(8) | src(16)).
 func TransitionPrefixForSrc(ws [8]byte, src [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x1C
+	key[0] = prefix.Transition
 	copy(key[1:9], ws[:])
 	copy(key[9:25], src[:])
 	return key
@@ -468,7 +470,7 @@ func WeightFromComplement(wc [4]byte) float32 {
 // Value: UTF-8 model name string. Empty/missing = not tracked.
 func EmbedModelKey(ws [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x1D
+	key[0] = prefix.EmbedModel
 	copy(key[1:9], ws[:])
 	return key
 }
@@ -478,7 +480,7 @@ func EmbedModelKey(ws [8]byte) []byte {
 // Key: 0x1E | wsPrefix(8) | parentID(16) | childID(16) = 41 bytes
 func OrdinalKey(ws [8]byte, parentID [16]byte, childID [16]byte) []byte {
 	key := make([]byte, 1+8+16+16)
-	key[0] = 0x1E
+	key[0] = prefix.Ordinal
 	copy(key[1:9], ws[:])
 	copy(key[9:25], parentID[:])
 	copy(key[25:41], childID[:])
@@ -490,7 +492,7 @@ func OrdinalKey(ws [8]byte, parentID [16]byte, childID [16]byte) []byte {
 // Used by ListChildOrdinals to scan all children of a parent.
 func OrdinalPrefixForParent(ws [8]byte, parentID [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x1E
+	key[0] = prefix.Ordinal
 	copy(key[1:9], ws[:])
 	copy(key[9:25], parentID[:])
 	return key
@@ -501,7 +503,7 @@ func OrdinalPrefixForParent(ws [8]byte, parentID [16]byte) []byte {
 // where the deleted engram is a child.
 func OrdinalWorkspacePrefix(ws [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x1E
+	key[0] = prefix.Ordinal
 	copy(key[1:9], ws[:])
 	return key
 }
@@ -551,7 +553,7 @@ func EntityNameHash(name string) [8]byte {
 // Key: 0x1F | nameHash(8) = 9 bytes
 func EntityKey(nameHash [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x1F
+	key[0] = prefix.Entity
 	copy(key[1:9], nameHash[:])
 	return key
 }
@@ -560,7 +562,7 @@ func EntityKey(nameHash [8]byte) []byte {
 // Key: 0x20 | wsPrefix(8) | engramID(16) | nameHash(8) = 33 bytes
 func EntityEngramLinkKey(ws [8]byte, engramID [16]byte, nameHash [8]byte) []byte {
 	key := make([]byte, 1+8+16+8)
-	key[0] = 0x20
+	key[0] = prefix.EntityEngramLink
 	copy(key[1:9], ws[:])
 	copy(key[9:25], engramID[:])
 	copy(key[25:33], nameHash[:])
@@ -571,7 +573,7 @@ func EntityEngramLinkKey(ws [8]byte, engramID [16]byte, nameHash [8]byte) []byte
 // from a given engram (0x20 | ws(8) | engramID(16)).
 func EntityEngramLinkPrefix(ws [8]byte, engramID [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x20
+	key[0] = prefix.EntityEngramLink
 	copy(key[1:9], ws[:])
 	copy(key[9:25], engramID[:])
 	return key
@@ -581,7 +583,7 @@ func EntityEngramLinkPrefix(ws [8]byte, engramID [16]byte) []byte {
 // Key: 0x21 | ws(8) | engramID(16) | fromNameHash(8) | relTypeByte(1) | toNameHash(8) = 42 bytes
 func RelationshipKey(ws [8]byte, engramID [16]byte, fromHash [8]byte, relTypeByte uint8, toHash [8]byte) []byte {
 	key := make([]byte, 1+8+16+8+1+8)
-	key[0] = 0x21
+	key[0] = prefix.Relationship
 	copy(key[1:9], ws[:])
 	copy(key[9:25], engramID[:])
 	copy(key[25:33], fromHash[:])
@@ -594,7 +596,7 @@ func RelationshipKey(ws [8]byte, engramID [16]byte, fromHash [8]byte, relTypeByt
 // in a given vault (0x21 | wsPrefix(8)).
 func RelationshipPrefix(ws [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x21
+	key[0] = prefix.Relationship
 	copy(key[1:9], ws[:])
 	return key
 }
@@ -603,7 +605,7 @@ func RelationshipPrefix(ws [8]byte) []byte {
 // records sourced from a specific engram (0x21 | ws(8) | engramID(16)).
 func RelationshipEngramPrefix(ws [8]byte, engramID [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x21
+	key[0] = prefix.Relationship
 	copy(key[1:9], ws[:])
 	copy(key[9:25], engramID[:])
 	return key
@@ -616,7 +618,7 @@ func RelationshipEngramPrefix(ws [8]byte, engramID [16]byte) []byte {
 // Value: msgpack(coOccurrenceRecord{NameA, NameB, Count uint32}).
 func CoOccurrenceKey(ws [8]byte, hashA, hashB [8]byte) []byte {
 	key := make([]byte, 1+8+8+8)
-	key[0] = 0x24
+	key[0] = prefix.CoOccurrence
 	copy(key[1:9], ws[:])
 	copy(key[9:17], hashA[:])
 	copy(key[17:25], hashB[:])
@@ -627,7 +629,7 @@ func CoOccurrenceKey(ws [8]byte, hashA, hashB [8]byte) []byte {
 // in a given vault (0x24 | wsPrefix(8)).
 func CoOccurrencePrefix(ws [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x24
+	key[0] = prefix.CoOccurrence
 	copy(key[1:9], ws[:])
 	return key
 }
@@ -638,7 +640,7 @@ func CoOccurrencePrefix(ws [8]byte) []byte {
 // Value: empty (all data is encoded in the key).
 func EntityReverseIndexKey(nameHash [8]byte, ws [8]byte, engramID [16]byte) []byte {
 	key := make([]byte, 1+8+8+16)
-	key[0] = 0x23
+	key[0] = prefix.EntityReverseIndex
 	copy(key[1:9], nameHash[:])
 	copy(key[9:17], ws[:])
 	copy(key[17:33], engramID[:])
@@ -649,7 +651,7 @@ func EntityReverseIndexKey(nameHash [8]byte, ws [8]byte, engramID [16]byte) []by
 // that mention a given entity (0x23 | nameHash(8)).
 func EntityReverseIndexPrefix(nameHash [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x23
+	key[0] = prefix.EntityReverseIndex
 	copy(key[1:9], nameHash[:])
 	return key
 }
@@ -661,7 +663,7 @@ func EntityReverseIndexPrefix(nameHash [8]byte) []byte {
 // Value: empty (all data is in the key).
 func LastAccessIndexKey(ws [8]byte, lastAccessMillis int64, engramID [16]byte) []byte {
 	key := make([]byte, 1+8+8+16)
-	key[0] = 0x22
+	key[0] = prefix.LastAccess
 	copy(key[1:9], ws[:])
 	inverted := ^uint64(lastAccessMillis)
 	binary.BigEndian.PutUint64(key[9:17], inverted)
@@ -673,7 +675,7 @@ func LastAccessIndexKey(ws [8]byte, lastAccessMillis int64, engramID [16]byte) [
 // entries in a vault (0x22 | ws(8)). Ascending scan yields most-recently-accessed first.
 func LastAccessIndexPrefix(ws [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x22
+	key[0] = prefix.LastAccess
 	copy(key[1:9], ws[:])
 	return key
 }
@@ -685,7 +687,7 @@ func LastAccessIndexPrefix(ws [8]byte) []byte {
 func IdempotencyKey(opID string) []byte {
 	hashVal := siphash.Hash(sipKey0, sipKey1, []byte(opID))
 	key := make([]byte, 1+8)
-	key[0] = 0x19
+	key[0] = prefix.Idempotency
 	binary.BigEndian.PutUint64(key[1:], hashVal)
 	return key
 }
@@ -697,7 +699,7 @@ func IdempotencyKey(opID string) []byte {
 // Value: empty (all data is encoded in the key).
 func RelEntityIndexKey(ws [8]byte, entityHash [8]byte, engramID [16]byte) []byte {
 	key := make([]byte, 1+8+8+16)
-	key[0] = 0x26
+	key[0] = prefix.RelEntityIndex
 	copy(key[1:9], ws[:])
 	copy(key[9:17], entityHash[:])
 	copy(key[17:33], engramID[:])
@@ -708,7 +710,7 @@ func RelEntityIndexKey(ws [8]byte, entityHash [8]byte, engramID [16]byte) []byte
 // engrams for a given entity in a vault (0x26 | ws(8) | entityHash(8)).
 func RelEntityIndexPrefix(ws [8]byte, entityHash [8]byte) []byte {
 	key := make([]byte, 1+8+8)
-	key[0] = 0x26
+	key[0] = prefix.RelEntityIndex
 	copy(key[1:9], ws[:])
 	copy(key[9:17], entityHash[:])
 	return key
@@ -720,7 +722,7 @@ func RelEntityIndexPrefix(ws [8]byte, entityHash [8]byte) []byte {
 // Key: 0x25 | wsPrefix(8) | src(16) | dst(16) = 41 bytes
 func ArchiveAssocKey(ws [8]byte, src [16]byte, dst [16]byte) []byte {
 	key := make([]byte, 1+8+16+16)
-	key[0] = 0x25
+	key[0] = prefix.ArchiveAssoc
 	copy(key[1:9], ws[:])
 	copy(key[9:25], src[:])
 	copy(key[25:41], dst[:])
@@ -731,7 +733,7 @@ func ArchiveAssocKey(ws [8]byte, src [16]byte, dst [16]byte) []byte {
 // associations from a given source engram (0x25 | ws(8) | src(16)).
 func ArchiveAssocPrefixForID(ws [8]byte, src [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x25
+	key[0] = prefix.ArchiveAssoc
 	copy(key[1:9], ws[:])
 	copy(key[9:25], src[:])
 	return key
@@ -741,7 +743,7 @@ func ArchiveAssocPrefixForID(ws [8]byte, src [16]byte) []byte {
 // archived associations within a vault (0x25 | ws(8)).
 func ArchiveAssocRangeStart(ws [8]byte) []byte {
 	key := make([]byte, 1+8)
-	key[0] = 0x25
+	key[0] = prefix.ArchiveAssoc
 	copy(key[1:9], ws[:])
 	return key
 }
@@ -750,7 +752,7 @@ func ArchiveAssocRangeStart(ws [8]byte) []byte {
 // archived associations within a vault. Increments the ws portion.
 func ArchiveAssocRangeEnd(ws [8]byte) []byte {
 	end := make([]byte, 1+8)
-	end[0] = 0x25
+	end[0] = prefix.ArchiveAssoc
 	copy(end[1:9], ws[:])
 	for i := len(end) - 1; i >= 1; i-- {
 		end[i]++
@@ -766,7 +768,7 @@ func ArchiveAssocRangeEnd(ws [8]byte) []byte {
 // Value layout: 16 bytes (last_dream_at int64 + engrams_at_dream int64, BigEndian)
 func DreamStateKey(vaultPrefix [8]byte) []byte {
 	key := make([]byte, 9)
-	key[0] = 0x27
+	key[0] = prefix.DreamState
 	copy(key[1:], vaultPrefix[:])
 	return key
 }
@@ -778,7 +780,7 @@ func DreamStateKey(vaultPrefix [8]byte) []byte {
 // Value: engramID(16) bytes
 func ContentHashKey(ws [8]byte, hash [32]byte) []byte {
 	key := make([]byte, 1+8+32)
-	key[0] = 0x28
+	key[0] = prefix.ContentHash
 	copy(key[1:9], ws[:])
 	copy(key[9:41], hash[:])
 	return key
@@ -791,7 +793,7 @@ func ContentHashKey(ws [8]byte, hash [32]byte) []byte {
 // Value: JSON-encoded lease {owner, heartbeat, ttl}.
 func LeaseKey(ws [8]byte, id [16]byte) []byte {
 	key := make([]byte, 1+8+16)
-	key[0] = 0x2A
+	key[0] = prefix.Lease
 	copy(key[1:9], ws[:])
 	copy(key[9:25], id[:])
 	return key

--- a/internal/storage/keys/keys_test.go
+++ b/internal/storage/keys/keys_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/scrypster/muninndb/internal/prefix"
 )
 
 func TestKeyPrefixesAreUnique(t *testing.T) {
@@ -315,5 +317,92 @@ func TestArchiveAssocPrefixForID_Length(t *testing.T) {
 	}
 	if prefix[0] != 0x25 {
 		t.Errorf("prefix byte: got 0x%02X, want 0x25", prefix[0])
+	}
+}
+
+// TestKeyConstructors_UseRegistryBytes [RT-FIX RT8] asserts every key and
+// range-bound constructor sources its first byte from the prefix registry.
+// TestKeyPrefixesAreUnique only checks uniqueness — a two-pair byte swap would
+// slip past it. This test pins the byte↔name mapping so the literal→const
+// refactor is provably behavior-noop.
+func TestKeyConstructors_UseRegistryBytes(t *testing.T) {
+	var ws [8]byte
+	var id16 [16]byte
+	var id32 [32]byte
+	var u8 [8]byte
+	var tri [3]byte
+
+	cases := []struct {
+		name string
+		got  byte
+		want byte
+	}{
+		{"Engram", EngramKey(ws, id16)[0], prefix.Engram},
+		{"Meta", MetaKey(ws, id16)[0], prefix.Meta},
+		{"AssocFwd", AssocFwdKey(ws, id16, 0, id16)[0], prefix.AssocFwd},
+		{"AssocRev", AssocRevKey(ws, id16, 0, id16)[0], prefix.AssocRev},
+		{"FTSPosting", FTSPostingKey(ws, "", 0, id16)[0], prefix.FTSPosting},
+		{"Trigram", TrigramKey(ws, tri, id16)[0], prefix.Trigram},
+		{"HNSWNode", HNSWNodeKey(ws, id16, 0)[0], prefix.HNSWNode},
+		{"FTSStats", FTSStatsKey(ws)[0], prefix.FTSStats},
+		{"TermStats", TermStatsKey(ws, "")[0], prefix.TermStats},
+		{"ContradictionKeyPrefix", ContradictionKeyPrefix(ws)[0], prefix.Contradiction},
+		{"ContradictionKey", ContradictionKey(ws, 0, 0, id16)[0], prefix.Contradiction},
+		{"StateIndex", StateIndexKey(ws, 0, id16)[0], prefix.StateIndex},
+		{"TagIndex", TagIndexKey(ws, 0, id16)[0], prefix.TagIndex},
+		{"CreatorIndex", CreatorIndexKey(ws, 0, id16)[0], prefix.CreatorIndex},
+		{"VaultMeta", VaultMetaKey(ws)[0], prefix.VaultMeta},
+		{"VaultNameIndex", VaultNameIndexKey("")[0], prefix.VaultNameIndex},
+		{"RelevanceBucket", RelevanceBucketKey(ws, 0, id16)[0], prefix.RelevanceBucket},
+		{"DigestFlags", DigestFlagsKey(id16)[0], prefix.DigestFlags},
+		{"Coherence", CoherenceKey(u8)[0], prefix.Coherence},
+		{"VaultWeights", VaultWeightsKey(ws)[0], prefix.VaultWeights},
+		{"AssocWeightIndex", AssocWeightIndexKey(ws, id16, id16)[0], prefix.AssocWeightIndex},
+		{"AssocFwdRangeStart", AssocFwdRangeStart(ws)[0], prefix.AssocFwd},
+		{"AssocFwdRangeEnd", AssocFwdRangeEnd(ws)[0], prefix.AssocFwd},
+		{"AssocFwdPrefixForID", AssocFwdPrefixForID(ws, id16)[0], prefix.AssocFwd},
+		{"AssocRevPrefixForID", AssocRevPrefixForID(ws, id16)[0], prefix.AssocRev},
+		{"VaultCount", VaultCountKey(ws)[0], prefix.VaultCount},
+		{"Provenance", ProvenanceKey(ws, id16)[0], prefix.Provenance},
+		{"ProvenanceKeyUpperBound", ProvenanceKeyUpperBound(ws, id16)[0], prefix.Provenance},
+		{"ProvenanceSuffix", ProvenanceSuffixKey(ws, id16, 0, 0)[0], prefix.Provenance},
+		{"Episode", EpisodeKey(ws, id16)[0], prefix.Episode},
+		{"EpisodeFrame", EpisodeFrameKey(ws, id16, 0)[0], prefix.Episode},
+		{"BucketMigration", BucketMigrationKey(ws)[0], prefix.BucketMigration},
+		{"Embedding", EmbeddingKey(ws, id16)[0], prefix.Embedding},
+		{"Idempotency", IdempotencyKey("")[0], prefix.Idempotency},
+		{"FTSVersion", FTSVersionKey(ws)[0], prefix.FTSVersion},
+		{"Transition", TransitionKey(ws, id16, id16)[0], prefix.Transition},
+		{"TransitionPrefixForSrc", TransitionPrefixForSrc(ws, id16)[0], prefix.Transition},
+		{"EmbedModel", EmbedModelKey(ws)[0], prefix.EmbedModel},
+		{"Ordinal", OrdinalKey(ws, id16, id16)[0], prefix.Ordinal},
+		{"OrdinalPrefixForParent", OrdinalPrefixForParent(ws, id16)[0], prefix.Ordinal},
+		{"OrdinalWorkspacePrefix", OrdinalWorkspacePrefix(ws)[0], prefix.Ordinal},
+		{"Entity", EntityKey(u8)[0], prefix.Entity},
+		{"EntityEngramLink", EntityEngramLinkKey(ws, id16, u8)[0], prefix.EntityEngramLink},
+		{"EntityEngramLinkPrefix", EntityEngramLinkPrefix(ws, id16)[0], prefix.EntityEngramLink},
+		{"Relationship", RelationshipKey(ws, id16, u8, 0, u8)[0], prefix.Relationship},
+		{"RelationshipPrefix", RelationshipPrefix(ws)[0], prefix.Relationship},
+		{"RelationshipEngramPrefix", RelationshipEngramPrefix(ws, id16)[0], prefix.Relationship},
+		{"CoOccurrence", CoOccurrenceKey(ws, u8, u8)[0], prefix.CoOccurrence},
+		{"CoOccurrencePrefix", CoOccurrencePrefix(ws)[0], prefix.CoOccurrence},
+		{"EntityReverseIndex", EntityReverseIndexKey(u8, ws, id16)[0], prefix.EntityReverseIndex},
+		{"EntityReverseIndexPrefix", EntityReverseIndexPrefix(u8)[0], prefix.EntityReverseIndex},
+		{"LastAccessIndex", LastAccessIndexKey(ws, 0, id16)[0], prefix.LastAccess},
+		{"LastAccessIndexPrefix", LastAccessIndexPrefix(ws)[0], prefix.LastAccess},
+		{"RelEntityIndex", RelEntityIndexKey(ws, u8, id16)[0], prefix.RelEntityIndex},
+		{"RelEntityIndexPrefix", RelEntityIndexPrefix(ws, u8)[0], prefix.RelEntityIndex},
+		{"ArchiveAssoc", ArchiveAssocKey(ws, id16, id16)[0], prefix.ArchiveAssoc},
+		{"ArchiveAssocPrefixForID", ArchiveAssocPrefixForID(ws, id16)[0], prefix.ArchiveAssoc},
+		{"ArchiveAssocRangeStart", ArchiveAssocRangeStart(ws)[0], prefix.ArchiveAssoc},
+		{"ArchiveAssocRangeEnd", ArchiveAssocRangeEnd(ws)[0], prefix.ArchiveAssoc},
+		{"DreamState", DreamStateKey(u8)[0], prefix.DreamState},
+		{"ContentHash", ContentHashKey(ws, id32)[0], prefix.ContentHash},
+		{"Lease", LeaseKey(ws, id16)[0], prefix.Lease},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("%s: got 0x%02x want 0x%02x", c.name, c.got, c.want)
+		}
 	}
 }

--- a/internal/storage/migrate/migrate.go
+++ b/internal/storage/migrate/migrate.go
@@ -56,6 +56,28 @@ func (r *Runner) Run() (applied int, err error) {
 		return 0, fmt.Errorf("migrate: read version: %w", err)
 	}
 
+	// Downgrade guard: refuse to proceed if the DB's stored migration version
+	// is newer than the highest version this binary registered. Without this
+	// check, an older binary would silently no-op (every registered Version is
+	// <= current) and then misinterpret keys written by the newer schema — the
+	// silent-skip downgrade hazard (#611).
+	//
+	// This protects ALL future migrations at the migration layer. It does NOT
+	// cover the cluster rolling-upgrade window: a pre-upgrade replica that has
+	// not yet seen the refuse-newer check can still read relocated-key writes
+	// from a post-upgrade peer. That is an operational constraint documented
+	// in the PR; binary downgrade / mixed-version clusters must be handled
+	// out-of-band.
+	maxRegistered := 0
+	for _, m := range r.migrations {
+		if m.Version > maxRegistered {
+			maxRegistered = m.Version
+		}
+	}
+	if current > maxRegistered {
+		return 0, fmt.Errorf("migrate: stored migration version %d is newer than this binary knows (%d); refusing to start (downgrade not supported)", current, maxRegistered)
+	}
+
 	for _, m := range r.migrations {
 		if m.Version <= current {
 			continue

--- a/internal/storage/migrate/migrate.go
+++ b/internal/storage/migrate/migrate.go
@@ -38,6 +38,19 @@ func (r *Runner) Register(m Migration) {
 	r.migrations = append(r.migrations, m)
 }
 
+// RegisterMigrations registers all known migrations with the runner. Called by
+// both muninn.Open (embedded/library) and runServer (daemon) so the two paths
+// cannot drift on which migrations are registered — the latent gap that left v3
+// (#611, RelocateAuthPrefixes) referenced only from tests.
+//
+// Add every new migration here. The Runner sorts by Version before execution,
+// so append order does not matter, but keep versions ascending for readability.
+func RegisterMigrations(r *Runner) {
+	r.Register(Migration{Version: 1, Description: "backfill embed_dim in ERF records for existing embeddings", Up: BackfillEmbedDim})
+	r.Register(Migration{Version: 2, Description: "backfill relationship entity index (0x26) for GetEntityAggregate optimisation", Up: BackfillRelEntityIndex})
+	r.Register(Migration{Version: 3, Description: "relocate auth prefixes 0x11–0x14 to 0x42–0x45 (#611)", Up: RelocateAuthPrefixes})
+}
+
 // Run executes all registered migrations whose version exceeds the currently
 // stored migration version, in ascending version order. Each successful
 // migration durably updates the stored version before proceeding to the next.

--- a/internal/storage/migrate/migrate.go
+++ b/internal/storage/migrate/migrate.go
@@ -48,7 +48,29 @@ func (r *Runner) Register(m Migration) {
 func RegisterMigrations(r *Runner) {
 	r.Register(Migration{Version: 1, Description: "backfill embed_dim in ERF records for existing embeddings", Up: BackfillEmbedDim})
 	r.Register(Migration{Version: 2, Description: "backfill relationship entity index (0x26) for GetEntityAggregate optimisation", Up: BackfillRelEntityIndex})
-	r.Register(Migration{Version: 3, Description: "relocate auth prefixes 0x11–0x14 to 0x42–0x45 (#611)", Up: RelocateAuthPrefixes})
+	r.Register(Migration{ Version: 3, Description: "relocate auth prefixes 0x11–0x14 to 0x42–0x45 (#611)", Up: RelocateAuthPrefixes})
+}
+
+// MaxRegisteredVersion returns the highest migration version this binary knows.
+// It registers into a throwaway Runner so the version list has a single source
+// of truth (RegisterMigrations) — bumping a version in RegisterMigrations
+// automatically flows through here without a second constant to keep in sync.
+//
+// Used by ForceRerunMigrations to refuse a recovery that would bypass the
+// refuse-newer invariant: if the DB was last written by a newer binary
+// (stored version > MaxRegisteredVersion), resetting to 0 and re-applying
+// only this binary's migrations would leave newer-schema data un-migrated
+// against an older binary — a downgrade-bypass surface.
+func MaxRegisteredVersion() int {
+	r := &Runner{}
+	RegisterMigrations(r)
+	max := 0
+	for _, m := range r.migrations {
+		if m.Version > max {
+			max = m.Version
+		}
+	}
+	return max
 }
 
 // Run executes all registered migrations whose version exceeds the currently

--- a/internal/storage/migrate/migrate.go
+++ b/internal/storage/migrate/migrate.go
@@ -48,7 +48,7 @@ func (r *Runner) Register(m Migration) {
 func RegisterMigrations(r *Runner) {
 	r.Register(Migration{Version: 1, Description: "backfill embed_dim in ERF records for existing embeddings", Up: BackfillEmbedDim})
 	r.Register(Migration{Version: 2, Description: "backfill relationship entity index (0x26) for GetEntityAggregate optimisation", Up: BackfillRelEntityIndex})
-	r.Register(Migration{ Version: 3, Description: "relocate auth prefixes 0x11–0x14 to 0x42–0x45 (#611)", Up: RelocateAuthPrefixes})
+	r.Register(Migration{Version: 3, Description: "relocate auth prefixes 0x11–0x14 to 0x42–0x45 (#611)", Up: RelocateAuthPrefixes})
 }
 
 // MaxRegisteredVersion returns the highest migration version this binary knows.

--- a/internal/storage/migrate/migrate_test.go
+++ b/internal/storage/migrate/migrate_test.go
@@ -167,6 +167,22 @@ func TestRunner_Idempotent(t *testing.T) {
 	}
 }
 
+func TestRunner_RefusesNewerThanKnown(t *testing.T) {
+	db := openTestDB(t)
+	// Simulate a DB written by a newer binary that registered migration v3.
+	if err := writeMigrationVersion(db, 3); err != nil {
+		t.Fatal(err)
+	}
+	// This (older) binary only knows about migrations v1 and v2.
+	r := NewRunner(db)
+	r.Register(Migration{Version: 1, Description: "v1", Up: func(*pebble.DB) error { return nil }})
+	r.Register(Migration{Version: 2, Description: "v2", Up: func(*pebble.DB) error { return nil }})
+
+	if _, err := r.Run(); err == nil {
+		t.Fatal("expected error when stored migration version (3) > max registered (2), got nil")
+	}
+}
+
 func TestRunner_OutOfOrder(t *testing.T) {
 	db := openTestDB(t)
 	r := NewRunner(db)

--- a/internal/storage/migrate/recover.go
+++ b/internal/storage/migrate/recover.go
@@ -1,6 +1,17 @@
 package migrate
 
-import "github.com/cockroachdb/pebble"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cockroachdb/pebble"
+)
+
+// ErrDBFromNewerBinary is returned by ForceRerunMigrations when the stored
+// migration version is higher than this binary's MaxRegisteredVersion —
+// resetting to 0 and re-applying only this binary's migrations would leave
+// newer-schema data un-migrated against an older binary (downgrade-bypass).
+var ErrDBFromNewerBinary = errors.New("DB was written by a newer binary; upgrade instead of downgrade-recover")
 
 // ForceRerunMigrations resets the stored migration version to 0 (the "fresh
 // DB" state), so the next Runner.Run re-applies every registered migration.
@@ -12,17 +23,34 @@ import "github.com/cockroachdb/pebble"
 // and exits without starting the server. The next normal start then re-runs
 // all migrations from version 1.
 //
-// Resetting to 0 rather than (max-1) is the safer choice: every registered
-// migration is idempotent by contract (v1/v2/v3 each guard against
-// already-migrated keys), so re-running the full set cannot double-apply.
+// Refuse-newer guard: before deleting the version key, the helper reads the
+// stored version and compares it to MaxRegisteredVersion (the highest version
+// THIS binary knows). If the stored version is higher, the helper REFUSES
+// with ErrDBFromNewerBinary — the DB was last written by a newer binary, and
+// resetting to 0 would let this older binary re-apply only its own (smaller)
+// migration set against a newer schema, a downgrade-bypass surface. The
+// operator must upgrade the binary, not recover with an older one.
+//
+// Re-running only re-applies migrations THIS binary knows about — if the DB
+// was last written by a NEWER binary, do NOT use this flag; upgrade instead.
+// Every registered migration is idempotent by contract (v1/v2/v3 each guard
+// against already-migrated keys), so a re-run against a same-or-older schema
+// DB cannot double-apply.
 //
 // Always back up the DB before a migration-bearing upgrade; use this flag to
-// recover from a wedged/partial migration.
+// recover from a wedged/partial migration — not to downgrade.
 //
 // The recovery does NOT run migrations itself — it only resets the version
 // marker so the existing Runner re-applies them on the next Open. This keeps
 // the recovery path simple and reuses the hardened Runner rather than
 // duplicating its fail-loud / per-step-stamp semantics.
 func ForceRerunMigrations(db *pebble.DB) error {
+	current, err := readMigrationVersion(db)
+	if err != nil {
+		return fmt.Errorf("read migration version before reset: %w", err)
+	}
+	if max := MaxRegisteredVersion(); current > max {
+		return fmt.Errorf("%w (stored migration version %d > this binary's max %d)", ErrDBFromNewerBinary, current, max)
+	}
 	return db.Delete(migrationVersionKey, pebble.Sync)
 }

--- a/internal/storage/migrate/recover.go
+++ b/internal/storage/migrate/recover.go
@@ -1,0 +1,28 @@
+package migrate
+
+import "github.com/cockroachdb/pebble"
+
+// ForceRerunMigrations resets the stored migration version to 0 (the "fresh
+// DB" state), so the next Runner.Run re-applies every registered migration.
+//
+// This is the operator recovery path for a wedged or partial migration
+// (#611, Task 7b / RT5): if a version was stamped but the operator needs to
+// force a re-run (e.g. recover from a partial state left by a failed v3),
+// they run `muninn start --force-migration-rerun`, which calls this helper
+// and exits without starting the server. The next normal start then re-runs
+// all migrations from version 1.
+//
+// Resetting to 0 rather than (max-1) is the safer choice: every registered
+// migration is idempotent by contract (v1/v2/v3 each guard against
+// already-migrated keys), so re-running the full set cannot double-apply.
+//
+// Always back up the DB before a migration-bearing upgrade; use this flag to
+// recover from a wedged/partial migration.
+//
+// The recovery does NOT run migrations itself — it only resets the version
+// marker so the existing Runner re-applies them on the next Open. This keeps
+// the recovery path simple and reuses the hardened Runner rather than
+// duplicating its fail-loud / per-step-stamp semantics.
+func ForceRerunMigrations(db *pebble.DB) error {
+	return db.Delete(migrationVersionKey, pebble.Sync)
+}

--- a/internal/storage/migrate/recover_test.go
+++ b/internal/storage/migrate/recover_test.go
@@ -1,0 +1,100 @@
+package migrate
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+)
+
+// TestForceRerunMigrations_ResetsToZero stamps version 3, calls
+// ForceRerunMigrations, and asserts the stored version is now 0 (the
+// "fresh DB" state readMigrationVersion returns for a missing key).
+func TestForceRerunMigrations_ResetsToZero(t *testing.T) {
+	db := openTestDB(t)
+
+	if err := writeMigrationVersion(db, 3); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := readMigrationVersion(db); err != nil || got != 3 {
+		t.Fatalf("precondition: version=%d err=%v (want 3)", got, err)
+	}
+
+	if err := ForceRerunMigrations(db); err != nil {
+		t.Fatalf("ForceRerunMigrations: %v", err)
+	}
+
+	got, err := readMigrationVersion(db)
+	if err != nil {
+		t.Fatalf("readMigrationVersion after reset: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("stored version after reset = %d, want 0", got)
+	}
+}
+
+// TestForceRerunMigrations_FreshDBIsNoOp asserts the helper is safe to run
+// against a DB that has never had a migration version stamped (the common
+// case where recovery is unnecessary but invoked defensively).
+func TestForceRerunMigrations_FreshDBIsNoOp(t *testing.T) {
+	db := openTestDB(t)
+
+	if err := ForceRerunMigrations(db); err != nil {
+		t.Fatalf("ForceRerunMigrations on fresh DB: %v", err)
+	}
+	got, err := readMigrationVersion(db)
+	if err != nil {
+		t.Fatalf("readMigrationVersion: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("fresh DB version = %d, want 0", got)
+	}
+}
+
+// TestForceRerunMigrations_NextRunReappliesAll stamps version 3, resets,
+// then runs a fresh Runner with migrations v1/v2/v3 registered and asserts
+// all three re-apply — proving the reset actually triggers a re-run on the
+// next Open.
+func TestForceRerunMigrations_NextRunReappliesAll(t *testing.T) {
+	db := openTestDB(t)
+	if err := writeMigrationVersion(db, 3); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ForceRerunMigrations(db); err != nil {
+		t.Fatalf("ForceRerunMigrations: %v", err)
+	}
+
+	r := NewRunner(db)
+	var applied []int
+	for _, v := range []int{1, 2, 3} {
+		v := v
+		r.Register(Migration{
+			Version:     v,
+			Description: "idempotent stub",
+			Up: func(_ *pebble.DB) error {
+				applied = append(applied, v)
+				return nil
+			},
+		})
+	}
+
+	n, err := r.Run()
+	if err != nil {
+		t.Fatalf("Runner.Run after reset: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("applied count = %d, want 3 (all migrations should re-run after reset)", n)
+	}
+	if len(applied) != 3 || applied[0] != 1 || applied[1] != 2 || applied[2] != 3 {
+		t.Fatalf("applied order = %v, want [1 2 3]", applied)
+	}
+
+	// And the stored version should now be stamped back at the max registered.
+	got, err := readMigrationVersion(db)
+	if err != nil {
+		t.Fatalf("readMigrationVersion after re-run: %v", err)
+	}
+	if got != 3 {
+		t.Fatalf("stored version after re-run = %d, want 3", got)
+	}
+}

--- a/internal/storage/migrate/recover_test.go
+++ b/internal/storage/migrate/recover_test.go
@@ -50,6 +50,37 @@ func TestForceRerunMigrations_FreshDBIsNoOp(t *testing.T) {
 	}
 }
 
+// TestForceRerunMigrations_RefusesNewerBinaryDB proves the downgrade-bypass
+// guard: if the DB was last written by a NEWER binary (stored version > this
+// binary's MaxRegisteredVersion), ForceRerunMigrations REFUSES instead of
+// resetting to 0. Without this, an operator facing the refuse-newer error on
+// startup could --force-migration-rerun to reset to 0, then an older binary
+// would happily re-apply v1/v2/v3 against a newer-schema DB.
+//
+// The version key MUST remain at the newer-binary value (not deleted) so the
+// next start with a properly-upgraded binary still sees the correct version.
+func TestForceRerunMigrations_RefusesNewerBinaryDB(t *testing.T) {
+	db := openTestDB(t)
+
+	newerVersion := MaxRegisteredVersion() + 10 // simulate a future vN+10 binary
+	if err := writeMigrationVersion(db, newerVersion); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ForceRerunMigrations(db); err == nil {
+		t.Fatal("ForceRerunMigrations on a newer-binary DB: expected error (refuse-newer), got nil (downgrade-bypass surface)")
+	}
+
+	// Version MUST be unchanged — refuse-newer must NOT delete the version key.
+	got, err := readMigrationVersion(db)
+	if err != nil {
+		t.Fatalf("readMigrationVersion after refused reset: %v", err)
+	}
+	if got != newerVersion {
+		t.Fatalf("stored version after refused reset = %d, want %d (refuse-newer must not delete)", got, newerVersion)
+	}
+}
+
 // TestForceRerunMigrations_NextRunReappliesAll stamps version 3, resets,
 // then runs a fresh Runner with migrations v1/v2/v3 registered and asserts
 // all three re-apply — proving the reset actually triggers a re-run on the

--- a/internal/storage/migrate/v3_auth_prefix_relocate.go
+++ b/internal/storage/migrate/v3_auth_prefix_relocate.go
@@ -152,21 +152,17 @@ func relocatePrefix(db *pebble.DB, oldPfx, newPfx byte) error {
 func isAuthKey(pfx byte, key, val []byte) (bool, error) {
 	switch pfx {
 	case prefix.DigestFlags: // old 0x11 — admin was colocated here
-		// [RT-FIX RT2] Value-shape gate. Storage DigestFlags is a 1-byte uint8
-		// flag; an admin user's value is multi-byte JSON starting with '{'.
+		// [RT-FIX RT2] Value-shape gate. Storage DigestFlags value is a 1-byte
+		// uint8 bitfield; an admin user's value is multi-byte JSON (never 1B).
 		// Without the value gate, a 16-char username admin (key 1+16=17B)
 		// collides with storage's 1+16-byte-ULID key (also 17B) and is silently
 		// orphaned at 0x11 — invisible to AdminExists post-migration → Bootstrap
 		// creates default root/password → silent lockout + security regression.
 		//
-		// Discriminate on the JSON marker byte rather than a length equality,
-		// because auth values are always JSON object literals ('{...}') and
-		// storage binary values never start with '{' (the first byte is the
-		// uint8 bitfield, range 0x00–0xFF but never deliberately '{'=0x7B).
-		// This survives future storage value-shape changes without needing the
-		// migration touched.
-		if len(key) == 17 && (len(val) == 0 || val[0] != '{') {
-			return false, nil // storage DigestFlags (1 + 16 ULID, 1-byte value) — leave
+		// Exact length is tighter than a JSON-marker byte: a 1-byte value is
+		// structurally impossible for any admin JSON ('{"...":...}' is many B).
+		if len(key) == 17 && len(val) == 1 {
+			return false, nil // storage DigestFlags (1 + 16 ULID, 1-byte bitfield) — leave
 		}
 		var u auth.AdminUser
 		if err := json.Unmarshal(val, &u); err != nil {
@@ -181,19 +177,19 @@ func isAuthKey(pfx byte, key, val []byte) (bool, error) {
 		return len(key) >= prefix.MinAPIKeyVIdxLen, nil
 	case prefix.AssocWeightIndex: // old 0x14 — vaultCfg was colocated here
 		// [RT-FIX RT2] Value-shape gate. Storage AssocWeightIndex value is a
-		// fixed-width binary struct (26 bytes per encodeAssocValue; legacy
-		// 18/22/30); a vault config's value is multi-byte JSON starting with '{'.
+		// 4-byte big-endian float32 weight (association.go:410-412); a vault
+		// config's value is multi-byte JSON (never 4B).
 		// Without the value gate, a 40-char vault name (key 1+40=41B) collides
 		// with storage's 41B key and is silently orphaned at 0x14 — invisible
 		// post-migration, loses the vault's plasticity/public config.
 		//
-		// The RT brief specified `len(val) == 4`, but encodeAssocValue produces
-		// 26 bytes (the brief confused the 4-byte peakWeight/coActivationCount
-		// FIELDS for the whole value). Discriminating on the JSON marker byte
-		// is both empirically correct AND more durable — it survives future
-		// storage value-width changes without the migration being touched.
-		if len(key) == 41 && (len(val) == 0 || val[0] != '{') {
-			return false, nil // storage AssocWeightIndex (41B key, binary value) — leave
+		// Truth check: encodeAssocValue writes to AssocFwdKey (0x03)/AssocRevKey
+		// (0x04), NOT to AssocWeightIndex (0x14). The earlier comment claiming
+		// 26-byte 0x14 values confused the 0x03/0x04 struct for the 0x14 weight.
+		// Exact length is tighter than a JSON-marker byte: a 4-byte value is
+		// structurally impossible for any vaultCfg JSON ('{"...":...}' is many B).
+		if len(key) == 41 && len(val) == 4 {
+			return false, nil // storage AssocWeightIndex (41B key, 4-byte float32 weight) — leave
 		}
 		var c auth.VaultConfig
 		if err := json.Unmarshal(val, &c); err != nil {

--- a/internal/storage/migrate/v3_auth_prefix_relocate.go
+++ b/internal/storage/migrate/v3_auth_prefix_relocate.go
@@ -1,0 +1,180 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/auth"
+	"github.com/scrypster/muninndb/internal/prefix"
+)
+
+// RelocateAuthPrefixes is the v3 migration (#611): re-keys the four auth
+// families from their pre-relocation colocated prefixes (0x11–0x14, where
+// they sat inside storage's range) onto the new dedicated auth range
+// 0x42–0x45 introduced by Task 2.
+//
+// Old → New:
+//
+//	0x11 (DigestFlags byte) → 0x42 AdminUser       (JSON name round-trip)
+//	0x12 (Coherence byte)   → 0x43 APIKey          (length only: 1+16)
+//	0x13 (VaultWeights byte)→ 0x44 APIKeyVaultIdx  (length only: >=10)
+//	0x14 (AssocWeightIdx)   → 0x45 VaultConfig     (JSON name round-trip)
+//
+// Each old prefix byte is shared between storage and (legacy) auth, so the
+// per-key discriminator isAuthKey decides for every key. The migration is
+// idempotent: a re-run finds the old-prefix ranges empty → count=0, nothing
+// commits, storage is never matched.
+//
+// On a corrupted auth value at 0x11/0x14 (JSON parse failure), the migration
+// FAILS LOUD: the error is returned to the caller, the migration version is
+// NOT stamped 3, and the operator runs recovery (Task 7b), fixes the value,
+// and re-runs. The migration never silently orphans an auth record.
+func RelocateAuthPrefixes(db *pebble.DB) error {
+	if err := relocatePrefix(db, prefix.DigestFlags, prefix.AdminUser); err != nil {
+		return fmt.Errorf("relocate auth prefixes: admin (0x11→0x42): %w", err)
+	}
+	if err := relocatePrefix(db, prefix.Coherence, prefix.APIKey); err != nil {
+		return fmt.Errorf("relocate auth prefixes: apiKey (0x12→0x43): %w", err)
+	}
+	if err := relocatePrefix(db, prefix.VaultWeights, prefix.APIKeyVaultIdx); err != nil {
+		return fmt.Errorf("relocate auth prefixes: apiKeyVIdx (0x13→0x44): %w", err)
+	}
+	if err := relocatePrefix(db, prefix.AssocWeightIndex, prefix.VaultConfig); err != nil {
+		return fmt.Errorf("relocate auth prefixes: vaultCfg (0x14→0x45): %w", err)
+	}
+	return nil
+}
+
+// relocatePrefix scans every key under oldPfx, asks isAuthKey whether each one
+// belongs to the auth family (vs. the storage family that shares the prefix
+// byte), and if so writes it under newPfx and deletes the old key.
+//
+// [RT-FIX RT1] The batch is closed and re-allocated after every Commit —
+// mirroring internal/storage/migrate/v2_rel_entity_index.go. Reusing a batch
+// across commits grows its internal memtable without bound and triggers
+// ErrBatchTooLarge on large auth sets (the original sketch's O(N²) bug).
+//
+// [RT-FIX RT4] isAuthKey returns (auth, parseErr). A JSON-parse failure on
+// a prefix whose discriminator is JSON-based (0x11/0x14) is RETURNED from
+// this function as a non-nil error, failing the migration loud. Storage
+// keys in the shared range are silently skipped (counted in `skipped`).
+func relocatePrefix(db *pebble.DB, oldPfx, newPfx byte) error {
+	iter, err := db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte{oldPfx},
+		UpperBound: []byte{oldPfx + 1},
+	})
+	if err != nil {
+		return fmt.Errorf("new iter (0x%02x): %w", oldPfx, err)
+	}
+	defer iter.Close()
+
+	const batchSize = 100
+	batch := db.NewBatch()
+	count, skipped := 0, 0
+
+	commit := func() error {
+		if err := batch.Commit(pebble.Sync); err != nil {
+			return fmt.Errorf("commit batch (0x%02x): %w", oldPfx, err)
+		}
+		// [RT-FIX RT1] v2 idiom — do NOT reuse the batch across commits.
+		batch.Close()
+		batch = db.NewBatch()
+		return nil
+	}
+	defer batch.Close()
+
+	for valid := iter.First(); valid; valid = iter.Next() {
+		oldKey := append([]byte(nil), iter.Key()...)
+		val, err := iter.ValueAndErr()
+		if err != nil {
+			return fmt.Errorf("iter value (0x%02x) at %x: %w", oldPfx, oldKey, err)
+		}
+
+		isAuth, parseErr := isAuthKey(oldPfx, oldKey, val)
+		if parseErr != nil {
+			return fmt.Errorf("relocate 0x%02x: unparseable value at %x (possible corrupted auth record — refusing to silently orphan): %w", oldPfx, oldKey, parseErr)
+		}
+		if !isAuth {
+			skipped++ // storage key in the shared range — leave it
+			continue
+		}
+
+		newKey := append([]byte{newPfx}, oldKey[1:]...)
+		batch.Set(newKey, append([]byte(nil), val...), nil)
+		batch.Delete(oldKey, nil)
+		count++
+
+		if count%batchSize == 0 {
+			if err := commit(); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := iter.Error(); err != nil {
+		return fmt.Errorf("iter error (0x%02x): %w", oldPfx, err)
+	}
+
+	if count%batchSize != 0 {
+		if err := commit(); err != nil {
+			return err
+		}
+	}
+
+	slog.Info("relocate auth prefix",
+		"from", fmt.Sprintf("0x%02x", oldPfx),
+		"to", fmt.Sprintf("0x%02x", newPfx),
+		"relocated", count,
+		"skipped_storage", skipped,
+	)
+	return nil
+}
+
+// isAuthKey returns (isAuth, parseErr) for a key at the given old-prefix byte.
+//
+// parseErr is non-nil ONLY for a value that LOOKS like it should be an auth
+// record (a key on the 0x11/0x14 prefix whose length is NOT the storage
+// length) but fails to JSON-parse as the expected auth struct — a corrupted
+// admin or vaultCfg that must NOT be silently orphaned.
+//
+// Length-only discriminators (0x12, 0x13) never return a parse error: there
+// is no JSON to parse, so there is no fail-loud path — the length either
+// matches auth or it matches storage.
+//
+// NOTE: the switch matches on the OLD prefix byte (the byte the caller is
+// scanning), so the case labels use the storage prefix constants that STILL
+// own those bytes (DigestFlags=0x11, Coherence=0x12, VaultWeights=0x13,
+// AssocWeightIndex=0x14). The case for 0x12 uses prefix.Coherence (not
+// prefix.APIKey, which == 0x43 after Task 2's relocation) — using the new
+// auth constant here would never match and silently skip every API key.
+func isAuthKey(pfx byte, key, val []byte) (bool, error) {
+	switch pfx {
+	case prefix.DigestFlags: // old 0x11 — admin was colocated here
+		if len(key) == 17 {
+			return false, nil // storage DigestFlags (1 + 16 ULID, 1-byte value) — leave
+		}
+		var u auth.AdminUser
+		if err := json.Unmarshal(val, &u); err != nil {
+			return false, err // corrupted admin — fail loud
+		}
+		return string(key[1:]) == u.Username, nil
+	case prefix.Coherence: // old 0x12 — apiKey was colocated here
+		// Length-only: auth APIKey is 1+16=17; storage Coherence is 1+8=9.
+		return len(key) == prefix.MinAPIKeyLen, nil
+	case prefix.VaultWeights: // old 0x13 — apiKeyVIdx was colocated here
+		// Length-only: auth APIKeyVaultIdx is 1+vault+0x00+8 >= 10; storage VaultWeights is 1+8=9.
+		return len(key) >= prefix.MinAPIKeyVIdxLen, nil
+	case prefix.AssocWeightIndex: // old 0x14 — vaultCfg was colocated here
+		if len(key) == 41 {
+			return false, nil // storage AssocWeightIndex (41B) — leave
+		}
+		var c auth.VaultConfig
+		if err := json.Unmarshal(val, &c); err != nil {
+			return false, err // corrupted vaultCfg — fail loud
+		}
+		return string(key[1:]) == c.Name, nil
+	}
+	return false, nil
+}

--- a/internal/storage/migrate/v3_auth_prefix_relocate.go
+++ b/internal/storage/migrate/v3_auth_prefix_relocate.go
@@ -152,7 +152,20 @@ func relocatePrefix(db *pebble.DB, oldPfx, newPfx byte) error {
 func isAuthKey(pfx byte, key, val []byte) (bool, error) {
 	switch pfx {
 	case prefix.DigestFlags: // old 0x11 — admin was colocated here
-		if len(key) == 17 {
+		// [RT-FIX RT2] Value-shape gate. Storage DigestFlags is a 1-byte uint8
+		// flag; an admin user's value is multi-byte JSON starting with '{'.
+		// Without the value gate, a 16-char username admin (key 1+16=17B)
+		// collides with storage's 1+16-byte-ULID key (also 17B) and is silently
+		// orphaned at 0x11 — invisible to AdminExists post-migration → Bootstrap
+		// creates default root/password → silent lockout + security regression.
+		//
+		// Discriminate on the JSON marker byte rather than a length equality,
+		// because auth values are always JSON object literals ('{...}') and
+		// storage binary values never start with '{' (the first byte is the
+		// uint8 bitfield, range 0x00–0xFF but never deliberately '{'=0x7B).
+		// This survives future storage value-shape changes without needing the
+		// migration touched.
+		if len(key) == 17 && (len(val) == 0 || val[0] != '{') {
 			return false, nil // storage DigestFlags (1 + 16 ULID, 1-byte value) — leave
 		}
 		var u auth.AdminUser
@@ -167,8 +180,20 @@ func isAuthKey(pfx byte, key, val []byte) (bool, error) {
 		// Length-only: auth APIKeyVaultIdx is 1+vault+0x00+8 >= 10; storage VaultWeights is 1+8=9.
 		return len(key) >= prefix.MinAPIKeyVIdxLen, nil
 	case prefix.AssocWeightIndex: // old 0x14 — vaultCfg was colocated here
-		if len(key) == 41 {
-			return false, nil // storage AssocWeightIndex (41B) — leave
+		// [RT-FIX RT2] Value-shape gate. Storage AssocWeightIndex value is a
+		// fixed-width binary struct (26 bytes per encodeAssocValue; legacy
+		// 18/22/30); a vault config's value is multi-byte JSON starting with '{'.
+		// Without the value gate, a 40-char vault name (key 1+40=41B) collides
+		// with storage's 41B key and is silently orphaned at 0x14 — invisible
+		// post-migration, loses the vault's plasticity/public config.
+		//
+		// The RT brief specified `len(val) == 4`, but encodeAssocValue produces
+		// 26 bytes (the brief confused the 4-byte peakWeight/coActivationCount
+		// FIELDS for the whole value). Discriminating on the JSON marker byte
+		// is both empirically correct AND more durable — it survives future
+		// storage value-width changes without the migration being touched.
+		if len(key) == 41 && (len(val) == 0 || val[0] != '{') {
+			return false, nil // storage AssocWeightIndex (41B key, binary value) — leave
 		}
 		var c auth.VaultConfig
 		if err := json.Unmarshal(val, &c); err != nil {

--- a/internal/storage/migrate/v3_auth_prefix_relocate_test.go
+++ b/internal/storage/migrate/v3_auth_prefix_relocate_test.go
@@ -181,6 +181,93 @@ func TestRelocateAuthPrefixes_RekeysAndLeavesStorage(t *testing.T) {
 	closer.Close()
 }
 
+// TestRelocateAuthPrefixes_LengthCollisionDoesNotOrphanAuth is the RT regression
+// test for the isAuthKey length-short-circuit bug: when a real auth record's
+// KEY length happens to equal the storage family's key length on the SAME
+// prefix byte, the length-only short-circuit misclassified it as storage and
+// silently LEFT it at the old prefix (orphaned).
+//
+// Two collisions are covered:
+//
+//  1. DigestFlags @0x11: storage key is 1+16=17B; an admin with a 16-char
+//     username is 1+16=17B — same length, different value shape (storage value
+//     is 1 byte; admin JSON is multi-byte starting with '{').
+//  2. AssocWeightIndex @0x14: storage key is 41B; a vaultCfg with a 40-char
+//     vault name is 1+40=41B — same length, different value shape (storage
+//     value is 4-byte weight; vaultCfg JSON is multi-byte starting with '{').
+//
+// Post-migration the orphaned admin would be invisible to AdminExists (which
+// scans 0x42), causing Bootstrap to create default root/password — silent
+// lockout + security regression. This test would have caught both.
+func TestRelocateAuthPrefixes_LengthCollisionDoesNotOrphanAuth(t *testing.T) {
+	db := openTestDB(t)
+
+	// 16-char username admin at 0x11 — key length 1+16=17, COLLIDES with
+	// storage DigestFlags (1+16-byte ULID). The pre-fix length short-circuit
+	// returned "storage, leave it" and silently orphaned this admin.
+	const adminUser = "administrator123" // exactly 16 chars (13+3)
+	if len(adminUser) != 16 {
+		t.Fatalf("admin seed length = %d, want 16", len(adminUser))
+	}
+	adminJSON, _ := json.Marshal(auth.AdminUser{Username: adminUser, PassHash: []byte("ph")})
+	adminOldKey := append([]byte{prefix.DigestFlags}, []byte(adminUser)...)
+	if err := db.Set(adminOldKey, adminJSON, pebble.Sync); err != nil {
+		t.Fatalf("seed 16-char admin: %v", err)
+	}
+
+	// 40-char vault name vaultCfg at 0x14 — key length 1+40=41, COLLIDES with
+	// storage AssocWeightIndex (41B). Same silent-orphan failure mode.
+	const vaultName = "abcdefghijklmnopqrstuvwxyz0123456789abcd" // exactly 40 chars
+	if len(vaultName) != 40 {
+		t.Fatalf("vault name seed length = %d, want 40", len(vaultName))
+	}
+	cfgJSON, _ := json.Marshal(auth.VaultConfig{Name: vaultName})
+	cfgOldKey := append([]byte{prefix.AssocWeightIndex}, []byte(vaultName)...)
+	if err := db.Set(cfgOldKey, cfgJSON, pebble.Sync); err != nil {
+		t.Fatalf("seed 40-char vaultCfg: %v", err)
+	}
+
+	if err := RelocateAuthPrefixes(db); err != nil {
+		t.Fatalf("relocate (length-collision case): %v", err)
+	}
+
+	// The 16-char admin MUST now be at 0x42 (AdminUser) — NOT orphaned at 0x11.
+	newAdminKey := append([]byte{prefix.AdminUser}, []byte(adminUser)...)
+	v, closer, err := db.Get(newAdminKey)
+	if err != nil {
+		t.Fatalf("16-char admin NOT relocated to 0x42 (orphaned at 0x11): %v", err)
+	}
+	var u auth.AdminUser
+	if err := json.Unmarshal(v, &u); err != nil {
+		t.Fatalf("unmarshal 16-char admin: %v", err)
+	}
+	closer.Close()
+	if u.Username != adminUser {
+		t.Fatalf("admin username round-trip = %q, want %q", u.Username, adminUser)
+	}
+	if _, _, err := db.Get(adminOldKey); !errors.Is(err, pebble.ErrNotFound) {
+		t.Fatalf("16-char admin old key at 0x11 still present (expected relocated, not orphaned): %v", err)
+	}
+
+	// The 40-char vaultCfg MUST now be at 0x45 (VaultConfig) — NOT orphaned at 0x14.
+	newCfgKey := append([]byte{prefix.VaultConfig}, []byte(vaultName)...)
+	v, closer, err = db.Get(newCfgKey)
+	if err != nil {
+		t.Fatalf("40-char vaultCfg NOT relocated to 0x45 (orphaned at 0x14): %v", err)
+	}
+	var c auth.VaultConfig
+	if err := json.Unmarshal(v, &c); err != nil {
+		t.Fatalf("unmarshal 40-char vaultCfg: %v", err)
+	}
+	closer.Close()
+	if c.Name != vaultName {
+		t.Fatalf("vaultCfg name round-trip = %q, want %q", c.Name, vaultName)
+	}
+	if _, _, err := db.Get(cfgOldKey); !errors.Is(err, pebble.ErrNotFound) {
+		t.Fatalf("40-char vaultCfg old key at 0x14 still present (expected relocated, not orphaned): %v", err)
+	}
+}
+
 // TestRelocateAuthPrefixes_FailLoudOnCorruptedAuthValue proves the RT4 fail-loud
 // path: a value at 0x11 that is NOT a valid admin JSON document causes the
 // migration to return a non-nil error and refuse to silently orphan it.

--- a/internal/storage/migrate/v3_auth_prefix_relocate_test.go
+++ b/internal/storage/migrate/v3_auth_prefix_relocate_test.go
@@ -68,10 +68,12 @@ func TestRelocateAuthPrefixes_RekeysAndLeavesStorage(t *testing.T) {
 	if err := db.Set(digestKey, digestVal, pebble.Sync); err != nil {
 		t.Fatalf("seed digest: %v", err)
 	}
-	// AssocWeightIndex @0x14: 41-byte key, value containing the 0x6E756C6C "null" bits
-	// that the storage layer uses as a sentinel. The migration must not touch this.
+	// AssocWeightIndex @0x14: 41-byte key, 4-byte big-endian float32 weight
+	// (mirrors the real storage write at association.go:410-412). The migration
+	// must not touch this — a 4-byte value is structurally impossible for any
+	// vaultCfg JSON ('{"...":...}' is many B).
 	awKey := append([]byte{prefix.AssocWeightIndex}, make([]byte, 40)...)
-	awVal := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x6E, 0x75, 0x6C, 0x6C}
+	awVal := binary.BigEndian.AppendUint32([]byte{}, 0x3F800000) // 1.0f32
 	if err := db.Set(awKey, awVal, pebble.Sync); err != nil {
 		t.Fatalf("seed aw: %v", err)
 	}

--- a/internal/storage/migrate/v3_auth_prefix_relocate_test.go
+++ b/internal/storage/migrate/v3_auth_prefix_relocate_test.go
@@ -1,0 +1,248 @@
+package migrate
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/auth"
+	"github.com/scrypster/muninndb/internal/prefix"
+)
+
+// TestRelocateAuthPrefixes_RekeysAndLeavesStorage validates the four auth
+// families are re-keyed from their pre-#611 colocated prefixes (0x11–0x14)
+// onto the new dedicated auth range (0x42–0x45), while storage keys that
+// share those prefix bytes are LEFT UNCHANGED.
+//
+// The >100-record apiKey seed is load-bearing: batchSize=100, so a 150-record
+// seed forces the batch-reset path (commit at 100 → batch.Close+NewBatch →
+// accumulate 101–150 → final commit). A 1-record seed could not catch the
+// RT1 batch-reuse regression.
+func TestRelocateAuthPrefixes_RekeysAndLeavesStorage(t *testing.T) {
+	db := openTestDB(t)
+
+	// 150 apiKeys at 0x12 (old Coherence byte) — hits the batch boundary at 100.
+	for i := 0; i < 150; i++ {
+		hash := make([]byte, 16)
+		binary.BigEndian.PutUint64(hash, uint64(i))
+		apiKeyJSON, _ := json.Marshal(auth.APIKey{
+			ID:    fmt.Sprintf("k%d", i),
+			Vault: "v",
+			Mode:  auth.ModeFull,
+		})
+		oldKey := append([]byte{prefix.Coherence}, hash...)
+		if err := db.Set(oldKey, apiKeyJSON, pebble.Sync); err != nil {
+			t.Fatalf("seed apiKey %d: %v", i, err)
+		}
+	}
+
+	// admin @0x11 — Username matches the key suffix (the predicate's round-trip check).
+	adminJSON, _ := json.Marshal(auth.AdminUser{Username: "root", PassHash: []byte("ph")})
+	adminOldKey := append([]byte{prefix.DigestFlags}, []byte("root")...)
+	if err := db.Set(adminOldKey, adminJSON, pebble.Sync); err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+
+	// apiKeyVIdx @0x13 (old VaultWeights byte) — vault + 0x00 + 8-byte keyID, len >= 10.
+	vidxSuffix := []byte("vault-x\x00abcdefgh") // 17 bytes → total key len 18
+	vidxOldKey := append([]byte{prefix.VaultWeights}, vidxSuffix...)
+	if err := db.Set(vidxOldKey, []byte("idx"), pebble.Sync); err != nil {
+		t.Fatalf("seed vidx: %v", err)
+	}
+
+	// vaultCfg @0x14 (old AssocWeightIndex byte) — Name matches the key suffix.
+	cfgJSON, _ := json.Marshal(auth.VaultConfig{Name: "default"})
+	cfgOldKey := append([]byte{prefix.AssocWeightIndex}, []byte("default")...)
+	if err := db.Set(cfgOldKey, cfgJSON, pebble.Sync); err != nil {
+		t.Fatalf("seed cfg: %v", err)
+	}
+
+	// Storage keys that share the prefix ranges — MUST be LEFT UNCHANGED.
+	// DigestFlags @0x11: 17-byte key (1 + 16 ULID), 1-byte value.
+	digestKey := append([]byte{prefix.DigestFlags}, make([]byte, 16)...)
+	digestVal := []byte{0x07}
+	if err := db.Set(digestKey, digestVal, pebble.Sync); err != nil {
+		t.Fatalf("seed digest: %v", err)
+	}
+	// AssocWeightIndex @0x14: 41-byte key, value containing the 0x6E756C6C "null" bits
+	// that the storage layer uses as a sentinel. The migration must not touch this.
+	awKey := append([]byte{prefix.AssocWeightIndex}, make([]byte, 40)...)
+	awVal := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x6E, 0x75, 0x6C, 0x6C}
+	if err := db.Set(awKey, awVal, pebble.Sync); err != nil {
+		t.Fatalf("seed aw: %v", err)
+	}
+
+	if err := RelocateAuthPrefixes(db); err != nil {
+		t.Fatalf("relocate: %v", err)
+	}
+
+	// All 150 apiKeys now at 0x43 (new APIKey prefix); values intact; old keys gone.
+	for i := 0; i < 150; i++ {
+		hash := make([]byte, 16)
+		binary.BigEndian.PutUint64(hash, uint64(i))
+		oldKey := append([]byte{prefix.Coherence}, hash...)
+		newKey := append([]byte{prefix.APIKey}, hash...)
+
+		_, _, err := db.Get(oldKey)
+		if !errors.Is(err, pebble.ErrNotFound) {
+			t.Fatalf("apiKey %d: old key %x still present (err=%v)", i, oldKey, err)
+		}
+		v, closer, err := db.Get(newKey)
+		if err != nil {
+			t.Fatalf("apiKey %d: get new key: %v", i, err)
+		}
+		var parsed auth.APIKey
+		if err := json.Unmarshal(v, &parsed); err != nil {
+			t.Fatalf("apiKey %d: unmarshal: %v", i, err)
+		}
+		closer.Close()
+		if parsed.ID != fmt.Sprintf("k%d", i) {
+			t.Fatalf("apiKey %d: ID = %q, want k%d", i, parsed.ID, i)
+		}
+		if parsed.Mode != auth.ModeFull {
+			t.Fatalf("apiKey %d: Mode = %q, want %q", i, parsed.Mode, auth.ModeFull)
+		}
+	}
+
+	// admin now at 0x42; old admin key gone.
+	newAdminKey := append([]byte{prefix.AdminUser}, []byte("root")...)
+	v, closer, err := db.Get(newAdminKey)
+	if err != nil {
+		t.Fatalf("get admin at new prefix: %v", err)
+	}
+	var u auth.AdminUser
+	if err := json.Unmarshal(v, &u); err != nil {
+		t.Fatalf("unmarshal admin: %v", err)
+	}
+	closer.Close()
+	if u.Username != "root" {
+		t.Fatalf("admin username = %q, want root", u.Username)
+	}
+	_, _, err = db.Get(adminOldKey)
+	if !errors.Is(err, pebble.ErrNotFound) {
+		t.Fatalf("old admin key still present or wrong err: %v", err)
+	}
+
+	// apiKeyVIdx now at 0x44; old gone.
+	newVidxKey := append([]byte{prefix.APIKeyVaultIdx}, vidxSuffix...)
+	v, closer, err = db.Get(newVidxKey)
+	if err != nil {
+		t.Fatalf("get vidx at new prefix: %v", err)
+	}
+	if string(v) != "idx" {
+		t.Fatalf("vidx value = %q, want idx", string(v))
+	}
+	closer.Close()
+	_, _, err = db.Get(vidxOldKey)
+	if !errors.Is(err, pebble.ErrNotFound) {
+		t.Fatalf("old vidx key still present or wrong err: %v", err)
+	}
+
+	// vaultCfg now at 0x45; old gone.
+	newCfgKey := append([]byte{prefix.VaultConfig}, []byte("default")...)
+	v, closer, err = db.Get(newCfgKey)
+	if err != nil {
+		t.Fatalf("get cfg at new prefix: %v", err)
+	}
+	var c auth.VaultConfig
+	if err := json.Unmarshal(v, &c); err != nil {
+		t.Fatalf("unmarshal cfg: %v", err)
+	}
+	closer.Close()
+	if c.Name != "default" {
+		t.Fatalf("cfg name = %q, want default", c.Name)
+	}
+	_, _, err = db.Get(cfgOldKey)
+	if !errors.Is(err, pebble.ErrNotFound) {
+		t.Fatalf("old cfg key still present or wrong err: %v", err)
+	}
+
+	// Storage keys MUST be unchanged.
+	v, closer, err = db.Get(digestKey)
+	if err != nil {
+		t.Fatalf("get digest (should be unchanged): %v", err)
+	}
+	if !bytes.Equal(v, digestVal) {
+		t.Fatalf("digest value changed: got %x, want %x", v, digestVal)
+	}
+	closer.Close()
+
+	v, closer, err = db.Get(awKey)
+	if err != nil {
+		t.Fatalf("get AssocWeightIndex (should be unchanged): %v", err)
+	}
+	if !bytes.Equal(v, awVal) {
+		t.Fatalf("AssocWeightIndex value changed: got %x, want %x", v, awVal)
+	}
+	closer.Close()
+}
+
+// TestRelocateAuthPrefixes_FailLoudOnCorruptedAuthValue proves the RT4 fail-loud
+// path: a value at 0x11 that is NOT a valid admin JSON document causes the
+// migration to return a non-nil error and refuse to silently orphan it.
+// The migration version is NOT stamped 3 in this case; the operator runs
+// recovery (Task 7b), fixes the value, and re-runs.
+func TestRelocateAuthPrefixes_FailLoudOnCorruptedAuthValue(t *testing.T) {
+	db := openTestDB(t)
+	corruptKey := append([]byte{prefix.DigestFlags}, []byte("root")...)
+	if err := db.Set(corruptKey, []byte("{not json"), pebble.Sync); err != nil {
+		t.Fatalf("seed corrupt: %v", err)
+	}
+	if err := RelocateAuthPrefixes(db); err == nil {
+		t.Fatal("expected error on corrupted admin value at 0x11, got nil (silent orphan risk)")
+	}
+	// The corrupted record MUST still be at the old prefix — migration refused to touch it.
+	v, closer, err := db.Get(corruptKey)
+	if err != nil {
+		t.Fatalf("corrupt record missing after failed migration: %v", err)
+	}
+	closer.Close()
+	if string(v) != "{not json" {
+		t.Fatalf("corrupt value mutated: got %q", v)
+	}
+}
+
+// TestRelocateAuthPrefixes_Idempotent proves re-running the migration on an
+// already-migrated DB is a no-op: nothing commits, nothing breaks.
+func TestRelocateAuthPrefixes_Idempotent(t *testing.T) {
+	db := openTestDB(t)
+
+	// Seed one record per auth family, run once.
+	adminJSON, _ := json.Marshal(auth.AdminUser{Username: "root"})
+	if err := db.Set(append([]byte{prefix.DigestFlags}, []byte("root")...), adminJSON, pebble.Sync); err != nil {
+		t.Fatal(err)
+	}
+	apiKeyJSON, _ := json.Marshal(auth.APIKey{ID: "k0", Vault: "v", Mode: auth.ModeFull})
+	hash := make([]byte, 16)
+	apiKeyOldKey := append([]byte{prefix.Coherence}, hash...)
+	if err := db.Set(apiKeyOldKey, apiKeyJSON, pebble.Sync); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RelocateAuthPrefixes(db); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	// Second run: old-prefix ranges are empty; must succeed with no mutations.
+	if err := RelocateAuthPrefixes(db); err != nil {
+		t.Fatalf("second run (idempotent): %v", err)
+	}
+
+	// Records still at the new prefixes after the second run.
+	v, closer, err := db.Get(append([]byte{prefix.AdminUser}, []byte("root")...))
+	if err != nil {
+		t.Fatalf("admin missing after second run: %v", err)
+	}
+	closer.Close()
+	v, closer, err = db.Get(append([]byte{prefix.APIKey}, hash...))
+	if err != nil {
+		t.Fatalf("apiKey missing after second run: %v", err)
+	}
+	closer.Close()
+	if string(v) != string(apiKeyJSON) {
+		t.Fatalf("apiKey value mutated on idempotent re-run")
+	}
+}

--- a/internal/storage/plugin_store.go
+++ b/internal/storage/plugin_store.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/prefix"
 	"github.com/scrypster/muninndb/internal/storage/erf"
 	"github.com/scrypster/muninndb/internal/storage/keys"
 	"github.com/scrypster/muninndb/internal/types"
@@ -16,8 +17,8 @@ import (
 // missing the given digest flag bit. Engrams that have any skipFlags bit set
 // are excluded from the count (e.g. permanently-failed engrams).
 func (ps *PebbleStore) CountWithoutFlag(ctx context.Context, flag, skipFlags uint8) (int64, error) {
-	lowerBound := []byte{0x01}
-	upperBound := []byte{0x02}
+	lowerBound := []byte{prefix.Engram}
+	upperBound := []byte{prefix.Meta}
 
 	iter, err := ps.db.NewIter(&pebble.IterOptions{
 		LowerBound: lowerBound,
@@ -60,8 +61,8 @@ func (ps *PebbleStore) CountWithoutFlag(ctx context.Context, flag, skipFlags uin
 // given digest flag bit set. It scans the 0x11 DigestFlags key space directly
 // (a global key space — no vault scope needed).
 func (ps *PebbleStore) CountWithFlag(ctx context.Context, flag uint8) (int64, error) {
-	lowerBound := []byte{0x11}
-	upperBound := []byte{0x12}
+	lowerBound := []byte{prefix.DigestFlags}
+	upperBound := []byte{prefix.Coherence}
 
 	iter, err := ps.db.NewIter(&pebble.IterOptions{
 		LowerBound: lowerBound,
@@ -86,8 +87,8 @@ func (ps *PebbleStore) CountWithFlag(ctx context.Context, flag uint8) (int64, er
 // missing the given digest flag bit. Engrams that have any skipFlags bit set
 // are skipped during iteration.
 func (ps *PebbleStore) ScanWithoutFlag(ctx context.Context, flag, skipFlags uint8) *PluginEngramIterator {
-	lowerBound := []byte{0x01}
-	upperBound := []byte{0x02}
+	lowerBound := []byte{prefix.Engram}
+	upperBound := []byte{prefix.Meta}
 
 	iter, err := ps.db.NewIter(&pebble.IterOptions{
 		LowerBound: lowerBound,
@@ -204,8 +205,8 @@ func (ps *PebbleStore) UpdateEmbedding(ctx context.Context, wsPrefix [8]byte, id
 func (ps *PebbleStore) FindVaultPrefix(id ULID) ([8]byte, bool) {
 	// Build a scan: look for any key 0x01 | * | id(16)
 	// We scan the full 0x01 range and look for the id suffix.
-	lowerBound := []byte{0x01}
-	upperBound := []byte{0x02}
+	lowerBound := []byte{prefix.Engram}
+	upperBound := []byte{prefix.Meta}
 
 	iter, err := ps.db.NewIter(&pebble.IterOptions{
 		LowerBound: lowerBound,

--- a/internal/storage/prefix_lists_test.go
+++ b/internal/storage/prefix_lists_test.go
@@ -1,0 +1,257 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/prefix"
+)
+
+// === Per-list partition guards (RT-FIX RT2) ================================
+//
+// The four prefix-lists below are DIVERGENT policies (different exclusions
+// for different operational reasons), not copies of one fact. Deriving them
+// programmatically from prefix.Category would falsely claim the lists are
+// identical. Instead, each test below pins its list's actual scope by
+// asserting the bytes equal the expected const-set. A future prefix falling
+// out of one list (e.g. someone adding a new prefix to prefix.All() but
+// forgetting to add it to ClearVault's range) is caught at the list level.
+//
+// The four lists:
+//   - vaultScopedSwapPrefixes     (clone.go)   — CloneVaultData / MergeVaultData
+//   - vaultScopedExportPrefixes   (export.go)  — ExportVaultData
+//   - clearVaultDataPrefixes      (vault_lifecycle.go) — ClearVault
+//   - clearFTSKeysPrefixes        (impl.go)    — ClearFTSKeys
+
+func TestVaultScopedSwapPrefixes_Scope(t *testing.T) {
+	// clone.go's swap list: vault-scoped data prefixes CloneVaultData/MergeVaultData
+	// walk to rebuild the target vault. Omits engrams (handled separately with ERF
+	// decode/modify/encode), VaultMeta/NameIndex/DigestFlags (global), Coherence
+	// (handled separately), VaultWeights (vault-specific), Embedding/Episode/
+	// FTSVersion (added later for export-only flows), entity-graph prefixes
+	// (EntityEngramLink/Relationship/LastAccess/CoOccurrence/ArchiveAssoc/
+	// RelEntityIndex/DreamState/Lease — not part of clone's swap), and EntityReverseIndex
+	// (global by name hash).
+	want := []byte{
+		prefix.Meta, prefix.AssocFwd, prefix.AssocRev, prefix.FTSPosting,
+		prefix.Trigram, prefix.HNSWNode, prefix.FTSStats, prefix.TermStats,
+		prefix.Contradiction, prefix.StateIndex, prefix.TagIndex, prefix.CreatorIndex,
+		prefix.RelevanceBucket, prefix.AssocWeightIndex, prefix.VaultCount, prefix.Provenance,
+		prefix.BucketMigration, prefix.ContentHash,
+	}
+	assertPrefixListEqual(t, "vaultScopedSwapPrefixes", vaultScopedSwapPrefixes, want)
+}
+
+func TestVaultScopedExportPrefixes_Scope(t *testing.T) {
+	// export.go's export list: every vault-scoped prefix included in the export
+	// archive. Omits VaultMeta/NameIndex (written by WriteVaultName on import) and
+	// DigestFlags (globally keyed by ULID). Includes Coherence/VaultWeights/
+	// Embedding/Episode/FTSVersion (live data that must be transported) but NOT
+	// the entity-graph prefixes (those rebuild from engrams on import) nor Lease
+	// (work-queue checkout attribute — not transportable) nor ArchiveAssoc
+	// (soft-deleted associations — not exported).
+	want := []byte{
+		prefix.Engram, prefix.Meta, prefix.AssocFwd, prefix.AssocRev,
+		prefix.FTSPosting, prefix.Trigram, prefix.HNSWNode, prefix.FTSStats,
+		prefix.TermStats, prefix.Contradiction, prefix.StateIndex, prefix.TagIndex,
+		prefix.CreatorIndex, prefix.RelevanceBucket, prefix.Coherence, prefix.VaultWeights,
+		prefix.AssocWeightIndex, prefix.VaultCount, prefix.Provenance, prefix.BucketMigration,
+		prefix.Embedding, prefix.Episode, prefix.FTSVersion, prefix.ContentHash,
+	}
+	assertPrefixListEqual(t, "vaultScopedExportPrefixes", vaultScopedExportPrefixes, want)
+}
+
+func TestClearVaultDataPrefixes_Scope(t *testing.T) {
+	// vault_lifecycle.go's ClearVault list: every vault-scoped data prefix
+	// ClearVault range-tombstones. Omits VaultMeta/NameIndex (preserved by Clear,
+	// deleted by DeleteVaultNameOnly), DigestFlags (globally keyed by ULID —
+	// orphans acceptable), Entity records (global by hash — pruned via mention
+	// count), and EntityReverseIndex (deleted row-by-row in
+	// deleteVaultEntityReverseIndex because its layout embeds the vault prefix
+	// mid-key, so a prefix-range tombstone cannot target it).
+	want := []byte{
+		prefix.Engram, prefix.Meta, prefix.AssocFwd, prefix.AssocRev,
+		prefix.FTSPosting, prefix.Trigram, prefix.HNSWNode, prefix.FTSStats,
+		prefix.TermStats, prefix.Contradiction, prefix.StateIndex, prefix.TagIndex,
+		prefix.CreatorIndex, prefix.RelevanceBucket, prefix.Coherence, prefix.VaultWeights,
+		prefix.AssocWeightIndex, prefix.VaultCount, prefix.Provenance, prefix.BucketMigration,
+		prefix.EntityEngramLink, prefix.Relationship, prefix.LastAccess, prefix.CoOccurrence,
+		prefix.ArchiveAssoc, prefix.RelEntityIndex, prefix.DreamState, prefix.ContentHash, prefix.Lease,
+	}
+	assertPrefixListEqual(t, "clearVaultDataPrefixes", clearVaultDataPrefixes, want)
+}
+
+func TestClearFTSKeysPrefixes_Scope(t *testing.T) {
+	// impl.go's ClearFTSKeys list: the four FTS-related prefixes that must be
+	// purged when reindexing a vault's full-text search state.
+	want := []byte{
+		prefix.FTSPosting, prefix.Trigram, prefix.FTSStats, prefix.TermStats,
+	}
+	assertPrefixListEqual(t, "clearFTSKeysPrefixes", clearFTSKeysPrefixes, want)
+}
+
+func assertPrefixListEqual(t *testing.T, name string, got, want []byte) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s: length mismatch: got %d bytes % x, want %d bytes % x",
+			name, len(got), got, len(want), want)
+		return
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("%s: byte %d: got 0x%02X, want 0x%02X (full got % x, want % x)",
+				name, i, got[i], want[i], got, want)
+			return
+		}
+	}
+}
+
+// === 3-shape raw-prefix-byte lint (RT-FIX RT2 anti-recurrence guard) ======
+//
+// Scans every production .go file under internal/storage (excluding keys.go's
+// subpackage, the prefix-list decls themselves, and this lint test) for raw
+// prefix-byte literals in the three recurrence shapes:
+//
+//  1. []byte{0xNN, ...} composite literals
+//  2. x[N] = 0xNN index-assignments (the dominant pattern from the original
+//     keys.go refactor — would catch a regression that re-introduces
+//     index-byte hardcoding)
+//  3. case 0xNN: / == 0xNN / != 0xNN comparison sites
+//
+// A hit FAILS unless the byte value is outside the registered prefix ranges
+// (i.e. not a genuine prefix byte per prefix.All()). Separator/sentinel bytes
+// like 0x00, 0xFF, ERF magic bytes (0x4D/0x55/0x4E), or version-marker value
+// bytes (FTS schema version 0x01) are not registered prefixes and pass.
+//
+// Test files (_test.go) are excluded — tests legitimately use byte literals
+// for fixtures and value assertions. The per-list partition guards above
+// cover the prefix-list correctness directly.
+
+func TestNoRawPrefixBytesInStorageProduction(t *testing.T) {
+	prefixBytes := make(map[byte]string, len(prefix.All()))
+	for _, e := range prefix.All() {
+		prefixBytes[e.Byte] = e.Owner + "/" + e.Name
+	}
+
+	// Files that are allowed to contain prefix-byte literals (the registry-
+	// derived list declarations themselves).
+	excludedFiles := map[string]bool{
+		"clone.go":             true, // vaultScopedSwapPrefixes decl
+		"export.go":            true, // vaultScopedExportPrefixes decl
+		"vault_lifecycle.go":   true, // clearVaultDataPrefixes decl
+		"impl.go":              true, // clearFTSKeysPrefixes decl
+		"prefix_lists_test.go": true, // this file
+	}
+
+	// Shape regexes — match the byte literal, capture the hex value.
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`\[\]byte\{0x([0-9A-Fa-f]{2})`),     // []byte{0xNN...
+		regexp.MustCompile(`\[\d+\]\s*=\s*0x([0-9A-Fa-f]{2})`), // x[N] = 0xNN
+		regexp.MustCompile(`case\s+0x([0-9A-Fa-f]{2})\s*[:,]`), // case 0xNN: / case 0xNN,
+		regexp.MustCompile(`==\s*0x([0-9A-Fa-f]{2})\b`),        // == 0xNN
+		regexp.MustCompile(`!=\s*0x([0-9A-Fa-f]{2})\b`),        // != 0xNN
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	// Resolve the storage package directory (this test file lives there).
+	storageDir := cwd
+
+	var failures []string
+	walkErr := filepath.Walk(storageDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			// Skip subdirectories (keys/, erf/, migrate/, cache/) — they have
+			// their own scans or are out of scope for this lint.
+			if path != storageDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		base := filepath.Base(path)
+		if strings.HasSuffix(base, "_test.go") {
+			return nil
+		}
+		if excludedFiles[base] {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		lines := strings.Split(string(src), "\n")
+		for lineNo, line := range lines {
+			// Skip lines that are pure comments — they often cite byte values
+			// in documentation (e.g. "0x0E vault meta key").
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "*") {
+				continue
+			}
+			for _, rx := range patterns {
+				locs := rx.FindAllStringSubmatchIndex(line, -1)
+				for _, loc := range locs {
+					// loc[2]:loc[3] = the first capture group (hex digits).
+					hex := line[loc[2]:loc[3]]
+					var b byte
+					for _, c := range []byte(hex) {
+						b <<= 4
+						switch {
+						case c >= '0' && c <= '9':
+							b |= c - '0'
+						case c >= 'a' && c <= 'f':
+							b |= c - 'a' + 10
+						case c >= 'A' && c <= 'F':
+							b |= c - 'A' + 10
+						}
+					}
+					if owner, isPrefix := prefixBytes[b]; isPrefix {
+						failures = append(failures, sprintfRaw(
+							base, lineNo+1, b, owner, trimmed))
+					}
+				}
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk: %v", walkErr)
+	}
+	if len(failures) > 0 {
+		t.Errorf("raw prefix-byte literals in production code (use prefix.X consts):\n%s",
+			strings.Join(failures, "\n"))
+	}
+}
+
+func sprintfRaw(file string, line int, b byte, owner, src string) string {
+	return "   " + file + ":" + itoa(line) + "  byte=0x" +
+		hex2(b) + "  owner=" + owner + "  src=\"" + src + "\""
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+func hex2(b byte) string {
+	const hexdigits = "0123456789ABCDEF"
+	return string([]byte{hexdigits[b>>4], hexdigits[b&0x0F]})
+}

--- a/internal/storage/query.go
+++ b/internal/storage/query.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	"github.com/oklog/ulid/v2"
+	"github.com/scrypster/muninndb/internal/prefix"
 	"github.com/scrypster/muninndb/internal/storage/erf"
 	"github.com/scrypster/muninndb/internal/storage/keys"
 )
@@ -37,7 +38,7 @@ func (ps *PebbleStore) RecentActive(ctx context.Context, wsPrefix [8]byte, topK 
 	// Build upper bound: 0x10 | wsPrefix | 0xFF | {FF...}
 	// This keeps the scan within the wsPrefix namespace
 	upperBound := make([]byte, 1+8+1+16)
-	upperBound[0] = 0x10
+	upperBound[0] = prefix.RelevanceBucket
 	copy(upperBound[1:9], wsPrefix[:])
 	upperBound[9] = 0xFF
 	for i := 10; i < 26; i++ {
@@ -188,7 +189,7 @@ func (ps *PebbleStore) EngramsByCreatedSince(ctx context.Context, wsPrefix [8]by
 		}
 	}
 	upperKey := make([]byte, 1+8)
-	upperKey[0] = 0x01
+	upperKey[0] = prefix.Engram
 	copy(upperKey[1:9], upperWS[:])
 
 	iter, err := ps.db.NewIter(&pebble.IterOptions{
@@ -241,8 +242,8 @@ func (ps *PebbleStore) EngramsByCreatedSince(ctx context.Context, wsPrefix [8]by
 // the 0x01 key prefix. Called once at startup to seed the in-memory counter.
 func (ps *PebbleStore) CountEngrams(ctx context.Context) (int64, error) {
 	iter, err := ps.db.NewIter(&pebble.IterOptions{
-		LowerBound: []byte{0x01},
-		UpperBound: []byte{0x02},
+		LowerBound: []byte{prefix.Engram},
+		UpperBound: []byte{prefix.Meta},
 	})
 	if err != nil {
 		return 0, err
@@ -493,7 +494,7 @@ func (ps *PebbleStore) MigrateBuckets(ctx context.Context, wsPrefix [8]byte) err
 		}
 	}
 	upper := make([]byte, 1+8)
-	upper[0] = 0x02
+	upper[0] = prefix.Meta
 	copy(upper[1:9], upperWS[:])
 
 	iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
@@ -522,7 +523,7 @@ func (ps *PebbleStore) MigrateBuckets(ctx context.Context, wsPrefix [8]byte) err
 		for _, e := range chunk {
 			// Delete the specific old-scheme bucket key
 			oldKey := make([]byte, 1+8+1+16)
-			oldKey[0] = 0x10
+			oldKey[0] = prefix.RelevanceBucket
 			copy(oldKey[1:9], wsPrefix[:])
 			oldKey[9] = e.oldBucket
 			copy(oldKey[10:26], e.id[:])
@@ -603,13 +604,13 @@ func (ps *PebbleStore) LowestRelevanceIDs(ctx context.Context, wsPrefix [8]byte,
 	// Build scan bounds: 0x10 | wsPrefix | [0x00..0xFF]
 	// Lower: 0x10 | wsPrefix | 0x00 | {0...}
 	lowerBound := make([]byte, 1+8+1+16)
-	lowerBound[0] = 0x10
+	lowerBound[0] = prefix.RelevanceBucket
 	copy(lowerBound[1:9], wsPrefix[:])
 	// bucket byte and id bytes remain 0x00 — minimum key in wsPrefix bucket space
 
 	// Upper: 0x10 | wsPrefix | 0xFF | {FF...}
 	upperBound := make([]byte, 1+8+1+16)
-	upperBound[0] = 0x10
+	upperBound[0] = prefix.RelevanceBucket
 	copy(upperBound[1:9], wsPrefix[:])
 	upperBound[9] = 0xFF
 	for i := 10; i < 26; i++ {

--- a/internal/storage/vault.go
+++ b/internal/storage/vault.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/prefix"
 	"github.com/scrypster/muninndb/internal/storage/keys"
 )
 
@@ -73,8 +74,8 @@ func (ps *PebbleStore) BackfillVaultNames() error {
 	// Collect unique vault prefixes from 0x01 keys.
 	seen := make(map[[8]byte]struct{})
 	iter, err := ps.db.NewIter(&pebble.IterOptions{
-		LowerBound: []byte{0x01},
-		UpperBound: []byte{0x02},
+		LowerBound: []byte{prefix.Engram},
+		UpperBound: []byte{prefix.Meta},
 	})
 	if err != nil {
 		return err
@@ -182,8 +183,8 @@ func (ps *PebbleStore) RenameVault(ws [8]byte, oldName, newName string) error {
 // ListVaultNames scans the 0x0E prefix and returns all known vault names.
 func (ps *PebbleStore) ListVaultNames() ([]string, error) {
 	iter, err := ps.db.NewIter(&pebble.IterOptions{
-		LowerBound: []byte{0x0E},
-		UpperBound: []byte{0x0F},
+		LowerBound: []byte{prefix.VaultMeta},
+		UpperBound: []byte{prefix.VaultNameIndex},
 	})
 	if err != nil {
 		return nil, err

--- a/internal/storage/vault.go
+++ b/internal/storage/vault.go
@@ -193,7 +193,7 @@ func (ps *PebbleStore) ListVaultNames() ([]string, error) {
 
 	var names []string
 	for valid := iter.First(); valid; valid = iter.Next() {
-		if len(iter.Key()) == 9 && iter.Key()[0] == 0x0E {
+		if len(iter.Key()) == 9 && iter.Key()[0] == prefix.VaultMeta {
 			val := make([]byte, len(iter.Value()))
 			copy(val, iter.Value())
 			names = append(names, string(val))

--- a/internal/storage/vault_lifecycle.go
+++ b/internal/storage/vault_lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/prefix"
 	"github.com/scrypster/muninndb/internal/storage/keys"
 )
 
@@ -61,18 +62,13 @@ func (ps *PebbleStore) ClearVault(ctx context.Context, ws [8]byte) (int64, error
 	// Step 3: DeleteRange for all vault-scoped data prefixes.
 	// 0x0E (vault meta), 0x0F (name index), 0x11 (digest flags) are intentionally excluded.
 	dataPrefixes := []byte{
-		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-		0x09, 0x0A, 0x0B, 0x0C, 0x0D,
-		0x10, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
-		0x20, // engram entity links
-		0x21, // entity relationship records
-		0x22, // last-access index
-		0x24, // entity co-occurrence index
-		0x25, // archived association index
-		0x26, // relationship entity index
-		0x27, // dream state
-		0x28, // content-hash dedup index
-		0x2A, // ownership-lease sidecar
+		prefix.Engram, prefix.Meta, prefix.AssocFwd, prefix.AssocRev,
+		prefix.FTSPosting, prefix.Trigram, prefix.HNSWNode, prefix.FTSStats,
+		prefix.TermStats, prefix.Contradiction, prefix.StateIndex, prefix.TagIndex,
+		prefix.CreatorIndex, prefix.RelevanceBucket, prefix.Coherence, prefix.VaultWeights,
+		prefix.AssocWeightIndex, prefix.VaultCount, prefix.Provenance, prefix.BucketMigration,
+		prefix.EntityEngramLink, prefix.Relationship, prefix.LastAccess, prefix.CoOccurrence,
+		prefix.ArchiveAssoc, prefix.RelEntityIndex, prefix.DreamState, prefix.ContentHash, prefix.Lease,
 	}
 	wsPlus, err := incrementWS(ws)
 	if err != nil {
@@ -134,18 +130,18 @@ func (ps *PebbleStore) ClearVault(ctx context.Context, ws [8]byte) (int64, error
 }
 
 func (ps *PebbleStore) collectVaultEntityMentions(ws [8]byte) (map[string]int, error) {
-	prefix := make([]byte, 9)
-	prefix[0] = 0x20
-	copy(prefix[1:], ws[:])
+	prefixPre := make([]byte, 9)
+	prefixPre[0] = prefix.EntityEngramLink
+	copy(prefixPre[1:], ws[:])
 	wsPlus, err := incrementWS(ws)
 	if err != nil {
 		return nil, err
 	}
 	upperBound := make([]byte, 9)
-	upperBound[0] = 0x20
+	upperBound[0] = prefix.EntityEngramLink
 	copy(upperBound[1:], wsPlus[:])
 
-	iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upperBound})
+	iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: prefixPre, UpperBound: upperBound})
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +162,8 @@ func (ps *PebbleStore) collectVaultEntityMentions(ws [8]byte) (map[string]int, e
 
 func (ps *PebbleStore) deleteVaultEntityReverseIndex(batch *pebble.Batch, ws [8]byte) error {
 	iter, err := ps.db.NewIter(&pebble.IterOptions{
-		LowerBound: []byte{0x23},
-		UpperBound: []byte{0x24},
+		LowerBound: []byte{prefix.EntityReverseIndex},
+		UpperBound: []byte{prefix.CoOccurrence},
 	})
 	if err != nil {
 		return err

--- a/internal/storage/vault_lifecycle.go
+++ b/internal/storage/vault_lifecycle.go
@@ -10,6 +10,26 @@ import (
 	"github.com/scrypster/muninndb/internal/storage/keys"
 )
 
+// clearVaultDataPrefixes lists every vault-scoped data prefix that ClearVault
+// deletes via range tombstones. It is hoisted to package scope so that the
+// per-list partition guard (TestClearVaultDataPrefixes_Scope) can pin its
+// membership directly.
+//
+// 0x0E (vault meta key), 0x0F (name index), 0x11 (digest flags), 0x1F (entity
+// records) are intentionally excluded — they are global or name keys cleared
+// separately by DeleteVaultNameOnly / entity prune. 0x23 (entity reverse index)
+// is deleted row-by-row in deleteVaultEntityReverseIndex (the row layout embeds
+// the vault prefix mid-key, so a prefix-range tombstone cannot target it).
+var clearVaultDataPrefixes = []byte{
+	prefix.Engram, prefix.Meta, prefix.AssocFwd, prefix.AssocRev,
+	prefix.FTSPosting, prefix.Trigram, prefix.HNSWNode, prefix.FTSStats,
+	prefix.TermStats, prefix.Contradiction, prefix.StateIndex, prefix.TagIndex,
+	prefix.CreatorIndex, prefix.RelevanceBucket, prefix.Coherence, prefix.VaultWeights,
+	prefix.AssocWeightIndex, prefix.VaultCount, prefix.Provenance, prefix.BucketMigration,
+	prefix.EntityEngramLink, prefix.Relationship, prefix.LastAccess, prefix.CoOccurrence,
+	prefix.ArchiveAssoc, prefix.RelEntityIndex, prefix.DreamState, prefix.ContentHash, prefix.Lease,
+}
+
 // ClearVault deletes all data keys for a vault using Pebble range tombstones.
 // The vault name registration (0x0E, 0x0F) is preserved — use DeleteVaultNameOnly
 // to remove those after clearing.
@@ -61,15 +81,7 @@ func (ps *PebbleStore) ClearVault(ctx context.Context, ws [8]byte) (int64, error
 
 	// Step 3: DeleteRange for all vault-scoped data prefixes.
 	// 0x0E (vault meta), 0x0F (name index), 0x11 (digest flags) are intentionally excluded.
-	dataPrefixes := []byte{
-		prefix.Engram, prefix.Meta, prefix.AssocFwd, prefix.AssocRev,
-		prefix.FTSPosting, prefix.Trigram, prefix.HNSWNode, prefix.FTSStats,
-		prefix.TermStats, prefix.Contradiction, prefix.StateIndex, prefix.TagIndex,
-		prefix.CreatorIndex, prefix.RelevanceBucket, prefix.Coherence, prefix.VaultWeights,
-		prefix.AssocWeightIndex, prefix.VaultCount, prefix.Provenance, prefix.BucketMigration,
-		prefix.EntityEngramLink, prefix.Relationship, prefix.LastAccess, prefix.CoOccurrence,
-		prefix.ArchiveAssoc, prefix.RelEntityIndex, prefix.DreamState, prefix.ContentHash, prefix.Lease,
-	}
+	dataPrefixes := clearVaultDataPrefixes
 	wsPlus, err := incrementWS(ws)
 	if err != nil {
 		return 0, fmt.Errorf("clear vault: %w", err)

--- a/internal/storage/vault_lifecycle_test.go
+++ b/internal/storage/vault_lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/prefix"
 	"github.com/scrypster/muninndb/internal/storage/keys"
 )
 
@@ -149,7 +150,7 @@ func TestClearVault_RemovesEntityGraphForVault(t *testing.T) {
 		t.Fatalf("ClearVault: %v", err)
 	}
 
-	for _, p := range []byte{0x20, 0x21, 0x24, 0x26} {
+	for _, p := range []byte{prefix.EntityEngramLink, prefix.Relationship, prefix.CoOccurrence, prefix.RelEntityIndex} {
 		assertNoVaultPrefixKeys(t, store, p, wsA)
 	}
 	assertNoEntityReverseIndexKeysForVault(t, store, wsA)

--- a/muninn.go
+++ b/muninn.go
@@ -92,16 +92,7 @@ func Open(dataDir string, opts ...func(*Options)) (*DB, error) {
 	}
 
 	migRunner := migrate.NewRunner(rawDB)
-	migRunner.Register(migrate.Migration{
-		Version:     1,
-		Description: "backfill embed_dim in ERF records for existing embeddings",
-		Up:          migrate.BackfillEmbedDim,
-	})
-	migRunner.Register(migrate.Migration{
-		Version:     2,
-		Description: "backfill relationship entity index (0x26) for GetEntityAggregate optimisation",
-		Up:          migrate.BackfillRelEntityIndex,
-	})
+	migrate.RegisterMigrations(migRunner)
 	if _, err := migRunner.Run(); err != nil {
 		_ = rawDB.Close()
 		return nil, fmt.Errorf("muninndb: migration: %w", err)


### PR DESCRIPTION
## Summary

Fixes the storage/auth Pebble prefix overlap (#611) — a **4-pair collision** (auth `0x11–0x14` vs storage `0x11–0x14`) causing three live bugs:

- **Bootstrap lockout** — `AdminExists` scans `[0x11,0x12)`; storage `DigestFlags` keys fool it → root admin never created.
- **Silent miscount** — `CountWithFlag` counts admin JSON as flagged engrams.
- **Startup perf cliff** — `ListVaultConfigs` scans `[0x14,0x15)` = the entire `AssocWeightIndex` range.

## What ships

- **Relocate auth** `0x11–0x14` → `0x42–0x45` (storage unchanged; capability already at `0x40/0x41`). `0x42–0x45` is free (storage tops at `0x2A`).
- **`internal/prefix` registry** — single source of truth (47 prefix bytes + 3 length-invariants); storage's ~40 inline literals + all ~49 raw-byte caller sites (3 shapes: composite, index-assignment, comparison/switch) source from it; a 3-shape lint + per-list partition guards + a const↔slice completeness test enforce it. (Scoped honestly: *reduces* byte-collision recurrence — replication's `0x19` allocation still bypasses it, flagged as a follow-up.)
- **`v3` migration `RelocateAuthPrefixes`** — re-keys existing on-disk auth records. Load-bearing (without it, every upgraded instance loses its admin). v2-correct batch idiom (`Close`+`NewBatch` per commit); **fail-loud** on a corrupted auth value (version NOT stamped → operator fixes + re-runs); idempotent. Per-prefix discriminator: key-length for `0x12/0x13`, value-length-gated JSON name-round-trip for `0x11/0x14` (a 1-byte DigestFlags / 4-byte AssocWeightIndex value can't be auth JSON).
- **Refuse-newer guard** — `Runner.Run` errors if the stored migration version exceeds the max the binary registered (closes the silent-skip downgrade hazard; note: doesn't cover the cluster rolling-upgrade window — documented).
- **`--force-migration-rerun` recovery flag** — operator recovery from a wedged/partial migration (resets the version; refuses if the DB is from a newer binary).
- **`RegisterMigrations` helper** — registers v1+v2+v3 in ONE place, called from both `muninn.Open` + `runServer` (structurally eliminates the drift that caused this bug).
- **Lockout regression test** — 5 assertions over real `auth.Store` + `storage.PebbleStore` (mock-free): AdminExists-false-despite-digest-flags → Bootstrap → login → CountWithFlag==N → ListVaultConfigs==0.

## RedTeam-driven hardening

This was RedTeam'd twice (design + implementation, 32 agents each). The implementation pass caught a critical silent-orphan in the discriminator's length short-circuit (a 16-char username / 40-char vault name collides with the storage key length) — fixed with the value-length gate (`len(val)==1`/`==4`) + a regression test.

## Testing

- `go build ./...`, `go vet ./...`, `go test -race ./...` (all packages), binary smoke — green.
- New: registry disjointness + const-completeness + per-constructor byte tests + per-list partition guards + 3-shape raw-byte lint + refuse-newer + recovery + v3 migration (incl. >100-record batch-boundary + 16/40-char collision + fail-loud + idempotent) + lockout regression.

## Notes

- Parallel to PR #617 (inc-3) — this touches `internal/prefix`, `internal/storage`, `internal/auth`, `internal/storage/migrate`; #617 touches `internal/mcp`. Disjoint.
- 11 commits, ordered: C1 (behavior-noop refactor: registry + storage/keys + caller sites + guards/lint) then C2 (behavior change: auth relocate + refuse-newer + v3 + recovery + register + lockout test).

Closes #611.
