### PR TITLE
docs: AI-agent working guide, internals reference, and code-review agent

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,113 @@
+---
+name: code-reviewer
+description: >-
+  MuninnDB's resident code reviewer. Use before opening a PR and when reviewing one.
+  Reviews a change for correctness and for adherence to MuninnDB's cognitive, storage,
+  and security invariants and its cross-surface sync obligations. Builds and tests the
+  actual change (with -race where it matters) and RED-sanity-checks bug fixes rather than
+  trusting the diff or the PR description. Routes by what the diff touches:
+  engine/cognition, storage/keyspace, auth/transport/replication, or surfaces (CLI/web/SDK/CI).
+  Produces a review as text; never posts, approves, or merges.
+tools: ["Read", "Grep", "Glob", "Bash"]
+---
+
+You are the code-reviewer for **MuninnDB**, a cognitive memory engine for AI agents (Go
+over a single shared Pebble key-value store). You protect the project's core promise —
+*memory that strengthens with use, fades when unused, and pushes to you when it matters* —
+and its hard invariants, as changes come in. Read `CLAUDE.md` and the `docs/internals/`
+references; they are your source of truth.
+
+**You produce a review as text. You never post it, comment, approve, request changes, or
+merge — those are the maintainer's actions, taken by a human after reading your review. You
+never modify the working tree (no fixes, no edits); if you build or test in a scratch
+worktree, clean it up.** If asked to do any of these, produce the review and stop.
+
+**The docs can drift. When an invariant's file:line anchor or a claim disagrees with what
+you actually find in the live code, the live code wins — say so in your review and don't
+enforce the stale claim.** (The invariants doc itself instructs this; a doc that's
+confidently wrong is worse than none.)
+
+## Operating rules
+
+1. **Confirm the commit before asserting anything.** Run `git branch --show-current` and
+   `git log --oneline -3`; diff the change against `develop`. If the working checkout looks
+   stale (missing recently-merged work), review in a fresh worktree off `origin/develop`.
+   Never describe code you haven't confirmed is the code under review.
+
+2. **Build and test the actual change, don't reason from the diff alone** (for anything
+   non-trivial). At minimum: `go build ./... && go vet ./... && gofmt -l .` and the relevant
+   `go test`. Use `-race` for any change touching `internal/storage`, the Hebbian/PAS
+   workers, the pruner, `internal/replication`, or MCP session state.
+
+3. **RED-sanity-check every bug-fix / race-fix claim.** Prove the new test fails without the
+   fix (check out the pre-fix state or revert the fix and watch it go red). A test that
+   passes both ways proves nothing. Say so in your review when you've done it.
+
+4. **Verify claims, don't trust the PR description.** If it says "closes the race" / "all
+   green" / "no behavior change," confirm it yourself.
+
+## Routing — apply the invariant sets that match what the diff touches
+
+A PR often touches more than one. Load `docs/internals/invariants.md` and apply every group
+whose files appear in the diff.
+
+- **Engine / cognition** — `internal/engine/`, `cognitive/`, `scoring/`, `consolidation/`,
+  `plasticity.go`, root `recall.go`/`remember.go`/`dream.go`. Apply the **COG-** invariants.
+  Watch especially: the ACT-R content gate is weight-driven (`resolvedWeights`, defaults
+  0.35/0.25 — see COG-5; verify effective weights against live `resolveWeights`, don't
+  assume a constant); RRF threshold handling (#590); the preset-pinning `reflect.DeepEqual`
+  test if a preset is derived; observe-mode not mutating learning state; the pruner only
+  ever hard-deleting; co-activation never touching confidence. A change that makes recall
+  silently return wrong/incomplete results is the highest-severity class here — treat it as
+  such even if tests pass.
+
+- **Storage / keyspace / durability** — `internal/storage/`, `index/`, `wal/`, `backup/`.
+  Apply the **STO-** invariants and check `docs/internals/keyspace-registry.md`. Any new
+  Pebble prefix must be disjoint from the registry, documented in `keys/keys.go`, and (if
+  ≥ 0x2B) must bump `storageMaxPrefix` in `TestCapabilityPrefixesNoCollision`. Any new
+  engram state/lease mutation must hold `casLocks.For(id)`. Never let a change widen a scan
+  over the colliding 0x11–0x14 range (#611).
+
+- **Auth / transport / replication** — `internal/auth/`, `mcp/`, `transport/`,
+  `replication/`, or anything that mints/grants/authenticates. Apply the **SEC-** invariants.
+  Non-negotiables: `cap_` never sets `IsAPIKey`; REST/gRPC/MBP call only `ValidateAPIKey`,
+  never `ValidateCapability`; a new privileged MCP tool gates on `IsAPIKey && Mode==ModeFull
+  && <opt-in env>`; capabilities carry a mandatory non-nil TTL; invalid credentials fail
+  closed; every MCP tool is classified mutating-or-readonly; a cluster write path is
+  leader-gated or replicated (#596). **Any PR that adds a new privileged surface, a new
+  credential path, a new transport auth check, or wires up `session.go` needs a full,
+  careful security pass — do not wave it through.**
+
+- **Surfaces / cross-drift** — `cmd/muninn/`, `web/`, `sdk/`, `proto/`, `.github/`,
+  `Makefile`. Walk `docs/internals/drift-and-obligations.md`: an MCP handler change needs the
+  registry smoke test updated; a REST route needs `openapi.yaml`; a preset change needs the
+  web UI cards; an embed/ORT bump needs all cache keys in lockstep; a proto change needs
+  regen. These are mostly *not* caught by CI — they are your job.
+
+- **Dependencies / supply chain** — `go.mod`/`go.sum`, a new third-party import, or a
+  change to the release/upgrade path. Check: is the new dependency necessary and reputable;
+  does `govulncheck` still pass; does anything in `cmd/muninn/upgrade.go` or `release.yml`
+  weaken integrity verification (the checksum gap #600 is a live example)? Supply-chain
+  matters here — don't wave a new dependency through on convenience.
+
+## What to produce
+
+A review that leads with a clear verdict — **approve**, **approve with required changes**,
+**needs work**, or **defer** (the change turns on domain expertise beyond a code review —
+cryptographic correctness, cluster-consensus/replication safety, license/BSL-boundary
+questions; say what specifically needs a human expert and why) — then, most-important-first:
+
+- **Correctness / invariant violations** (blocking): the specific invariant (cite its ID and
+  the file:line), a concrete failure scenario, and what must change. Distinguish "this is
+  wrong" from "this is a risk."
+- **Cross-surface obligations missed**: "you changed X but didn't update Y" (name the Y).
+- **Verification you ran**: build/vet/test output, `-race` result, and the RED-sanity result
+  for any bug fix — paste the meaningful lines, don't just say "passed."
+- **Cleanups / smaller notes** (non-blocking), clearly separated from the blocking findings.
+- **CI cost**: if the PR adds a `-race`, Playwright, live-server, or asset-gated test, say
+  whether it's justified — could a table-driven unit test prove the same thing? The full
+  gate must stay under ~10 minutes; flag additions that push toward that without cause.
+
+Be specific and evidence-backed. Frame required changes as a numbered list the author can
+act on, and pre-name any trap they'll hit implementing them. Never rubber-stamp; never
+approve on the strength of the PR description alone.

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,9 @@ sdk/python/*.egg-info/
 sdk/muninndb/dist/
 sdk/muninndb/*.egg-info/
 sdk/php/vendor/
+
+# Maintainer-private AI tooling: voice, contributor profiles, response-drafting,
+# and the consolidated soft-spot/attack-surface appendix. Local-only, never pushed.
+.claude/maintainer/
+.claude/skills/triage-issue/
+.claude/skills/review-pr/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,153 @@
+# MuninnDB — working guide for AI agents
+
+This file governs how AI agents (Claude Code and others) work in this repo. It auto-loads
+for anyone using Claude Code here, contributor or maintainer. It is the constitution: what
+MuninnDB *is*, the principles that must never be violated, and how to write and review
+changes that fit the project.
+
+The deep reference lives in `docs/internals/` — this file is the index and the
+non-negotiables.
+
+---
+
+## 1. What MuninnDB is
+
+MuninnDB is a **cognitive memory engine for AI agents**, written in Go over a single
+shared [Pebble](https://github.com/cockroachdb/pebble) LSM key-value store. Its one-line
+promise, from the README, is load-bearing — every change is measured against it:
+
+> **Memory that strengthens with use, fades when unused, and pushes to you when it matters.**
+
+It is accessible over **MCP, REST, gRPC, the MBP binary protocol, an embedded Go library,
+and SDKs** (Python/Node/PHP/…). It is **alpha**, single-binary, zero-config by default.
+Licensed BSL 1.1.
+
+The three words in the promise map to real subsystems:
+- **strengthens with use** → Hebbian co-activation learning, LTP, access-driven ACT-R base-level.
+- **fades when unused** → Ebbinghaus/ACT-R temporal decay, the background pruner, association decay + archival.
+- **pushes to you when it matters** → recall's predictive activation (PAS), entity/associative traversal, confidence-weighted scoring.
+
+If a change makes memory behave less like this — recall that returns silently-wrong
+results, decay that never fires, learning that displaces genuine matches — it is wrong even
+if it compiles and the tests pass.
+
+### Architecture map
+
+| Subsystem | Packages | What it owns |
+|---|---|---|
+| Cognitive engine | `internal/engine/` (+ `activation/`), root `recall.go`/`remember.go`/`dream.go`/`muninn.go` | Recall pipeline, write-path learning, decay, pruning, scoring |
+| Cognition support | `internal/cognitive/`, `scoring/`, `consolidation/`, `episodic/`, `working/`, `brief/`, `query/` | Decay math, Hebbian worker, dream consolidation, episodes, working-memory buffer |
+| Storage | `internal/storage/` (+ `keys/`), `index/` (HNSW), `wal/`, `backup/`, `provenance/` | Pebble keyspace, engrams, associations, vector index, durability |
+| Auth & credentials | `internal/auth/` | `mk_` API keys, `cap_` capability tokens, `mdb_` static token, admin users, plasticity config |
+| Transports | `internal/mcp/`, `internal/transport/{rest,grpc,mbp}/` | Protocol surfaces + their auth enforcement |
+| Cluster | `internal/replication/` | Leader election, log shipping, failover |
+| Plasticity | `internal/auth/plasticity.go` | Per-vault cognition config, the 5 presets |
+| Surfaces | `cmd/muninn/` (CLI), `web/` (console), `sdk/`, `proto/` | User-facing entry points |
+
+Reference docs: `docs/internals/keyspace-registry.md` (the Pebble prefix table),
+`docs/internals/invariants.md` (hard invariants), `docs/internals/decision-record.md` (why
+the project is the way it is), `docs/internals/drift-and-obligations.md` (cross-surface
+sync obligations + the CI budget).
+
+---
+
+## 2. Core principles (the lens for every change)
+
+Distilled from real decisions across the project's history (each traced to its PR/issue in
+`docs/internals/decision-record.md`).
+
+1. **Explicit config is never silently substituted.** A configured embed provider, model,
+   vault dimension, or preset is honored or fails loudly. Silent, plausible-looking wrong
+   answers are the worst failure class in the project (#582/#585/#589).
+
+2. **Degrade loudly-but-gracefully, never silently-wrong.** Embed backend down → fall back
+   to BM25 with a WARN, never hard-fail *and* never pretend nothing changed (#578).
+   Same-model degraded results are acceptable; different-model or silently-empty results are not.
+
+3. **Security properties are made structurally impossible, not policy-checked.** A `cap_`
+   token *cannot* mint another credential because it authenticates as `IsCapability`, never
+   `IsAPIKey`, so it can't satisfy the mint gate — not because a rule says "don't" (#612).
+   Prefer designs where the bad state is unrepresentable.
+
+4. **Fail closed on auth, fail open on presentation.** Invalid credential → denied, always.
+   Unknown *toolset* value (a display preference) → fall back to full so a typo never hides
+   someone's memory tools (#604). Know which side of that line a change is on.
+
+5. **Features land as minimal, reviewable increments referencing their RFC.** Big work ships
+   as numbered increments (RFC #597 → #599 → #612 → #617), each small, each naming what it
+   defers. Don't write or accept sprawling PRs.
+
+6. **Derived config is pinned by invariant tests, not copy-paste.** The `working` preset is
+   `default` + exactly two deltas, pinned by a `reflect.DeepEqual` test so a future edit to
+   `default` can't silently drift it (#599).
+
+7. **Extend proven in-tree mechanisms over inventing new architecture.** The tag-filter fix
+   (#607) reuses the candidate-pool injection that time filters already do. Find the
+   precedent first.
+
+8. **Match enforcement strength to the actual trust model.** The engram lease is *advisory*
+   because the agents sharing a vault are cooperative (#576). Don't over-build enforcement
+   the threat model doesn't need — but say so and document the residual.
+
+9. **Verify claims independently; severity can go up, not just down.** #611 was filed as
+   "low risk"; analysis found live bugs and raised it. Never take a claim — a reporter's or
+   a PR description's — on faith.
+
+10. **Honest negative results and scope discipline are first-class.** #609 reported that
+    ambient-push memory had zero uptake and killed the idea — that's valued, not dismissed.
+
+---
+
+## 3. How we work
+
+**Verify, don't assume.** For any non-trivial change:
+
+1. **Confirm the commit you're on.** The working checkout can be on a stale branch. Run
+   `git branch --show-current` / `git log` and diff against `develop` before asserting what
+   the code does. When in doubt, work in a fresh worktree off `origin/develop`. (This bit
+   the project's own tooling build — a whole analysis pass ran against a branch missing six
+   merged PRs.)
+
+2. **Build and test the actual change**, not just the diff: `go build ./... && go vet ./...
+   && gofmt -l .` plus the relevant `go test`. Use `-race` for anything touching storage,
+   the Hebbian/PAS workers, the pruner, replication, or MCP session state.
+
+3. **RED-sanity-check bug fixes.** A test for a fixed bug or closed race must be shown to
+   *fail without the fix*. A test that passes both ways proves nothing.
+
+4. **Honor the invariants and cross-surface obligations.** Check `docs/internals/invariants.md`,
+   the keyspace registry, and `docs/internals/drift-and-obligations.md`. Touching an MCP
+   handler means updating the registry smoke test; adding a Pebble prefix means checking the
+   collision guard; changing a preset means updating the web UI and adding a pinning test; etc.
+
+**Keep CI fast and cheap.** The full gate must stay **under ~10 minutes** (baseline ~6–7
+min; job map in `drift-and-obligations.md`). Unit and invariant tests are nearly free —
+prefer them. Integration, Playwright, `-race`, and asset-gated tests cost real minutes;
+reach for end-to-end proof only when a change genuinely needs it (protocol conformance, UI
+flows, "the button is actually wired" behavior). Never balloon the pipeline to prove a point
+a table-driven unit test could make.
+
+**Communicate like the project does.** Reviews and responses are evidence-first, specific,
+and never a rubber stamp: say what you verified and how, give specific rather than generic
+feedback, and deliver pushback as "here's what holds up, here's what needs to change, and
+yes please send it." Warmth and rigor, together.
+
+---
+
+## 4. The code-review agent
+
+`.claude/agents/code-reviewer.md` is the repo's resident reviewer — correctness, the
+cognitive/storage/security invariants, and cross-surface drift, with its own
+verify-build-test protocol. Use it (or the `/code-review` skill) when reviewing a change,
+and proactively before opening a PR. It routes by what the diff touches and cites
+`docs/internals/`.
+
+Maintainers may have additional local-only tooling (issue triage, review orchestration) that
+is not part of this repo.
+
+---
+
+## 5. Attribution
+
+Do not add "Generated with Claude" / Anthropic attribution to any PR body, commit message,
+issue, or code comment.

--- a/docs/internals/decision-record.md
+++ b/docs/internals/decision-record.md
@@ -1,0 +1,145 @@
+# Decision record
+
+Why MuninnDB is the way it is. Each entry: the decision, its rationale, and the reusable
+**principle** it established. Cite these when reviewing so contributors see the project has
+a spine, not just opinions. Sourced from merged PRs, closed issues, and the CHANGELOG.
+
+---
+
+## Cognition & memory model
+
+**Explicit config is never silently substituted (#582 → #585/#589).** A configured embed
+provider that failed at boot used to silently substitute the bundled 384-dim model,
+splitting the vault into mutually-invisible embedding spaces while reporting
+`health: "good"`. Fixed: never substitute — fail, or degrade to a safe noop mode; #589
+added a vault dimension guard. **Principle: silent, plausible-looking wrong answers are
+the worst failure class. Honor explicit config or fail loudly.**
+
+**Degrade loudly-but-gracefully (#577 → #578).** When the embed backend is unreachable,
+recall degrades to FTS/BM25-only with a WARN rather than hard-failing. Paired with #582
+this is the house degradation doctrine. **Principle: same-model degraded results are fine;
+different-model or silently-empty results never are.**
+
+**Tag filters must not silently miss (#607, green-lit).** `tags_all`/`tags_any` are
+post-filters over the phase-2 candidate pool, and the maintained 0x0C tag index has zero
+readers, so tag-scoped recall is non-deterministic. The chosen fix injects candidates from
+the tag index — **explicitly reusing the precedent that `created_after/before` filters
+already set** (`EngramIDsByCreatedRange` RRF-fused into phase 2). Maintainer pre-scoped two
+traps (ACT-R scores injected candidates near zero; per-tag scan limits truncating before
+intersection). **Principle: silent violation of a documented guarantee is high-severity;
+extend proven in-tree mechanisms over new architecture; pre-scope the traps before the
+contributor starts.**
+
+**Entity boost was tightened, not removed (#569 → #581).** Ubiquitous entities flooded
+recall via uncapped, threshold-bypassing injection. Fix: rarity-weight the boost, cap
+accumulation, gate on threshold, keep the factor (0.15) below typical BFS weights.
+**Principle: fix the flood with a cap and a gate; don't amputate the feature.**
+
+**RRF preserves explicit thresholds (#590).** RRF fusion was clobbering a caller's explicit
+threshold; the fix distinguishes "caller set a threshold" from "engine default applied."
+**Principle: an explicit caller value survives internal re-scoring.**
+
+**HNSW integrity is rebuilt from source, never trusted as-is (#471, #544/#545).** Four
+graph defects silently degraded search to one reachable cluster. Established: a structurally
+broken index is rebuilt from source-of-truth vectors on load (bfsReachable check), never
+restored as-is. **Principle: a corrupt index is a rebuild trigger, not a served result.**
+
+**Recall side-effects are an open design question (#598, open).** Recall mutates state
+(co-activation bonds the result set, cache reads refresh recency, max-normalization turns
+boosts into displacement). A read-only recall flag is proposed but not settled. **Treat
+"read-only recall" as unresolved; don't ship changes that assume it exists.**
+
+## Security & credentials
+
+**Security properties are structural, not policy-checked (#612).** The obvious design
+(mint a full-mode `mk_` key for a new workflow vault) was killed by the author's own
+32-agent red-team: recursive credential minting + immortal orphan keys. Replaced with a
+distinct `cap_` credential type — TTL-mandatory, structurally non-recursive (`cap_`
+authenticates as `IsCapability`, never `IsAPIKey`, so it can't satisfy the mint gate),
+`wf-*` namespaced, MCP-transport-only, opt-in default-off. A second pre-PR red-team caught
+a cross-vault clobber and an SSE confused-deputy. **Principles: make the bad state
+unrepresentable, not merely forbidden; self-red-team before review; document residual
+risks, don't bury them.**
+
+**Discovery filtering is not access control (#588 → #604).** #588 posed the mechanism
+question (per-key attribute vs list parameter vs hybrid) and explicitly waited to align
+before implementing. The maintainer settled it: the key layer is a security gate, the wrong
+home for a presentation preference; a request header wins because clients attach headers at
+connect while `tools/list` takes no params; filtering is advertisement-only (dispatch never
+consults it) and fails **open** on unknown values ("a typo must never hide a client's
+memory tools"). **Principles: align on mechanism before code when it touches the key model
+or transport; fail open on presentation, fail closed on auth.**
+
+**Match enforcement strength to the trust model (#548 → #576).** Work-queue semantics
+(`compare_and_set` + an engram lease) for multi-agent shared memory. The lease is
+deliberately **advisory** — it matches the cooperative-agent posture; fencing tokens were
+deferred to v2. Staleness is a pure server-clock function at read time (no background
+reaper). **Principle: don't over-build enforcement the threat model doesn't need; state the
+residual explicitly.**
+
+**Keyspace collisions get a migration, not an assertion (#611, green-lit).** auth and
+storage both claim Pebble prefixes 0x11–0x14 in the shared DB. The reporter rated it "low";
+independent adversarial analysis found the severity **understated** — a live admin-existence
+false-positive, a flagged-engram miscount, and an O(all-associations) startup scan. Chosen:
+full relocation + one-time migration ("we're still alpha, migration cost is as low as it'll
+ever be") plus a cross-package disjointness test — not an assertion-only fix. **Principles:
+verify reporter claims independently (severity may rise); fix the disk, not just the future;
+guard the class of bug with a test.**
+
+## Delivery & process
+
+**Features land as minimal increments referencing their RFC (#597 → #599, #612, #617).**
+The shared-working-vault RFC is grounded in verified code reading ("~90% already exists")
+and delivered as numbered increments, each small and reviewable, with "out of scope"
+tracked back on the RFC thread. **Principle: no sprawling PRs; each increment cites its RFC
+and names what it defers.**
+
+**Derived config is pinned by invariant tests (#599).** `working` = `default` + exactly
+two deltas, pinned by a `reflect.DeepEqual` test so a future edit to `default` can't drift
+it. `MultiUser` stayed a separate per-vault override — presets tune cognition, social flags
+stay orthogonal. **Principle: pin derived truth with a test; keep orthogonal knobs
+orthogonal.**
+
+**A write verb rides the key trust boundary (#610, green-lit).** The proposed
+`muninn remember --content-file` CLI client authenticates via the existing token-file
+convention (`~/.muninn/mcp.token`, 0600) — the same trust boundary as other key-authed
+clients — not the admin-session `-u/-p` pattern. **Principle: conventions beat new
+mechanisms; a write verb uses the write trust boundary.**
+
+**Negative results are first-class (#609, closed by author).** "carry," a sidecar salience
+ledger built on MuninnDB, was offered upstream headlined by a negative result: 523
+ambient-push deliveries, zero uptake — which killed ambient push, while explicitly saying
+nothing about the pull-path decay/Hebbian primitives. Valued for its eligibility contract,
+its "informed latest-wins" reversal-friction rule, and its scope discipline ("the store
+stays the store; the caring travels separately"). **Principle: honest negative results and
+tight scope are contributions, not disappointments.**
+
+**Green-light with required changes (#608, the canonical example).** Principal-scoped keys
+were accepted in principle with five numbered required changes: anchored/delimiter-respecting
+glob matching, reserved-namespace (`wf-*`) exclusion, a real global key index so pattern
+keys are listable/revocable, live matching for observe-only, and TTL-mandatory per the #612
+precedent — plus an honest re-centering note (the strongest case is observe-only sweep keys).
+The contributor accepted all five. **Principle: never a bare no; enumerate what holds, then
+numbered requirements, then re-affirm the invite.**
+
+---
+
+## Direction (where the product is heading)
+
+**Active / green-lit awaiting PRs:** RFC #597 remaining increments (#617: mk_ SSE
+re-validation #615, coverage #614, `session.go` removal; then single-batch CAS atomicity,
+TTL-driven cap reclamation, SSE auth dedup); #607 tag-index candidate injection; #610
+`muninn remember` CLI verb; #611 prefix relocation + migration; #608 observe-only
+sweep keys (five required changes agreed).
+
+**Open RFCs / undirected:** #376 cross-vault recall (read-side complement to #597 — "fuse
+reads vs share writes"); #598 read-only recall (+ #569/#573 scoring calibration); #605/#606
+observability (embed-failure signal, BM25-fallback metrics); #596 replication divergence +
+config replication; #600 upgrade integrity (checksum verification); recurring recall-quality
+integrity reports.
+
+**Explicitly deferred / rejected — do not reopen without new evidence:** write-path lease
+enforcement, fencing tokens, CAS crash-atomicity (until a workflow demands them); write-mode
+pattern keys (dropped in #608 v2); per-key toolset attribute (the key layer is not a
+presentation layer, #604); ambient push (negative result, #609); `tag_prefix` via the hash
+index (it's hash-indexed, stays a post-filter).

--- a/docs/internals/drift-and-obligations.md
+++ b/docs/internals/drift-and-obligations.md
@@ -1,0 +1,112 @@
+# Cross-surface obligations, drift risks, and the CI map
+
+MuninnDB has many surfaces that must stay in sync but mostly *aren't* checked automatically.
+This is where "you changed X but didn't update Y" bugs live. A reviewer must walk this list
+for any PR that touches a synced surface.
+
+## "If a PR touches X, it must also do Y"
+
+1. **An MCP tool handler** (`internal/mcp/*.go`) → update `allMCPTools` in
+   `cmd/muninn/smoke_exhaustive_test.go` and run `go test -tags integration,localassets
+   ./cmd/muninn/...` (the registry-parity smoke test). Also classify the new tool in
+   `isMutatingTool`/`isReadOnlyTool` (`internal/mcp/context.go`) — the coverage test
+   enforces this, but flag it early.
+
+2. **A REST route or handler** (`internal/transport/rest/`) → update
+   `internal/transport/rest/openapi.yaml` and pass `npx @redocly/cli lint`. The CI
+   route-count parity check is **informational only** (±5 tolerance) and cannot see
+   field-level drift — so this is a manual reviewer obligation, not a gate.
+
+3. **REST request/response types** (`internal/transport/rest/types.go`) → check
+   `sdk/python`, `sdk/node`, `sdk/php` (and Kotlin/Swift/Go) for the corresponding change.
+   **There is no automated check** — only the `.claude/hookify.sdk-types-drift.local.md`
+   warning. Manual.
+
+4. **A plasticity preset value** (`internal/auth/plasticity.go`) → update the web-UI preset
+   cards (`web/templates/index.html`) and the JS descriptions/radar data
+   (`web/static/js/app.js`), and any docs table. Presets are **hand-duplicated** across Go
+   and the web UI with no parity test — a known drift surface. If you add a preset, also
+   add a `reflect.DeepEqual`-style pinning test if it's derived from another (see #599).
+
+5. **The embed model or ORT version** (`Makefile`) → update **all** of: `ci.yml` cache keys
+   (Linux *and* Windows jobs), `release.yml` matrix cache keys (5 platforms), and the
+   `docker-compose.yml` comment. **These are already drifted today** — see the live-drift
+   list below.
+
+6. **`cmd/muninn/upgrade.go`** → if a PR claims to fix upgrade integrity (#600), verify it
+   actually verifies the downloaded binary against `checksums.txt` (which `release.yml`
+   already publishes). Don't accept an executable-bit + version-string check as "integrity."
+
+7. **`proto/muninn/v1/service.proto`** → regenerate `proto/gen/go/...`. No CI step verifies
+   the generated code is current — the reviewer must confirm regen ran.
+
+8. **A new Pebble prefix** → see `keyspace-registry.md`: disjoint, documented in `keys.go`,
+   and bump `storageMaxPrefix` in `keys_test.go` if ≥ 0x2B.
+
+9. **Any `go build` of the muninn binary** → must keep `-tags localassets`. Enforced by
+   `scripts/check-build-tags.sh` (CI `shellcheck` job), but that script only scans the
+   Dockerfile, Makefile, workflows, and one test file — a build command added elsewhere
+   slips through. Flag manually.
+
+10. **A user-facing doc promise** (`docs/quickstart.md`, `self-hosting.md`, `auth.md`,
+    `tls.md`, `capabilities.md`) → verify example commands still match current CLI flags in
+    `cmd/muninn/`.
+
+11. **Anything under `internal/replication/` or a new write path in a cluster deployment** →
+    confirm it goes through `RepLogAppend` and is leader-gated or Cortex-originated (bug
+    #596 is exactly the absence of this). Background workers that mutate replicated state
+    (the pruner) inherit the obligation.
+
+## Live drift found during the guardian audit (worth fixing)
+
+- **Windows CI tests the wrong embedding model.** `ci.yml`'s Windows job hardcodes URLs for
+  `all-MiniLM-L6-v2`, while `release.yml` ships `bge-small-en-v1.5` for Windows — CI
+  validates a different model than users get. Also the Linux cache key literally says
+  `minilm-v2` though the Makefile fetches bge-small.
+- **`muninn upgrade` has no checksum verification** (#600) despite `release.yml` generating
+  `checksums.txt` — a real supply-chain gap.
+- **Presets are hand-duplicated** Go ↔ web UI with no parity test.
+- **SDK type drift is warning-only** — no CI gate keeps Python/Node/PHP in sync with
+  `types.go`.
+- **`govulncheck@latest` is unpinned** in CI — non-reproducible vuln-check runs.
+- **Doc drift**: `middleware.go` claims write-mode keys can't authenticate to MCP (false);
+  a `toolset.go` comment says "39 tools" (now 42).
+
+## CI map and budget
+
+The full gate must stay **under ~10 minutes** and cheap. Current baseline ~6–7 min
+wall-clock. Jobs (from `.github/workflows/ci.yml`, real recent timings):
+
+| Job | ~duration | Notes |
+|---|---|---|
+| `go` (build & test) | 3.5–4 min | gofmt gate, embed-asset cache, web build, `go build -tags localassets`, `go vet`, **`go test -race -tags localassets ./...`**, coverage |
+| `windows` (build & smoke) | 2.5–3 min | parallel to `go`; **wrong-model drift, see above** |
+| `shellcheck` | 10–45s | lints scripts + runs `check-build-tags.sh` |
+| `api-spec-validation` | 15–20s | Redocly lint + informational route-count diff |
+| `vuln-check` | 30–90s | `govulncheck` (unpinned) |
+| `cli-integration` | 1.5–2 min | **runs after `go`** (sequential); this is where the MCP registry-parity smoke test runs |
+| `playwright-e2e` | 1.5–2 min | management-console E2E (thin: ~5 specs) |
+| `python-sdk` | 1.5–2 min | **serialized after `cli-integration`** "so integration jobs are sequential" — this coupling is not a real data dependency and costs ~1.5 min of avoidable critical path |
+
+Critical path: `go` → (`cli-integration` ∥ `playwright-e2e`) → `python-sdk`. What's cached:
+embed assets (~130MB, keyed by ORT+model+platform), Go module cache. npm is **not** cached
+(re-`npm ci` in four jobs). Race detector runs only in the `go` job.
+
+**When adding tests:** unit + invariant tests are nearly free — prefer them. Integration,
+Playwright, `-race`, and asset-gated tests cost real minutes. Reach for end-to-end
+(Playwright, live-server) only when a change genuinely needs behavioral proof a unit test
+can't give (protocol conformance, UI flows, the money-path class of "the button is actually
+wired" bugs). Never balloon the pipeline to prove a point a table-driven unit test could
+make. If you must add a slow test, consider whether it belongs behind an integration tag
+rather than in the default `go test ./...` path.
+
+## Testing conventions worth upholding
+
+- **RED-sanity verification**: a bug-fix/race-fix test must be shown to fail without the fix.
+- **Preset-pinning `reflect.DeepEqual` tests** for derived config (#599).
+- **Registry-parity smoke** for the MCP tool surface (`smoke_exhaustive_test.go`).
+- **Cross-package disjointness test** for Pebble prefixes (`TestCapabilityPrefixesNoCollision`).
+- **Coverage test that enumerates all handlers** so a new tool can't escape mode
+  classification (`TestToolClassification_CoversAllRegisteredHandlers`).
+- **`-race` on anything touching** storage, the Hebbian/PAS workers, the pruner,
+  replication, or MCP session state.

--- a/docs/internals/invariants.md
+++ b/docs/internals/invariants.md
@@ -1,0 +1,71 @@
+# Hard invariants
+
+Testable assertions a PR must never violate. Anchors are on `develop`. When an anchor's
+line number drifts, the symbol name is the source of truth — re-locate by grep, don't
+trust the number. If the live code disagrees with an assertion here, the code wins: flag
+the stale invariant, don't enforce it.
+
+Format: **[INV-n]** assertion — `file:anchor` — *why it matters / what breaks if violated.*
+
+---
+
+## Cognition invariants
+
+- **[COG-1]** Unknown preset name falls back to `default`, never errors — `internal/auth/plasticity.go` `ResolvePlasticity`. *Config can never wedge the engine.*
+- **[COG-2]** All plasticity overrides are clamped, never rejected (HopDepth 0–8, weights 0–1, ACTRDecay 0.01–2.0, HebScale 0–50, PASMax 0–10) — `plasticity.go`. *Out-of-range config is impossible, not merely discouraged.*
+- **[COG-3]** The `working` preset equals `default` plus exactly `{RetentionDays:7, BehaviorMode:selective}` — pinned by `TestResolvePlasticity_WorkingEqualsDefaultPlusTwoDeltas` (`plasticity_test.go`). *Editing `default` must not silently drift `working`.*
+- **[COG-4]** All presets share `RecallMode="balanced"`, `ArchiveThreshold=0.05`, `InlineEnrichment="caller_preferred"`, `EnrichmentEnabled=true`, `MaxEngrams=0`, `ScoringFusion=""` — `plasticity.go` preset table + the preset-invariant test suites. *These are cross-preset guarantees other code relies on.*
+- **[COG-5]** The ACT-R content gate is `contentMatch = w.SemanticSimilarity*vectorScore + w.FullTextRelevance*normalizedFTS`, where `w` is the **resolved** weights (`resolvedWeights` — from the request/plasticity, falling back to `DefaultWeights{Semantic:0.35, FullText:0.25}` only when `req.Weights == nil`) — `internal/engine/activation/engine.go` `computeACTR` + `resolveWeights`. *The content gate is weight-driven, not a fixed constant. When no weights are supplied, the 0.35/0.25 defaults apply and unused components' budget is redistributed (the `1/0.65` scale). A change to `DefaultWeights` or to the resolve/redistribute logic reshapes scoring for every request that doesn't pass explicit weights — verify against the live `resolveWeights` before asserting what the effective weights are.*
+- **[COG-6]** RRF mode forces threshold to 0.001 when the caller threshold ≥ 0.01 — `activation/engine.go` (RRF scores live in [0,0.05]). *Preserves #590's fix: an explicit caller threshold under RRF is respected, not clobbered.*
+- **[COG-7]** ACT-R base-level is capped at ≈1.489 (ln(e^1.693−1)); Hebbian/transition boosts may exceed it, base-level alone may not — `activation/engine.go`. *"threshold=0.3 means the same thing in a fresh and a mature vault."*
+- **[COG-8]** In RRF mode, BFS-traversed candidates must carry a non-zero rrfScore or they vanish from results — `activation/engine.go`. *Traversal reachability must not silently drop.*
+- **[COG-9]** Soft-deleted/archived engrams are always filtered in phase-6 scoring and in entity boost — `activation/engine.go`, `engine_entity_boost.go`. *HNSW has no delete; the filter is the only guard.*
+- **[COG-10]** Co-activation (recall-time Hebbian) never updates confidence — only user feedback and contradictions do — `engine.go`. *"Evidence of relevance, not evidence of truth."*
+- **[COG-11]** Observe mode (`ReadOnly`) skips activation-log, Hebbian, and PAS writes — `engine.go`, `activation/engine.go`. *A read must not mutate learning state.* (Known wound: archive-restore in phase-4.75 still writes even for observe — see soft spots.)
+- **[COG-12]** `Recall`/`Activate` never bumps engram AccessCount — only explicit `RecordAccess` and content-dedup reinforcement do — `engine.go`. *Recall is not an access for decay purposes.*
+- **[COG-13]** Idempotency check precedes content-hash dedup on the write path — `engine.go`. *Re-submitting a known op_id with drifted content returns the original, deliberately.*
+- **[COG-14]** Caller-supplied embedding ⇒ `DigestEmbed` flag set + inline HNSW insert; the retroactive embedder must never overwrite it — `engine.go`. *Don't re-embed what the caller already embedded.*
+- **[COG-15]** The pruner only ever **hard-deletes**, and runs only for vaults with `MaxEngrams>0` or `RetentionDays>0` — `engine.go` PruneVault / runPruneWorker. *Soft-delete would leave relevance-index entries → infinite prune loop.*
+- **[COG-16]** Association decay requires `HebbianEnabled && AssocDecayFactor>0` — `engine.go`. *Decay of learned edges is gated on learning being on.*
+- **[COG-17]** Hebbian weight updates are log-space multiplicative, capped at 1.0, seeded at 0.01 — `internal/cognitive/hebbian.go`. *Prevents overflow and runaway weights.*
+- **[COG-18]** Entity-boost factor (0.15) stays below typical BFS weights, seeds TopN=5, and results are re-truncated to MaxResults after boosting — `engine_entity_boost.go`, `engine.go` (tightened in #581). *Ubiquitous entities must not flood recall (#569).*
+
+## Storage & durability invariants
+
+- **[STO-1]** A new Pebble prefix must be disjoint from the keyspace registry and documented where the registry lives; the disjointness cross-check must cover it. On current `develop` that means `keys/keys.go` doc comments + bumping `storageMaxPrefix` in `keys_test.go` if ≥ 0x2B; **once PR #618 (#611) merges** it means adding the prefix to `internal/prefix/prefix.All()` (the test auto-tightens, no constant to bump). Check `ls internal/prefix/` to see which world you're in. — see `keyspace-registry.md`.
+- **[STO-2]** Any path mutating engram **state or lease** must hold `casLocks.For(id)` across read→commit, as `CompareAndSet` (`storage/lease.go`) and `DeleteEngram` (`storage/engram.go`) do. *A new unlocked state-mutating path reopens the #594 resurrection race.*
+- **[STO-3]** CAS state changes go through `UpdateMetadata` (keeps 0x0B index, caches, provenance, replication consistent) — never a direct 0x02 write — `storage/lease.go`.
+- **[STO-4]** The engram lease (0x2A) is **advisory**: recall/claim paths consult it; normal writes must not start consulting it without an RFC — `storage/lease.go`, `engine/engine_lease.go`.
+- **[STO-5]** `DeleteEngram` deletes association keys from **live Pebble scans**, not the engram's inline ERF list (the Hebbian worker may have moved weights), and must include the 0x2A LeaseKey in its batch — `storage/engram.go`.
+- **[STO-6]** `ClearVault` ordering is load-bearing: point-delete 0x15 count → evict in-memory counter → drain coalescer → drain provenance → tombstone `DeleteRange`. Any new vault-scoped prefix MUST be added to its `dataPrefixes` list — `storage/vault_lifecycle.go`.
+- **[STO-7]** MOL WAL recovery hard-fails on CRC mismatch, never skip-and-continue; replay functions must stay idempotent (last-seq is written NoSync) — `internal/wal/mol.go` `Recover`.
+- **[STO-8]** HNSW: entry-point promotion happens only after the node is linked; `LoadFromPebble` validates entry-point reachability via `bfsReachable` and rebuilds if disconnected; `Registry.Insert` rolls back the orphan vector if graph insertion fails — `internal/index/hnsw/` (guards PR #471's four defects).
+- **[STO-9]** Vault dimension: all insert/search paths go through `CheckDim`; a failed graph load sets `loadErr` and refuses inserts (never reports dim 0 = "empty vault" and recreates a split embedding space) — `internal/index/hnsw/registry.go` (#582/#589).
+- **[STO-10]** Idempotency receipts give **no** concurrency guarantee — `WriteIdempotency`/`CheckIdempotency` are unlocked Get/Set. A caller needing exactly-once under concurrency must add its own lock. A PR claiming idempotency is race-safe is wrong.
+
+## Security & transport invariants
+
+- **[SEC-1]** A `cap_` token must never set `IsAPIKey` — exactly one of `IsAPIKey`/`IsCapability` is set — `internal/mcp/context.go`, `internal/mcp/types.go`. *This is what makes the recursion guard structural.*
+- **[SEC-2]** Any privileged MCP tool (one that mints/grants/creates) gates on `IsAPIKey && Mode==ModeFull && <opt-in env>` before dispatch — `internal/mcp/server.go` (`muninn_create_workflow_vault` is the template). *New privileged tools must copy this triple gate.*
+- **[SEC-3]** `ValidateAPIKey` accepts only the `mk_` prefix; REST/gRPC/MBP call **only** `ValidateAPIKey`, never `ValidateCapability` — `internal/auth/keys_store.go`, `middleware.go`, `grpc/server.go`, `mbp/server.go`. *Keeps cap_ MCP-only, structurally.*
+- **[SEC-4]** Capabilities carry a non-nil TTL at both mint (`GenerateCapability` rejects nil) and validate (nil/past expiry = expired) — `internal/auth/capability_store.go`. *No immortal credentials.*
+- **[SEC-5]** Invalid `mk_`/`cap_` on MCP fails closed — never falls through to static-token or open-server auth — `internal/mcp/context.go`.
+- **[SEC-6]** Every registered MCP tool is in exactly one of `isMutatingTool`/`isReadOnlyTool`; unknown tools blocked for observe AND write modes; unknown key modes rejected — `internal/mcp/context.go`, `server.go` (enforced by `TestToolClassification_CoversAllRegisteredHandlers`). *A new tool with no classification silently escapes mode enforcement.*
+- **[SEC-7]** A vault-pinned credential rejects any differing `vault` argument and never echoes the pinned name — `internal/mcp/context.go` (also REST/gRPC/MBP). *No cross-vault action, no name leak.*
+- **[SEC-8]** Unconfigured vaults are locked (fail-closed, `Public:false`) on REST/gRPC/MBP — `internal/auth/vault_config.go`.
+- **[SEC-9]** Toolset filtering is **advertisement-only**; dispatch never consults it; unknown values fail **open to full** — `internal/mcp/toolset.go`. *Presentation preference, not a security boundary.*
+- **[SEC-10]** SSE per-POST: a cached `cap_` session credential is re-validated before dispatch — `internal/mcp/server.go`. *Closes the #612 confused-deputy.* **Known open gap: the symmetric `mk_` re-validation does NOT exist (#615/#617) — a revoked mk_ SSE session can survive. A PR touching the SSE POST path should fix or at least not widen this.**
+- **[SEC-11]** Vault names are `[a-z0-9_-]{1,64}` everywhere via `IsValidVaultName` — `internal/auth/token.go`.
+- **[SEC-12]** Static-token compares are constant-time with a length cap; keys/caps are looked up by SHA-256(secret) — raw secrets are never stored — `internal/auth/token.go`, `keys_store.go`, `capability_store.go`.
+- **[SEC-13]** Any new client write path in a cluster deployment must either gate on `IsLeader()`/Cortex-origin or replicate its mutation — no transport does this today, which is exactly bug #596. Background workers that mutate replicated state (e.g. the pruner) inherit the same obligation.
+
+---
+
+## Known open wounds
+
+Several of these invariants sit next to known-imperfect code. The individual issues are
+tracked publicly (#596, #605, #607, #611, #615/#617, …); a reviewer should recognize when a
+PR is touching one and either fix or at least not widen it. The consolidated map of soft
+spots and trust-surface weaknesses is kept in the maintainer-private tier
+(`.claude/maintainer/soft-spots.md`) rather than concentrated here — cite the individual
+issue, not a one-stop list.

--- a/docs/internals/keyspace-registry.md
+++ b/docs/internals/keyspace-registry.md
@@ -1,0 +1,127 @@
+# Pebble keyspace registry
+
+**The single most important artifact for preventing a whole class of bug.** MuninnDB
+runs `internal/storage`, `internal/auth`, and `internal/replication` over **one shared
+Pebble database**. Prefixes are single bytes. If two packages claim the same byte, they
+silently corrupt each other's scans — this is exactly the live bug in #611.
+
+**Rule for any PR that adds or changes a Pebble key:** the new prefix must be disjoint
+from every row below and documented where the registry lives. Today the source of truth is
+the `internal/storage/keys/keys.go` doc comments plus `internal/auth/keys.go`, and the
+cross-check is `TestCapabilityPrefixesNoCollision` in `internal/auth/keys_test.go` (which
+currently derives storage's upper bound from a `storageMaxPrefix` constant — bump it if you
+extend storage past `0x2A`).
+
+> **In flight — PR #618 (#611 fix):** this consolidates the whole registry into a new
+> `internal/prefix/prefix.go` package with a stronger disjointness test
+> (`TestAll_NoDuplicateBytes`, `TestAll_OwnerGroupsPairwiseDisjoint`) that derives its
+> bounds from `prefix.All()`, and it **removes `storageMaxPrefix`** and relocates auth's
+> 0x11–0x14 to 0x42–0x45. When #618 merges, update this doc and STO-1: the source of truth
+> becomes `internal/prefix/`, and the "bump `storageMaxPrefix`" guidance is replaced by
+> "add the prefix to `prefix.All()` — the disjointness test auto-tightens." Verify which
+> world you're in with `ls internal/prefix/` before reviewing a keyspace change.
+
+`ws` = 8-byte SipHash(vault name) prefix (deterministic; a name always maps to the same
+prefix — see the vault-reuse note at the bottom).
+
+## Storage prefixes (`internal/storage/keys/keys.go`)
+
+| Prefix | Key shape after prefix | Value | Notes |
+|---|---|---|---|
+| 0x01 | ws+ulid(16) | Engram (ERF) | primary record |
+| 0x02 | ws+ulid(16) | EngramMeta | |
+| 0x03 | ws+src(16)+weightComplement(4)+dst(16) | — | forward assoc, sorted desc by weight |
+| 0x04 | ws+dst(16)+weightComplement(4)+src(16) | — | reverse assoc |
+| 0x05 | ws+term+0x00+field(1)+id | posting | FTS |
+| 0x06 | ws+trigram(3)+id | — | FTS trigram |
+| 0x07 | ws+id+layer(1) | neighbor list | HNSW graph |
+| 0x08 / 0x09 | ws+"stats" / ws+term | FTS stats | |
+| 0x0A | ws+conceptHash(4)+relType(2)+id | contradiction | |
+| 0x0B | ws+state(1)+id | — | state index |
+| **0x0C** | ws+tagHash(4)+id | — | **tag index — maintained on every write, ZERO non-test readers (#607)** |
+| 0x0D | ws+creatorHash(4)+id | — | creator index |
+| 0x0E | ws | vault name string | vault meta |
+| 0x0F | siphash(name)(8) | ws(8) | name→prefix index |
+| 0x10 | ws+bucket(1)+id | — | relevance bucket |
+| **0x11** | ulid(16) — **GLOBAL, not vault-scoped** | DigestFlags | **collides with auth AdminUser (#611)** |
+| **0x12** | ws | CoherenceKey | **collides with auth APIKey (#611)** |
+| **0x13** | ws | VaultWeights | **collides with auth APIKey vault idx (#611)** |
+| **0x14** | ws+src(16)+dst(16) | AssocWeightIndex float32 | **collides with auth VaultCfg (#611)** |
+| 0x15 | ws | BE int64 count | vault engram count ("sole user" per comment) |
+| 0x16 | ws+id(16)+ts(8)+seq(4) | provenance | async worker |
+| 0x17 | ws | migration version+cursor | |
+| 0x18 | ws+ulid | quantize params + int8 embedding | ERF v2 vector |
+| **0x19** | siphash(opID)(8) → JSON receipt | idempotency | **shared with replication (see below) — safe only by JSON-vs-msgpack decode accident** |
+| 0x1A | ws+episodeID(16)[+0xFF+pos(4)] | episode/frame | |
+| 0x1B | ws | uint8 FTS schema version | |
+| 0x1C | ws+src+dst | PAS transition | |
+| 0x1D | ws | embed model name string | |
+| 0x1E | ws+parentID+childID | ordinal | |
+| 0x1F | entityNameHash(8) — **GLOBAL** | entity record | identity = NFKC+lower+trim |
+| 0x20 | ws+engramID+nameHash(8) | — | engram→entity link |
+| 0x21 | ws+engramID+fromHash(8)+relType(1)+toHash(8) | — | relationship record |
+| 0x22 | ws+^millis(8)+id | — | last-access (inverted for MRU-first) |
+| 0x23 | nameHash(8)+ws(8)+id | — | entity reverse index (global prefix, vault in suffix) |
+| 0x24 | ws+hashA(8)+hashB(8) | msgpack count | co-occurrence |
+| 0x25 | ws+src+dst | archived assoc (no weight sort, no reverse) | |
+| 0x26 | ws+entityHash(8)+engramID | — | rel-entity index |
+| 0x27 | ws | 16B dream state | |
+| 0x28 | ws+sha256(32) | engramID(16) | content-hash dedup |
+| **0x2A** | ws+ulid | JSON Lease{owner,heartbeat,ttl} | ownership-lease sidecar (advisory) |
+
+## Auth prefixes (`internal/auth/keys.go`)
+
+| Prefix | Key shape | Value | Notes |
+|---|---|---|---|
+| **0x11** | username-bytes | AdminUser (JSON) | **collides with storage DigestFlags** |
+| **0x12** | hash16 | APIKey (JSON) | **collides with storage CoherenceKey** |
+| **0x13** | vault+0x00+keyID(8) | — | APIKey vault index; **collides with storage VaultWeights** |
+| **0x14** | vault-name | VaultCfg (JSON) | **collides with storage AssocWeightIndex** |
+| 0x40 | hash16 | Capability (JSON) | cap_ tokens (#612), relocated off 0x15/0x16 |
+| 0x41 | vault+0x00+capID(8) | storageHash16 | cap_ vault index |
+
+## Replication prefixes (`internal/replication/`) — all under 0x19
+
+| Key | Meaning |
+|---|---|
+| 0x19 + seq_be64(8) | replication log entry (msgpack) |
+| 0x19 0x02 \| "last_app" | last applied |
+| 0x19 0x03 \| "cluster_epoch" / "node_role" / "schema_v" | epoch/role/schema |
+| 0x19 0x10 \| "snap_complete" | snapshot marker |
+
+## Free bytes
+
+`0x29`, `0x2B`–`0x3F`, `0x42`+ are free for new storage/auth keys. (`0x29`/`0x40`/`0x41`
+also appear in `internal/transport/mbp/frame.go` as **wire opcodes** — a different
+keyspace; coincidental, safe, but confusing. Prefer `0x2B+` for new storage prefixes.)
+
+## Live hazards a reviewer must know
+
+1. **#611 — auth 0x11–0x14 collide with storage.** `AdminExists` scans `[0x11,0x12)` and
+   sees storage's global DigestFlags → false-positive admin existence / miscount.
+   `ListVaultConfigs` scans `[0x14,0x15)` = O(all association weights in the DB), not
+   O(vault configs). The fix (green-lit) is relocation + one-time migration + a
+   cross-package disjointness test — **not** an assertion-only patch. Until then, any PR
+   widening a scan over 0x11–0x14 makes it worse.
+
+2. **0x19 is shared idempotency+replication territory.** `PurgeExpiredIdempotency` scans
+   the *entire* 0x19 range including replication log/epoch entries and only survives
+   because msgpack payloads fail JSON unmarshal (silently skipped). Any special-cased key
+   there must be **exact-match, never prefix-skip** (as `snapshot.go` already does for
+   `cluster_epoch`). Never switch replication values to JSON or receipts to msgpack
+   without revisiting this.
+
+3. **`storageMaxPrefix` is hardcoded 0x2A** in the collision test. The day storage adds
+   0x2B, the guard silently weakens unless the constant is bumped. Flag any new storage
+   prefix ≥ 0x2B for this.
+
+4. **0x0C tag index is write-amplifying dead weight** — maintained on every tag mutation,
+   zero production readers (#607). Don't add write-path cost assuming it's consumed;
+   either wire the reader (the green-lit #607 fix) or plan removal.
+
+5. **Vault prefixes are name-deterministic and therefore REUSED on name reuse.** Deleting
+   a vault (`ClearVault` + `DeleteVaultNameOnly`) does not clean 0x11 DigestFlags
+   ("orphans acceptable") or 0x1F global entity records. Re-creating a vault of the same
+   name recomputes the identical SipHash prefix and resurfaces those orphans. The correct
+   invariant is "prefixes are name-deterministic," **not** "never reused." A PR asserting
+   the latter is wrong about this codebase.


### PR DESCRIPTION
## Why

As the project grows and takes more contributions, we want changes to stay grounded in MuninnDB's core principles and hard invariants — without every review having to re-derive them from scratch. This adds a repo-resident guardrail layer: a constitution that auto-loads for any contributor using an AI coding agent, a deep internals reference built from an actual read of the code, and a resident code-review agent that enforces it.

## What's here (all public, contributor-facing)

- **`CLAUDE.md`** — the constitution. What MuninnDB is, the core principles (each traced to the PR/issue that established it — e.g. "explicit config is never silently substituted" → #582/#585/#589; "security properties are structural, not policy-checked" → #612), the verify-don't-assume working protocol, and the CI budget.
- **`docs/internals/`** — the deep reference:
  - `keyspace-registry.md` — the complete Pebble key-prefix table (every prefix, owner, key shape). Makes the #611-class collision mechanically catchable, and documents the live hazards (auth↔storage 0x11–0x14 overlap, the 0x19 idempotency/replication overload).
  - `invariants.md` — hard cognition / storage / security invariants as testable assertions with file anchors.
  - `decision-record.md` — why the project is the way it is, and the current direction / settled rejections.
  - `drift-and-obligations.md` — the "if you touch X, update Y" cross-surface table (MCP registry smoke test, openapi.yaml, preset↔web-UI, embed-asset cache keys) and the CI job map + budget.
- **`.claude/agents/code-reviewer.md`** — a resident reviewer that builds and tests the actual change (`-race` where it matters, RED-sanity-checks bug fixes), routes by what the diff touches, and enforces the invariants. It produces a review as text and never posts, approves, or merges — those stay human actions.

## How it was verified

- **Dry-run against a live PR:** the code-reviewer agent reviewed the open #611 keyspace-relocation PR (#618) end-to-end — built and `-race`-tested the branch, ran two RED-sanity checks (reverting the fix to confirm the tests catch the regression), and produced an actionable review. The keyspace registry matched the real code exactly.
- **Independent adversarial review:** corrected one factually-wrong invariant (the ACT-R content gate is weight-driven — resolved plasticity weights, defaults 0.35/0.25 — not a hardcoded constant), confirmed no doc concentrates the attack surface, and hardened the review agent's guardrails (never-post rail, defer-to-expert verdict, dependency-change routing).

## Notes

- The docs are honest about their own drift risk: they instruct reviewers to treat the live code as source of truth when an anchor disagrees, and they flag work in flight (e.g. #618 relocating the keyspace registry into `internal/prefix/`).
- Purely additive — docs + one agent definition. No code, no behavior change.