### PR TITLE
fix(enrich): preserve transient provider failures

### DIFF
--- a/internal/plugin/enrich/anthropic.go
+++ b/internal/plugin/enrich/anthropic.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -108,13 +107,12 @@ func (p *AnthropicLLMProvider) Complete(ctx context.Context, system, user string
 
 	resp, err := p.client.Do(httpReq)
 	if err != nil {
-		return "", fmt.Errorf("request failed: %w", err)
+		return "", providerTransportError(p.Name(), err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("anthropic returned status %d: %s", resp.StatusCode, string(bodyBytes))
+		return "", providerHTTPError(p.Name(), resp)
 	}
 
 	var messagesResp anthropicMessagesResponse

--- a/internal/plugin/enrich/enrich.go
+++ b/internal/plugin/enrich/enrich.go
@@ -2,8 +2,10 @@ package enrich
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -34,8 +36,10 @@ type LLMProviderConfig struct {
 // defaultBreaker thresholds: 5 consecutive failures open the circuit;
 // it probes again after 30 s.
 const (
-	breakerMaxFails   = 5
-	breakerResetAfter = 30 * time.Second
+	breakerMaxFails    = 5
+	breakerResetAfter  = 30 * time.Second
+	providerBackoffMin = time.Second
+	providerBackoffMax = time.Minute
 )
 
 // EnrichService implements plugin.EnrichPlugin.
@@ -54,6 +58,17 @@ type EnrichService struct {
 	// so it is always non-nil. OnStateChange may be wired after construction
 	// (before concurrent use) to emit logs and update the plugin registry.
 	breaker *circuit.Breaker
+
+	// backpressure is provider-wide: a transient response from any engram
+	// delays every subsequent call through this service. The function seams
+	// keep time-based behavior deterministic in tests.
+	backpressureMu    sync.Mutex
+	retryNotBefore    time.Time
+	retryableFailures int
+	backpressureGen   uint64
+	nowFn             func() time.Time
+	waitFn            func(context.Context, time.Duration) error
+	jitterFn          func(time.Duration) time.Duration
 }
 
 // NewEnrichService creates an EnrichService from a provider URL.
@@ -84,6 +99,9 @@ func NewEnrichService(providerURL string) (*EnrichService, error) {
 		provCfg:  provCfg,
 		name:     name,
 		breaker:  circuit.New(breakerMaxFails, breakerResetAfter),
+		nowFn:    time.Now,
+		waitFn:   waitContext,
+		jitterFn: addBackoffJitter,
 	}
 
 	return es, nil
@@ -203,19 +221,132 @@ func (s *EnrichService) Enrich(ctx context.Context, eng *storage.Engram) (*plugi
 	if s.pipeline == nil {
 		return nil, fmt.Errorf("enrich service not initialized")
 	}
+	admissionGen, err := s.waitForProvider(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	// Fast path: no circuit breaker (test construction or future embedded use).
 	if s.breaker == nil {
-		return s.pipeline.Run(ctx, eng)
+		result, err := s.pipeline.Run(ctx, eng)
+		s.recordProviderOutcome(err, admissionGen)
+		return result, err
 	}
 
 	var result *plugin.EnrichmentResult
-	err := s.breaker.Do(func() error {
+	err = s.breaker.Do(func() error {
 		var runErr error
 		result, runErr = s.pipeline.Run(ctx, eng)
 		return runErr
 	})
+	s.recordProviderOutcome(err, admissionGen)
 	return result, err
+}
+
+func (s *EnrichService) waitForProvider(ctx context.Context) (uint64, error) {
+	for {
+		s.backpressureMu.Lock()
+		now := s.now()
+		wait := s.retryNotBefore.Sub(now)
+		generation := s.backpressureGen
+		s.backpressureMu.Unlock()
+		if wait <= 0 {
+			return generation, nil
+		}
+		if err := s.wait(ctx, wait); err != nil {
+			return 0, err
+		}
+	}
+}
+
+func (s *EnrichService) recordProviderOutcome(err error, admissionGen uint64) {
+	if err == nil {
+		s.backpressureMu.Lock()
+		// A success may have been admitted before a concurrent request created
+		// a newer throttle. Only an outcome from the active generation can clear
+		// provider-wide backpressure.
+		if admissionGen == s.backpressureGen {
+			s.retryableFailures = 0
+			s.retryNotBefore = time.Time{}
+		}
+		s.backpressureMu.Unlock()
+		return
+	}
+
+	var providerErr *plugin.ProviderError
+	if !errors.As(err, &providerErr) || !providerErr.Retryable {
+		return
+	}
+
+	s.backpressureMu.Lock()
+	defer s.backpressureMu.Unlock()
+	s.backpressureGen++
+	s.retryableFailures++
+	delay := time.Duration(0)
+	if providerErr.HasRetryAfter && providerErr.RetryAfter > 0 {
+		delay = providerErr.RetryAfter
+	} else {
+		delay = exponentialProviderBackoff(s.retryableFailures)
+		delay = s.jitter(delay)
+		if delay > providerBackoffMax {
+			delay = providerBackoffMax
+		}
+	}
+	until := s.now().Add(delay)
+	if until.After(s.retryNotBefore) {
+		s.retryNotBefore = until
+	}
+}
+
+func exponentialProviderBackoff(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	shift := attempt - 1
+	if shift > 6 {
+		shift = 6
+	}
+	delay := providerBackoffMin * time.Duration(1<<shift)
+	if delay > providerBackoffMax {
+		return providerBackoffMax
+	}
+	return delay
+}
+
+func addBackoffJitter(delay time.Duration) time.Duration {
+	return delay + time.Duration(rand.Float64()*0.25*float64(delay))
+}
+
+func waitContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *EnrichService) now() time.Time {
+	if s.nowFn != nil {
+		return s.nowFn()
+	}
+	return time.Now()
+}
+
+func (s *EnrichService) wait(ctx context.Context, delay time.Duration) error {
+	if s.waitFn != nil {
+		return s.waitFn(ctx, delay)
+	}
+	return waitContext(ctx, delay)
+}
+
+func (s *EnrichService) jitter(delay time.Duration) time.Duration {
+	if s.jitterFn != nil {
+		return s.jitterFn(delay)
+	}
+	return addBackoffJitter(delay)
 }
 
 // LLMStats returns a point-in-time snapshot of LLM call metrics.

--- a/internal/plugin/enrich/enrich_test.go
+++ b/internal/plugin/enrich/enrich_test.go
@@ -2,8 +2,16 @@ package enrich
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/scrypster/muninndb/internal/config"
+	"github.com/scrypster/muninndb/internal/engine/circuit"
 	"github.com/scrypster/muninndb/internal/plugin"
 	"github.com/scrypster/muninndb/internal/storage"
 )
@@ -187,6 +195,254 @@ func TestEnrichService_Enrich_Success(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestEnrichService_HTTP429Then200HonorsRetryAfter(t *testing.T) {
+	now := time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)
+	var clockMu sync.Mutex
+	readNow := func() time.Time {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		return now
+	}
+	advance := func(wait time.Duration) {
+		clockMu.Lock()
+		now = now.Add(wait)
+		clockMu.Unlock()
+	}
+	var requestMu sync.Mutex
+	var requestTimes []time.Time
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestMu.Lock()
+		requestTimes = append(requestTimes, readNow())
+		attempt := len(requestTimes)
+		requestMu.Unlock()
+		if attempt == 1 {
+			w.Header().Set("Retry-After", "5")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"{\"summary\":\"recovered\",\"key_points\":[\"ok\"]}"}}]}`))
+	}))
+	defer srv.Close()
+
+	provider := NewOpenAILLMProvider()
+	provider.baseURL = srv.URL
+	provider.model = "test"
+	provider.apiKey = "test-key"
+	pipeline := NewPipeline(provider, NewTokenBucketLimiter(100, 100))
+	pipeline.SetConfig(&config.PluginConfig{EnrichMode: "light"})
+	es := &EnrichService{
+		provider: provider,
+		pipeline: pipeline,
+		breaker:  circuit.New(5, time.Hour),
+		nowFn:    readNow,
+		waitFn: func(_ context.Context, wait time.Duration) error {
+			advance(wait)
+			return nil
+		},
+		jitterFn: func(wait time.Duration) time.Duration { return wait },
+	}
+	eng := &storage.Engram{ID: storage.NewULID(), Concept: "original", Content: "pending"}
+
+	if _, err := es.Enrich(context.Background(), eng); !plugin.IsRetryableProviderError(err) {
+		t.Fatalf("first Enrich error = %v, want typed 429", err)
+	}
+	result, err := es.Enrich(context.Background(), eng)
+	if err != nil || result == nil || result.Summary != "recovered" {
+		t.Fatalf("recovery result = (%#v, %v)", result, err)
+	}
+	requestMu.Lock()
+	defer requestMu.Unlock()
+	if len(requestTimes) != 2 {
+		t.Fatalf("requests = %d, want 2", len(requestTimes))
+	}
+	if got := requestTimes[1].Sub(requestTimes[0]); got < 5*time.Second {
+		t.Fatalf("second request after %v, want at least 5s", got)
+	}
+}
+
+func TestEnrichService_OlderConcurrentSuccessCannotClearNewThrottle(t *testing.T) {
+	now := time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)
+	var clockMu sync.Mutex
+	readNow := func() time.Time {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		return now
+	}
+	var waitsMu sync.Mutex
+	var waits []time.Duration
+	entered := make(chan int, 2)
+	releaseThrottle := make(chan struct{})
+	releaseOlderSuccess := make(chan struct{})
+	var calls atomic.Int32
+	mock := NewMockLLMProvider()
+	mock.customComplete = func(context.Context, string, string) (string, error) {
+		call := int(calls.Add(1))
+		if call <= 2 {
+			entered <- call
+		}
+		switch call {
+		case 1:
+			<-releaseThrottle
+			return "", &plugin.ProviderError{
+				Provider: "fake", StatusCode: 429, Retryable: true,
+				RetryAfter: 5 * time.Second, HasRetryAfter: true,
+			}
+		case 2:
+			<-releaseOlderSuccess
+		}
+		return `{"summary":"ok","key_points":[]}`, nil
+	}
+	pipeline := NewPipeline(mock, NewTokenBucketLimiter(100, 100))
+	pipeline.SetConfig(&config.PluginConfig{EnrichMode: "light"})
+	es := &EnrichService{
+		provider: mock,
+		pipeline: pipeline,
+		breaker:  circuit.New(5, time.Hour),
+		nowFn:    readNow,
+		waitFn: func(_ context.Context, wait time.Duration) error {
+			waitsMu.Lock()
+			waits = append(waits, wait)
+			waitsMu.Unlock()
+			clockMu.Lock()
+			now = now.Add(wait)
+			clockMu.Unlock()
+			return nil
+		},
+		jitterFn: func(wait time.Duration) time.Duration { return wait },
+	}
+	eng := &storage.Engram{ID: storage.NewULID()}
+	results := make(chan error, 2)
+	go func() { _, err := es.Enrich(context.Background(), eng); results <- err }()
+	go func() { _, err := es.Enrich(context.Background(), eng); results <- err }()
+	<-entered
+	<-entered // both calls were admitted before either outcome
+
+	close(releaseThrottle)
+	if err := <-results; !plugin.IsRetryableProviderError(err) {
+		t.Fatalf("first completed result = %v, want throttle", err)
+	}
+	close(releaseOlderSuccess)
+	if err := <-results; err != nil {
+		t.Fatalf("older concurrent call = %v, want success", err)
+	}
+
+	if _, err := es.Enrich(context.Background(), eng); err != nil {
+		t.Fatalf("post-throttle request failed: %v", err)
+	}
+	waitsMu.Lock()
+	defer waitsMu.Unlock()
+	if len(waits) != 1 || waits[0] != 5*time.Second {
+		t.Fatalf("waits = %v, want [5s]; older success cleared newer throttle", waits)
+	}
+}
+
+func TestEnrichService_RepeatedThrottleUsesBoundedExponentialBackoff(t *testing.T) {
+	now := time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)
+	var waits []time.Duration
+	requests := 0
+	mock := NewMockLLMProvider()
+	mock.customComplete = func(context.Context, string, string) (string, error) {
+		requests++
+		return "", &plugin.ProviderError{Provider: "fake", StatusCode: 429, Retryable: true}
+	}
+	pipeline := NewPipeline(mock, NewTokenBucketLimiter(100, 100))
+	pipeline.SetConfig(&config.PluginConfig{EnrichMode: "light"})
+	es := &EnrichService{
+		provider: mock,
+		pipeline: pipeline,
+		breaker:  circuit.New(100, time.Hour),
+		nowFn:    func() time.Time { return now },
+		waitFn: func(_ context.Context, wait time.Duration) error {
+			waits = append(waits, wait)
+			now = now.Add(wait)
+			return nil
+		},
+		jitterFn: func(wait time.Duration) time.Duration { return wait },
+	}
+	eng := &storage.Engram{ID: storage.NewULID()}
+
+	for range 4 {
+		if _, err := es.Enrich(context.Background(), eng); !plugin.IsRetryableProviderError(err) {
+			t.Fatalf("Enrich error = %v, want retryable throttle", err)
+		}
+	}
+	if requests != 4 {
+		t.Fatalf("requests = %d, want exactly one per attempt", requests)
+	}
+	want := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second}
+	if len(waits) != len(want) {
+		t.Fatalf("waits = %v, want %v", waits, want)
+	}
+	for i := range want {
+		if waits[i] != want[i] {
+			t.Fatalf("waits = %v, want %v", waits, want)
+		}
+	}
+}
+
+func TestExponentialProviderBackoffIsCapped(t *testing.T) {
+	if got := exponentialProviderBackoff(100); got != providerBackoffMax {
+		t.Fatalf("backoff = %v, want cap %v", got, providerBackoffMax)
+	}
+}
+
+func TestEnrichService_BackpressureWaitHonorsContextCancellation(t *testing.T) {
+	now := time.Now()
+	mock := NewMockLLMProvider()
+	requests := 0
+	mock.customComplete = func(context.Context, string, string) (string, error) {
+		requests++
+		return "", &plugin.ProviderError{
+			Provider: "fake", StatusCode: 429, Retryable: true,
+			RetryAfter: time.Minute, HasRetryAfter: true,
+		}
+	}
+	pipeline := NewPipeline(mock, NewTokenBucketLimiter(100, 100))
+	pipeline.SetConfig(&config.PluginConfig{EnrichMode: "light"})
+	es := &EnrichService{
+		provider: mock,
+		pipeline: pipeline,
+		breaker:  circuit.New(5, time.Hour),
+		nowFn:    func() time.Time { return now },
+		waitFn: func(ctx context.Context, _ time.Duration) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+		jitterFn: func(wait time.Duration) time.Duration { return wait },
+	}
+	eng := &storage.Engram{ID: storage.NewULID()}
+	_, _ = es.Enrich(context.Background(), eng)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := es.Enrich(ctx, eng)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Enrich error = %v, want context.Canceled", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, canceled wait must not call provider again", requests)
+	}
+}
+
+func TestEnrichService_AuthenticationFailureStillOpensCircuit(t *testing.T) {
+	mock := NewMockLLMProvider()
+	mock.customComplete = func(context.Context, string, string) (string, error) {
+		return "", &plugin.ProviderError{Provider: "fake", StatusCode: 401, Retryable: false}
+	}
+	pipeline := NewPipeline(mock, NewTokenBucketLimiter(100, 100))
+	pipeline.SetConfig(&config.PluginConfig{EnrichMode: "light"})
+	es := &EnrichService{provider: mock, pipeline: pipeline, breaker: circuit.New(1, time.Hour)}
+	eng := &storage.Engram{ID: storage.NewULID()}
+
+	if _, err := es.Enrich(context.Background(), eng); err == nil || plugin.IsRetryableProviderError(err) {
+		t.Fatalf("first Enrich error = %v, want observable non-retryable auth failure", err)
+	}
+	if _, err := es.Enrich(context.Background(), eng); !errors.Is(err, circuit.ErrOpen) {
+		t.Fatalf("second Enrich error = %v, want circuit.ErrOpen", err)
 	}
 }
 

--- a/internal/plugin/enrich/google.go
+++ b/internal/plugin/enrich/google.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -125,13 +124,12 @@ func (p *GoogleLLMProvider) Complete(ctx context.Context, system, user string) (
 
 	resp, err := p.client.Do(httpReq)
 	if err != nil {
-		return "", fmt.Errorf("request failed: %w", err)
+		return "", providerTransportError(p.Name(), err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("google returned status %d: %s", resp.StatusCode, string(bodyBytes))
+		return "", providerHTTPError(p.Name(), resp)
 	}
 
 	var genResp googleGenerateResponse

--- a/internal/plugin/enrich/ollama.go
+++ b/internal/plugin/enrich/ollama.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -105,13 +104,12 @@ func (p *OllamaLLMProvider) Complete(ctx context.Context, system, user string) (
 
 	resp, err := p.client.Do(httpReq)
 	if err != nil {
-		return "", fmt.Errorf("request failed: %w", err)
+		return "", providerTransportError(p.Name(), err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("ollama returned status %d: %s", resp.StatusCode, string(bodyBytes))
+		return "", providerHTTPError(p.Name(), resp)
 	}
 
 	var chatResp ollamaChatResponse

--- a/internal/plugin/enrich/openai.go
+++ b/internal/plugin/enrich/openai.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -121,13 +120,12 @@ func (p *OpenAILLMProvider) Complete(ctx context.Context, system, user string) (
 
 	resp, err := p.client.Do(httpReq)
 	if err != nil {
-		return "", fmt.Errorf("request failed: %w", err)
+		return "", providerTransportError(p.Name(), err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("openai returned status %d: %s", resp.StatusCode, string(bodyBytes))
+		return "", providerHTTPError(p.Name(), resp)
 	}
 
 	var chatResp openaiChatResponse

--- a/internal/plugin/enrich/pipeline.go
+++ b/internal/plugin/enrich/pipeline.go
@@ -2,6 +2,7 @@ package enrich
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -132,6 +133,9 @@ func (p *EnrichmentPipeline) Run(ctx context.Context, eng *storage.Engram) (resu
 	if p.stageEnabled("entities") && !engramHasEntities(eng) {
 		ents, err := p.extractEntities(ctx, eng)
 		if err != nil {
+			if shouldAbortPipeline(err) {
+				return nil, fmt.Errorf("enrich entities: %w", err)
+			}
 			slog.Warn("enrich: entity extraction failed", "id", eng.ID.String(), "err", err)
 			stageErrors = append(stageErrors, fmt.Sprintf("entities: %v", err))
 			ents = nil
@@ -144,6 +148,9 @@ func (p *EnrichmentPipeline) Run(ctx context.Context, eng *storage.Engram) (resu
 	if p.stageEnabled("relationships") && len(entities) > 0 {
 		rels, err := p.extractRelationships(ctx, eng, entities)
 		if err != nil {
+			if shouldAbortPipeline(err) {
+				return nil, fmt.Errorf("enrich relationships: %w", err)
+			}
 			slog.Warn("enrich: relationship extraction failed", "id", eng.ID.String(), "err", err)
 			stageErrors = append(stageErrors, fmt.Sprintf("relationships: %v", err))
 			rels = nil
@@ -155,6 +162,9 @@ func (p *EnrichmentPipeline) Run(ctx context.Context, eng *storage.Engram) (resu
 	if p.stageEnabled("classification") && !engramHasClassification(eng) {
 		memType, typeLabel, category, subcategory, tags, err := p.classify(ctx, eng)
 		if err != nil {
+			if shouldAbortPipeline(err) {
+				return nil, fmt.Errorf("enrich classification: %w", err)
+			}
 			slog.Warn("enrich: classification failed", "id", eng.ID.String(), "err", err)
 			stageErrors = append(stageErrors, fmt.Sprintf("classification: %v", err))
 		} else {
@@ -172,6 +182,9 @@ func (p *EnrichmentPipeline) Run(ctx context.Context, eng *storage.Engram) (resu
 	if p.stageEnabled("summary") && !engramHasSummary(eng) {
 		summary, keyPoints, err := p.summarize(ctx, eng)
 		if err != nil {
+			if shouldAbortPipeline(err) {
+				return nil, fmt.Errorf("enrich summary: %w", err)
+			}
 			slog.Warn("enrich: summarization failed", "id", eng.ID.String(), "err", err)
 			stageErrors = append(stageErrors, fmt.Sprintf("summary: %v", err))
 		} else {
@@ -191,6 +204,14 @@ func (p *EnrichmentPipeline) Run(ctx context.Context, eng *storage.Engram) (resu
 	}
 
 	return result, nil
+}
+
+func shouldAbortPipeline(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var providerErr *plugin.ProviderError
+	return errors.As(err, &providerErr)
 }
 
 // engramHasEntities returns true if the engram already has caller-provided entities,

--- a/internal/plugin/enrich/pipeline_test.go
+++ b/internal/plugin/enrich/pipeline_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/scrypster/muninndb/internal/config"
+	"github.com/scrypster/muninndb/internal/plugin"
 	"github.com/scrypster/muninndb/internal/storage"
 )
 
@@ -20,6 +21,55 @@ type MockLLMProvider struct {
 	failCount      int
 	entityResponse string
 	customComplete func(ctx context.Context, system, user string) (string, error)
+}
+
+func TestPipelineRun_RetryableProviderErrorStopsAndPreservesMetadata(t *testing.T) {
+	providerErr := &plugin.ProviderError{
+		Provider:      "mock",
+		StatusCode:    429,
+		Retryable:     true,
+		RetryAfter:    5 * time.Second,
+		HasRetryAfter: true,
+	}
+	calls := 0
+	mock := NewMockLLMProvider()
+	mock.customComplete = func(context.Context, string, string) (string, error) {
+		calls++
+		return "", fmt.Errorf("complete: %w", providerErr)
+	}
+	pipeline := NewPipeline(mock, NewTokenBucketLimiter(100, 100))
+
+	result, err := pipeline.Run(context.Background(), &storage.Engram{})
+	if err == nil {
+		t.Fatal("expected retryable provider error")
+	}
+	if result != nil {
+		t.Fatalf("result = %#v, want nil on systemic transient failure", result)
+	}
+	if calls != 1 {
+		t.Fatalf("provider calls = %d, want 1 (pipeline must stop after throttle)", calls)
+	}
+	var got *plugin.ProviderError
+	if !errors.As(err, &got) || got != providerErr {
+		t.Fatalf("retryability metadata was not preserved: %v", err)
+	}
+}
+
+func TestPipelineRun_MalformedSuccessfulOutputRemainsPermanent(t *testing.T) {
+	mock := NewMockLLMProvider()
+	mock.customComplete = func(context.Context, string, string) (string, error) {
+		return "not-json", nil
+	}
+	pipeline := NewPipeline(mock, NewTokenBucketLimiter(100, 100))
+
+	result, err := pipeline.Run(context.Background(), &storage.Engram{})
+	if err == nil || result != nil {
+		t.Fatalf("malformed output = (%#v, %v), want permanent failure", result, err)
+	}
+	var providerErr *plugin.ProviderError
+	if errors.As(err, &providerErr) {
+		t.Fatalf("malformed successful output must not be retryable provider failure: %+v", providerErr)
+	}
 }
 
 func NewMockLLMProvider() *MockLLMProvider {

--- a/internal/plugin/enrich/provider_error.go
+++ b/internal/plugin/enrich/provider_error.go
@@ -1,0 +1,71 @@
+package enrich
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
+)
+
+func providerHTTPError(provider string, resp *http.Response) error {
+	// Drain a bounded amount so the standard transport can reuse the
+	// connection, but never retain or log the provider's response body.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+	retryAfter, hasRetryAfter := parseRetryAfter(resp.Header.Get("Retry-After"), time.Now())
+	return &plugin.ProviderError{
+		Provider:      provider,
+		StatusCode:    resp.StatusCode,
+		Retryable:     retryableHTTPStatus(resp.StatusCode),
+		RetryAfter:    retryAfter,
+		HasRetryAfter: hasRetryAfter,
+	}
+}
+
+func providerTransportError(provider string, err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("%s provider request: %w", provider, err)
+	}
+	return &plugin.ProviderError{Provider: provider, Retryable: true, Err: err}
+}
+
+func retryableHTTPStatus(status int) bool {
+	switch status {
+	case http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds >= 0 {
+		const maxRetryAfterSeconds = int64(^uint64(0)>>1) / int64(time.Second)
+		if seconds > maxRetryAfterSeconds {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	when, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+	if !when.After(now) {
+		return 0, true
+	}
+	return when.Sub(now), true
+}

--- a/internal/plugin/enrich/provider_error_test.go
+++ b/internal/plugin/enrich/provider_error_test.go
@@ -1,0 +1,93 @@
+package enrich
+
+import (
+	"context"
+	"errors"
+	"math"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
+)
+
+func TestRetryableHTTPStatusPolicy(t *testing.T) {
+	tests := []struct {
+		status    int
+		retryable bool
+	}{
+		{http.StatusRequestTimeout, true},
+		{http.StatusTooManyRequests, true},
+		{http.StatusInternalServerError, true},
+		{http.StatusBadGateway, true},
+		{http.StatusServiceUnavailable, true},
+		{http.StatusGatewayTimeout, true},
+		{http.StatusBadRequest, false},
+		{http.StatusUnauthorized, false},
+		{http.StatusForbidden, false},
+		{http.StatusNotFound, false},
+		{http.StatusNotImplemented, false},
+	}
+	for _, tt := range tests {
+		if got := retryableHTTPStatus(tt.status); got != tt.retryable {
+			t.Errorf("status %d retryable = %v, want %v", tt.status, got, tt.retryable)
+		}
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+		valid bool
+	}{
+		{name: "delta seconds", value: "7", want: 7 * time.Second, valid: true},
+		{name: "http date", value: now.Add(12 * time.Second).Format(http.TimeFormat), want: 12 * time.Second, valid: true},
+		{name: "zero is valid", value: "0", valid: true},
+		{name: "invalid", value: "later", valid: false},
+		{name: "negative", value: "-1", valid: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, valid := parseRetryAfter(tt.value, now)
+			if got != tt.want || valid != tt.valid {
+				t.Fatalf("parseRetryAfter(%q) = (%v, %v), want (%v, %v)", tt.value, got, valid, tt.want, tt.valid)
+			}
+		})
+	}
+}
+
+func TestParseRetryAfter_DeltaSecondsOverflow(t *testing.T) {
+	now := time.Now()
+	maxSafeSeconds := int64(math.MaxInt64) / int64(time.Second)
+	got, valid := parseRetryAfter(strconv.FormatInt(maxSafeSeconds, 10), now)
+	if !valid || got != time.Duration(maxSafeSeconds)*time.Second {
+		t.Fatalf("largest safe Retry-After = (%v, %v)", got, valid)
+	}
+	if got, valid := parseRetryAfter(strconv.FormatInt(maxSafeSeconds+1, 10), now); valid || got != 0 {
+		t.Fatalf("overflowing Retry-After = (%v, %v), want invalid", got, valid)
+	}
+}
+
+func TestProviderTransportErrorClassification(t *testing.T) {
+	cause := errors.New("dial failed")
+	err := providerTransportError("fake", cause)
+	var providerErr *plugin.ProviderError
+	if !errors.As(err, &providerErr) || !providerErr.Retryable || providerErr.StatusCode != 0 {
+		t.Fatalf("transport error classification = %#v", err)
+	}
+	if !errors.Is(err, cause) {
+		t.Fatalf("transport cause was not preserved: %v", err)
+	}
+
+	cancelErr := providerTransportError("fake", context.Canceled)
+	if !errors.Is(cancelErr, context.Canceled) {
+		t.Fatalf("context cancellation was not preserved: %v", cancelErr)
+	}
+	if errors.As(cancelErr, &providerErr) {
+		t.Fatalf("context cancellation must remain control flow, got ProviderError: %v", cancelErr)
+	}
+}

--- a/internal/plugin/enrich/providers_test.go
+++ b/internal/plugin/enrich/providers_test.go
@@ -3,10 +3,14 @@ package enrich
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/plugin"
 )
 
 // --- Ollama ---
@@ -235,6 +239,7 @@ func TestOpenAIProvider_Complete_UsesStructuredReasoningFallback(t *testing.T) {
 
 func TestOpenAIProvider_Complete_ErrorStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "2")
 		w.WriteHeader(http.StatusTooManyRequests)
 		w.Write([]byte("rate limited"))
 	}))
@@ -248,6 +253,16 @@ func TestOpenAIProvider_Complete_ErrorStatus(t *testing.T) {
 	_, err := p.Complete(context.Background(), "s", "u")
 	if err == nil {
 		t.Fatal("expected error for 429 status")
+	}
+	var providerErr *plugin.ProviderError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("expected typed ProviderError, got %T: %v", err, err)
+	}
+	if providerErr.StatusCode != http.StatusTooManyRequests || !providerErr.Retryable {
+		t.Fatalf("unexpected classification: %+v", providerErr)
+	}
+	if !providerErr.HasRetryAfter || providerErr.RetryAfter != 2*time.Second {
+		t.Fatalf("Retry-After = %v (present=%v), want 2s", providerErr.RetryAfter, providerErr.HasRetryAfter)
 	}
 }
 

--- a/internal/plugin/provider_error.go
+++ b/internal/plugin/provider_error.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -43,9 +44,40 @@ func IsRetryableProviderError(err error) bool {
 }
 
 // IsProviderError reports whether err contains a provider failure, regardless
-// of retryability. Provider failures are systemic; they are never evidence
-// that an individual engram's content is permanently malformed.
+// of retryability.
 func IsProviderError(err error) bool {
 	var providerErr *ProviderError
 	return errors.As(err, &providerErr)
+}
+
+// isPermanentContentStatus reports whether an HTTP status indicates the request
+// itself is the problem — the engram's content is too large or malformed and
+// will fail identically on every retry. These are per-engram permanent failures,
+// distinct from systemic conditions (auth/config 401/403, throttling 429, or
+// upstream 5xx) that affect the provider rather than this specific engram.
+func isPermanentContentStatus(code int) bool {
+	switch code {
+	case http.StatusBadRequest, // 400 (e.g. context_length_exceeded)
+		http.StatusNotFound,              // 404 (e.g. unknown model/deployment)
+		http.StatusRequestEntityTooLarge, // 413 (payload too large)
+		http.StatusUnprocessableEntity:   // 422 (content rejected)
+		return true
+	default:
+		return false
+	}
+}
+
+// IsPermanentContent reports whether the failure is caused by this engram's
+// content and will therefore fail identically on every retry. Such engrams must
+// be latched with DigestEnrichFailed so the batch continues and followers drain,
+// rather than breaking the pass and wedging every engram sorted after it (#587).
+func (e *ProviderError) IsPermanentContent() bool {
+	return !e.Retryable && isPermanentContentStatus(e.StatusCode)
+}
+
+// IsPermanentContentProviderError reports whether err contains a content-caused
+// provider failure that is permanent for the originating engram.
+func IsPermanentContentProviderError(err error) bool {
+	var providerErr *ProviderError
+	return errors.As(err, &providerErr) && providerErr.IsPermanentContent()
 }

--- a/internal/plugin/provider_error.go
+++ b/internal/plugin/provider_error.go
@@ -1,0 +1,51 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ProviderError classifies failures returned by an external enrichment
+// provider without retaining response bodies, request content, or credentials.
+// StatusCode is zero for transport failures.
+type ProviderError struct {
+	Provider      string
+	StatusCode    int
+	Retryable     bool
+	RetryAfter    time.Duration
+	HasRetryAfter bool
+	Err           error
+}
+
+func (e *ProviderError) Error() string {
+	provider := e.Provider
+	if provider == "" {
+		provider = "enrichment"
+	}
+	if e.StatusCode != 0 {
+		return fmt.Sprintf("%s provider returned HTTP %d", provider, e.StatusCode)
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("%s provider transport failed: %v", provider, e.Err)
+	}
+	return fmt.Sprintf("%s provider failed", provider)
+}
+
+// Unwrap preserves transport causes such as context cancellation.
+func (e *ProviderError) Unwrap() error { return e.Err }
+
+// IsRetryableProviderError reports whether err contains a retryable provider
+// failure through any number of wrapping layers.
+func IsRetryableProviderError(err error) bool {
+	var providerErr *ProviderError
+	return errors.As(err, &providerErr) && providerErr.Retryable
+}
+
+// IsProviderError reports whether err contains a provider failure, regardless
+// of retryability. Provider failures are systemic; they are never evidence
+// that an individual engram's content is permanently malformed.
+func IsProviderError(err error) bool {
+	var providerErr *ProviderError
+	return errors.As(err, &providerErr)
+}

--- a/internal/plugin/retroactive.go
+++ b/internal/plugin/retroactive.go
@@ -428,6 +428,7 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 		}
 	}
 
+engramLoop:
 	for iter.Next() {
 		select {
 		case <-ctx.Done():
@@ -503,6 +504,14 @@ func (rp *RetroactiveProcessor) processBatch(ctx context.Context) bool {
 			rp.statsMu.Lock()
 			rp.stats.Errors++
 			rp.statsMu.Unlock()
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return true
+			}
+			if errors.Is(err, circuit.ErrOpen) || IsProviderError(err) {
+				// Systemic provider condition: stop this pass so the processor cannot
+				// fan a throttle or configuration outage across the pending queue.
+				break engramLoop
+			}
 			// LLM-originated failures (bad output, parse error) are permanent for
 			// this engram. Mark DigestEnrichFailed so the processor does not retry
 			// it indefinitely, which would trip the circuit breaker and block
@@ -627,9 +636,15 @@ func (rp *RetroactiveProcessor) processEnrichEngram(ctx context.Context, eng *En
 			if errors.Is(err, circuit.ErrOpen) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return err
 			}
-			// Permanent LLM failure (bad output, HTTP error, parse error).
+			if IsRetryableProviderError(err) {
+				return fmt.Errorf("transient enrichment provider failure: %w", err)
+			}
+			if IsProviderError(err) {
+				return fmt.Errorf("enrichment provider failure: %w", err)
+			}
+			// Permanent per-engram LLM failure (bad output or parse error).
 			// Wrap with errLLMFailed so the caller can mark DigestEnrichFailed.
-			return fmt.Errorf("%w: %v", errLLMFailed, err)
+			return fmt.Errorf("%w: %w", errLLMFailed, err)
 		}
 		if result == nil {
 			return errLLMFailed

--- a/internal/plugin/retroactive.go
+++ b/internal/plugin/retroactive.go
@@ -507,21 +507,28 @@ engramLoop:
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return true
 			}
-			if errors.Is(err, circuit.ErrOpen) || IsProviderError(err) {
-				// Systemic provider condition: stop this pass so the processor cannot
-				// fan a throttle or configuration outage across the pending queue.
-				break engramLoop
-			}
-			// LLM-originated failures (bad output, parse error) are permanent for
-			// this engram. Mark DigestEnrichFailed so the processor does not retry
-			// it indefinitely, which would trip the circuit breaker and block
-			// enrichment for all other memories. Storage/persistence errors are NOT
-			// marked — they are transient and should be retried when storage recovers.
+			// Permanent per-engram failures — LLM-originated (bad output, parse
+			// error) or content-caused provider 4xx (400/413/422/404). Mark
+			// DigestEnrichFailed so the processor does not retry indefinitely
+			// (which would trip the circuit breaker) and, crucially, so
+			// ScanWithoutFlag excludes this engram on the next pass. A content 4xx
+			// that sorts first would otherwise re-break every pass and wedge every
+			// follower forever (#587). Continue so the rest of the batch drains.
+			// Storage/persistence errors are NOT latched — they are transient and
+			// retried once storage recovers.
 			if errors.Is(err, errLLMFailed) {
 				if flagErr := rp.store.SetDigestFlag(ctx, eng.ID, DigestEnrichFailed); flagErr != nil {
 					slog.Warn("retroactive processor: failed to set DigestEnrichFailed",
 						"plugin", rp.plugin.Name(), "engram_id", eng.ID.String(), "error", flagErr)
 				}
+				continue
+			}
+			if errors.Is(err, circuit.ErrOpen) || IsProviderError(err) {
+				// Systemic provider condition (throttle, auth/config outage,
+				// transport): stop this pass so the processor cannot fan the
+				// failure across the pending queue. The engram stays pending and
+				// retries once the provider recovers.
+				break engramLoop
 			}
 			continue
 		}
@@ -638,6 +645,13 @@ func (rp *RetroactiveProcessor) processEnrichEngram(ctx context.Context, eng *En
 			}
 			if IsRetryableProviderError(err) {
 				return fmt.Errorf("transient enrichment provider failure: %w", err)
+			}
+			if IsPermanentContentProviderError(err) {
+				// Content-caused 4xx (400/413/422/404): this engram's content is
+				// too large or malformed and will fail identically forever. Wrap
+				// with errLLMFailed so the caller stamps DigestEnrichFailed and
+				// continues, exactly as develop did for LLM failures (#587).
+				return fmt.Errorf("%w: %w", errLLMFailed, err)
 			}
 			if IsProviderError(err) {
 				return fmt.Errorf("enrichment provider failure: %w", err)

--- a/internal/plugin/retroactive_test.go
+++ b/internal/plugin/retroactive_test.go
@@ -134,6 +134,92 @@ func TestRetroactiveProcessor_AuthenticationFailureRemainsPendingAndStopsBatch(t
 	}
 }
 
+// flagAwareStore faithfully models PebbleStore's flag-driven scan: it stores
+// per-engram digest flags and, on every pass, ScanWithoutFlag restarts from the
+// keyspace head and excludes engrams whose flags intersect flagBit or skipFlags.
+// This is the exact substrate the #587 wedge needs to reproduce — a content 4xx
+// that sorts first must LATCH so it is skipped next pass, otherwise it re-breaks
+// every pass and starves every follower.
+type flagAwareStore struct {
+	mockPluginStore
+	engrams []*Engram // fixed keyspace order
+	flags   map[ULID]uint8
+}
+
+func newFlagAwareStore(engrams ...*Engram) *flagAwareStore {
+	return &flagAwareStore{engrams: engrams, flags: make(map[ULID]uint8)}
+}
+
+func (s *flagAwareStore) pending(flagBit, skipFlags uint8) []*Engram {
+	var out []*Engram
+	for _, e := range s.engrams {
+		if f := s.flags[e.ID]; f&flagBit != 0 || f&skipFlags != 0 {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func (s *flagAwareStore) CountWithoutFlag(_ context.Context, flagBit, skipFlags uint8) (int64, error) {
+	return int64(len(s.pending(flagBit, skipFlags))), nil
+}
+
+func (s *flagAwareStore) ScanWithoutFlag(_ context.Context, flagBit, skipFlags uint8) EngramIterator {
+	return &mockIterator{engrams: s.pending(flagBit, skipFlags)}
+}
+
+func (s *flagAwareStore) SetDigestFlag(_ context.Context, id ULID, flag uint8) error {
+	s.flags[id] |= flag
+	return nil
+}
+
+func (s *flagAwareStore) GetDigestFlags(_ context.Context, id ULID) (uint8, error) {
+	return s.flags[id], nil
+}
+
+// TestRetroactiveProcessor_ContentFourxxLatchesAndFollowersDrain pins the #587
+// fix: a non-retryable content HTTP 400 on the engram that sorts FIRST must be
+// stamped DigestEnrichFailed and NOT break the pass, so the follower enriches.
+// Before the fix this wedged forever — the 400 broke every pass at the head and
+// no engram sorted after it was ever reached.
+func TestRetroactiveProcessor_ContentFourxxLatchesAndFollowersDrain(t *testing.T) {
+	first := &Engram{ID: ULID{1}, Concept: "content-400", Content: "oversized"}
+	second := &Engram{ID: ULID{2}, Concept: "enrichable", Content: "content"}
+	store := newFlagAwareStore(first, second)
+
+	enrichPlugin := &enrichMockForRetro{
+		mockPlugin: mockPlugin{name: "enrich-content-400", tier: TierEnrich},
+		enrichFunc: func(_ context.Context, e *Engram) (*EnrichmentResult, error) {
+			if e.ID == first.ID {
+				return nil, fmt.Errorf("pipeline: %w", &ProviderError{
+					Provider:   "fake",
+					StatusCode: 400,
+					Retryable:  false,
+				})
+			}
+			return &EnrichmentResult{Summary: "enriched"}, nil
+		},
+	}
+	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
+
+	// Multiple passes: even one pass suffices with the fix, but repeated passes
+	// prove the head engram does not re-break the batch.
+	for i := 0; i < 3; i++ {
+		rp.processBatch(context.Background())
+	}
+
+	if store.flags[first.ID]&DigestEnrichFailed == 0 {
+		t.Fatalf("first engram (content 400) was not latched with DigestEnrichFailed; flags=%#x", store.flags[first.ID])
+	}
+	if store.flags[second.ID]&DigestEnrich == 0 {
+		t.Fatalf("follower engram never enriched — batch wedged on the content 400 (#587); flags=%#x", store.flags[second.ID])
+	}
+	if rp.Stats().Processed != 1 {
+		t.Fatalf("processed = %d, want 1 (the follower)", rp.Stats().Processed)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Constructor & field tests
 // ---------------------------------------------------------------------------

--- a/internal/plugin/retroactive_test.go
+++ b/internal/plugin/retroactive_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -18,15 +19,119 @@ type enrichMockForRetro struct {
 	mockPlugin
 	enrichResult *EnrichmentResult
 	enrichErr    error
+	enrichFunc   func(context.Context, *Engram) (*EnrichmentResult, error)
 	callCount    int
 }
 
-func (m *enrichMockForRetro) Enrich(_ context.Context, _ *Engram) (*EnrichmentResult, error) {
+func (m *enrichMockForRetro) Enrich(ctx context.Context, eng *Engram) (*EnrichmentResult, error) {
 	m.callCount++
+	if m.enrichFunc != nil {
+		return m.enrichFunc(ctx, eng)
+	}
 	if m.enrichErr != nil {
 		return nil, m.enrichErr
 	}
 	return m.enrichResult, nil
+}
+
+func TestRetroactiveProcessor_RetryableProviderErrorRemainsPendingThenEnriches(t *testing.T) {
+	eng := &Engram{Concept: "pending", Content: "content"}
+	store := &mockPluginStore{countResult: 1}
+	attempt := 0
+	enrichPlugin := &enrichMockForRetro{
+		mockPlugin: mockPlugin{name: "enrich-throttled", tier: TierEnrich},
+		enrichFunc: func(context.Context, *Engram) (*EnrichmentResult, error) {
+			attempt++
+			if attempt == 1 {
+				return nil, fmt.Errorf("pipeline: %w", &ProviderError{
+					Provider:      "fake",
+					StatusCode:    429,
+					Retryable:     true,
+					RetryAfter:    time.Second,
+					HasRetryAfter: true,
+				})
+			}
+			return &EnrichmentResult{Summary: "enriched"}, nil
+		},
+	}
+	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
+
+	store.scanResult = &mockIterator{engrams: []*Engram{eng, &Engram{Concept: "later", Content: "content"}}}
+	rp.processBatch(context.Background())
+	if enrichPlugin.callCount != 1 {
+		t.Fatalf("calls after throttle = %d, want 1 (batch must stop globally)", enrichPlugin.callCount)
+	}
+	if store.setFlagCalls != 0 {
+		t.Fatalf("429 set digest flags %v; engram must remain pending", store.setFlags)
+	}
+
+	store.scanResult = &mockIterator{engrams: []*Engram{eng}}
+	rp.processBatch(context.Background())
+	if enrichPlugin.callCount != 2 {
+		t.Fatalf("calls after recovery = %d, want 2", enrichPlugin.callCount)
+	}
+	if rp.Stats().Processed != 1 {
+		t.Fatalf("processed = %d, want original engram enriched", rp.Stats().Processed)
+	}
+	for _, flag := range store.setFlags {
+		if flag == DigestEnrichFailed {
+			t.Fatalf("DigestEnrichFailed was set because of 429: %v", store.setFlags)
+		}
+	}
+}
+
+func TestProcessEnrichEngram_RetryableWrappingPreservesMetadata(t *testing.T) {
+	providerErr := &ProviderError{Provider: "fake", StatusCode: 503, Retryable: true}
+	store := &mockPluginStore{}
+	rp := NewRetroactiveProcessor(store, &enrichMockForRetro{
+		mockPlugin: mockPlugin{name: "wrapped", tier: TierEnrich},
+		enrichErr:  fmt.Errorf("service: %w", providerErr),
+	}, DigestEnrich)
+
+	err := rp.processEnrichEngram(context.Background(), &Engram{})
+	var got *ProviderError
+	if !errors.As(err, &got) || got != providerErr {
+		t.Fatalf("retryability metadata was not preserved: %v", err)
+	}
+}
+
+func TestProcessEnrichEngram_PermanentProviderWrappingPreservesMetadata(t *testing.T) {
+	providerErr := &ProviderError{Provider: "fake", StatusCode: 401, Retryable: false}
+	store := &mockPluginStore{}
+	rp := NewRetroactiveProcessor(store, &enrichMockForRetro{
+		mockPlugin: mockPlugin{name: "auth-failed", tier: TierEnrich},
+		enrichErr:  fmt.Errorf("pipeline: %w", providerErr),
+	}, DigestEnrich)
+
+	err := rp.processEnrichEngram(context.Background(), &Engram{})
+	if errors.Is(err, errLLMFailed) {
+		t.Fatalf("systemic authentication error became per-engram failure: %v", err)
+	}
+	var got *ProviderError
+	if !errors.As(err, &got) || got != providerErr {
+		t.Fatalf("provider metadata was not preserved: %v", err)
+	}
+}
+
+func TestRetroactiveProcessor_AuthenticationFailureRemainsPendingAndStopsBatch(t *testing.T) {
+	eng := &Engram{Concept: "pending", Content: "content"}
+	store := &mockPluginStore{
+		countResult: 2,
+		scanResult:  &mockIterator{engrams: []*Engram{eng, &Engram{Concept: "later"}}},
+	}
+	enrichPlugin := &enrichMockForRetro{
+		mockPlugin: mockPlugin{name: "auth-failed", tier: TierEnrich},
+		enrichErr:  &ProviderError{Provider: "fake", StatusCode: 401, Retryable: false},
+	}
+	rp := NewRetroactiveProcessor(store, enrichPlugin, DigestEnrich)
+
+	rp.processBatch(context.Background())
+	if enrichPlugin.callCount != 1 {
+		t.Fatalf("provider calls = %d, want 1 after systemic auth failure", enrichPlugin.callCount)
+	}
+	if store.setFlagCalls != 0 {
+		t.Fatalf("authentication failure set permanent flags: %v", store.setFlags)
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- classify enrichment provider failures with typed status, retryability, and optional `Retry-After` metadata
- preserve provider errors through the pipeline, service, and retroactive processor
- apply provider-wide `Retry-After` or bounded exponential backoff with jitter
- leave systemic provider failures pending and stop the current batch instead of setting `DigestEnrichFailed`
- retain the permanent-failure guard for successful-but-malformed LLM output

## Root cause

Provider clients returned plain formatted errors for every non-200 response. The pipeline then flattened stage errors into strings, and `processEnrichEngram` classified every non-circuit/non-context error as `errLLMFailed`. `processBatch` consequently stamped `DigestEnrichFailed` after a 429, permanently excluding that engram from automatic enrichment.

The pipeline could also continue into later stages after a provider throttle, amplifying the rate-limit event across both stages and subsequent engrams.

## Error policy

- `429`, `408`, `500`, `502`, `503`, `504`, and non-context transport failures are retryable systemic provider failures.
- Valid `Retry-After` delta-seconds and HTTP dates are preserved; overflowing delta-seconds are rejected safely.
- Retryable failures still count toward the general circuit breaker. A throttled provider is unavailable, and the breaker remains a useful second safety net. Explicit provider-wide backpressure prevents burst amplification, while typed classification prevents the breaker from poisoning individual engrams.
- Nonretryable provider failures such as authentication/configuration responses are also systemic: they remain pending, stop the pass, and stay observable through the breaker rather than becoming per-engram failures.
- Successful HTTP responses with malformed/unusable model output remain permanent per-engram failures and continue to set `DigestEnrichFailed`, preserving the #390 infinite-retry protection.

Generation ordering prevents an older concurrent success from clearing a newer throttle window. Tests use injected time/wait seams and do not sleep.

## Verification

- RED-first regressions demonstrated the original permanent flagging, missing backpressure, concurrent throttle erasure, and duration overflow.
- `go test -count=1 ./internal/plugin/enrich ./internal/plugin ./internal/engine/circuit`
- `go test -race -count=1 ./internal/plugin/enrich ./internal/plugin ./internal/engine/circuit`
- `go build -tags localassets ./...`
- `go vet ./...`
- `gofmt -l .`
- `go test -count=1 ./...`

## Compatibility and operations

- No wire format, storage schema, digest-bit, configuration, or public protocol changes.
- Provider HTTP error strings no longer include response bodies, avoiding accidental content or credential exposure; status and typed metadata remain available.
- During provider outages, pending enrichment work pauses globally and resumes after recovery. Long-lived authentication/configuration failures surface through circuit health and do not silently consume or permanently exclude memories.

Follow-up issues for pre-existing, out-of-scope findings: #641 and #642.

Fixes #640
