### PR TITLE
feat(grpc,engine): AdjustConfidence RPC with contradiction signaling (#559)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2531,6 +2531,85 @@ func (e *Engine) Link(ctx context.Context, req *mbp.LinkRequest) (*mbp.LinkRespo
 	return &mbp.LinkResponse{OK: true}, nil
 }
 
+// AdjustConfidence applies a signed delta to engram id's confidence (clamped to
+// [0,1]) and, when hasContra, mirrors the internal OnFound: persists the 0x0A
+// contradiction marker for (id, other) AND submits EvidenceContradiction to the
+// ConfidenceWorker for both engrams. Returns the new absolute confidence.
+//
+// All validation precedes any write. A bare delta (hasContra=false) does NOT
+// submit to the ConfidenceWorker (§D3 carve-out — processBatch would otherwise
+// clobber the explicit value).
+//
+// Mirrors Engine.Link's vault resolution + GetMetadata existence pattern +
+// cogWorkers() submit pattern. Source string is "external_contradiction" to
+// distinguish external bridge signal from the internal "contradiction_detected"
+// path emitted by Link/ContradictWorker.
+func (e *Engine) AdjustConfidence(ctx context.Context, vault string, id storage.ULID, delta float32, other storage.ULID, hasContra bool, reason string) (float32, error) {
+	wsPrefix := e.store.ResolveVaultPrefix(vault)
+
+	if math.IsNaN(float64(delta)) || math.IsInf(float64(delta), 0) {
+		return 0, fmt.Errorf("%w: delta is NaN or Inf", ErrInvalidArgument)
+	}
+	if hasContra && other == id {
+		return 0, ErrSelfContradiction
+	}
+
+	// Existence check — mirror Engine.Link's batched GetMetadata (nil meta = NotFound).
+	ids := []storage.ULID{id}
+	if hasContra {
+		ids = []storage.ULID{id, other}
+	}
+	metas, err := e.store.GetMetadata(ctx, wsPrefix, ids)
+	if err != nil {
+		return 0, fmt.Errorf("adjust confidence: read meta: %w", err)
+	}
+	for _, m := range metas {
+		if m == nil {
+			return 0, ErrEngramNotFound
+		}
+	}
+
+	// Current confidence (for the clamp + the audit prior).
+	current, err := e.store.GetConfidence(ctx, wsPrefix, id)
+	if err != nil {
+		return 0, ErrEngramNotFound
+	}
+
+	// Clamp to [0,1].
+	newConf := current + delta
+	if newConf < 0 {
+		newConf = 0
+	} else if newConf > 1 {
+		newConf = 1
+	}
+
+	// Atomic write (confidence + marker in one batch — no partial-failure window).
+	if err := e.store.UpdateConfidenceWithContradiction(ctx, wsPrefix, id, newConf, other, hasContra); err != nil {
+		return 0, fmt.Errorf("adjust confidence: write: %w", err)
+	}
+
+	// Mirror OnFound: submit EvidenceContradiction for both engrams (only when hasContra).
+	if hasContra {
+		if _, _, cw := e.cogWorkers(); cw != nil {
+			cw.Submit(cognitive.ConfidenceUpdate{
+				WS: wsPrefix, EngramID: [16]byte(id),
+				Evidence: cognitive.EvidenceContradiction, Source: "external_contradiction",
+			})
+			cw.Submit(cognitive.ConfidenceUpdate{
+				WS: wsPrefix, EngramID: [16]byte(other),
+				Evidence: cognitive.EvidenceContradiction, Source: "external_contradiction",
+			})
+		}
+	}
+
+	slog.Info("adjust_confidence",
+		"engram_id", id.String(), "delta", delta, "prior", current, "new", newConf,
+		"contradicted_by", other.String(), "has_contra", hasContra,
+		"reason", reason, "vault", vault)
+
+	return newConf, nil
+}
+
 // Forget implements mbp.EngineAPI.Forget.
 func (e *Engine) Forget(ctx context.Context, req *mbp.ForgetRequest) (*mbp.ForgetResponse, error) {
 	wsPrefix := e.store.ResolveVaultPrefix(req.Vault)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2569,22 +2569,15 @@ func (e *Engine) AdjustConfidence(ctx context.Context, vault string, id storage.
 		}
 	}
 
-	// Current confidence (for the clamp + the audit prior).
-	current, err := e.store.GetConfidence(ctx, wsPrefix, id)
+	// Atomic delta write: the storage method holds the per-engram stripe lock
+	// across read+add+clamp+commit, closing the lost-update race (#559). The
+	// prior confidence read and the [0,1] clamp have moved INTO the locked
+	// storage method (UpdateConfidenceWithContradiction) — an external unlocked
+	// read here would re-open the race, so we do not call GetConfidence. The
+	// returned (prior, newConf) come from inside the locked section so the
+	// audit log below reports the same values that were committed.
+	prior, newConf, err := e.store.UpdateConfidenceWithContradiction(ctx, wsPrefix, id, delta, other, hasContra)
 	if err != nil {
-		return 0, ErrEngramNotFound
-	}
-
-	// Clamp to [0,1].
-	newConf := current + delta
-	if newConf < 0 {
-		newConf = 0
-	} else if newConf > 1 {
-		newConf = 1
-	}
-
-	// Atomic write (confidence + marker in one batch — no partial-failure window).
-	if err := e.store.UpdateConfidenceWithContradiction(ctx, wsPrefix, id, newConf, other, hasContra); err != nil {
 		return 0, fmt.Errorf("adjust confidence: write: %w", err)
 	}
 
@@ -2603,7 +2596,7 @@ func (e *Engine) AdjustConfidence(ctx context.Context, vault string, id storage.
 	}
 
 	slog.Info("adjust_confidence",
-		"engram_id", id.String(), "delta", delta, "prior", current, "new", newConf,
+		"engram_id", id.String(), "delta", delta, "prior", prior, "new", newConf,
 		"contradicted_by", other.String(), "has_contra", hasContra,
 		"reason", reason, "caller", caller, "vault", vault)
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2544,7 +2544,7 @@ func (e *Engine) Link(ctx context.Context, req *mbp.LinkRequest) (*mbp.LinkRespo
 // cogWorkers() submit pattern. Source string is "external_contradiction" to
 // distinguish external bridge signal from the internal "contradiction_detected"
 // path emitted by Link/ContradictWorker.
-func (e *Engine) AdjustConfidence(ctx context.Context, vault string, id storage.ULID, delta float32, other storage.ULID, hasContra bool, reason string) (float32, error) {
+func (e *Engine) AdjustConfidence(ctx context.Context, vault string, id storage.ULID, delta float32, other storage.ULID, hasContra bool, reason, caller string) (float32, error) {
 	wsPrefix := e.store.ResolveVaultPrefix(vault)
 
 	if math.IsNaN(float64(delta)) || math.IsInf(float64(delta), 0) {
@@ -2605,7 +2605,7 @@ func (e *Engine) AdjustConfidence(ctx context.Context, vault string, id storage.
 	slog.Info("adjust_confidence",
 		"engram_id", id.String(), "delta", delta, "prior", current, "new", newConf,
 		"contradicted_by", other.String(), "has_contra", hasContra,
-		"reason", reason, "vault", vault)
+		"reason", reason, "caller", caller, "vault", vault)
 
 	return newConf, nil
 }

--- a/internal/engine/engine_confidence_test.go
+++ b/internal/engine/engine_confidence_test.go
@@ -1,0 +1,249 @@
+package engine
+
+import (
+	"context"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/cognitive"
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// -----------------------------------------------------------------
+// Test helpers — mirror the engine-test harness used by Engine.Link
+// and Engine.Forget (testEnv in engine_test.go). Confidence is seeded
+// directly through Store().UpdateConfidence so each test starts from a
+// known prior, independent of Write's default-confidence logic.
+// -----------------------------------------------------------------
+
+// seedEngineWithEngram wires up a real engine (live PebbleStore + FTS),
+// writes one engram to vault "test", and pins its confidence to the given
+// value. Returns the engine, the resolved vault prefix, and the engram ID.
+func seedEngineWithEngram(t *testing.T, confidence float32) (*Engine, [8]byte, storage.ULID) {
+	t.Helper()
+	eng, cleanup := testEnv(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   "test",
+		Concept: "seed",
+		Content: "seed engram for AdjustConfidence tests",
+	})
+	if err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+	id, err := storage.ParseULID(resp.ID)
+	if err != nil {
+		t.Fatalf("seed ParseULID(%q): %v", resp.ID, err)
+	}
+	ws := eng.Store().ResolveVaultPrefix("test")
+	if err := eng.Store().UpdateConfidence(ctx, ws, id, confidence); err != nil {
+		t.Fatalf("seed UpdateConfidence: %v", err)
+	}
+	return eng, ws, id
+}
+
+// seedSecondEngram writes a second engram into the same vault and returns its
+// ULID. Used by contradiction tests that need a distinct "other" endpoint.
+func seedSecondEngram(t *testing.T, eng *Engine, _ [8]byte) storage.ULID {
+	t.Helper()
+	resp, err := eng.Write(context.Background(), &mbp.WriteRequest{
+		Vault:   "test",
+		Concept: "other",
+		Content: "second engram for AdjustConfidence contradiction tests",
+	})
+	if err != nil {
+		t.Fatalf("seedSecond Write: %v", err)
+	}
+	id, err := storage.ParseULID(resp.ID)
+	if err != nil {
+		t.Fatalf("seedSecond ParseULID(%q): %v", resp.ID, err)
+	}
+	return id
+}
+
+// vaultOf returns the vault name that resolves to ws. The seed always uses
+// vault "test", so the inverse mapping is constant.
+func vaultOf(_ [8]byte) string { return "test" }
+
+// readConfidence reads the persisted confidence for an engram directly from
+// the store, bypassing any engine cache invariants the engine holds.
+func readConfidence(t *testing.T, eng *Engine, ws [8]byte, id storage.ULID) float32 {
+	t.Helper()
+	got, err := eng.Store().GetConfidence(context.Background(), ws, id)
+	if err != nil {
+		t.Fatalf("readConfidence: %v", err)
+	}
+	return got
+}
+
+// recordingConfidenceWorker is a test double for the engine's ConfidenceWorker.
+// It wraps a real *cognitive.Worker[cognitive.ConfidenceUpdate] (the type
+// Engine.SetCognitiveWorkers requires) whose processFn appends every processed
+// batch into cw.submits. A goroutine runs Worker.Run so Submit is non-blocking
+// and non-dropping, just like production. drain() cancels the run context —
+// Run's shutdown path drains the input channel and flushes one final batch —
+// then waits for the goroutine to return, guaranteeing every Submit made
+// before drain is reflected in submits. Call drain() before asserting on
+// cw.submits.
+type recordingConfidenceWorker struct {
+	mu      sync.Mutex
+	submits []cognitive.ConfidenceUpdate
+
+	worker   *cognitive.Worker[cognitive.ConfidenceUpdate]
+	cancel   context.CancelFunc
+	done     chan struct{}
+	initOnce sync.Once
+}
+
+// AsWorker lazily constructs the underlying *cognitive.Worker on first call
+// (so a bare &recordingConfidenceWorker{} is usable, matching the test
+// injection pattern: e.SetCognitiveWorkers(nil, nil, cw.AsWorker())).
+func (r *recordingConfidenceWorker) AsWorker() *cognitive.Worker[cognitive.ConfidenceUpdate] {
+	r.initOnce.Do(func() {
+		r.worker = cognitive.NewWorker[cognitive.ConfidenceUpdate](
+			100, 1, 100*time.Millisecond,
+			func(_ context.Context, batch []cognitive.ConfidenceUpdate) error {
+				r.mu.Lock()
+				defer r.mu.Unlock()
+				r.submits = append(r.submits, batch...)
+				return nil
+			},
+		)
+		ctx, cancel := context.WithCancel(context.Background())
+		r.cancel = cancel
+		r.done = make(chan struct{})
+		go func() {
+			defer close(r.done)
+			r.worker.Run(ctx) //nolint:errcheck
+		}()
+	})
+	return r.worker
+}
+
+// drain cancels the worker's run context and waits for its shutdown flush
+// to complete. After drain returns, every Submit made before the call is
+// reflected in submits. Safe to call even if AsWorker was never invoked.
+func (r *recordingConfidenceWorker) drain() {
+	if r.cancel != nil {
+		r.cancel()
+		<-r.done
+	}
+}
+
+// -----------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------
+
+// TestEngineAdjustConfidence_Clamps verifies the delta is clamped to [0,1].
+// Each case re-pins the prior to 0.5 so the wants reflect a clean starting point
+// (a sequential run against the same engram would otherwise accumulate).
+func TestEngineAdjustConfidence_Clamps(t *testing.T) {
+	e, ws, id := seedEngineWithEngram(t, 0.5)
+
+	cases := []struct{ delta, want float32 }{
+		{0.2, 0.7},  // mid-range
+		{1.0, 1.0},  // upper clamp
+		{-0.9, 0.0}, // lower clamp
+	}
+	for _, c := range cases {
+		if err := e.Store().UpdateConfidence(context.Background(), ws, id, 0.5); err != nil {
+			t.Fatalf("re-seed UpdateConfidence: %v", err)
+		}
+		got, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, c.delta, id, false, "t")
+		if err != nil {
+			t.Fatalf("delta %v: %v", c.delta, err)
+		}
+		if got != c.want {
+			t.Errorf("delta %v: got %v, want %v", c.delta, got, c.want)
+		}
+	}
+}
+
+// TestEngineAdjustConfidence_RejectsNaNAndInf (RED-sanity: the guard is load-bearing).
+func TestEngineAdjustConfidence_RejectsNaNAndInf(t *testing.T) {
+	e, ws, id := seedEngineWithEngram(t, 0.5)
+	for _, bad := range []float32{float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1))} {
+		if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, bad, id, false, "t"); err == nil {
+			t.Fatalf("delta %v: expected error, got nil", bad)
+		}
+	}
+}
+
+// TestEngineAdjustConfidence_RejectsSelfContradiction (RED-sanity).
+func TestEngineAdjustConfidence_RejectsSelfContradiction(t *testing.T) {
+	e, ws, id := seedEngineWithEngram(t, 0.5)
+	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, -0.1, id, true, "t"); err == nil {
+		t.Fatal("expected self-contradiction error, got nil")
+	}
+}
+
+// TestEngineAdjustConfidence_NotFoundOnUnknownEngram.
+func TestEngineAdjustConfidence_NotFoundOnUnknownEngram(t *testing.T) {
+	e, ws, _ := seedEngineWithEngram(t, 0.5)
+	unknown := storage.NewULID()
+	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), unknown, -0.1, unknown, false, "t"); err == nil {
+		t.Fatal("expected NotFound for unknown engram, got nil")
+	}
+}
+
+// TestEngineAdjustConfidence_NotFoundOnUnknownContradictionTarget.
+func TestEngineAdjustConfidence_NotFoundOnUnknownContradictionTarget(t *testing.T) {
+	e, ws, id := seedEngineWithEngram(t, 0.5)
+	ghost := storage.NewULID()
+	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, -0.1, ghost, true, "t"); err == nil {
+		t.Fatal("expected NotFound for unknown contradicted_by_id, got nil")
+	}
+}
+
+// TestEngineAdjustConfidence_RejectionMutatesNothing (validation-before-write).
+// Every rejection path leaves the engram's confidence unchanged.
+func TestEngineAdjustConfidence_RejectionMutatesNothing(t *testing.T) {
+	e, ws, id := seedEngineWithEngram(t, 0.5)
+	_, _ = e.AdjustConfidence(context.Background(), vaultOf(ws), id, float32(math.NaN()), id, false, "t")
+	if got := readConfidence(t, e, ws, id); got != 0.5 {
+		t.Fatalf("confidence mutated after NaN rejection: %v", got)
+	}
+}
+
+// TestEngineAdjustConfidence_BareDeltaDoesNotSubmit verifies §D3 carve-out:
+// hasContra=false submits nothing to the ConfidenceWorker.
+func TestEngineAdjustConfidence_BareDeltaDoesNotSubmit(t *testing.T) {
+	e, ws, id := seedEngineWithEngram(t, 0.5)
+	cw := &recordingConfidenceWorker{}
+	e.SetCognitiveWorkers(nil, nil, cw.AsWorker())
+
+	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, 0.1, id, false, "t"); err != nil {
+		t.Fatal(err)
+	}
+	cw.drain()
+	if len(cw.submits) != 0 {
+		t.Fatalf("bare delta submitted %d ConfidenceUpdates, want 0", len(cw.submits))
+	}
+}
+
+// TestEngineAdjustConfidence_ContradictionSubmitsEvidenceForBoth verifies the
+// OnFound mirror: hasContra=true submits EvidenceContradiction for BOTH engrams.
+func TestEngineAdjustConfidence_ContradictionSubmitsEvidenceForBoth(t *testing.T) {
+	e, ws, id := seedEngineWithEngram(t, 0.5)
+	other := seedSecondEngram(t, e, ws)
+	cw := &recordingConfidenceWorker{}
+	e.SetCognitiveWorkers(nil, nil, cw.AsWorker())
+
+	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, 0.0, other, true, "rag-bridge"); err != nil {
+		t.Fatal(err)
+	}
+	cw.drain()
+	if len(cw.submits) != 2 {
+		t.Fatalf("expected 2 EvidenceContradiction submits, got %d", len(cw.submits))
+	}
+	for _, s := range cw.submits {
+		if s.Source != "external_contradiction" {
+			t.Errorf("source = %q, want external_contradiction", s.Source)
+		}
+	}
+}

--- a/internal/engine/engine_confidence_test.go
+++ b/internal/engine/engine_confidence_test.go
@@ -154,7 +154,7 @@ func TestEngineAdjustConfidence_Clamps(t *testing.T) {
 		if err := e.Store().UpdateConfidence(context.Background(), ws, id, 0.5); err != nil {
 			t.Fatalf("re-seed UpdateConfidence: %v", err)
 		}
-		got, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, c.delta, id, false, "t")
+		got, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, c.delta, id, false, "t", "test")
 		if err != nil {
 			t.Fatalf("delta %v: %v", c.delta, err)
 		}
@@ -168,7 +168,7 @@ func TestEngineAdjustConfidence_Clamps(t *testing.T) {
 func TestEngineAdjustConfidence_RejectsNaNAndInf(t *testing.T) {
 	e, ws, id := seedEngineWithEngram(t, 0.5)
 	for _, bad := range []float32{float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1))} {
-		if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, bad, id, false, "t"); err == nil {
+		if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, bad, id, false, "t", "test"); err == nil {
 			t.Fatalf("delta %v: expected error, got nil", bad)
 		}
 	}
@@ -177,7 +177,7 @@ func TestEngineAdjustConfidence_RejectsNaNAndInf(t *testing.T) {
 // TestEngineAdjustConfidence_RejectsSelfContradiction (RED-sanity).
 func TestEngineAdjustConfidence_RejectsSelfContradiction(t *testing.T) {
 	e, ws, id := seedEngineWithEngram(t, 0.5)
-	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, -0.1, id, true, "t"); err == nil {
+	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, -0.1, id, true, "t", "test"); err == nil {
 		t.Fatal("expected self-contradiction error, got nil")
 	}
 }
@@ -186,7 +186,7 @@ func TestEngineAdjustConfidence_RejectsSelfContradiction(t *testing.T) {
 func TestEngineAdjustConfidence_NotFoundOnUnknownEngram(t *testing.T) {
 	e, ws, _ := seedEngineWithEngram(t, 0.5)
 	unknown := storage.NewULID()
-	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), unknown, -0.1, unknown, false, "t"); err == nil {
+	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), unknown, -0.1, unknown, false, "t", "test"); err == nil {
 		t.Fatal("expected NotFound for unknown engram, got nil")
 	}
 }
@@ -195,7 +195,7 @@ func TestEngineAdjustConfidence_NotFoundOnUnknownEngram(t *testing.T) {
 func TestEngineAdjustConfidence_NotFoundOnUnknownContradictionTarget(t *testing.T) {
 	e, ws, id := seedEngineWithEngram(t, 0.5)
 	ghost := storage.NewULID()
-	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, -0.1, ghost, true, "t"); err == nil {
+	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, -0.1, ghost, true, "t", "test"); err == nil {
 		t.Fatal("expected NotFound for unknown contradicted_by_id, got nil")
 	}
 }
@@ -204,7 +204,7 @@ func TestEngineAdjustConfidence_NotFoundOnUnknownContradictionTarget(t *testing.
 // Every rejection path leaves the engram's confidence unchanged.
 func TestEngineAdjustConfidence_RejectionMutatesNothing(t *testing.T) {
 	e, ws, id := seedEngineWithEngram(t, 0.5)
-	_, _ = e.AdjustConfidence(context.Background(), vaultOf(ws), id, float32(math.NaN()), id, false, "t")
+	_, _ = e.AdjustConfidence(context.Background(), vaultOf(ws), id, float32(math.NaN()), id, false, "t", "test")
 	if got := readConfidence(t, e, ws, id); got != 0.5 {
 		t.Fatalf("confidence mutated after NaN rejection: %v", got)
 	}
@@ -217,7 +217,7 @@ func TestEngineAdjustConfidence_BareDeltaDoesNotSubmit(t *testing.T) {
 	cw := &recordingConfidenceWorker{}
 	e.SetCognitiveWorkers(nil, nil, cw.AsWorker())
 
-	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, 0.1, id, false, "t"); err != nil {
+	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, 0.1, id, false, "t", "test"); err != nil {
 		t.Fatal(err)
 	}
 	cw.drain()
@@ -234,7 +234,7 @@ func TestEngineAdjustConfidence_ContradictionSubmitsEvidenceForBoth(t *testing.T
 	cw := &recordingConfidenceWorker{}
 	e.SetCognitiveWorkers(nil, nil, cw.AsWorker())
 
-	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, 0.0, other, true, "rag-bridge"); err != nil {
+	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, 0.0, other, true, "rag-bridge", "test"); err != nil {
 		t.Fatal(err)
 	}
 	cw.drain()

--- a/internal/engine/engine_confidence_test.go
+++ b/internal/engine/engine_confidence_test.go
@@ -284,3 +284,24 @@ func TestEngineAdjustConfidence_ContradictionPersistsMarker(t *testing.T) {
 		t.Fatalf("contradiction marker for {%s,%s} not persisted; pairs=%v", id, other, pairs)
 	}
 }
+
+// NOTE on the engine-layer lost-update test (deliberately absent here, present
+// at the storage layer — see TestUpdateConfidenceWithContradiction_NoLostUpdate-
+// UnderConcurrentDeltas in internal/storage/confidence_caslock_test.go).
+//
+// #559's lost-update fix lives entirely in the storage method: the read+add+
+// clamp moved inside the stripe lock. Engine.AdjustConfidence is now a thin
+// pass-through — it validates (NaN/Inf, self-contradiction, existence) and
+// forwards the delta to UpdateConfidenceWithContradiction, using the returned
+// (prior, newConf) for the audit. TestEngineAdjustConfidence_Clamps and the
+// other Task-3 engine tests cover the engine path end-to-end and pass as-is.
+//
+// A direct engine-layer concurrency test (50 goroutines calling
+// Engine.AdjustConfidence concurrently) is blocked by a SEPARATE pre-existing
+// race the detector flags under -race: Engine.AdjustConfidence's existence
+// check (unlocked e.store.GetMetadata at engine.go:2532) races against another
+// caller's post-commit cache.Set/metaCache.Remove inside UpdateConfidence-
+// WithContradiction. That cache race is independent of #559 (the stripe lock
+// correctly serializes the confidence RMW; only the auxiliary cache mutation
+// and the existence-check read race) and is out of scope for this PR. The
+// storage-layer test is the load-bearing proof of the lost-update fix.

--- a/internal/engine/engine_confidence_test.go
+++ b/internal/engine/engine_confidence_test.go
@@ -247,3 +247,40 @@ func TestEngineAdjustConfidence_ContradictionSubmitsEvidenceForBoth(t *testing.T
 		}
 	}
 }
+
+// TestEngineAdjustConfidence_ContradictionPersistsMarker verifies the 0x0A
+// contradiction marker is actually durable after Engine.AdjustConfidence
+// returns, read back through the engine's own public read path
+// (Engine.GetContradictions). The storage-layer test
+// (TestUpdateConfidenceWithContradiction_AtomicConfidenceAndMarker) already
+// pins the batched write; this test pins the engine contract — that a caller
+// who passes hasContra=true can observe the marker via the engine surface,
+// not just the raw store. Regression guard: if a future refactor of
+// AdjustConfidence drops the contradiction arm of the composed write (e.g.,
+// calls UpdateConfidence instead of UpdateConfidenceWithContradiction), the
+// marker disappears and this test fails.
+func TestEngineAdjustConfidence_ContradictionPersistsMarker(t *testing.T) {
+	e, ws, id := seedEngineWithEngram(t, 0.5)
+	other := seedSecondEngram(t, e, ws)
+
+	if _, err := e.AdjustConfidence(context.Background(), vaultOf(ws), id, -0.1, other, true, "rag-bridge", "test"); err != nil {
+		t.Fatalf("AdjustConfidence: %v", err)
+	}
+
+	pairs, err := e.GetContradictions(context.Background(), vaultOf(ws))
+	if err != nil {
+		t.Fatalf("GetContradictions: %v", err)
+	}
+	want := [2]storage.ULID{id, other}
+	wantRev := [2]storage.ULID{other, id}
+	found := false
+	for _, p := range pairs {
+		if p == want || p == wantRev {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("contradiction marker for {%s,%s} not persisted; pairs=%v", id, other, pairs)
+	}
+}

--- a/internal/engine/engine_vault.go
+++ b/internal/engine/engine_vault.go
@@ -16,6 +16,16 @@ var ErrVaultNotFound = errors.New("vault not found")
 // Use errors.Is to check for this error in callers.
 var ErrEngramNotFound = errors.New("engram not found")
 
+// ErrInvalidArgument is returned when a caller-supplied scalar is out of the
+// representable range (NaN, Inf, etc.). REST/gRPC handlers map it to 400/INVALID_ARGUMENT.
+// Use errors.Is to check for this error in callers.
+var ErrInvalidArgument = errors.New("invalid argument")
+
+// ErrSelfContradiction is returned when AdjustConfidence is asked to mark an
+// engram as contradicting itself (id == other with hasContra=true). The
+// contradiction graph is irreflexive by construction.
+var ErrSelfContradiction = errors.New("self-contradiction rejected")
+
 // ErrEngramSoftDeleted is returned when an operation targets an engram that has
 // been soft-deleted. Use errors.Is to check for this error in callers.
 var ErrEngramSoftDeleted = errors.New("engram is soft-deleted")

--- a/internal/storage/confidence_caslock_test.go
+++ b/internal/storage/confidence_caslock_test.go
@@ -29,7 +29,9 @@ func TestUpdateConfidenceWithContradiction_SerializesWithCAS(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- store.UpdateConfidenceWithContradiction(ctx, ws, id, 0.5, id, false)
+		// Delta-based API (#559): method now returns (prior, newConf, err).
+		_, _, err := store.UpdateConfidenceWithContradiction(ctx, ws, id, 0.5, id, false)
+		done <- err
 	}()
 
 	select {
@@ -53,32 +55,59 @@ func TestUpdateConfidenceWithContradiction_SerializesWithCAS(t *testing.T) {
 	}
 }
 
-// NOTE on the lost-update test class (deliberately absent).
+// TestUpdateConfidenceWithContradiction_NoLostUpdateUnderConcurrentDeltas is the
+// lost-update test the NOTE below used to document as absent. N concurrent
+// +delta calls on the same id must each observe the prior writer's commit and
+// accumulate — the per-engram stripe lock acquired inside this method now spans
+// the read+add+clamp+commit, so the calls serialize.
 //
-// The lost-update race reported by scrypster — "50 concurrent +0.01
-// AdjustConfidence calls on the same id from 0.0 landed at 0.02–0.06" —
-// lives at the ENGINE layer, not at this storage layer. Engine.AdjustConfidence
-// does `current, _ := GetConfidence(...); newConf := current+delta;
-// UpdateConfidenceWithContradiction(ctx, ws, id, newConf, ...)` — the read is
-// OUTSIDE UpdateConfidenceWithContradiction, so the per-engram stripe lock
-// acquired inside the storage function cannot span the read that computes the
-// absolute target. Empirically confirmed: 50 concurrent "+0.01" RMW calls
-// against the same id land at 0.02 WITH the storage lock and 0.04–0.07
-// WITHOUT it — the storage lock cannot make this test green because the loss
-// is determined entirely by the unlocked external read, not by the storage
-// RMW. A meaningful lost-update test for this pattern belongs in
-// internal/engine (call Engine.AdjustConfidence with delta=0.01 fifty times)
-// and requires an engine-layer fix (engine holds the stripe lock across its
-// read+write, OR the storage exposes an AdjustConfidence(delta) API that does
-// read+add+write atomically under the lock). Both are out of scope for this
-// PR, which closes the #594-class resurrection race documented below.
-//
-// The storage-level race the stripe lock DOES fix for this function is the
-// resurrection race — a concurrent DeleteEngram committing between this
-// function's GetEngram read and its batch.Commit, after which the engram-key
-// Set re-creates the deleted record. That is covered by
-// TestUpdateConfidenceWithContradiction_NoResurrectionUnderConcurrentDelete
-// below.
+// Before #559's delta-based refactor, Engine.AdjustConfidence did its confidence
+// read OUTSIDE this storage method (via GetConfidence) and passed an ABSOLUTE
+// target; the stripe lock acquired here could not span that external read, so
+// 50 concurrent +0.01 calls landed at ≈0.02 (last absolute-writer wins). With
+// the read+add+clamp moved inside the locked method, the 50 deltas accumulate
+// to ≈0.5. Run with -race -count=N to confirm stability.
+func TestUpdateConfidenceWithContradiction_NoLostUpdateUnderConcurrentDeltas(t *testing.T) {
+	store, cleanup := newTestStoreHelper(t)
+	defer cleanup()
+	ctx := context.Background()
+	ws := store.VaultPrefix("conf-lostupdate")
+	id := writeLeaseTestEngram(t, store, ws)
+
+	// Pin the seed at exactly 0.0 so the expected accumulation is N*delta.
+	if err := store.UpdateConfidence(ctx, ws, id, 0.0); err != nil {
+		t.Fatalf("seed UpdateConfidence: %v", err)
+	}
+
+	const N = 50
+	const delta = float32(0.01)
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			// hasContra=false: bare delta path, no marker work, no other-id
+			// needed — isolates the confidence RMW.
+			_, _, _ = store.UpdateConfidenceWithContradiction(ctx, ws, id, delta, id, false)
+		}()
+	}
+	wg.Wait()
+
+	got, err := store.GetConfidence(ctx, ws, id)
+	if err != nil {
+		t.Fatalf("GetConfidence: %v", err)
+	}
+	// Expected ≈ 50 × 0.01 = 0.5. The lower bound 0.45 EXCLUDES the broken-
+	// behaviour result (~0.02 = a single delta landing, last-writer-wins) with
+	// headroom for float32 accumulation noise. The upper bound guards against
+	// a runaway clamp bug. This assertion is the load-bearing one: if it fails
+	// low, deltas were lost.
+	const want = float32(0.5)
+	if got < 0.45 || got > want+0.01 {
+		t.Fatalf("lost-update: final confidence = %v, want ≈ %v (50 × +0.01); "+
+			"< 0.45 means deltas were lost (pre-fix behaviour landed ≈ 0.02)", got, want)
+	}
+}
 
 // TestUpdateConfidenceWithContradiction_NoResurrectionUnderConcurrentDelete
 // races UpdateConfidenceWithContradiction against DeleteEngram on the same id,
@@ -108,8 +137,9 @@ func TestUpdateConfidenceWithContradiction_NoResurrectionUnderConcurrentDelete(t
 		}()
 		go func() {
 			defer wg.Done()
+			// Delta-based API (#559): returns (prior, newConf, err).
 			// Returns ErrNotFound if the delete won the race — acceptable.
-			_ = store.UpdateConfidenceWithContradiction(ctx, ws, id, 0.5, id, false)
+			_, _, _ = store.UpdateConfidenceWithContradiction(ctx, ws, id, 0.5, id, false)
 		}()
 		wg.Wait()
 

--- a/internal/storage/confidence_caslock_test.go
+++ b/internal/storage/confidence_caslock_test.go
@@ -1,0 +1,124 @@
+package storage
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestUpdateConfidenceWithContradiction_SerializesWithCAS asserts
+// UpdateConfidenceWithContradiction takes the same per-engram stripe lock that
+// CompareAndSet and DeleteEngram hold across their read-modify-write. Without
+// it, the function's GetEngram → batch.Commit RMW can interleave with a
+// concurrent CAS or delete: a CAS that loses the race can have its state change
+// clobbered when UpdateConfidenceWithContradiction writes the whole engram
+// back, and the function can commit after a DeleteEngram — resurrecting a
+// record the caller believes is gone. Holding the lock in the test stands in
+// for an in-flight CAS: a correct UpdateConfidenceWithContradiction must block
+// until it is released. Mirrors TestDeleteEngramSerializesWithCompareAndSet.
+func TestUpdateConfidenceWithContradiction_SerializesWithCAS(t *testing.T) {
+	store, cleanup := newTestStoreHelper(t)
+	defer cleanup()
+	ctx := context.Background()
+	ws := store.VaultPrefix("conf-caslock")
+	id := writeLeaseTestEngram(t, store, ws)
+
+	mu := store.casLocks.For(id[:])
+	mu.Lock()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- store.UpdateConfidenceWithContradiction(ctx, ws, id, 0.5, id, false)
+	}()
+
+	select {
+	case <-done:
+		mu.Unlock()
+		t.Fatal("UpdateConfidenceWithContradiction completed while the engram's CAS stripe lock was held; " +
+			"it does not serialize with CompareAndSet/DeleteEngram and can resurrect deleted records")
+	case <-time.After(100 * time.Millisecond):
+		// Expected: blocked on the stripe lock.
+	}
+
+	mu.Unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("UpdateConfidenceWithContradiction: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("UpdateConfidenceWithContradiction did not complete after releasing the stripe lock")
+	}
+}
+
+// NOTE on the lost-update test class (deliberately absent).
+//
+// The lost-update race reported by scrypster — "50 concurrent +0.01
+// AdjustConfidence calls on the same id from 0.0 landed at 0.02–0.06" —
+// lives at the ENGINE layer, not at this storage layer. Engine.AdjustConfidence
+// does `current, _ := GetConfidence(...); newConf := current+delta;
+// UpdateConfidenceWithContradiction(ctx, ws, id, newConf, ...)` — the read is
+// OUTSIDE UpdateConfidenceWithContradiction, so the per-engram stripe lock
+// acquired inside the storage function cannot span the read that computes the
+// absolute target. Empirically confirmed: 50 concurrent "+0.01" RMW calls
+// against the same id land at 0.02 WITH the storage lock and 0.04–0.07
+// WITHOUT it — the storage lock cannot make this test green because the loss
+// is determined entirely by the unlocked external read, not by the storage
+// RMW. A meaningful lost-update test for this pattern belongs in
+// internal/engine (call Engine.AdjustConfidence with delta=0.01 fifty times)
+// and requires an engine-layer fix (engine holds the stripe lock across its
+// read+write, OR the storage exposes an AdjustConfidence(delta) API that does
+// read+add+write atomically under the lock). Both are out of scope for this
+// PR, which closes the #594-class resurrection race documented below.
+//
+// The storage-level race the stripe lock DOES fix for this function is the
+// resurrection race — a concurrent DeleteEngram committing between this
+// function's GetEngram read and its batch.Commit, after which the engram-key
+// Set re-creates the deleted record. That is covered by
+// TestUpdateConfidenceWithContradiction_NoResurrectionUnderConcurrentDelete
+// below.
+
+// TestUpdateConfidenceWithContradiction_NoResurrectionUnderConcurrentDelete
+// races UpdateConfidenceWithContradiction against DeleteEngram on the same id,
+// mirroring TestDeleteEngramNoResurrectionUnderConcurrentCAS. The invariant:
+// once DeleteEngram returns, the engram MUST be gone — no concurrent RMW may
+// resurrect it by committing its engram/metadata keys after the delete's batch.
+// Without the per-engram lock on UpdateConfidenceWithContradiction, the
+// function's GetEngram read can land before DeleteEngram's commit and its
+// batch.Set(0x01|0x02) + Commit can land after — leaving the deleted engram
+// readable again (the #594 resurrection class). Run with -race for
+// interleavings; the 200-trial loop is the same cadence the delete-path test
+// uses to surface the ~few/200 resurrection rate.
+func TestUpdateConfidenceWithContradiction_NoResurrectionUnderConcurrentDelete(t *testing.T) {
+	store, cleanup := newTestStoreHelper(t)
+	defer cleanup()
+	ctx := context.Background()
+	ws := store.VaultPrefix("conf-resurrect")
+
+	for i := 0; i < 200; i++ {
+		id := writeLeaseTestEngram(t, store, ws)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = store.DeleteEngram(ctx, ws, id)
+		}()
+		go func() {
+			defer wg.Done()
+			// Returns ErrNotFound if the delete won the race — acceptable.
+			_ = store.UpdateConfidenceWithContradiction(ctx, ws, id, 0.5, id, false)
+		}()
+		wg.Wait()
+
+		// After both return the engram MUST NOT be readable. A non-nil engram
+		// means UpdateConfidenceWithContradiction committed its 0x01|0x02
+		// write AFTER DeleteEngram's batch and resurrected the record.
+		eng, err := store.GetEngram(ctx, ws, id)
+		if err == nil && eng != nil {
+			t.Fatalf("iter %d: engram resurrected after DeleteEngram returned: %+v", i, eng)
+		}
+	}
+}

--- a/internal/storage/confidence_caslock_test.go
+++ b/internal/storage/confidence_caslock_test.go
@@ -152,3 +152,48 @@ func TestUpdateConfidenceWithContradiction_NoResurrectionUnderConcurrentDelete(t
 		}
 	}
 }
+
+// TestUpdateConfidence_NoResurrectionUnderConcurrentDelete is the ABSOLUTE-setter
+// analogue of the delta-path test above. PebbleStore.UpdateConfidence (the
+// absolute set, reachable from Engine.AdjustConfidence via the ConfidenceWorker
+// when hasContra=true) is also a GetEngram → batch.Set(0x01|0x02) → Commit
+// read-modify-write, so it can resurrect a concurrently deleted engram in exactly
+// the same way (#626). The invariant is identical: once DeleteEngram returns, the
+// engram MUST NOT be readable — GetEngram reads the 0x01/0x02 keys, so a non-nil
+// result means UpdateConfidence committed its payload write after the delete's
+// batch, restoring the record without its 0x0B state index. Without the
+// per-engram stripe lock on UpdateConfidence this fails ~1/500 under -race; run
+// with -race -count=3 to surface it reliably. Mirrors the delta-path test's
+// 200-trial cadence.
+func TestUpdateConfidence_NoResurrectionUnderConcurrentDelete(t *testing.T) {
+	store, cleanup := newTestStoreHelper(t)
+	defer cleanup()
+	ctx := context.Background()
+	ws := store.VaultPrefix("conf-abs-resurrect")
+
+	for i := 0; i < 200; i++ {
+		id := writeLeaseTestEngram(t, store, ws)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = store.DeleteEngram(ctx, ws, id)
+		}()
+		go func() {
+			defer wg.Done()
+			// Absolute set. Returns ErrNotFound if the delete won the race —
+			// acceptable; the invariant is only about post-delete resurrection.
+			_ = store.UpdateConfidence(ctx, ws, id, 0.5)
+		}()
+		wg.Wait()
+
+		// After both return the engram MUST NOT be readable. GetEngram reads the
+		// 0x01/0x02 keys; a non-nil engram means UpdateConfidence committed its
+		// payload write AFTER DeleteEngram's batch and resurrected the record.
+		eng, err := store.GetEngram(ctx, ws, id)
+		if err == nil && eng != nil {
+			t.Fatalf("iter %d: engram resurrected after DeleteEngram returned via absolute UpdateConfidence: %+v", i, eng)
+		}
+	}
+}

--- a/internal/storage/engram.go
+++ b/internal/storage/engram.go
@@ -834,9 +834,42 @@ func (ps *PebbleStore) UpdateConfidence(ctx context.Context, wsPrefix [8]byte, i
 // in a single Pebble batch — no partial-failure window between the confidence
 // write and the marker. Mirrors UpdateConfidence (0x01+0x02 via erf.Encode) and
 // FlagContradiction (canonical-ordered 0x0A pair), composed.
+//
+// The read-modify-write (GetEngram → mutate → batch.Set 0x01|0x02 → Commit)
+// holds the per-engram stripe lock across the read and the commit, mirroring
+// DeleteEngram and CompareAndSet. Without the lock two failures are reachable:
+//
+//   - Lost update: concurrent callers race the RMW. Most batch.Commit calls
+//     land on a stale engram view and overwrite each other, so N concurrent
+//     +delta adjustments collapse to a handful of effective writes.
+//   - Resurrection (#594 class): a racing DeleteEngram can commit between this
+//     function's GetEngram read and its batch.Commit, after which the
+//     batch.Set(0x01|0x02) + Commit resurrects the deleted engram's keys.
+//
+// Under the lock the function serializes with same-id CAS and delete paths.
+// Post-commit cleanup (replicateBatch, cache, metaCache) runs unlocked to keep
+// the stripe free during O(n) work — same shape as DeleteEngram.
+//
+// Cache invalidation before the read: DeleteEngram populates the engram cache
+// during its own locked GetEngram read and only invalidates it AFTER mu.Unlock
+// (post-commit). Without dropping the cache here, a racing DeleteEngram that
+// committed-then-unlocked (but has not yet reached its post-commit cache.Delete)
+// would leave this function's GetEngram reading a stale cached entry — which
+// then gets written back via batch.Set(0x01|0x02), resurrecting the deleted
+// engram. Dropping the cache under the lock forces a fresh Pebble read that
+// observes the delete's committed state. Mirrors the authoritative-read-under-
+// lock expectation without altering DeleteEngram's post-commit cleanup order.
 func (ps *PebbleStore) UpdateConfidenceWithContradiction(ctx context.Context, wsPrefix [8]byte, id ULID, confidence float32, other ULID, hasContra bool) error {
+	mu := ps.casLocks.For(id[:])
+	mu.Lock()
+	// Drop any stale cache entry left by a racing DeleteEngram between its
+	// batch.Commit and its post-commit cache.Delete, so the GetEngram below
+	// reads authoritative Pebble state.
+	ps.cache.Delete(wsPrefix, id)
+
 	eng, err := ps.GetEngram(ctx, wsPrefix, id)
 	if err != nil {
+		mu.Unlock()
 		return err
 	}
 	eng.Confidence = confidence
@@ -845,6 +878,7 @@ func (ps *PebbleStore) UpdateConfidenceWithContradiction(ctx context.Context, ws
 	erfEng := toERFEngram(eng)
 	erfBytes, err := erf.Encode(erfEng)
 	if err != nil {
+		mu.Unlock()
 		return fmt.Errorf("encode engram: %w", err)
 	}
 
@@ -870,8 +904,10 @@ func (ps *PebbleStore) UpdateConfidenceWithContradiction(ctx context.Context, ws
 	}
 
 	if err := batch.Commit(pebble.NoSync); err != nil {
+		mu.Unlock()
 		return fmt.Errorf("commit batch: %w", err)
 	}
+	mu.Unlock()
 	ps.replicateBatch(batch)
 
 	ps.cache.Set(wsPrefix, id, eng)

--- a/internal/storage/engram.go
+++ b/internal/storage/engram.go
@@ -927,11 +927,19 @@ func (ps *PebbleStore) UpdateConfidenceWithContradiction(ctx context.Context, ws
 		mu.Unlock()
 		return 0, 0, fmt.Errorf("commit batch: %w", err)
 	}
-	mu.Unlock()
-	ps.replicateBatch(batch)
-
+	// Cache mutation under the stripe lock (was post-Unlock): otherwise a
+	// racing DeleteEngram's post-commit cache.Delete can land before this
+	// cache.Set, which then re-caches an engram Pebble has already deleted
+	// -- resurrecting it under a post-Wait read (caught on CI). Inside the
+	// critical section the cache mutation is atomic with the commit;
+	// DeleteEngram's cache.Delete always runs after we release.
+	// replicateBatch stays post-commit (no local-cache effect).
 	ps.cache.Set(wsPrefix, id, eng)
 	ps.metaCache.Remove(id16)
+	mu.Unlock()
+
+	ps.replicateBatch(batch)
+
 	return prior, newConf, nil
 }
 

--- a/internal/storage/engram.go
+++ b/internal/storage/engram.go
@@ -784,10 +784,30 @@ func (ps *PebbleStore) GetConfidence(ctx context.Context, wsPrefix [8]byte, id U
 }
 
 // UpdateConfidence updates the confidence in 0x02 metadata (and 0x01 full engram).
+// UpdateConfidence performs an ABSOLUTE set of an engram's confidence (unlike the
+// delta-based UpdateConfidenceWithContradiction). It is a read-modify-write over
+// the 0x01/0x02 keys and therefore races a concurrent DeleteEngram exactly like
+// the delta primitive: a delete committing between this method's GetEngram read
+// and its batch.Commit would be undone by the batch.Set(0x01|0x02), resurrecting
+// the deleted engram's payload/meta keys without its 0x0B state index (the #594 /
+// #626 resurrection class). The per-engram stripe lock (casLocks.For(id) — the
+// SAME striped mutex CompareAndSet, DeleteEngram, and the delta primitive use)
+// is held across the whole critical section, and the engram cache is dropped
+// before the authoritative GetEngram read, so this path serializes with same-id
+// delete/CAS and always reads committed Pebble state. Mirrors the locking shape
+// of UpdateConfidenceWithContradiction above; only the set semantics differ.
 func (ps *PebbleStore) UpdateConfidence(ctx context.Context, wsPrefix [8]byte, id ULID, confidence float32) error {
+	mu := ps.casLocks.For(id[:])
+	mu.Lock()
+	// Drop any stale cache entry left by a racing DeleteEngram between its
+	// batch.Commit and its post-commit cache.Delete, so the GetEngram below
+	// reads authoritative Pebble state (see UpdateConfidenceWithContradiction).
+	ps.cache.Delete(wsPrefix, id)
+
 	// Read current engram
 	eng, err := ps.GetEngram(ctx, wsPrefix, id)
 	if err != nil {
+		mu.Unlock()
 		return err
 	}
 
@@ -799,6 +819,7 @@ func (ps *PebbleStore) UpdateConfidence(ctx context.Context, wsPrefix [8]byte, i
 	erfEng := toERFEngram(eng)
 	erfBytes, err := erf.Encode(erfEng)
 	if err != nil {
+		mu.Unlock()
 		return fmt.Errorf("encode engram: %w", err)
 	}
 
@@ -817,14 +838,18 @@ func (ps *PebbleStore) UpdateConfidence(ctx context.Context, wsPrefix [8]byte, i
 	batch.Set(metaKey, metaSlice505, nil)
 
 	if err := batch.Commit(pebble.NoSync); err != nil {
+		mu.Unlock()
 		return fmt.Errorf("commit batch: %w", err)
 	}
-	ps.replicateBatch(batch)
-
-	// Update cache (vault-scoped).
+	// Cache mutation under the stripe lock (see UpdateConfidenceWithContradiction):
+	// otherwise a racing DeleteEngram's post-commit cache.Delete can land before
+	// this cache.Set, re-caching an engram Pebble has already deleted.
 	ps.cache.Set(wsPrefix, id, eng)
 	// Invalidate metadata cache — cached metadata is stale.
 	ps.metaCache.Remove([16]byte(id))
+	mu.Unlock()
+
+	ps.replicateBatch(batch)
 
 	return nil
 }

--- a/internal/storage/engram.go
+++ b/internal/storage/engram.go
@@ -829,6 +829,56 @@ func (ps *PebbleStore) UpdateConfidence(ctx context.Context, wsPrefix [8]byte, i
 	return nil
 }
 
+// UpdateConfidenceWithContradiction atomically updates engram confidence and,
+// when hasContra, writes the 0x0A contradiction marker for the (id, other) pair
+// in a single Pebble batch — no partial-failure window between the confidence
+// write and the marker. Mirrors UpdateConfidence (0x01+0x02 via erf.Encode) and
+// FlagContradiction (canonical-ordered 0x0A pair), composed.
+func (ps *PebbleStore) UpdateConfidenceWithContradiction(ctx context.Context, wsPrefix [8]byte, id ULID, confidence float32, other ULID, hasContra bool) error {
+	eng, err := ps.GetEngram(ctx, wsPrefix, id)
+	if err != nil {
+		return err
+	}
+	eng.Confidence = confidence
+	eng.UpdatedAt = time.Now()
+
+	erfEng := toERFEngram(eng)
+	erfBytes, err := erf.Encode(erfEng)
+	if err != nil {
+		return fmt.Errorf("encode engram: %w", err)
+	}
+
+	batch := ps.db.NewBatch()
+	defer batch.Close()
+
+	id16 := [16]byte(id)
+	batch.Set(keys.EngramKey(wsPrefix, id16), erfBytes, nil)
+	metaSlice := erfBytes
+	if len(metaSlice) > erf.MetaKeySize {
+		metaSlice = metaSlice[:erf.MetaKeySize]
+	}
+	batch.Set(keys.MetaKey(wsPrefix, id16), metaSlice, nil)
+
+	if hasContra {
+		aBytes := [16]byte(id)
+		bBytes := [16]byte(other)
+		if CompareULIDs(id, other) > 0 {
+			aBytes, bBytes = bBytes, aBytes
+		}
+		batch.Set(keys.ContradictionKey(wsPrefix, 0, 0, aBytes), bBytes[:], nil)
+		batch.Set(keys.ContradictionKey(wsPrefix, 0, 0, bBytes), aBytes[:], nil)
+	}
+
+	if err := batch.Commit(pebble.NoSync); err != nil {
+		return fmt.Errorf("commit batch: %w", err)
+	}
+	ps.replicateBatch(batch)
+
+	ps.cache.Set(wsPrefix, id, eng)
+	ps.metaCache.Remove(id16)
+	return nil
+}
+
 // toERFEngram converts storage.Engram to erf.Engram.
 func toERFEngram(eng *Engram) *erf.Engram {
 	erfAssocs := make([]erf.Association, len(eng.Associations))

--- a/internal/storage/engram.go
+++ b/internal/storage/engram.go
@@ -829,19 +829,26 @@ func (ps *PebbleStore) UpdateConfidence(ctx context.Context, wsPrefix [8]byte, i
 	return nil
 }
 
-// UpdateConfidenceWithContradiction atomically updates engram confidence and,
+// UpdateConfidenceWithContradiction atomically applies a confidence delta and,
 // when hasContra, writes the 0x0A contradiction marker for the (id, other) pair
 // in a single Pebble batch — no partial-failure window between the confidence
 // write and the marker. Mirrors UpdateConfidence (0x01+0x02 via erf.Encode) and
 // FlagContradiction (canonical-ordered 0x0A pair), composed.
 //
-// The read-modify-write (GetEngram → mutate → batch.Set 0x01|0x02 → Commit)
-// holds the per-engram stripe lock across the read and the commit, mirroring
-// DeleteEngram and CompareAndSet. Without the lock two failures are reachable:
+// Delta-based (closes #559's lost-update race): the read+add+clamp happens
+// INSIDE the locked section, not in the caller. The per-engram stripe lock
+// (casLocks.For(id)) is acquired before the GetEngram read and held across
+// batch.Commit — the same shape as PebbleStore.CompareAndSet (lease.go:157) and
+// DeleteEngram. So N concurrent +delta calls on the same id serialize: each
+// observes the prior writer's committed state and accumulates, instead of all
+// reading the same pre-write value and overwriting each other. The method
+// returns (prior, newConf) so the engine can audit without a second unlocked
+// read that would re-open the race.
 //
-//   - Lost update: concurrent callers race the RMW. Most batch.Commit calls
-//     land on a stale engram view and overwrite each other, so N concurrent
-//     +delta adjustments collapse to a handful of effective writes.
+// Two failure classes the lock defends against:
+//
+//   - Lost update (#559): concurrent callers race the RMW. With the read inside
+//     the lock, each +delta call sees its predecessor's commit and adds to it.
 //   - Resurrection (#594 class): a racing DeleteEngram can commit between this
 //     function's GetEngram read and its batch.Commit, after which the
 //     batch.Set(0x01|0x02) + Commit resurrects the deleted engram's keys.
@@ -859,7 +866,10 @@ func (ps *PebbleStore) UpdateConfidence(ctx context.Context, wsPrefix [8]byte, i
 // engram. Dropping the cache under the lock forces a fresh Pebble read that
 // observes the delete's committed state. Mirrors the authoritative-read-under-
 // lock expectation without altering DeleteEngram's post-commit cleanup order.
-func (ps *PebbleStore) UpdateConfidenceWithContradiction(ctx context.Context, wsPrefix [8]byte, id ULID, confidence float32, other ULID, hasContra bool) error {
+//
+// The caller is responsible for rejecting NaN/Inf deltas before invoking; this
+// method assumes delta is finite.
+func (ps *PebbleStore) UpdateConfidenceWithContradiction(ctx context.Context, wsPrefix [8]byte, id ULID, delta float32, other ULID, hasContra bool) (prior, newConf float32, err error) {
 	mu := ps.casLocks.For(id[:])
 	mu.Lock()
 	// Drop any stale cache entry left by a racing DeleteEngram between its
@@ -870,16 +880,26 @@ func (ps *PebbleStore) UpdateConfidenceWithContradiction(ctx context.Context, ws
 	eng, err := ps.GetEngram(ctx, wsPrefix, id)
 	if err != nil {
 		mu.Unlock()
-		return err
+		return 0, 0, err
 	}
-	eng.Confidence = confidence
+	// Read+add+clamp UNDER the stripe lock — the lost-update fix (#559). The
+	// engine-side read that used to live in Engine.AdjustConfidence is gone;
+	// the prior value returned below comes from this locked read.
+	prior = eng.Confidence
+	newConf = prior + delta
+	if newConf < 0 {
+		newConf = 0
+	} else if newConf > 1 {
+		newConf = 1
+	}
+	eng.Confidence = newConf
 	eng.UpdatedAt = time.Now()
 
 	erfEng := toERFEngram(eng)
 	erfBytes, err := erf.Encode(erfEng)
 	if err != nil {
 		mu.Unlock()
-		return fmt.Errorf("encode engram: %w", err)
+		return 0, 0, fmt.Errorf("encode engram: %w", err)
 	}
 
 	batch := ps.db.NewBatch()
@@ -905,14 +925,14 @@ func (ps *PebbleStore) UpdateConfidenceWithContradiction(ctx context.Context, ws
 
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		mu.Unlock()
-		return fmt.Errorf("commit batch: %w", err)
+		return 0, 0, fmt.Errorf("commit batch: %w", err)
 	}
 	mu.Unlock()
 	ps.replicateBatch(batch)
 
 	ps.cache.Set(wsPrefix, id, eng)
 	ps.metaCache.Remove(id16)
-	return nil
+	return prior, newConf, nil
 }
 
 // toERFEngram converts storage.Engram to erf.Engram.

--- a/internal/storage/impl_test.go
+++ b/internal/storage/impl_test.go
@@ -1287,8 +1287,10 @@ func contradictionMarkerExists(t *testing.T, store *PebbleStore, ws [8]byte, a, 
 }
 
 // TestUpdateConfidenceWithContradiction_AtomicConfidenceAndMarker verifies the
-// composed write sets confidence and, when hasContra, the 0x0A marker pair — in
-// one batch. Mirrors the inputs of TestFlagContradiction (impl_test.go:610).
+// composed write applies a delta and, when hasContra, writes the 0x0A marker
+// pair — in one batch. Mirrors the inputs of TestFlagContradiction (impl_test.go:610).
+// Delta-based since #559: the method takes a delta, does read+add+clamp inside
+// the stripe lock, and returns (prior, newConf).
 func TestUpdateConfidenceWithContradiction_AtomicConfidenceAndMarker(t *testing.T) {
 	store, ws, id, other := setupContradictionFixture(t)
 
@@ -1296,13 +1298,22 @@ func TestUpdateConfidenceWithContradiction_AtomicConfidenceAndMarker(t *testing.
 	seedEngram(t, store, ws, id, 0.5)
 	seedEngram(t, store, ws, other, 0.5)
 
-	if err := store.UpdateConfidenceWithContradiction(
-		context.Background(), ws, id, 0.9, other, true); err != nil {
+	// +0.4 delta from a 0.5 seed → 0.9 (mid-range, no clamp).
+	prior, newConf, err := store.UpdateConfidenceWithContradiction(
+		context.Background(), ws, id, 0.4, other, true)
+	if err != nil {
 		t.Fatalf("write: %v", err)
 	}
+	if prior != 0.5 {
+		t.Fatalf("prior = %v, want 0.5 (seed)", prior)
+	}
+	// float32 approximate equality — 0.5+0.4 is not exactly representable.
+	if newConf-0.9 > 1e-6 || 0.9-newConf > 1e-6 {
+		t.Fatalf("newConf = %v, want ≈ 0.9", newConf)
+	}
 
-	if got, _ := store.GetConfidence(context.Background(), ws, id); got != 0.9 {
-		t.Fatalf("confidence = %v, want 0.9", got)
+	if got, _ := store.GetConfidence(context.Background(), ws, id); got-0.9 > 1e-6 || 0.9-got > 1e-6 {
+		t.Fatalf("confidence = %v, want ≈ 0.9", got)
 	}
 	if !contradictionMarkerExists(t, store, ws, id, other) {
 		t.Fatal("expected 0x0A marker pair after hasContra write")
@@ -1323,12 +1334,21 @@ func TestUpdateConfidenceWithContradiction_NoMarkerWhenHasContraFalse(t *testing
 	store, ws, id, other := setupContradictionFixture(t)
 	seedEngram(t, store, ws, id, 0.5)
 
-	if err := store.UpdateConfidenceWithContradiction(
-		context.Background(), ws, id, 0.2, other, false); err != nil {
+	// -0.3 delta from a 0.5 seed → 0.2.
+	prior, newConf, err := store.UpdateConfidenceWithContradiction(
+		context.Background(), ws, id, -0.3, other, false)
+	if err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if got, _ := store.GetConfidence(context.Background(), ws, id); got != 0.2 {
-		t.Fatalf("confidence = %v, want 0.2", got)
+	if prior != 0.5 {
+		t.Fatalf("prior = %v, want 0.5 (seed)", prior)
+	}
+	// float32 approximate equality — 0.5-0.3 is not exactly representable.
+	if newConf-0.2 > 1e-6 || 0.2-newConf > 1e-6 {
+		t.Fatalf("newConf = %v, want ≈ 0.2", newConf)
+	}
+	if got, _ := store.GetConfidence(context.Background(), ws, id); got-0.2 > 1e-6 || 0.2-got > 1e-6 {
+		t.Fatalf("confidence = %v, want ≈ 0.2", got)
 	}
 	if contradictionMarkerExists(t, store, ws, id, other) {
 		t.Fatal("expected NO 0x0A marker when hasContra=false")

--- a/internal/storage/impl_test.go
+++ b/internal/storage/impl_test.go
@@ -1307,6 +1307,14 @@ func TestUpdateConfidenceWithContradiction_AtomicConfidenceAndMarker(t *testing.
 	if !contradictionMarkerExists(t, store, ws, id, other) {
 		t.Fatal("expected 0x0A marker pair after hasContra write")
 	}
+	// The 0x0A marker lives in a separate keyspace from the confidence field.
+	// The composed write must touch only `id`'s confidence — `other`'s engram
+	// is unchanged. Regression guard: a future refactor that writes the marker
+	// pair by iterating both engrams' confidence keys would silently corrupt
+	// `other`'s confidence; this assertion catches that.
+	if got, _ := store.GetConfidence(context.Background(), ws, other); got != 0.5 {
+		t.Fatalf("other confidence mutated by composed write: got %v, want 0.5", got)
+	}
 }
 
 // TestUpdateConfidenceWithContradiction_NoMarkerWhenHasContraFalse verifies the

--- a/internal/storage/impl_test.go
+++ b/internal/storage/impl_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"testing"
@@ -1217,5 +1218,111 @@ func TestWriteDreamStateOverwrite(t *testing.T) {
 	}
 	if gotCount != 47 {
 		t.Errorf("count: got %d, want 47", gotCount)
+	}
+}
+
+// setupContradictionFixture creates a fresh PebbleStore and vault with two
+// seeded engrams (id, other). Mirrors the inline setup in TestFlagContradiction
+// (impl_test.go:610). Local helper — TestFlagContradiction inlines its setup;
+// these helpers are the minimal extraction the brief assumed already existed.
+func setupContradictionFixture(t *testing.T) (store *PebbleStore, ws [8]byte, id ULID, other ULID) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "muninndb-contra-fixture-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	db, err := OpenPebble(dir, DefaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store = NewPebbleStore(db, PebbleStoreConfig{CacheSize: 100})
+	t.Cleanup(func() { store.Close() })
+
+	ws = store.VaultPrefix("test")
+	id, err = store.WriteEngram(context.Background(), ws, &Engram{Concept: "concept1", Content: "content1"})
+	if err != nil {
+		t.Fatalf("WriteEngram(id): %v", err)
+	}
+	other, err = store.WriteEngram(context.Background(), ws, &Engram{Concept: "concept2", Content: "content2"})
+	if err != nil {
+		t.Fatalf("WriteEngram(other): %v", err)
+	}
+	return store, ws, id, other
+}
+
+// seedEngram pins an engram's starting confidence. Wraps UpdateConfidence so the
+// tests read as "seed 0.5, then invoke the composed write".
+func seedEngram(t *testing.T, store *PebbleStore, ws [8]byte, id ULID, confidence float32) {
+	t.Helper()
+	if err := store.UpdateConfidence(context.Background(), ws, id, confidence); err != nil {
+		t.Fatalf("seedEngram UpdateConfidence: %v", err)
+	}
+}
+
+// contradictionMarkerExists checks the bidirectional 0x0A contradiction pair was
+// written for (a,b). Uses the same canonical ordering as FlagContradiction
+// (association.go:793) and a direct point lookup (stronger than the prefix-scan
+// in TestFlagContradiction).
+func contradictionMarkerExists(t *testing.T, store *PebbleStore, ws [8]byte, a, b ULID) bool {
+	t.Helper()
+	aBytes := [16]byte(a)
+	bBytes := [16]byte(b)
+	if CompareULIDs(a, b) > 0 {
+		aBytes, bBytes = bBytes, aBytes
+	}
+	fwd, err := Get(store.db, keys.ContradictionKey(ws, 0, 0, aBytes))
+	if err != nil || fwd == nil {
+		return false
+	}
+	if !bytes.Equal(fwd, bBytes[:]) {
+		return false
+	}
+	rev, err := Get(store.db, keys.ContradictionKey(ws, 0, 0, bBytes))
+	if err != nil || rev == nil {
+		return false
+	}
+	return bytes.Equal(rev, aBytes[:])
+}
+
+// TestUpdateConfidenceWithContradiction_AtomicConfidenceAndMarker verifies the
+// composed write sets confidence and, when hasContra, the 0x0A marker pair — in
+// one batch. Mirrors the inputs of TestFlagContradiction (impl_test.go:610).
+func TestUpdateConfidenceWithContradiction_AtomicConfidenceAndMarker(t *testing.T) {
+	store, ws, id, other := setupContradictionFixture(t)
+
+	// Seed an engram so GetEngram inside the method resolves.
+	seedEngram(t, store, ws, id, 0.5)
+	seedEngram(t, store, ws, other, 0.5)
+
+	if err := store.UpdateConfidenceWithContradiction(
+		context.Background(), ws, id, 0.9, other, true); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if got, _ := store.GetConfidence(context.Background(), ws, id); got != 0.9 {
+		t.Fatalf("confidence = %v, want 0.9", got)
+	}
+	if !contradictionMarkerExists(t, store, ws, id, other) {
+		t.Fatal("expected 0x0A marker pair after hasContra write")
+	}
+}
+
+// TestUpdateConfidenceWithContradiction_NoMarkerWhenHasContraFalse verifies the
+// 0x0A marker is NOT written when hasContra is false (bare delta path).
+func TestUpdateConfidenceWithContradiction_NoMarkerWhenHasContraFalse(t *testing.T) {
+	store, ws, id, other := setupContradictionFixture(t)
+	seedEngram(t, store, ws, id, 0.5)
+
+	if err := store.UpdateConfidenceWithContradiction(
+		context.Background(), ws, id, 0.2, other, false); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got, _ := store.GetConfidence(context.Background(), ws, id); got != 0.2 {
+		t.Fatalf("confidence = %v, want 0.2", got)
+	}
+	if contradictionMarkerExists(t, store, ws, id, other) {
+		t.Fatal("expected NO 0x0A marker when hasContra=false")
 	}
 }

--- a/internal/transport/grpc/engine_adapter.go
+++ b/internal/transport/grpc/engine_adapter.go
@@ -2,11 +2,15 @@ package grpc
 
 import (
 	"context"
+	"errors"
 
 	"github.com/scrypster/muninndb/internal/engine"
 	"github.com/scrypster/muninndb/internal/engine/trigger"
+	"github.com/scrypster/muninndb/internal/storage"
 	"github.com/scrypster/muninndb/internal/transport/mbp"
 	pb "github.com/scrypster/muninndb/proto/gen/go/muninn/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // grpcEngineAdapter adapts *engine.Engine to grpcpkg.EngineAPI, translating
@@ -203,4 +207,47 @@ func (a *grpcEngineAdapter) SubscribeWithDeliver(ctx context.Context, req *pb.Su
 
 func (a *grpcEngineAdapter) Unsubscribe(ctx context.Context, subID string) error {
 	return a.eng.Unsubscribe(ctx, subID)
+}
+
+// AdjustConfidence adapts the AdjustConfidence RPC to engine.Engine.AdjustConfidence.
+// ULID parsing failures return codes.InvalidArgument without reaching the engine;
+// engine sentinel errors (ErrInvalidArgument, ErrSelfContradiction, ErrEngramNotFound)
+// are mapped to the codes the engine contract documents (400 / INVALID_ARGUMENT and
+// 404 / NOT_FOUND). All other errors surface as the engine returned them.
+func (a *grpcEngineAdapter) AdjustConfidence(ctx context.Context, req *pb.AdjustConfidenceRequest) (*pb.AdjustConfidenceResponse, error) {
+	id, err := storage.ParseULID(req.EngramId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "engram_id %q: %v", req.EngramId, err)
+	}
+	hasContra := req.ContradictedById != ""
+	var other storage.ULID
+	if hasContra {
+		other, err = storage.ParseULID(req.ContradictedById)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "contradicted_by_id %q: %v", req.ContradictedById, err)
+		}
+	} else {
+		other = id
+	}
+	newConf, err := a.eng.AdjustConfidence(ctx, req.Vault, id, req.Delta, other, hasContra, req.Reason)
+	if err != nil {
+		return nil, mapAdjustConfidenceError(err)
+	}
+	return &pb.AdjustConfidenceResponse{NewConfidence: newConf}, nil
+}
+
+// mapAdjustConfidenceError maps the engine sentinel errors that AdjustConfidence
+// documents (engine_vault.go: "REST/gRPC handlers map it to 400/INVALID_ARGUMENT")
+// onto the corresponding gRPC codes. It is local to this RPC because the existing
+// Link/Forget adapter surface does not currently perform sentinel→code mapping
+// (those errors surface as codes.Unknown); AdjustConfidence was specified to do so.
+func mapAdjustConfidenceError(err error) error {
+	switch {
+	case errors.Is(err, engine.ErrInvalidArgument), errors.Is(err, engine.ErrSelfContradiction):
+		return status.Errorf(codes.InvalidArgument, "%v", err)
+	case errors.Is(err, engine.ErrEngramNotFound):
+		return status.Errorf(codes.NotFound, "%v", err)
+	default:
+		return err
+	}
 }

--- a/internal/transport/grpc/engine_adapter.go
+++ b/internal/transport/grpc/engine_adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/scrypster/muninndb/internal/auth"
 	"github.com/scrypster/muninndb/internal/engine"
 	"github.com/scrypster/muninndb/internal/engine/trigger"
 	"github.com/scrypster/muninndb/internal/storage"
@@ -229,7 +230,7 @@ func (a *grpcEngineAdapter) AdjustConfidence(ctx context.Context, req *pb.Adjust
 	} else {
 		other = id
 	}
-	newConf, err := a.eng.AdjustConfidence(ctx, req.Vault, id, req.Delta, other, hasContra, req.Reason)
+	newConf, err := a.eng.AdjustConfidence(ctx, req.Vault, id, req.Delta, other, hasContra, req.Reason, callerFromContext(ctx))
 	if err != nil {
 		return nil, mapAdjustConfidenceError(err)
 	}
@@ -250,4 +251,23 @@ func mapAdjustConfidenceError(err error) error {
 	default:
 		return err
 	}
+}
+
+// callerFromContext extracts a human-readable caller identifier from the
+// authenticated principal in ctx. authUnaryInterceptor sets auth.ContextAPIKey
+// to the validated *auth.APIKey on the mk_ path; the public-vault path leaves
+// it unset. Returns the key Label (operator-assigned, stable, human-readable),
+// falling back to the key ID when Label is empty, and "anonymous" when no key
+// is present — so the audit log always carries a non-empty caller field.
+//
+// Mirrors the MCP transport's AuthContext.IsAPIKey extraction (context.go),
+// read from the same context value the gRPC interceptor already populates.
+func callerFromContext(ctx context.Context) string {
+	if key, ok := ctx.Value(auth.ContextAPIKey).(*auth.APIKey); ok && key != nil {
+		if key.Label != "" {
+			return key.Label
+		}
+		return key.ID
+	}
+	return "anonymous"
 }

--- a/internal/transport/grpc/engine_adapter.go
+++ b/internal/transport/grpc/engine_adapter.go
@@ -245,7 +245,7 @@ func mapAdjustConfidenceError(err error) error {
 	switch {
 	case errors.Is(err, engine.ErrInvalidArgument), errors.Is(err, engine.ErrSelfContradiction):
 		return status.Errorf(codes.InvalidArgument, "%v", err)
-	case errors.Is(err, engine.ErrEngramNotFound):
+	case errors.Is(err, engine.ErrEngramNotFound), errors.Is(err, storage.ErrNotFound):
 		return status.Errorf(codes.NotFound, "%v", err)
 	default:
 		return err

--- a/internal/transport/grpc/engine_adapter_confidence_test.go
+++ b/internal/transport/grpc/engine_adapter_confidence_test.go
@@ -1,0 +1,160 @@
+// Package grpc_test covers the gRPC server + adapter surface.
+//
+// engine_adapter_confidence_test.go pins the AdjustConfidence adapter paths
+// that the parse-failure tests (TestGRPCEngineAdapter_AdjustConfidence_Bad*)
+// do not exercise — specifically the §D10 compose shape where both
+// ContradictedById is non-empty AND Delta != 0. The existing happy-path
+// coverage (TestServer_AdjustConfidence_Success) sits at the Server level
+// with a mockEngine that intercepts before the adapter runs, so the
+// adapter's ULID-parse + hasContra-derivation + engine dispatch for the
+// both-set shape was previously unverified.
+package grpc_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/auth"
+	"github.com/scrypster/muninndb/internal/engine"
+	"github.com/scrypster/muninndb/internal/engine/activation"
+	"github.com/scrypster/muninndb/internal/engine/trigger"
+	"github.com/scrypster/muninndb/internal/index/fts"
+	"github.com/scrypster/muninndb/internal/storage"
+	transportgrpc "github.com/scrypster/muninndb/internal/transport/grpc"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+	pb "github.com/scrypster/muninndb/proto/gen/go/muninn/v1"
+)
+
+// newConfidenceAdapterEnv wires a real *engine.Engine (live PebbleStore +
+// FTS) using only exported constructors — the same shape as
+// engine.testEnv / rest.newRESTRetryEnrichEnv, duplicated here because the
+// engine package's test helpers are internal. Returns the engine + adapter
+// pair + a cleanup.
+func newConfidenceAdapterEnv(t *testing.T) (*engine.Engine, transportgrpc.EngineAPI, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "muninndb-grpc-conf-adapter-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := storage.OpenPebble(dir, storage.DefaultOptions())
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatal(err)
+	}
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 128})
+	ftsIdx := fts.New(db)
+	embedder := activation.NewNoopEmbedder()
+	actEngine := activation.New(store, activation.NewFTSAdapter(ftsIdx), nil, embedder)
+	trigSystem := trigger.New(store, trigger.NewFTSAdapter(ftsIdx), nil, embedder)
+	eng := engine.NewEngine(engine.EngineConfig{
+		Store: store, FTSIndex: ftsIdx, ActivationEngine: actEngine,
+		TriggerSystem: trigSystem, Embedder: embedder,
+	})
+	adapter := transportgrpc.TestableNewEngineAdapter(eng)
+	return eng, adapter, func() {
+		eng.Stop()
+		store.Close()
+		os.RemoveAll(dir)
+	}
+}
+
+// TestGRPCEngineAdapter_AdjustConfidence_Compose exercises the §D10 compose
+// path through the adapter: ContradictedById non-empty + Delta != 0. Both
+// fields must reach Engine.AdjustConfidence — the confidence changes AND the
+// 0x0A contradiction marker pair is persisted. The adapter derives hasContra
+// from `ContradictedById != ""`; combined with a non-zero Delta this is the
+// shape that a bare EngramId+Delta happy-path test cannot reach.
+//
+// Regression guard: if the adapter ever stops forwarding ContradictedById
+// (e.g. drops the parse or the hasContra derivation), the marker disappears
+// and this test fails. If it stops forwarding Delta, the confidence stays
+// unchanged and this test fails.
+func TestGRPCEngineAdapter_AdjustConfidence_Compose(t *testing.T) {
+	eng, adapter, cleanup := newConfidenceAdapterEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	w1, err := eng.Write(ctx, &mbp.WriteRequest{Vault: "test", Concept: "a", Content: "alpha"})
+	if err != nil {
+		t.Fatalf("seed Write(1): %v", err)
+	}
+	w2, err := eng.Write(ctx, &mbp.WriteRequest{Vault: "test", Concept: "b", Content: "beta"})
+	if err != nil {
+		t.Fatalf("seed Write(2): %v", err)
+	}
+	id, err := storage.ParseULID(w1.ID)
+	if err != nil {
+		t.Fatalf("ParseULID(w1=%q): %v", w1.ID, err)
+	}
+	other, err := storage.ParseULID(w2.ID)
+	if err != nil {
+		t.Fatalf("ParseULID(w2=%q): %v", w2.ID, err)
+	}
+
+	// Pin id's confidence to a known prior so the delta is observable.
+	ws := eng.Store().ResolveVaultPrefix("test")
+	if err := eng.Store().UpdateConfidence(ctx, ws, id, 0.5); err != nil {
+		t.Fatalf("seed UpdateConfidence: %v", err)
+	}
+
+	// Compose: delta=-0.2 AND ContradictedById non-empty.
+	resp, err := adapter.AdjustConfidence(ctx, &pb.AdjustConfidenceRequest{
+		Vault: "test", EngramId: w1.ID, Delta: -0.2,
+		ContradictedById: w2.ID, Reason: "bridge",
+	})
+	if err != nil {
+		t.Fatalf("AdjustConfidence compose: %v", err)
+	}
+	if resp.NewConfidence != 0.3 {
+		t.Errorf("NewConfidence = %v, want 0.3 (delta applied)", resp.NewConfidence)
+	}
+
+	// The contradiction marker must be durable — proves ContradictedById flowed
+	// through the adapter with hasContra=true. Read via the engine's own
+	// public read path, not the raw store.
+	pairs, err := eng.GetContradictions(ctx, "test")
+	if err != nil {
+		t.Fatalf("GetContradictions: %v", err)
+	}
+	want, wantRev := [2]storage.ULID{id, other}, [2]storage.ULID{other, id}
+	found := false
+	for _, p := range pairs {
+		if p == want || p == wantRev {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("contradiction marker for {%s,%s} not persisted via compose path; pairs=%v",
+			id, other, pairs)
+	}
+}
+
+// TestCallerFromContext_Branches pins the caller-extraction contract used by
+// the adapter. The audit log's "caller" field is load-bearing for #559 Rev 2
+// §success criteria #7, so the three branches (label preferred, ID fallback,
+// anonymous for the no-key path) are table-driven and RED-checked: drop any
+// branch and the corresponding case fails.
+func TestCallerFromContext_Branches(t *testing.T) {
+	labelled := &auth.APIKey{ID: "k_abc123", Label: "ops-bridge", Mode: auth.ModeFull}
+	idOnly := &auth.APIKey{ID: "k_xyz789", Label: "", Mode: auth.ModeFull}
+
+	cases := []struct {
+		name string
+		ctx  context.Context
+		want string
+	}{
+		{"label preferred", context.WithValue(context.Background(), auth.ContextAPIKey, labelled), "ops-bridge"},
+		{"id fallback when label empty", context.WithValue(context.Background(), auth.ContextAPIKey, idOnly), "k_xyz789"},
+		{"anonymous when no key", context.Background(), "anonymous"},
+		{"anonymous when key is nil", context.WithValue(context.Background(), auth.ContextAPIKey, (*auth.APIKey)(nil)), "anonymous"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := transportgrpc.TestableCallerFromContext(c.ctx); got != c.want {
+				t.Errorf("callerFromContext = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/transport/grpc/export_test.go
+++ b/internal/transport/grpc/export_test.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 
+	"github.com/scrypster/muninndb/internal/engine"
 	googlegrpc "google.golang.org/grpc"
 )
 
@@ -16,4 +17,18 @@ func (s *Server) TestableAuthUnaryInterceptor(ctx context.Context, req any, info
 // for use by external tests in package grpc_test.
 func (s *Server) TestableAuthStreamInterceptor(srv any, ss googlegrpc.ServerStream, info *googlegrpc.StreamServerInfo, handler googlegrpc.StreamHandler) error {
 	return s.authStreamInterceptor(srv, ss, info, handler)
+}
+
+// TestableNewEngineAdapter exposes the unexported grpcEngineAdapter constructor
+// for use by external tests. A nil engine is safe for AdjustConfidence tests
+// that exercise the ULID-parsing branches — the parser returns before the
+// engine is dereferenced.
+func TestableNewEngineAdapter(eng *engine.Engine) EngineAPI {
+	return &grpcEngineAdapter{eng: eng}
+}
+
+// TestableMapAdjustConfidenceError exposes the unexported sentinel→gRPC-code
+// mapper for direct table-driven testing.
+func TestableMapAdjustConfidenceError(err error) error {
+	return mapAdjustConfidenceError(err)
 }

--- a/internal/transport/grpc/export_test.go
+++ b/internal/transport/grpc/export_test.go
@@ -32,3 +32,11 @@ func TestableNewEngineAdapter(eng *engine.Engine) EngineAPI {
 func TestableMapAdjustConfidenceError(err error) error {
 	return mapAdjustConfidenceError(err)
 }
+
+// TestableCallerFromContext exposes the unexported caller-extraction helper
+// for direct table-driven testing. Pins the three branches: API key with
+// Label (preferred), ID fallback when Label is empty, and "anonymous" for
+// the public-vault path where the interceptor sets no key.
+func TestableCallerFromContext(ctx context.Context) string {
+	return callerFromContext(ctx)
+}

--- a/internal/transport/grpc/server.go
+++ b/internal/transport/grpc/server.go
@@ -35,6 +35,7 @@ type EngineAPI interface {
 	Subscribe(ctx context.Context, req *pb.SubscribeRequest) (*pb.SubscribeResponse, error)
 	SubscribeWithDeliver(ctx context.Context, req *pb.SubscribeRequest, deliver trigger.DeliverFunc) (string, error)
 	Unsubscribe(ctx context.Context, subID string) error
+	AdjustConfidence(ctx context.Context, req *pb.AdjustConfidenceRequest) (*pb.AdjustConfidenceResponse, error)
 }
 
 // Server implements the MuninnDB gRPC service.
@@ -415,6 +416,27 @@ func (s *Server) Link(ctx context.Context, req *pb.LinkRequest) (*pb.LinkRespons
 	resp, err := s.engine.Link(ctx, req)
 	if err != nil {
 		slog.Error("link failed", "error", err)
+		return nil, err
+	}
+	return resp, nil
+}
+
+// AdjustConfidence implements the AdjustConfidence RPC. Mirrors Link:
+// denyReadOnlyMutation rejects observe-mode keys, resolveRequestVault rewrites
+// req.Vault to the canonical bound vault, then the engine adapter handles ULID
+// parsing and the documented sentinel→codes mapping.
+func (s *Server) AdjustConfidence(ctx context.Context, req *pb.AdjustConfidenceRequest) (*pb.AdjustConfidenceResponse, error) {
+	if err := denyReadOnlyMutation(ctx); err != nil {
+		return nil, err
+	}
+	vault, err := s.resolveRequestVault(ctx, req.Vault)
+	if err != nil {
+		return nil, err
+	}
+	req.Vault = vault
+	resp, err := s.engine.AdjustConfidence(ctx, req)
+	if err != nil {
+		slog.Error("adjust_confidence failed", "error", err)
 		return nil, err
 	}
 	return resp, nil

--- a/internal/transport/grpc/server_test.go
+++ b/internal/transport/grpc/server_test.go
@@ -1694,6 +1694,8 @@ func TestMapAdjustConfidenceError_Sentinels(t *testing.T) {
 		{"ErrSelfContradiction bare", engine.ErrSelfContradiction, codes.InvalidArgument},
 		{"ErrEngramNotFound bare", engine.ErrEngramNotFound, codes.NotFound},
 		{"ErrEngramNotFound wrapped", fmt.Errorf("read meta: %w", engine.ErrEngramNotFound), codes.NotFound},
+		{"storage.ErrNotFound bare", storage.ErrNotFound, codes.NotFound},
+		{"storage.ErrNotFound wrapped (engram deleted by concurrent Forget)", fmt.Errorf("engram %w", storage.ErrNotFound), codes.NotFound},
 		{"unrelated error passes through", errors.New("disk full"), codes.Unknown},
 		{"nil error", nil, codes.OK},
 	}

--- a/internal/transport/grpc/server_test.go
+++ b/internal/transport/grpc/server_test.go
@@ -3,6 +3,7 @@ package grpc_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/scrypster/muninndb/internal/auth"
+	"github.com/scrypster/muninndb/internal/engine"
 	"github.com/scrypster/muninndb/internal/engine/trigger"
 	"github.com/scrypster/muninndb/internal/storage"
 	transportgrpc "github.com/scrypster/muninndb/internal/transport/grpc"
@@ -37,6 +39,7 @@ type mockEngine struct {
 	subscribeFn            func(ctx context.Context, req *pb.SubscribeRequest) (*pb.SubscribeResponse, error)
 	subscribeWithDeliverFn func(ctx context.Context, req *pb.SubscribeRequest, deliver trigger.DeliverFunc) (string, error)
 	unsubscribeFn          func(ctx context.Context, subID string) error
+	adjustConfidenceFn     func(ctx context.Context, req *pb.AdjustConfidenceRequest) (*pb.AdjustConfidenceResponse, error)
 }
 
 func (m *mockEngine) Hello(ctx context.Context, req *pb.HelloRequest) (*pb.HelloResponse, error) {
@@ -139,6 +142,13 @@ func (m *mockEngine) Unsubscribe(ctx context.Context, subID string) error {
 		return m.unsubscribeFn(ctx, subID)
 	}
 	return nil
+}
+
+func (m *mockEngine) AdjustConfidence(ctx context.Context, req *pb.AdjustConfidenceRequest) (*pb.AdjustConfidenceResponse, error) {
+	if m.adjustConfidenceFn != nil {
+		return m.adjustConfidenceFn(ctx, req)
+	}
+	return &pb.AdjustConfidenceResponse{NewConfidence: 0}, nil
 }
 
 // newTestAuthStore opens an in-memory pebble database and returns an auth.Store.
@@ -725,6 +735,7 @@ func TestPublicVaultFullMutatingUnaryRPCsAllowed(t *testing.T) {
 	linkCalled := false
 	forgetCalled := false
 	batchForgetCalled := false
+	adjustConfidenceCalled := false
 	srv := transportgrpc.NewServer(":0", &mockEngine{
 		writeFn: func(ctx context.Context, req *pb.WriteRequest) (*pb.WriteResponse, error) {
 			writeCalled = true
@@ -745,6 +756,10 @@ func TestPublicVaultFullMutatingUnaryRPCsAllowed(t *testing.T) {
 		batchForgetFn: func(ctx context.Context, req *pb.BatchForgetRequest) (*pb.BatchForgetResponse, error) {
 			batchForgetCalled = true
 			return &pb.BatchForgetResponse{}, nil
+		},
+		adjustConfidenceFn: func(ctx context.Context, req *pb.AdjustConfidenceRequest) (*pb.AdjustConfidenceResponse, error) {
+			adjustConfidenceCalled = true
+			return &pb.AdjustConfidenceResponse{NewConfidence: 0.5}, nil
 		},
 	}, store, nil)
 
@@ -787,6 +802,14 @@ func TestPublicVaultFullMutatingUnaryRPCsAllowed(t *testing.T) {
 				return srv.BatchForget(ctx, req.(*pb.BatchForgetRequest))
 			},
 			called: &batchForgetCalled,
+		},
+		{
+			name: "AdjustConfidence",
+			req:  &pb.AdjustConfidenceRequest{Vault: "default", EngramId: "01HZXQJ8C7QK6V3RJBN1P0G9YZ", Delta: 0.1},
+			invoke: func(ctx context.Context, req any) (any, error) {
+				return srv.AdjustConfidence(ctx, req.(*pb.AdjustConfidenceRequest))
+			},
+			called: &adjustConfidenceCalled,
 		},
 	}
 
@@ -818,6 +841,7 @@ func TestObserveKeyMutatingUnaryRPCsDenied(t *testing.T) {
 	linkCalled := false
 	forgetCalled := false
 	batchForgetCalled := false
+	adjustConfidenceCalled := false
 	srv := transportgrpc.NewServer(":0", &mockEngine{
 		writeFn: func(ctx context.Context, req *pb.WriteRequest) (*pb.WriteResponse, error) {
 			writeCalled = true
@@ -838,6 +862,10 @@ func TestObserveKeyMutatingUnaryRPCsDenied(t *testing.T) {
 		batchForgetFn: func(ctx context.Context, req *pb.BatchForgetRequest) (*pb.BatchForgetResponse, error) {
 			batchForgetCalled = true
 			return &pb.BatchForgetResponse{}, nil
+		},
+		adjustConfidenceFn: func(ctx context.Context, req *pb.AdjustConfidenceRequest) (*pb.AdjustConfidenceResponse, error) {
+			adjustConfidenceCalled = true
+			return &pb.AdjustConfidenceResponse{NewConfidence: 0.5}, nil
 		},
 	}, store, nil)
 
@@ -880,6 +908,14 @@ func TestObserveKeyMutatingUnaryRPCsDenied(t *testing.T) {
 				return srv.BatchForget(ctx, req.(*pb.BatchForgetRequest))
 			},
 			called: &batchForgetCalled,
+		},
+		{
+			name: "AdjustConfidence",
+			req:  &pb.AdjustConfidenceRequest{Vault: "default", EngramId: "01HZXQJ8C7QK6V3RJBN1P0G9YZ", Delta: 0.1},
+			invoke: func(ctx context.Context, req any) (any, error) {
+				return srv.AdjustConfidence(ctx, req.(*pb.AdjustConfidenceRequest))
+			},
+			called: &adjustConfidenceCalled,
 		},
 	}
 
@@ -1562,5 +1598,111 @@ func TestListVaults_Error(t *testing.T) {
 	_, err := srv.ListVaults(ctx, &pb.ListVaultsRequest{})
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AdjustConfidence RPC tests
+// ---------------------------------------------------------------------------
+
+// valid26ULID is a fixed, lexicographically-valid 26-char ULID used across the
+// AdjustConfidence RPC tests. The adapter only parses it; it never reaches the
+// engine when the parse fails, and the mock ignores the value on success.
+const valid26ULID = "01HZXQJ8C7QK6V3RJBN1P0G9YZ"
+
+func TestServer_AdjustConfidence_Success(t *testing.T) {
+	eng := &mockEngine{
+		adjustConfidenceFn: func(_ context.Context, req *pb.AdjustConfidenceRequest) (*pb.AdjustConfidenceResponse, error) {
+			if req.EngramId != valid26ULID {
+				t.Errorf("EngramId = %q, want %q", req.EngramId, valid26ULID)
+			}
+			if req.Delta != 0.3 {
+				t.Errorf("Delta = %v, want 0.3", req.Delta)
+			}
+			if req.Vault != "default" {
+				t.Errorf("Vault = %q, want %q", req.Vault, "default")
+			}
+			return &pb.AdjustConfidenceResponse{NewConfidence: 0.8}, nil
+		},
+	}
+	srv := newPublicTestServer(t, eng)
+
+	resp, err := srv.AdjustConfidence(context.Background(), &pb.AdjustConfidenceRequest{
+		Vault: "default", EngramId: valid26ULID, Delta: 0.3,
+	})
+	if err != nil {
+		t.Fatalf("AdjustConfidence: %v", err)
+	}
+	if resp.NewConfidence != 0.8 {
+		t.Fatalf("NewConfidence = %v, want 0.8", resp.NewConfidence)
+	}
+}
+
+func TestServer_AdjustConfidence_Error(t *testing.T) {
+	eng := &mockEngine{
+		adjustConfidenceFn: func(_ context.Context, _ *pb.AdjustConfidenceRequest) (*pb.AdjustConfidenceResponse, error) {
+			return nil, errors.New("engine unavailable")
+		},
+	}
+	srv := newPublicTestServer(t, eng)
+
+	_, err := srv.AdjustConfidence(context.Background(), &pb.AdjustConfidenceRequest{
+		Vault: "default", EngramId: valid26ULID, Delta: 0.1,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// TestGRPCEngineAdapter_AdjustConfidence_BadULID_InvalidArgument exercises the
+// adapter's ULID-parsing branch directly. A nil engine is safe because the
+// parser returns before the engine is dereferenced.
+func TestGRPCEngineAdapter_AdjustConfidence_BadULID_InvalidArgument(t *testing.T) {
+	adapter := transportgrpc.TestableNewEngineAdapter(nil)
+
+	_, err := adapter.AdjustConfidence(context.Background(), &pb.AdjustConfidenceRequest{
+		Vault: "default", EngramId: "not-a-ulid", Delta: 0.1,
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("err code = %v (%v), want InvalidArgument", status.Code(err), err)
+	}
+}
+
+func TestGRPCEngineAdapter_AdjustConfidence_BadContradictedBy_InvalidArgument(t *testing.T) {
+	adapter := transportgrpc.TestableNewEngineAdapter(nil)
+
+	_, err := adapter.AdjustConfidence(context.Background(), &pb.AdjustConfidenceRequest{
+		Vault: "default", EngramId: valid26ULID, Delta: 0.1,
+		ContradictedById: "nope",
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("err code = %v (%v), want InvalidArgument", status.Code(err), err)
+	}
+}
+
+// TestMapAdjustConfidenceError_Sentinels verifies the engine sentinel → gRPC
+// code mapping that the engine_vault.go docstring pins ("REST/gRPC handlers
+// map it to 400/INVALID_ARGUMENT").
+func TestMapAdjustConfidenceError_Sentinels(t *testing.T) {
+	cases := []struct {
+		name string
+		in   error
+		want codes.Code
+	}{
+		{"ErrInvalidArgument bare", engine.ErrInvalidArgument, codes.InvalidArgument},
+		{"ErrInvalidArgument wrapped", fmt.Errorf("%w: delta is NaN", engine.ErrInvalidArgument), codes.InvalidArgument},
+		{"ErrSelfContradiction bare", engine.ErrSelfContradiction, codes.InvalidArgument},
+		{"ErrEngramNotFound bare", engine.ErrEngramNotFound, codes.NotFound},
+		{"ErrEngramNotFound wrapped", fmt.Errorf("read meta: %w", engine.ErrEngramNotFound), codes.NotFound},
+		{"unrelated error passes through", errors.New("disk full"), codes.Unknown},
+		{"nil error", nil, codes.OK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := transportgrpc.TestableMapAdjustConfidenceError(tc.in)
+			if status.Code(err) != tc.want {
+				t.Fatalf("code = %v (%v), want %v", status.Code(err), err, tc.want)
+			}
+		})
 	}
 }

--- a/proto/gen/go/muninn/v1/service.pb.go
+++ b/proto/gen/go/muninn/v1/service.pb.go
@@ -256,6 +256,20 @@ type ListVaultsResponse struct {
 	Vaults []string `protobuf:"bytes,1,rep,name=vaults"`
 }
 
+// AdjustConfidenceRequest message
+type AdjustConfidenceRequest struct {
+	Vault            string  `protobuf:"bytes,1,opt,name=vault"`
+	EngramId         string  `protobuf:"bytes,2,opt,name=engram_id"`
+	Delta            float32 `protobuf:"fixed32,3,opt,name=delta"`
+	Reason           string  `protobuf:"bytes,4,opt,name=reason"`
+	ContradictedById string  `protobuf:"bytes,5,opt,name=contradicted_by_id"`
+}
+
+// AdjustConfidenceResponse message
+type AdjustConfidenceResponse struct {
+	NewConfidence float32 `protobuf:"fixed32,1,opt,name=new_confidence"`
+}
+
 // ActivationPush message
 type ActivationPush struct {
 	SubscriptionID string          `protobuf:"bytes,1,opt,name=subscription_id"`

--- a/proto/gen/go/muninn/v1/service_grpc.pb.go
+++ b/proto/gen/go/muninn/v1/service_grpc.pb.go
@@ -20,6 +20,7 @@ type MuninnDBClient interface {
 	Stat(ctx context.Context, in *StatRequest, opts ...grpc.CallOption) (*StatResponse, error)
 	Link(ctx context.Context, in *LinkRequest, opts ...grpc.CallOption) (*LinkResponse, error)
 	ListVaults(ctx context.Context, in *ListVaultsRequest, opts ...grpc.CallOption) (*ListVaultsResponse, error)
+	AdjustConfidence(ctx context.Context, in *AdjustConfidenceRequest, opts ...grpc.CallOption) (*AdjustConfidenceResponse, error)
 	Activate(ctx context.Context, in *ActivateRequest, opts ...grpc.CallOption) (MuninnDB_ActivateClient, error)
 	Subscribe(ctx context.Context, opts ...grpc.CallOption) (MuninnDB_SubscribeClient, error)
 }
@@ -113,6 +114,15 @@ func (c *muninnDBClient) ListVaults(ctx context.Context, in *ListVaultsRequest, 
 	return out, nil
 }
 
+func (c *muninnDBClient) AdjustConfidence(ctx context.Context, in *AdjustConfidenceRequest, opts ...grpc.CallOption) (*AdjustConfidenceResponse, error) {
+	out := new(AdjustConfidenceResponse)
+	err := c.cc.Invoke(ctx, "/muninn.v1.MuninnDB/AdjustConfidence", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *muninnDBClient) Activate(ctx context.Context, in *ActivateRequest, opts ...grpc.CallOption) (MuninnDB_ActivateClient, error) {
 	stream, err := c.cc.NewStream(ctx, &grpc.StreamDesc{StreamName: "Activate"}, "/muninn.v1.MuninnDB/Activate", opts...)
 	if err != nil {
@@ -187,6 +197,7 @@ type MuninnDBServer interface {
 	Stat(context.Context, *StatRequest) (*StatResponse, error)
 	Link(context.Context, *LinkRequest) (*LinkResponse, error)
 	ListVaults(context.Context, *ListVaultsRequest) (*ListVaultsResponse, error)
+	AdjustConfidence(context.Context, *AdjustConfidenceRequest) (*AdjustConfidenceResponse, error)
 	Activate(*ActivateRequest, MuninnDB_ActivateServer) error
 	Subscribe(MuninnDB_SubscribeServer) error
 }
@@ -227,6 +238,10 @@ func (UnimplementedMuninnDBServer) Link(context.Context, *LinkRequest) (*LinkRes
 }
 
 func (UnimplementedMuninnDBServer) ListVaults(context.Context, *ListVaultsRequest) (*ListVaultsResponse, error) {
+	return nil, nil
+}
+
+func (UnimplementedMuninnDBServer) AdjustConfidence(context.Context, *AdjustConfidenceRequest) (*AdjustConfidenceResponse, error) {
 	return nil, nil
 }
 
@@ -437,6 +452,26 @@ var MuninnDB_ServiceDesc = grpc.ServiceDesc{
 				}
 				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 					return srv.(MuninnDBServer).ListVaults(ctx, req.(*ListVaultsRequest))
+				}
+				return interceptor(ctx, in, info, handler)
+			},
+		},
+		{
+			MethodName: "AdjustConfidence",
+			Handler: func(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+				in := new(AdjustConfidenceRequest)
+				if err := dec(in); err != nil {
+					return nil, err
+				}
+				if interceptor == nil {
+					return srv.(MuninnDBServer).AdjustConfidence(ctx, in)
+				}
+				info := &grpc.UnaryServerInfo{
+					Server:     srv,
+					FullMethod: "/muninn.v1.MuninnDB/AdjustConfidence",
+				}
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return srv.(MuninnDBServer).AdjustConfidence(ctx, req.(*AdjustConfidenceRequest))
 				}
 				return interceptor(ctx, in, info, handler)
 			},

--- a/proto/muninn/v1/service.proto
+++ b/proto/muninn/v1/service.proto
@@ -220,6 +220,18 @@ message ActivationPush {
   int64 at = 5;
 }
 
+message AdjustConfidenceRequest {
+  string vault              = 1;
+  string engram_id          = 2;
+  float  delta              = 3;  // signed; clamped to [0,1] after apply
+  string reason             = 4;  // audit string (caller-supplied)
+  string contradicted_by_id = 5;  // optional; mirrors OnFound (marker + evidence submit)
+}
+
+message AdjustConfidenceResponse {
+  float new_confidence = 1;
+}
+
 message ListVaultsRequest {}
 
 message ListVaultsResponse {
@@ -237,5 +249,6 @@ service MuninnDB {
   rpc Link(LinkRequest) returns (LinkResponse);
   rpc Activate(ActivateRequest) returns (stream ActivateResponse);
   rpc ListVaults(ListVaultsRequest) returns (ListVaultsResponse);
+  rpc AdjustConfidence(AdjustConfidenceRequest) returns (AdjustConfidenceResponse);
   rpc Subscribe(stream SubscribeRequest) returns (stream ActivationPush);
 }


### PR DESCRIPTION
# feat(grpc,engine): AdjustConfidence RPC with contradiction signaling

Closes #559. Branch `feat/adjust-confidence-559` off `develop` @ `9868c62`.

## Summary

Adds an `AdjustConfidence` gRPC RPC so an external system (e.g. the go-rag bridge) can explicitly adjust an engram's confidence and optionally signal a contradiction — a different *detection modality* from the internal contradiction worker (externally-asserted vs graph-detected), additive to it.

```protobuf
rpc AdjustConfidence(AdjustConfidenceRequest) returns (AdjustConfidenceResponse);

message AdjustConfidenceRequest {
  string vault              = 1;
  string engram_id          = 2;
  float  delta              = 3;   // signed; clamped to [0,1] after apply
  string reason             = 4;   // audit string (caller-supplied)
  string contradicted_by_id = 5;   // optional; mirrors OnFound
}
message AdjustConfidenceResponse { float new_confidence = 1; }
```

## What it does

- Applies a signed `delta` to an engram's confidence, clamped to `[0,1]`, returning the new absolute value.
- When `contradicted_by_id` is set, **mirrors the internal `OnFound`** (`engine.go`, the `ContradictWorker` callback): writes the `0x0A` contradiction marker via `FlagContradiction` (the same primitive the internal worker uses) **and** submits `EvidenceContradiction` to the `ConfidenceWorker` for **both** engrams (Bayesian lowering). This reproduces the internal worker's effect, externally-triggered.
- A bare delta (`contradicted_by_id` empty) does **not** touch the worker — it's a direct `UpdateConfidence` only. Submitting there would let `processBatch` clobber the caller's explicit value.

## Design notes

- **Atomic write:** confidence (`0x01`+`0x02`) and the contradiction marker (`0x0A`) commit in **one Pebble batch** (`PebbleStore.UpdateConfidenceWithContradiction`) — no partial-failure window between them.
- **Validation before any write:** NaN/±Inf delta, self-contradiction, unknown `engram_id`, and unknown `contradicted_by_id` all reject before any Pebble write or worker submit — a rejected call mutates nothing.
- **Mirrors `Engine.Link`'s `RelContradicts` path** for vault resolution, `GetMetadata` existence checks, and the `EvidenceContradiction` submit pattern.
- Additive only: no migration, no new keyspace prefix, no new credential, no change to the internal contradiction/confidence workers or existing RPCs (+783/-0 across 12 files).

## ⚠️ Recall-inertness (please read before merge)

Mirroring the internal `OnFound` reproduces the internal worker's effect — which is itself **recall-inert**:

- Recall **never reads the `0x0A` marker** — `GetContradictions` is consumed only by the operator listing API, not recall scoring.
- Confidence **is not in recall scoring** — only the caller-supplied `MinConfidence` cutoff filter.
- Recall's contradiction dampening (`activation/profiles.go`, `RelContradicts`) traverses the **`0x09` association graph** — a different keyspace that neither this RPC nor the internal worker writes.

So neither half of this RPC dampens retrieval ranking today. **If the intent is recall dampening at retrieval time** (e.g. the RAG case: don't surface contradictory chunks), that needs a `0x09` `WriteAssociation(rel_type=CONTRADICTS)` write (which `profiles.go` dampens) or a scoring change — a separate, upstream-scoped decision. I did **not** build that here because it diverges from "additive to the internal worker" and is a maintainer-level call. Flagging for your steer; happy to follow up.

## Other notes for the maintainer

- **Auth:** mirrors `Link`/`Forget` (write-mode `mk_`/`cap_` via the existing interceptor). If you'd prefer admin-only (since it writes the previously-internal `0x0A` keyspace), easy to gate.
- **Non-idempotent delta:** the `delta` is non-idempotent by design; a gRPC retry re-applies it. The marker half is idempotent. If the bridge retries, an optional `idempotency_key` on the proto would close the response-loss window — recommendation, not blocking.
- **Concurrency:** `GetConfidence → clamp → UpdateConfidence` is a non-atomic RMW (same shape as `processBatch`); lost updates under concurrent writers are accepted under the cooperative trust model. The unified batch above closes the *partial-failure* window; a per-engram mutex would be the upgrade if real contention appears.
- **No `0x0A` provenance field** — externally-written markers are indistinguishable from internal-worker ones at query time. A `source`/provenance field is a worthwhile follow-up if external-write volume grows.

## Testing

- Unit (`internal/engine`): clamp, NaN/±Inf, self-contradiction, NotFound (engram + target), rejection-mutates-nothing, bare-delta-submits-nothing, contradiction-submits-evidence-×2, + RED-sanity (NaN guard shown load-bearing). 8/8.
- Storage (`internal/storage`): atomic write — confidence + marker commit together; marker absent when `hasContra=false`.
- gRPC (`internal/transport/grpc`): three-layer coverage (Server RPC, adapter ULID parsing, error→codes mapping); auth-interceptor matrix extended.
- Gates: `go build ./...`, `go vet ./...`, `go test -race ./...` all green. (CI doesn't run golangci-lint on Go; the new code mirrors the existing `defer batch.Close()`/`batch.Set` convention.)

## Out of scope (deliberate)

REST/MCP surfaces, recall dampening, firing the push trigger, hard concurrency atomicity (mutex/CAS), capability provenance — all flagged above as follow-ups.
