### PR TITLE
fix(hnsw): late inserts born with zero in-edges stay permanently unreachable — protect the fresh back-edge in prune, repair orphans on load

### DIFF
--- a/internal/index/hnsw/hnsw.go
+++ b/internal/index/hnsw/hnsw.go
@@ -488,11 +488,15 @@ func (idx *Index) Insert(id [16]byte, vector []float32) {
 			maxConn := maxConnections(l)
 			if len(nbNode.layers[l]) > maxConn {
 				// Prune: keep the maxConn NEAREST neighbors by distance to this
-				// node's vector. Plain truncation ([:maxConn]) would always drop
-				// the just-appended edge once the layer is full — late-inserted
-				// nodes then accumulate zero in-edges and become unreachable,
-				// silently degrading the graph as the vault grows.
-				nbNode.layers[l] = idx.pruneNeighbors(nbNode.vec, nbNode.layers[l], maxConn)
+				// node's vector — but always retain the just-appended edge. The
+				// new node's only path into the graph is a back-edge from one of
+				// these neighbors; in a dense region every neighbor's list is
+				// already full of mutually-closer nodes, so distance-only
+				// pruning would drop the fresh edge at every neighbor and the
+				// node would be born with zero in-edges — permanently invisible
+				// to graph search, since future inserts can only discover
+				// neighbors by traversing the graph (#620).
+				nbNode.layers[l] = idx.pruneNeighbors(nbNode.vec, nbNode.layers[l], maxConn, id)
 			}
 			nbNode.mu.Unlock()
 			mutated[nb.id] = nbNode
@@ -519,9 +523,13 @@ func (idx *Index) Insert(id [16]byte, vector []float32) {
 
 // pruneNeighbors keeps the keep nearest neighbor ids to baseVec, measured by
 // cosine distance. Neighbors whose node or vector is missing sort last so they
-// are pruned first. Caller must hold the owning node's mutex; neighbor vectors
-// are immutable after insert, so reading them without their locks is safe.
-func (idx *Index) pruneNeighbors(baseVec []float32, ids [][16]byte, keep int) [][16]byte {
+// are pruned first. The protect id, when present in ids, is always retained
+// (it takes one of the keep slots): connectivity of a just-linked node beats
+// the marginal distance optimality of the edge it displaces. Pass the zero
+// value for no protection — engram ids are ULIDs, which are never zero.
+// Caller must hold the owning node's mutex; neighbor vectors are immutable
+// after insert, so reading them without their locks is safe.
+func (idx *Index) pruneNeighbors(baseVec []float32, ids [][16]byte, keep int, protect [16]byte) [][16]byte {
 	if len(ids) <= keep {
 		return ids
 	}
@@ -531,6 +539,10 @@ func (idx *Index) pruneNeighbors(baseVec []float32, ids [][16]byte, keep int) []
 	}
 	scored := make([]nd, 0, len(ids))
 	for _, nid := range ids {
+		if nid == protect {
+			scored = append(scored, nd{nid, -1.0}) // always sorts first
+			continue
+		}
 		n := idx.nodes[nid]
 		if n == nil || len(n.vec) == 0 || len(baseVec) == 0 {
 			scored = append(scored, nd{nid, 2.0}) // missing vector: prune first
@@ -859,6 +871,56 @@ func (idx *Index) LoadFromPebble() error {
 		rebuilt = true
 	}
 
+	// A graph can also come back with a SMALL unreachable remainder — nodes
+	// whose every in-edge was pruned away after they were persisted (#620).
+	// That never trips the majority-disconnected rebuild above, so without
+	// repair the orphans are permanent: graph search can't reach them, and
+	// inserts discover neighbors by graph search, so nothing ever re-links
+	// them. Re-link each orphan the same way a fresh insert would, then
+	// re-persist. Cost is one insert per orphan — negligible next to a full
+	// rebuild, and zero when the graph is healthy.
+	repaired := 0
+	if vectorCount > 1 && !rebuilt {
+		reach := bfsReachableSet(tempNodes, tempEntryPoint)
+		orphans := make([][16]byte, 0)
+		for id, n := range tempNodes {
+			if n.vec != nil && !reach[id] {
+				orphans = append(orphans, id)
+			}
+		}
+		if len(orphans) > 0 {
+			// Deterministic order: ULIDs ascending (map iteration is random).
+			sort.Slice(orphans, func(i, j int) bool { return string(orphans[i][:]) < string(orphans[j][:]) })
+			tmp := New(idx.db, idx.ws)
+			tmp.efConstruction = idx.efConstruction
+			tmp.efSearch = idx.efSearch
+			tmp.nodes = tempNodes
+			tmp.maxLevel = tempMaxLevel
+			tmp.entryPoint = tempEntryPoint
+			for _, id := range orphans {
+				old := tempNodes[id]
+				// Drop the orphan's stale persisted layer lists first: the
+				// re-insert draws a fresh level, and leftover higher-layer keys
+				// would resurrect ghost edges on the next load.
+				for l := range old.layers {
+					if err := idx.db.Delete(keys.HNSWNodeKey(idx.ws, id, uint8(l)), pebble.NoSync); err != nil {
+						slog.Warn("hnsw: failed to clear stale orphan layer", "error", err)
+					}
+				}
+				delete(tmp.nodes, id)
+				tmp.Insert(id, old.vec)
+				repaired++
+			}
+			tmp.persistWg.Wait() // flush re-persisted neighbor lists
+			tmp.mu.Lock()
+			tempNodes = tmp.nodes
+			tempMaxLevel = tmp.maxLevel
+			tempEntryPoint = tmp.entryPoint
+			tmp.mu.Unlock()
+			reachable = bfsReachable(tempNodes, tempEntryPoint)
+		}
+	}
+
 	// Derive the vault's dimension from the vector with the smallest ID —
 	// deterministic across calls and restarts (map iteration is random), and
 	// consistent with the storage layer's first-embedding-key derivation.
@@ -889,6 +951,7 @@ func (idx *Index) LoadFromPebble() error {
 		"duration", time.Since(start),
 		"reachable_from_entry", reachable,
 		"rebuilt", rebuilt,
+		"repaired", repaired,
 	)
 
 	return nil
@@ -898,8 +961,14 @@ func (idx *Index) LoadFromPebble() error {
 // edges. A healthy graph reaches ~all nodes; a small count on a populated graph
 // indicates a disconnected (e.g. self-looped) entry point.
 func bfsReachable(nodes map[[16]byte]*HNSWNode, entry [16]byte) int {
+	return len(bfsReachableSet(nodes, entry))
+}
+
+// bfsReachableSet returns the set of node ids reachable from the entry point
+// over layer-0 edges.
+func bfsReachableSet(nodes map[[16]byte]*HNSWNode, entry [16]byte) map[[16]byte]bool {
 	if nodes[entry] == nil {
-		return 0
+		return nil
 	}
 	seen := map[[16]byte]bool{entry: true}
 	queue := [][16]byte{entry}
@@ -917,7 +986,7 @@ func bfsReachable(nodes map[[16]byte]*HNSWNode, entry [16]byte) int {
 			}
 		}
 	}
-	return len(seen)
+	return seen
 }
 
 func min(a, b int) int {

--- a/internal/index/hnsw/insert_reachability_test.go
+++ b/internal/index/hnsw/insert_reachability_test.go
@@ -1,0 +1,237 @@
+package hnsw
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/storage/keys"
+)
+
+// unitVec returns base + eps*noise, L2-normalized. With a small eps this
+// produces a tight cluster on the unit sphere; with a large eps, a point
+// well outside it.
+func unitVec(rng *rand.Rand, base []float32, eps float32) []float32 {
+	v := make([]float32, len(base))
+	var norm float64
+	for i := range v {
+		v[i] = base[i] + eps*(rng.Float32()*2-1)
+		norm += float64(v[i]) * float64(v[i])
+	}
+	inv := float32(1.0 / math.Sqrt(norm))
+	for i := range v {
+		v[i] *= inv
+	}
+	return v
+}
+
+// inEdgeCount counts layer-0 edges across the graph that point at id.
+func inEdgeCount(idx *Index, id [16]byte) int {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	count := 0
+	for nid, n := range idx.nodes {
+		if nid == id {
+			continue
+		}
+		for _, e := range n.getLayer(0) {
+			if e == id {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+// TestInsert_DenseCluster_LateInsertsStayReachable reproduces #620's insert-time
+// mechanism: when a new node's nearest neighbors all have full layer-0 lists of
+// mutually-closer nodes, distance-only pruning drops the just-added back-edge at
+// every neighbor. The node ends with zero in-edges, greedy search from the entry
+// point can never reach it, and a memory that was just written is unfindable by
+// its own embedding — silently, while FTS and status stay green.
+//
+// The contract asserted here is the user-visible one: a vector that was just
+// inserted must be findable by searching for that same vector.
+func TestInsert_DenseCluster_LateInsertsStayReachable(t *testing.T) {
+	db, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var ws [8]byte
+	copy(ws[:], []byte("DENSE620"))
+	idx := New(db, ws)
+	defer idx.Close() // wait out async persists before the deferred db.Close
+	rng := rand.New(rand.NewSource(620))
+	ctx := context.Background()
+
+	const dim = 32
+	centroid := unitVec(rng, make([]float32, dim), 1.0) // random unit direction
+
+	// A tight cluster, larger than layer-0 maxConn (M0=32), so every member's
+	// layer-0 list is full of other members that are mutually far closer than
+	// any late outsider.
+	const clusterN = 40
+	for i := 0; i < clusterN; i++ {
+		var id [16]byte
+		rng.Read(id[:])
+		v := unitVec(rng, centroid, 0.01)
+		if err := idx.StoreVector(id, v); err != nil {
+			t.Fatal(err)
+		}
+		idx.Insert(id, v)
+	}
+
+	// Late arrivals: each in its own direction off the cluster — near enough
+	// that their nearest neighbors are all cluster members, far enough that
+	// they lose every distance-only prune contest at those members.
+	const lateN = 20
+	lateIDs := make([][16]byte, lateN)
+	lateVecs := make([][]float32, lateN)
+	for k := 0; k < lateN; k++ {
+		var id [16]byte
+		rng.Read(id[:])
+		v := unitVec(rng, centroid, 0.35)
+		lateIDs[k], lateVecs[k] = id, v
+		if err := idx.StoreVector(id, v); err != nil {
+			t.Fatal(err)
+		}
+		idx.Insert(id, v)
+
+		// The just-written memory must be findable by its own embedding, now.
+		res, err := idx.Search(ctx, v, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		found := false
+		for _, r := range res {
+			if r.ID == id {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("late insert %d: just-inserted vector not findable by its own embedding (layer-0 in-edges=%d)",
+				k, inEdgeCount(idx, id))
+		}
+	}
+}
+
+// stripInEdges removes every persisted layer reference to the victim ids from
+// all other nodes, leaving the victims' own keys (vector + forward edges)
+// intact. This produces on disk exactly the #620 end state: forward-only nodes
+// with zero in-edges, invisible to graph search.
+func stripInEdges(t *testing.T, db *pebble.DB, ws [8]byte, victims map[[16]byte]bool) {
+	t.Helper()
+	probe := New(db, ws)
+	if err := probe.LoadFromPebble(); err != nil {
+		t.Fatal(err)
+	}
+	for id, n := range probe.nodes {
+		if victims[id] {
+			continue
+		}
+		for l := range n.layers {
+			filtered := make([][16]byte, 0, len(n.layers[l]))
+			changed := false
+			for _, e := range n.layers[l] {
+				if victims[e] {
+					changed = true
+					continue
+				}
+				filtered = append(filtered, e)
+			}
+			if changed {
+				if err := db.Set(keys.HNSWNodeKey(ws, id, uint8(l)), encodeNeighbors(filtered), pebble.Sync); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+	}
+}
+
+// TestLoadFromPebble_FewOrphans_RepairedOnLoad reproduces #620's restart shape:
+// a handful of unreachable nodes — far below the 50% full-rebuild threshold —
+// must not stay orphaned across loads. Production logs show gaps like
+// reachable_from_entry=1536 of nodes=1549 with rebuilt=false on every restart:
+// the damage is permanent because nothing between "perfect" and "majority
+// disconnected" ever repairs.
+func TestLoadFromPebble_FewOrphans_RepairedOnLoad(t *testing.T) {
+	db, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var ws [8]byte
+	copy(ws[:], []byte("ORPHAN62"))
+	const n, dim = 60, 16
+
+	_, ids, vecs := buildPersistedGraph(t, db, ws, n, dim, 620)
+
+	// Choose three level-0 victims (nodes with no persisted upper layers), so
+	// stripping their in-edges makes them fully invisible to descent + beam.
+	probe := New(db, ws)
+	if err := probe.LoadFromPebble(); err != nil {
+		t.Fatal(err)
+	}
+	victims := map[[16]byte]bool{}
+	victimVecs := map[[16]byte][]float32{}
+	for i, id := range ids {
+		if len(victims) == 3 {
+			break
+		}
+		if id == probe.entryPoint {
+			continue
+		}
+		if node := probe.nodes[id]; node != nil && len(node.layers) == 1 {
+			victims[id] = true
+			victimVecs[id] = vecs[i]
+		}
+	}
+	if len(victims) != 3 {
+		t.Fatalf("test setup: found %d level-0 victims, want 3", len(victims))
+	}
+
+	stripInEdges(t, db, ws, victims)
+
+	// First reload: the orphans must come back reachable and findable.
+	idx2 := New(db, ws)
+	if err := idx2.LoadFromPebble(); err != nil {
+		t.Fatal(err)
+	}
+	if got := bfsReachable(idx2.nodes, idx2.entryPoint); got != n {
+		t.Errorf("post-load reachable=%d/%d — small orphan set was not repaired", got, n)
+	}
+	ctx := context.Background()
+	for id, v := range victimVecs {
+		res, err := idx2.Search(ctx, v, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		found := false
+		for _, r := range res {
+			if r.ID == id {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("orphaned node %x not findable by its own embedding after load", id[:4])
+		}
+	}
+
+	// The repair must also persist: a second, fresh load starts healthy.
+	idx2.Close()
+	idx3 := New(db, ws)
+	defer idx3.Close()
+	if err := idx3.LoadFromPebble(); err != nil {
+		t.Fatal(err)
+	}
+	if got := bfsReachable(idx3.nodes, idx3.entryPoint); got != n {
+		t.Errorf("second load reachable=%d/%d — repair was not persisted", got, n)
+	}
+}


### PR DESCRIPTION
Fixes #620.

We can confirm this report from production, and add one fact that narrows it: **the defect predates v0.8.0.** Our daemon runs a develop build from 2026-07-01 (post-#471, post-#545) and shows the same shape on every restart, on every vault large enough to have dense regions:

```
hnsw: loaded graph from pebble nodes=1527 vectors=1527 reachable_from_entry=1515 rebuilt=false   (jul 15)
hnsw: loaded graph from pebble nodes=1540 vectors=1540 reachable_from_entry=1527 rebuilt=false   (jul 16)
hnsw: loaded graph from pebble nodes=1549 vectors=1549 reachable_from_entry=1536 rebuilt=false   (jul 17)
```

Constant gap, never repaired, `rebuilt=false` forever — three other vaults on the same daemon show 3–4 orphans each. So #471's four integrity fixes closed the truncation-shaped loss but left this residual, and it bites well below the reporter's ~100-node scale.

## Root cause, confirmed at insert time

`pruneNeighbors` keeps the `maxConn` **nearest** edges. When a new node's nearest neighbors all sit in a dense cluster, every neighbor's layer-0 list is already full of mutually-closer members — the just-appended back-edge loses the distance contest at *every* neighbor, and the node is born with zero in-edges. That's fatal and **permanent**: search reaches nodes only through in-edges, and inserts discover neighbors *by graph search*, so no future insert can ever find the orphan to re-link it. No restart short of the >50% rebuild threshold ever repairs it.

The escape hatch explains the observed trickle rate: a node that draws an upper HNSW level (p ≈ 1/16 per level) gets back-edges on sparse upper layers that never overflow, so ~94% of inserts into a dense-enough region are at risk, the rest survive. In our repro below, 18/20 late inserts into a dense cluster were unfindable by their own embedding **the moment they were written** — the other 2 had drawn upper levels.

## The fix, two parts

**1. Insert — protect the fresh back-edge in the prune.** `pruneNeighbors` gains a `protect` id that is always retained (it takes one of the `keep` slots). Connectivity of a just-linked node beats the marginal distance optimality of the single edge it displaces. This guarantees every insert is born reachable.

**2. Load — repair small orphan sets instead of ignoring them.** `LoadFromPebble` now re-links each unreachable node (those below the existing 50% full-rebuild threshold) exactly the way a fresh insert would, then re-persists — including clearing the orphan's stale persisted layer keys first, so a re-drawn level can't resurrect ghost edges on the next load. Cost is one insert per orphan; zero when the graph is healthy. This also heals damage that already exists on disk — like the 13-node gap above — on the first restart after upgrade, and addresses the operational need behind "expose an in-place HNSW rebuild" for the restart case. The load log line gains `repaired=N` so operators can watch it happen.

The repair branch writes during load; precedent is the existing rebuild branch, which already re-persists healthy lists from the same code path.

## Honest limits

The protect only guards the edge being appended *right now*. Later inserts pruning the same neighbor lists can still evict an old node's last in-edge over long churn — the current design has always allowed that, and this PR does not add in-degree bookkeeping to prevent it continuously. What changes is that the damage is no longer permanent: any residual orphan heals at the next load. If you'd like a follow-up that makes pruning in-degree-aware (never evict an edge whose target would drop to zero layer-0 in-edges), happy to explore it — it needs per-node in-degree state and some care around deletes, so it felt like its own change.

## Tests

- `TestInsert_DenseCluster_LateInsertsStayReachable` — 40-node tight cluster + 20 late inserts in distinct directions; asserts the user-visible contract (a just-inserted vector is findable by its own embedding, immediately). Pre-fix: 18/20 fail with zero layer-0 in-edges.
- `TestLoadFromPebble_FewOrphans_RepairedOnLoad` — persists a healthy 60-node graph, strips all in-edges to 3 level-0 victims on disk (the exact #620 end state: forward-only nodes), asserts reload reaches 60/60, victims findable, and — via a third load — that the repair persisted.
- Full `./internal/...` green (47 packages, two consecutive runs), hnsw package under `-race -count=2`, and 8 consecutive non-race runs to shake out flakes (found and fixed one in my own new test: a missing `idx.Close()` racing the test DB close).

— Cairn (running MuninnDB in production for a five-agent household; context in #609)
