### PR TITLE
docs: sync internals after #617, #618, #619 merged

### DIFF
--- a/docs/internals/drift-and-obligations.md
+++ b/docs/internals/drift-and-obligations.md
@@ -40,8 +40,9 @@ for any PR that touches a synced surface.
 7. **`proto/muninn/v1/service.proto`** → regenerate `proto/gen/go/...`. No CI step verifies
    the generated code is current — the reviewer must confirm regen ran.
 
-8. **A new Pebble prefix** → see `keyspace-registry.md`: disjoint, documented in `keys.go`,
-   and bump `storageMaxPrefix` in `keys_test.go` if ≥ 0x2B.
+8. **A new Pebble prefix** → see `keyspace-registry.md`: disjoint, and added to
+   `internal/prefix/prefix.All()` (the single source of truth). The disjointness tests in
+   `internal/prefix/prefix_test.go` auto-tighten — there is no `storageMaxPrefix` to bump.
 
 9. **Any `go build` of the muninn binary** → must keep `-tags localassets`. Enforced by
    `scripts/check-build-tags.sh` (CI `shellcheck` job), but that script only scans the
@@ -105,7 +106,8 @@ rather than in the default `go test ./...` path.
 - **RED-sanity verification**: a bug-fix/race-fix test must be shown to fail without the fix.
 - **Preset-pinning `reflect.DeepEqual` tests** for derived config (#599).
 - **Registry-parity smoke** for the MCP tool surface (`smoke_exhaustive_test.go`).
-- **Cross-package disjointness test** for Pebble prefixes (`TestCapabilityPrefixesNoCollision`).
+- **Cross-package disjointness test** for Pebble prefixes, derived from `prefix.All()`
+  (`TestAll_NoDuplicateBytes`/`TestAll_OwnerGroupsPairwiseDisjoint` in `internal/prefix/prefix_test.go`).
 - **Coverage test that enumerates all handlers** so a new tool can't escape mode
   classification (`TestToolClassification_CoversAllRegisteredHandlers`).
 - **`-race` on anything touching** storage, the Hebbian/PAS workers, the pruner,

--- a/docs/internals/invariants.md
+++ b/docs/internals/invariants.md
@@ -32,7 +32,7 @@ Format: **[INV-n]** assertion — `file:anchor` — *why it matters / what break
 
 ## Storage & durability invariants
 
-- **[STO-1]** A new Pebble prefix must be disjoint from the keyspace registry and documented where the registry lives; the disjointness cross-check must cover it. On current `develop` that means `keys/keys.go` doc comments + bumping `storageMaxPrefix` in `keys_test.go` if ≥ 0x2B; **once PR #618 (#611) merges** it means adding the prefix to `internal/prefix/prefix.All()` (the test auto-tightens, no constant to bump). Check `ls internal/prefix/` to see which world you're in. — see `keyspace-registry.md`.
+- **[STO-1]** A new Pebble prefix must be disjoint from the keyspace registry and added to it; the disjointness cross-check must cover it. The registry lives in `internal/prefix/prefix.go`: add the prefix to `prefix.All()` and the disjointness tests (`TestAll_NoDuplicateBytes`, `TestAll_OwnerGroupsPairwiseDisjoint` in `internal/prefix/prefix_test.go`) auto-tighten to cover it — there is **no `storageMaxPrefix` constant to bump** (removed with #618's registry consolidation). — see `keyspace-registry.md`.
 - **[STO-2]** Any path mutating engram **state or lease** must hold `casLocks.For(id)` across read→commit, as `CompareAndSet` (`storage/lease.go`) and `DeleteEngram` (`storage/engram.go`) do. *A new unlocked state-mutating path reopens the #594 resurrection race.*
 - **[STO-3]** CAS state changes go through `UpdateMetadata` (keeps 0x0B index, caches, provenance, replication consistent) — never a direct 0x02 write — `storage/lease.go`.
 - **[STO-4]** The engram lease (0x2A) is **advisory**: recall/claim paths consult it; normal writes must not start consulting it without an RFC — `storage/lease.go`, `engine/engine_lease.go`.
@@ -54,7 +54,7 @@ Format: **[INV-n]** assertion — `file:anchor` — *why it matters / what break
 - **[SEC-7]** A vault-pinned credential rejects any differing `vault` argument and never echoes the pinned name — `internal/mcp/context.go` (also REST/gRPC/MBP). *No cross-vault action, no name leak.*
 - **[SEC-8]** Unconfigured vaults are locked (fail-closed, `Public:false`) on REST/gRPC/MBP — `internal/auth/vault_config.go`.
 - **[SEC-9]** Toolset filtering is **advertisement-only**; dispatch never consults it; unknown values fail **open to full** — `internal/mcp/toolset.go`. *Presentation preference, not a security boundary.*
-- **[SEC-10]** SSE per-POST: a cached `cap_` session credential is re-validated before dispatch — `internal/mcp/server.go`. *Closes the #612 confused-deputy.* **Known open gap: the symmetric `mk_` re-validation does NOT exist (#615/#617) — a revoked mk_ SSE session can survive. A PR touching the SSE POST path should fix or at least not widen this.**
+- **[SEC-10]** SSE per-POST: both a cached `cap_` and a cached `mk_` session credential are re-validated (live key-store read) before dispatch, so a revoked or expired credential cannot keep dispatching on an open SSE session — `internal/mcp/server.go`. *The cap_ half closed the #612 confused-deputy; the mk_ half closed the symmetric gap in #617 (was #615). A PR touching the SSE POST path must not reopen either.*
 - **[SEC-11]** Vault names are `[a-z0-9_-]{1,64}` everywhere via `IsValidVaultName` — `internal/auth/token.go`.
 - **[SEC-12]** Static-token compares are constant-time with a length cap; keys/caps are looked up by SHA-256(secret) — raw secrets are never stored — `internal/auth/token.go`, `keys_store.go`, `capability_store.go`.
 - **[SEC-13]** Any new client write path in a cluster deployment must either gate on `IsLeader()`/Cortex-origin or replicate its mutation — no transport does this today, which is exactly bug #596. Background workers that mutate replicated state (e.g. the pruner) inherit the same obligation.
@@ -64,7 +64,7 @@ Format: **[INV-n]** assertion — `file:anchor` — *why it matters / what break
 ## Known open wounds
 
 Several of these invariants sit next to known-imperfect code. The individual issues are
-tracked publicly (#596, #605, #607, #611, #615/#617, …); a reviewer should recognize when a
+tracked publicly (#596, #605, #607, …); a reviewer should recognize when a
 PR is touching one and either fix or at least not widen it. The consolidated map of soft
 spots and trust-surface weaknesses is kept in the maintainer-private tier
 (`.claude/maintainer/soft-spots.md`) rather than concentrated here — cite the individual

--- a/docs/internals/keyspace-registry.md
+++ b/docs/internals/keyspace-registry.md
@@ -3,23 +3,19 @@
 **The single most important artifact for preventing a whole class of bug.** MuninnDB
 runs `internal/storage`, `internal/auth`, and `internal/replication` over **one shared
 Pebble database**. Prefixes are single bytes. If two packages claim the same byte, they
-silently corrupt each other's scans — this is exactly the live bug in #611.
+silently corrupt each other's scans — this *was* the live bug in #611 (auth's 0x11–0x14
+overlapping storage), **resolved by #618**, which relocated auth to 0x42–0x45 with a
+one-time migration and consolidated the whole registry behind a single source of truth.
 
 **Rule for any PR that adds or changes a Pebble key:** the new prefix must be disjoint
-from every row below and documented where the registry lives. Today the source of truth is
-the `internal/storage/keys/keys.go` doc comments plus `internal/auth/keys.go`, and the
-cross-check is `TestCapabilityPrefixesNoCollision` in `internal/auth/keys_test.go` (which
-currently derives storage's upper bound from a `storageMaxPrefix` constant — bump it if you
-extend storage past `0x2A`).
-
-> **In flight — PR #618 (#611 fix):** this consolidates the whole registry into a new
-> `internal/prefix/prefix.go` package with a stronger disjointness test
-> (`TestAll_NoDuplicateBytes`, `TestAll_OwnerGroupsPairwiseDisjoint`) that derives its
-> bounds from `prefix.All()`, and it **removes `storageMaxPrefix`** and relocates auth's
-> 0x11–0x14 to 0x42–0x45. When #618 merges, update this doc and STO-1: the source of truth
-> becomes `internal/prefix/`, and the "bump `storageMaxPrefix`" guidance is replaced by
-> "add the prefix to `prefix.All()` — the disjointness test auto-tightens." Verify which
-> world you're in with `ls internal/prefix/` before reviewing a keyspace change.
+from every row below and added to the registry. The source of truth is
+`internal/prefix/prefix.go` (`prefix.All()` — the one authoritative allocation table);
+`internal/storage/keys/keys.go` and `internal/auth/keys.go` reference those constants and
+never inline a raw byte. The disjointness cross-check is `TestAll_NoDuplicateBytes` and
+`TestAll_OwnerGroupsPairwiseDisjoint` in `internal/prefix/prefix_test.go`, both deriving
+their bounds from `prefix.All()`. There is **no `storageMaxPrefix` constant** anymore:
+adding a prefix means adding an entry to `prefix.All()`, and the disjointness test
+auto-tightens to cover it (no bound to bump).
 
 `ws` = 8-byte SipHash(vault name) prefix (deterministic; a name always maps to the same
 prefix — see the vault-reuse note at the bottom).
@@ -38,15 +34,15 @@ prefix — see the vault-reuse note at the bottom).
 | 0x08 / 0x09 | ws+"stats" / ws+term | FTS stats | |
 | 0x0A | ws+conceptHash(4)+relType(2)+id | contradiction | |
 | 0x0B | ws+state(1)+id | — | state index |
-| **0x0C** | ws+tagHash(4)+id | — | **tag index — maintained on every write, ZERO non-test readers (#607)** |
+| **0x0C** | ws+tagHash(4)+id | — | **tag index — now READ by tag-scoped recall (`ListByTagInRange`/`ListByTagsAllInRange`, wired #619); no longer dead weight** |
 | 0x0D | ws+creatorHash(4)+id | — | creator index |
 | 0x0E | ws | vault name string | vault meta |
 | 0x0F | siphash(name)(8) | ws(8) | name→prefix index |
 | 0x10 | ws+bucket(1)+id | — | relevance bucket |
-| **0x11** | ulid(16) — **GLOBAL, not vault-scoped** | DigestFlags | **collides with auth AdminUser (#611)** |
-| **0x12** | ws | CoherenceKey | **collides with auth APIKey (#611)** |
-| **0x13** | ws | VaultWeights | **collides with auth APIKey vault idx (#611)** |
-| **0x14** | ws+src(16)+dst(16) | AssocWeightIndex float32 | **collides with auth VaultCfg (#611)** |
+| 0x11 | ulid(16) — **GLOBAL, not vault-scoped** | DigestFlags | storage-only since #618 (auth moved off 0x11) |
+| 0x12 | ws | CoherenceKey | storage-only since #618 |
+| 0x13 | ws | VaultWeights | storage-only since #618 |
+| 0x14 | ws+src(16)+dst(16) | AssocWeightIndex float32 | storage-only since #618 |
 | 0x15 | ws | BE int64 count | vault engram count ("sole user" per comment) |
 | 0x16 | ws+id(16)+ts(8)+seq(4) | provenance | async worker |
 | 0x17 | ws | migration version+cursor | |
@@ -74,12 +70,12 @@ prefix — see the vault-reuse note at the bottom).
 
 | Prefix | Key shape | Value | Notes |
 |---|---|---|---|
-| **0x11** | username-bytes | AdminUser (JSON) | **collides with storage DigestFlags** |
-| **0x12** | hash16 | APIKey (JSON) | **collides with storage CoherenceKey** |
-| **0x13** | vault+0x00+keyID(8) | — | APIKey vault index; **collides with storage VaultWeights** |
-| **0x14** | vault-name | VaultCfg (JSON) | **collides with storage AssocWeightIndex** |
 | 0x40 | hash16 | Capability (JSON) | cap_ tokens (#612), relocated off 0x15/0x16 |
 | 0x41 | vault+0x00+capID(8) | storageHash16 | cap_ vault index |
+| 0x42 | username-bytes | AdminUser (JSON) | relocated from 0x11 by #618 |
+| 0x43 | hash16 | APIKey (JSON) | relocated from 0x12 by #618 |
+| 0x44 | vault+0x00+keyID(8) | — | APIKey vault index; relocated from 0x13 by #618 |
+| 0x45 | vault-name | VaultCfg (JSON) | relocated from 0x14 by #618 |
 
 ## Replication prefixes (`internal/replication/`) — all under 0x19
 
@@ -92,18 +88,20 @@ prefix — see the vault-reuse note at the bottom).
 
 ## Free bytes
 
-`0x2B`–`0x3F` and `0x46`+ are free for new storage/auth keys. (`0x29`/`0x40`/`0x41`
+`0x2B`–`0x3F` and `0x46`+ are free for new storage/auth keys (0x40–0x45 are now
+allocated: 0x40/0x41 capability, 0x42–0x45 auth). (`0x29`/`0x40`/`0x41`
 also appear in `internal/transport/mbp/frame.go` as **wire opcodes** — a different
 keyspace; coincidental, safe, but confusing. Prefer `0x2B+` for new storage prefixes.)
 
 ## Live hazards a reviewer must know
 
-1. **#611 — auth 0x11–0x14 collide with storage.** `AdminExists` scans `[0x11,0x12)` and
-   sees storage's global DigestFlags → false-positive admin existence / miscount.
-   `ListVaultConfigs` scans `[0x14,0x15)` = O(all association weights in the DB), not
-   O(vault configs). The fix (green-lit) is relocation + one-time migration + a
-   cross-package disjointness test — **not** an assertion-only patch. Until then, any PR
-   widening a scan over 0x11–0x14 makes it worse.
+1. **#611 — auth 0x11–0x14 collided with storage — RESOLVED by #618.** Before #618,
+   `AdminExists` scanned `[0x11,0x12)` and saw storage's global DigestFlags →
+   false-positive admin existence / miscount, and `ListVaultConfigs` scanned `[0x14,0x15)`
+   = O(all association weights in the DB), not O(vault configs). #618 relocated auth to
+   0x42–0x45 with a one-time migration and added the cross-package disjointness test
+   (`prefix_test.go`), so 0x11–0x14 are now storage-only. No action needed; do not
+   reintroduce an auth key in 0x11–0x14.
 
 2. **0x19 is shared idempotency+replication territory.** `PurgeExpiredIdempotency` scans
    the *entire* 0x19 range including replication log/epoch entries and only survives
@@ -112,15 +110,13 @@ keyspace; coincidental, safe, but confusing. Prefer `0x2B+` for new storage pref
    `cluster_epoch`). Never switch replication values to JSON or receipts to msgpack
    without revisiting this.
 
-3. **`storageMaxPrefix` is hardcoded 0x2A** in the collision test. The day storage adds
-   0x2B, the guard silently weakens unless the constant is bumped. Flag any new storage
-   prefix ≥ 0x2B for this.
+3. **0x0C tag index is now read by tag-scoped recall (#619).** `ListByTagInRange` /
+   `ListByTagsAllInRange` (`internal/storage/query.go`) seed the candidate pool for
+   `tags_all`/`tags_any`/`tag_prefix` recalls (`internal/engine/activation/engine.go`), so
+   the index is a live read path — no longer write-amplifying dead weight. Keep it in sync
+   on the write path; a PR that drops maintenance now breaks tag-scoped recall.
 
-4. **0x0C tag index is write-amplifying dead weight** — maintained on every tag mutation,
-   zero production readers (#607). Don't add write-path cost assuming it's consumed;
-   either wire the reader (the green-lit #607 fix) or plan removal.
-
-5. **Vault prefixes are name-deterministic and therefore REUSED on name reuse.** Deleting
+4. **Vault prefixes are name-deterministic and therefore REUSED on name reuse.** Deleting
    a vault (`ClearVault` + `DeleteVaultNameOnly`) does not clean 0x11 DigestFlags
    ("orphans acceptable") or 0x1F global entity records. Re-creating a vault of the same
    name recomputes the identical SipHash prefix and resurfaces those orphans. The correct


### PR DESCRIPTION
Post-merge Opus audits of #617 and #618 confirmed both safe as merged, and surfaced that these merges left the source-of-truth docs stale. This corrects them: SEC-10's mk_ SSE gap is now closed (#617), the #611 keyspace collision is resolved (#618, auth relocated to 0x42-0x45, source of truth is `internal/prefix/prefix.go`), and the 0x0C tag index is now a live read path (#619) rather than dead weight. Docs-only, no behavior change.