### PR TITLE
fix(engine): carry entity links and relationships across evolve, funding the mention ledgers

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -3023,6 +3023,28 @@ func (e *Engine) Evolve(ctx context.Context, vault, oldID, newContent, reason st
 		Trust:      storage.TrustInferred, // all new MCP writes default to inferred
 	}
 
+	// Carry the predecessor's entity links and relationship records forward
+	// (#622): Evolve wrote no 0x20/0x23 links and no 0x21/0x26 relationship
+	// records for the successor, so every evolved memory silently vanished
+	// from FindByEntity and entity scoring from the moment it was evolved.
+	// The link and relationship keys are queued into the same atomic batch as
+	// the engram writes; the mention-count and co-occurrence ledgers are funded
+	// post-commit (see below).
+	var carriedEntities []string
+	var carriedRels []storage.RelationshipRecord
+	if err := e.store.ScanEngramEntities(ctx, wsPrefix, oldULID, func(name string) error {
+		carriedEntities = append(carriedEntities, name)
+		return nil
+	}); err != nil {
+		return storage.ULID{}, fmt.Errorf("evolve: scan predecessor entities: %w", err)
+	}
+	if err := e.store.ScanEngramRelationships(ctx, wsPrefix, oldULID, func(rec storage.RelationshipRecord) error {
+		carriedRels = append(carriedRels, rec)
+		return nil
+	}); err != nil {
+		return storage.ULID{}, fmt.Errorf("evolve: scan predecessor relationships: %w", err)
+	}
+
 	// Build the supersedes association (new → old).
 	supersedes := &storage.Association{
 		TargetID:      oldULID,
@@ -3046,8 +3068,62 @@ func (e *Engine) Evolve(ctx context.Context, vault, oldID, newContent, reason st
 	if err := batch.UpdateEngramState(ctx, wsPrefix, oldULID, storage.StateSoftDeleted); err != nil {
 		return storage.ULID{}, fmt.Errorf("evolve: batch update old state: %w", err)
 	}
+	for _, name := range carriedEntities {
+		if err := batch.WriteEntityEngramLink(ctx, wsPrefix, newULID, name); err != nil {
+			return storage.ULID{}, fmt.Errorf("evolve: batch carry entity link: %w", err)
+		}
+	}
+	for _, rec := range carriedRels {
+		if err := batch.WriteRelationshipRecord(ctx, wsPrefix, newULID, rec); err != nil {
+			return storage.ULID{}, fmt.Errorf("evolve: batch carry relationship: %w", err)
+		}
+	}
 	if err := batch.Commit(); err != nil {
 		return storage.ULID{}, fmt.Errorf("evolve: batch commit: %w", err)
+	}
+
+	// Fund the ledgers for the carried links. The mention-count and
+	// co-occurrence ledgers are one increment per link key created, one
+	// decrement per link key destroyed: DeleteEngram decrements both
+	// unconditionally for every link it removes, so a carried link with no
+	// matching increment becomes an unfunded liability that the pruner cashes
+	// in — hard-delete the predecessor and MentionCount under-reads while the
+	// successor is still linked, and a co-occurrence pair drops to zero and
+	// vanishes from ScanEntityClusters while both entities are still mentioned
+	// together. Done post-commit, mirroring DeleteEngram's post-commit
+	// decrements: a crash here leaves counts slightly low with the links
+	// intact, the mirror image of DeleteEngram's slightly-high stale case.
+	for _, name := range carriedEntities {
+		if err := e.store.IncrementEntityMentionCount(ctx, name); err != nil {
+			slog.Warn("engine: evolve: failed to increment mention count for carried entity", "entity", name, "engram", newULID.String(), "err", err)
+		}
+	}
+	// Cap mirrors DeleteEngram's maxCoOccurrenceEntities. Beyond the cap the
+	// ledger is best-effort on both sides — DeleteEngram's first-50 comes from
+	// map iteration, so the truncated subsets need not be identical — matching
+	// the pre-existing behaviour for >50-entity engrams rather than fixing it.
+	const maxCoOccurrenceEntities = 50
+	coNames := carriedEntities
+	if len(coNames) > maxCoOccurrenceEntities {
+		slog.Warn("engine: evolve: engram has unusually many carried entities, co-occurrence funding capped",
+			"engram", newULID.String(), "entity_count", len(carriedEntities), "cap", maxCoOccurrenceEntities)
+		coNames = coNames[:maxCoOccurrenceEntities]
+	}
+	for i := 0; i < len(coNames); i++ {
+		for j := i + 1; j < len(coNames); j++ {
+			if err := e.store.IncrementEntityCoOccurrence(ctx, wsPrefix, coNames[i], coNames[j]); err != nil {
+				slog.Warn("engine: evolve: failed to increment co-occurrence for carried pair", "a", coNames[i], "b", coNames[j], "engram", newULID.String(), "err", err)
+			}
+		}
+	}
+
+	// Mark entity extraction complete when the successor carries a curated set,
+	// so the retroactive enrichment provider does not re-extract over it.
+	if len(carriedEntities) > 0 {
+		existingFlags, _ := e.store.GetDigestFlags(ctx, plugin.ULID(newULID))
+		if err := e.store.SetDigestFlag(ctx, newULID, existingFlags|plugin.DigestEntities); err != nil {
+			slog.Warn("engine: evolve: failed to set DigestEntities flag", "id", newULID.String(), "err", err)
+		}
 	}
 
 	// ── Content-hash bookkeeping: delete old mapping, add new mapping ──

--- a/internal/engine/engine_evolve_entity_test.go
+++ b/internal/engine/engine_evolve_entity_test.go
@@ -1,0 +1,184 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/scrypster/muninndb/internal/plugin"
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// engramEntities returns the entity names linked to id via the 0x20 forward index.
+func engramEntities(t *testing.T, eng *Engine, ws [8]byte, id storage.ULID) []string {
+	t.Helper()
+	var names []string
+	err := eng.store.ScanEngramEntities(context.Background(), ws, id, func(name string) error {
+		names = append(names, name)
+		return nil
+	})
+	require.NoError(t, err)
+	return names
+}
+
+// engramRelationships returns the 0x21 relationship records stored for id.
+func engramRelationships(t *testing.T, eng *Engine, ws [8]byte, id storage.ULID) []storage.RelationshipRecord {
+	t.Helper()
+	var recs []storage.RelationshipRecord
+	err := eng.store.ScanEngramRelationships(context.Background(), ws, id, func(rec storage.RelationshipRecord) error {
+		recs = append(recs, rec)
+		return nil
+	})
+	require.NoError(t, err)
+	return recs
+}
+
+// coOccurrenceCount reads the 0x24 pair count for two entities, 0 if the key
+// is absent.
+func coOccurrenceCount(t *testing.T, eng *Engine, ws [8]byte, a, b string) int {
+	t.Helper()
+	count := 0
+	err := eng.store.ScanEntityClusters(context.Background(), ws, 1, func(nameA, nameB string, c int) error {
+		if (nameA == a && nameB == b) || (nameA == b && nameB == a) {
+			count = c
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return count
+}
+
+// TestEvolve_CarriesEntityLinks is the core #622 regression test: the
+// supersede-successor must inherit the predecessor's entity links so it stays
+// visible to FindByEntity. Fails on the pre-fix Evolve (successor had zero
+// links).
+func TestEvolve_CarriesEntityLinks(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "test", Concept: "db choice", Content: "PostgreSQL runs payments",
+		Entities: []mbp.InlineEntity{
+			{Name: "PostgreSQL", Type: "product"},
+			{Name: "payments", Type: "concept"},
+		},
+	})
+	require.NoError(t, err)
+
+	newID, err := eng.Evolve(ctx, "test", resp.ID, "PostgreSQL 17 runs payments now", "version bump", nil, "")
+	require.NoError(t, err)
+
+	ws := eng.store.ResolveVaultPrefix("test")
+	names := engramEntities(t, eng, ws, newID)
+	require.ElementsMatch(t, []string{"PostgreSQL", "payments"}, names,
+		"successor must carry the predecessor's entity links")
+
+	// The successor must be reachable through the 0x23 reverse index too.
+	found := false
+	err = eng.store.ScanEntityEngrams(ctx, "PostgreSQL", func(gotWS [8]byte, gotID storage.ULID) error {
+		if gotWS == ws && gotID == newID {
+			found = true
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.True(t, found, "successor must appear in the entity reverse index")
+
+	// DigestEntities must be set so enrichment does not re-extract over the carry.
+	flags, err := eng.store.GetDigestFlags(ctx, plugin.ULID(newID))
+	require.NoError(t, err)
+	require.NotZero(t, flags&plugin.DigestEntities)
+}
+
+// TestEvolve_MentionCountConservation pins the funding rule for the carried
+// links. The ledger is one increment per link key created, one decrement per
+// link key destroyed: DeleteEngram decrements unconditionally for every link
+// it removes, so a carried link must be funded at carry time or the pruner
+// cashes in the difference — hard-delete the predecessor (the recommended
+// evolve-then-retention path) and MentionCount under-reads while the successor
+// is still linked, and the co-occurrence pair key is destroyed at zero,
+// removing the pair from ScanEntityClusters while both entities are still
+// mentioned together.
+//
+// Conservation: write gives 1, evolve with carry gives 2, hard-deleting the
+// predecessor gives 1 — and the pair key must survive the hard delete.
+func TestEvolve_MentionCountConservation(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "test", Concept: "pairing", Content: "Ada pairs with Grace",
+		Entities: []mbp.InlineEntity{
+			{Name: "Ada", Type: "person"},
+			{Name: "Grace", Type: "person"},
+		},
+	})
+	require.NoError(t, err)
+	ws := eng.store.ResolveVaultPrefix("test")
+	oldULID, err := storage.ParseULID(resp.ID)
+	require.NoError(t, err)
+
+	rec, err := eng.store.GetEntityRecord(ctx, "ada")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	require.Equal(t, int32(1), rec.MentionCount, "write funds one mention")
+	require.Equal(t, 1, coOccurrenceCount(t, eng, ws, "Ada", "Grace"),
+		"write funds one co-occurrence")
+
+	newID, err := eng.Evolve(ctx, "test", resp.ID, "Ada still pairs with Grace", "refresh", nil, "")
+	require.NoError(t, err)
+
+	rec, err = eng.store.GetEntityRecord(ctx, "ada")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	require.Equal(t, int32(2), rec.MentionCount,
+		"carry creates a second link key and must fund it")
+	require.Equal(t, 2, coOccurrenceCount(t, eng, ws, "Ada", "Grace"),
+		"carry creates a second pair mention and must fund it")
+
+	// Hard-delete the predecessor — what retention pruning does to evolve
+	// predecessors. Its decrement must be matched by the carry's increment.
+	require.NoError(t, eng.store.DeleteEngram(ctx, ws, oldULID))
+
+	rec, err = eng.store.GetEntityRecord(ctx, "ada")
+	require.NoError(t, err)
+	require.NotNil(t, rec, "entity record must survive predecessor pruning")
+	require.Equal(t, int32(1), rec.MentionCount,
+		"after pruning the predecessor, the count reflects the successor's link")
+	require.Equal(t, 1, coOccurrenceCount(t, eng, ws, "Ada", "Grace"),
+		"pair key must survive predecessor pruning — dropping to zero would remove the pair from clustering while the successor still mentions both")
+
+	// The successor's links themselves are untouched by the predecessor delete.
+	require.ElementsMatch(t, []string{"Ada", "Grace"}, engramEntities(t, eng, ws, newID))
+}
+
+// TestEvolve_CarriesRelationshipRecords: the predecessor's 0x21 relationship
+// records travel with the links.
+func TestEvolve_CarriesRelationshipRecords(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "test", Concept: "pair", Content: "A talks to B",
+		Entities: []mbp.InlineEntity{{Name: "A", Type: "concept"}, {Name: "B", Type: "concept"}},
+	})
+	require.NoError(t, err)
+
+	ws := eng.store.ResolveVaultPrefix("test")
+	oldULID, err := storage.ParseULID(resp.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, engramRelationships(t, eng, ws, oldULID),
+		"precondition: inline entity pair produces a co_occurs_with record")
+
+	newID, err := eng.Evolve(ctx, "test", resp.ID, "A still talks to B", "refresh", nil, "")
+	require.NoError(t, err)
+
+	recs := engramRelationships(t, eng, ws, newID)
+	require.Len(t, recs, 1)
+	require.Equal(t, "co_occurs_with", recs[0].RelType)
+}

--- a/internal/storage/batch.go
+++ b/internal/storage/batch.go
@@ -12,6 +12,7 @@ import (
 	"github.com/scrypster/muninndb/internal/storage/erf"
 	"github.com/scrypster/muninndb/internal/storage/keys"
 	"github.com/scrypster/muninndb/internal/wal"
+	"github.com/vmihailenco/msgpack/v5"
 )
 
 // stateUpdate records a (workspace, id) pair whose state was changed via
@@ -211,6 +212,54 @@ func (b *pebbleStoreBatch) UpdateEngramState(ctx context.Context, ws [8]byte, id
 	}
 	// Track for cache invalidation in Commit.
 	b.stateUpdatedIDs = append(b.stateUpdatedIDs, stateUpdate{ws: ws, id: id})
+	return nil
+}
+
+// WriteEntityEngramLink queues the 0x20 forward and 0x23 reverse entity-link keys
+// into the batch. Mirrors PebbleStore.WriteEntityEngramLink key construction; it
+// does not touch the 0x1F entity record. The mention-count ledger is one
+// increment per link key created and one decrement per link key destroyed
+// (DeleteEngram decrements unconditionally), so callers creating links through
+// this method must fund them — post-commit, via IncrementEntityMentionCount —
+// or the counts go stale-low once the linked engrams are hard-deleted (#622).
+func (b *pebbleStoreBatch) WriteEntityEngramLink(ctx context.Context, ws [8]byte, engramID ULID, entityName string) error {
+	if b.committed {
+		return fmt.Errorf("batch already committed")
+	}
+	nameHash := keys.EntityNameHash(entityName)
+	if err := b.batch.Set(keys.EntityEngramLinkKey(ws, [16]byte(engramID), nameHash), []byte(entityName), nil); err != nil {
+		return fmt.Errorf("batch write entity link fwd: %w", err)
+	}
+	if err := b.batch.Set(keys.EntityReverseIndexKey(nameHash, ws, [16]byte(engramID)), nil, nil); err != nil {
+		return fmt.Errorf("batch write entity link rev: %w", err)
+	}
+	return nil
+}
+
+// WriteRelationshipRecord queues the 0x21 relationship record and both 0x26
+// relationship-entity index keys into the batch. Same value encoding as
+// PebbleStore.UpsertRelationshipRecord.
+func (b *pebbleStoreBatch) WriteRelationshipRecord(ctx context.Context, ws [8]byte, engramID ULID, record RelationshipRecord) error {
+	if b.committed {
+		return fmt.Errorf("batch already committed")
+	}
+	record.UpdatedAt = time.Now().UnixNano()
+	val, err := msgpack.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("batch relationship record marshal: %w", err)
+	}
+	fromHash := keys.EntityNameHash(record.FromEntity)
+	toHash := keys.EntityNameHash(record.ToEntity)
+	relTypeByte := relTypeByteFromString(record.RelType)
+	if err := b.batch.Set(keys.RelationshipKey(ws, [16]byte(engramID), fromHash, relTypeByte, toHash), val, nil); err != nil {
+		return fmt.Errorf("batch relationship record: set 0x21: %w", err)
+	}
+	if err := b.batch.Set(keys.RelEntityIndexKey(ws, fromHash, [16]byte(engramID)), nil, nil); err != nil {
+		return fmt.Errorf("batch relationship record: set 0x26 from: %w", err)
+	}
+	if err := b.batch.Set(keys.RelEntityIndexKey(ws, toHash, [16]byte(engramID)), nil, nil); err != nil {
+		return fmt.Errorf("batch relationship record: set 0x26 to: %w", err)
+	}
 	return nil
 }
 

--- a/internal/storage/entity.go
+++ b/internal/storage/entity.go
@@ -859,6 +859,36 @@ func (ps *PebbleStore) UpdateDigest(ctx context.Context, id ULID, summary string
 	return nil
 }
 
+// IncrementEntityMentionCount increments the MentionCount on the global entity
+// record for the given name without touching any other field — unlike
+// UpsertEntityRecord it never rewrites Type, Source or Confidence, so it is
+// safe to call for links carried from a predecessor whose entity metadata must
+// survive untouched. No-ops if the record does not exist: a carried link whose
+// 0x1F record is already gone has nothing to fund, and DecrementEntityMentionCount
+// floors at 0 on the other side, so the ledger stays consistent.
+// Safe for concurrent calls — uses per-entity locking.
+func (ps *PebbleStore) IncrementEntityMentionCount(ctx context.Context, name string) error {
+	mu := ps.getEntityLock(name)
+	mu.Lock()
+	defer mu.Unlock()
+
+	existing, err := ps.GetEntityRecord(ctx, name)
+	if err != nil {
+		return fmt.Errorf("increment entity mention count: %w", err)
+	}
+	if existing == nil {
+		return nil
+	}
+
+	existing.MentionCount++
+	existing.UpdatedAt = time.Now().UnixNano()
+	val, err := msgpack.Marshal(existing)
+	if err != nil {
+		return fmt.Errorf("increment entity mention count: marshal: %w", err)
+	}
+	return ps.db.Set(keys.EntityKey(keys.EntityNameHash(name)), val, pebble.NoSync)
+}
+
 // DecrementEntityMentionCount decrements the MentionCount on the global entity
 // record for the given name, floored at 0. No-ops if the record does not exist.
 // When the count reaches 0, the 0x23 reverse index is scanned to confirm no live

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -33,6 +33,18 @@ type StoreBatch interface {
 	// Reads the current engram from the underlying store, sets its state, and queues
 	// updated 0x01 and 0x02 key writes.
 	UpdateEngramState(ctx context.Context, ws [8]byte, id ULID, newState LifecycleState) error
+	// WriteEntityEngramLink queues the 0x20 forward and 0x23 reverse entity-link
+	// keys into the batch. Like PebbleStore.WriteEntityEngramLink, it does not
+	// touch the 0x1F entity record — callers that need the record created must
+	// use UpsertEntityRecord separately, and callers carrying links to an
+	// existing record must fund the mention-count ledger post-commit via
+	// IncrementEntityMentionCount (one increment per link created, matching
+	// DeleteEngram's one decrement per link destroyed).
+	WriteEntityEngramLink(ctx context.Context, ws [8]byte, engramID ULID, entityName string) error
+	// WriteRelationshipRecord queues the 0x21 relationship record and both 0x26
+	// relationship-entity index keys into the batch. Same encoding as
+	// PebbleStore.UpsertRelationshipRecord.
+	WriteRelationshipRecord(ctx context.Context, ws [8]byte, engramID ULID, record RelationshipRecord) error
 	// Commit atomically commits all queued writes.
 	Commit() error
 	// Discard releases the batch without writing anything.


### PR DESCRIPTION
Fixes #622. Scope narrowed per review: this PR is now the write-path carry only. The inline-entities feature and the startup repair moved to their own PRs (stacked on this one) so the migration piece can get its independent pass without holding the fix hostage.

Evolve inherited Concept and Tags but wrote no 0x20/0x23 entity links and no 0x21/0x26 relationship records for the successor, so every evolved memory silently vanished from FindByEntity and entity scoring from the moment it was evolved.

**What this PR does**

- Evolve reads the predecessor's entity links and relationship records and queues them into the existing atomic batch via two new `StoreBatch` methods (`WriteEntityEngramLink`, `WriteRelationshipRecord`). No signature change.
- **The carried links fund the mention-count and co-occurrence ledgers** (review item 4 — the reversal). Both ledgers are one increment per link key created, one decrement per link key destroyed: `DeleteEngram` decrements unconditionally, so an unfunded carried link is a liability the pruner cashes in. Funding happens post-commit via a new `IncrementEntityMentionCount` (touches only MentionCount/UpdatedAt on the 0x1F record — never Type, Source or Confidence) and `IncrementEntityCoOccurrence`, mirroring `DeleteEngram`'s post-commit decrements and its 50-entity pair cap. Beyond the cap the ledger is best-effort on both sides (DeleteEngram's first-50 comes from map iteration), matching the pre-existing behaviour for >50-entity engrams rather than claiming to fix it.
- `TestEvolve_DoesNotDoubleCountMentions` is deleted and replaced by the conservation test you specified: write funds 1, evolve carries and funds to 2, hard-deleting the predecessor returns 1 **with the co-occurrence pair key still present** — the pair no longer vanishes from `ScanEntityClusters` while the successor still mentions both. The inverted reasoning is in the comment blocks on both the batch method and the funding site.
- `DigestEntities` is set on the successor so enrichment does not re-extract over the carried set.

**Verification**

Rebased on develop (d5f36e3, includes #655); `go vet -tags localassets ./...` clean and the two #655-added `Evolve` call sites compile — the branch is a fresh base, not the stale 21 July check. RED both ways: with the carry neutralized, `TestEvolve_CarriesEntityLinks`, `TestEvolve_CarriesRelationshipRecords` and the conservation test fail; with carry kept but funding disabled, the conservation test fails alone. Full `./internal/...` green, storage and engine under `-race`.
