### PR TITLE
fix(engine): inherit MemoryType and TypeLabel across evolve

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2993,11 +2993,26 @@ func (e *Engine) Evolve(ctx context.Context, vault, oldID, newContent, reason st
 	if concept == "" {
 		concept = oldEng.Concept
 	}
+	// MemoryType and TypeLabel are inherited alongside Concept and Tags. Evolve
+	// exposes no parameter for either, so leaving them unset reset the type to
+	// the MemoryType zero value, Fact — a decision or procedure was silently
+	// relabelled a fact on every evolve, and again at each hop down a supersede
+	// chain (issue #653).
+	//
+	// Summary is deliberately NOT inherited. It is content-derived (see the
+	// field doc on storage.Engram), and Evolve replaces the content, so the
+	// predecessor's summary is false of the successor. Leaving it empty is also
+	// what lets the summarize stage regenerate it: engramHasSummary and the
+	// retroactive processor both treat a non-empty Summary as caller-authoritative
+	// and skip the stage, which would pin the stale text permanently and leave
+	// KeyPoints — produced only by that stage — empty forever.
 	newEng := &storage.Engram{
 		ID:         newULID,
 		Concept:    concept,
 		Content:    newContent,
 		Tags:       oldEng.Tags,
+		MemoryType: oldEng.MemoryType,
+		TypeLabel:  oldEng.TypeLabel,
 		Confidence: 1.0,
 		Stability:  30.0,
 		State:      storage.StateActive,

--- a/internal/engine/engine_evolve_test.go
+++ b/internal/engine/engine_evolve_test.go
@@ -135,3 +135,96 @@ func TestEvolve_ConceptRenameWhenProvided(t *testing.T) {
 	assert.Equal(t, "answer owed to Alice on #895", oldEng.Concept,
 		"predecessor concept must not be mutated")
 }
+
+// TestEvolve_InheritsMemoryTypeAndTypeLabel verifies that MemoryType and
+// TypeLabel are carried to the successor, alongside Concept and Tags.
+//
+// Evolve exposes no parameter for either, so before #653 they were simply
+// absent from the successor's struct literal and MemoryType fell back to its
+// zero value, Fact. A stored decision or procedure silently became a fact, and
+// a caller filtering or routing on memory type saw the successor as a different
+// kind of thing than the predecessor.
+//
+// Summary is asserted to be EMPTY on the successor, not inherited: it is
+// content-derived, Evolve replaces the content, and a non-empty Summary would
+// suppress the summarize stage that regenerates both it and KeyPoints.
+func TestEvolve_InheritsMemoryTypeAndTypeLabel(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const (
+		originalSummary   = "one-line summary describing the predecessor content"
+		originalTypeLabel = "architectural_decision"
+	)
+
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:      "test",
+		Concept:    "Original",
+		Content:    "v1",
+		Summary:    originalSummary,
+		MemoryType: uint8(storage.TypeDecision),
+		TypeLabel:  originalTypeLabel,
+	})
+	require.NoError(t, err)
+
+	ws := eng.store.ResolveVaultPrefix("test")
+
+	// Guard: the predecessor really carries what the test claims it does, so a
+	// failure below indicts Evolve rather than Write.
+	oldULID, err := storage.ParseULID(resp.ID)
+	require.NoError(t, err)
+	pred, err := eng.store.GetEngram(ctx, ws, oldULID)
+	require.NoError(t, err)
+	require.NotNil(t, pred)
+	require.Equal(t, originalSummary, pred.Summary, "precondition: predecessor summary")
+	require.Equal(t, storage.TypeDecision, pred.MemoryType, "precondition: predecessor type")
+
+	newID, err := eng.Evolve(ctx, "test", resp.ID, "v2", "update", nil, "")
+	require.NoError(t, err)
+
+	succ, err := eng.store.GetEngram(ctx, ws, newID)
+	require.NoError(t, err)
+	require.NotNil(t, succ)
+
+	assert.Empty(t, succ.Summary,
+		"summary must NOT be inherited: it describes the predecessor's content, and a "+
+			"non-empty value suppresses the summarize stage that regenerates it and KeyPoints")
+	assert.Equal(t, storage.TypeDecision, succ.MemoryType,
+		"memory type must be inherited, not reset to the zero value (Fact)")
+	assert.Equal(t, originalTypeLabel, succ.TypeLabel,
+		"free-form type label must be inherited")
+}
+
+// TestEvolve_TypeSurvivesSupersedeChain pins the compounding case: the type must
+// not decay at any hop. A single-hop assertion would still pass if inheritance
+// read from a default-filled intermediate rather than the true predecessor.
+func TestEvolve_TypeSurvivesSupersedeChain(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:      "test",
+		Concept:    "Chained",
+		Content:    "v1",
+		Summary:    "summary v1",
+		MemoryType: uint8(storage.TypeProcedure),
+	})
+	require.NoError(t, err)
+
+	ws := eng.store.ResolveVaultPrefix("test")
+	id := resp.ID
+	for hop := 1; hop <= 3; hop++ {
+		newID, err := eng.Evolve(ctx, "test", id, "content", "update", nil, "")
+		require.NoError(t, err, "evolve hop %d", hop)
+
+		got, err := eng.store.GetEngram(ctx, ws, newID)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, storage.TypeProcedure, got.MemoryType,
+			"type must survive hop %d of the supersede chain", hop)
+
+		id = newID.String()
+	}
+}


### PR DESCRIPTION
Fixes #653.

Sent ahead of a maintainer reply on the issue since the change is small and self-contained — happy to close it if you would rather shape the approach differently.

**Scope note:** an earlier revision of this PR also inherited `Summary`. That was wrong and has been removed — see the [correction comment](https://github.com/scrypster/muninndb/issues/653#issuecomment-5080967748) on the issue for the trace. The short version: `Summary` is content-derived, `Evolve` replaces the content, and a non-empty `Summary` reads as caller-authoritative to both `engramHasSummary` and the retroactive processor — so inheriting it would pin stale text permanently *and* leave `KeyPoints` empty forever, since the summarize stage is their only producer.

### The change

`Engine.Evolve` built its successor with a struct literal that explicitly inherited `Concept` and `Tags` and never set `MemoryType` or `TypeLabel`. Evolve exposes no parameter for either, so they took the Go zero value — and `MemoryType`'s zero value is `Fact`. A stored `decision` or `procedure` was not left "unclassified", it was silently relabelled a fact, with no error and nothing in the log.

Two lines, inheriting alongside the fields already carried:

```go
MemoryType: oldEng.MemoryType,
TypeLabel:  oldEng.TypeLabel,
```

Inheriting the type does suppress LLM reclassification, via `engramHasClassification`. That is deliberate and is the difference from the summary case: a memory's type is not invalidated by editing its content — an updated `decision` is still a `decision` — so the inherited value is true of the successor, and suppressing the stage also saves an LLM call per evolve. A summary describes specific text; replace the text and the description is false.

### Tests

- `TestEvolve_InheritsMemoryTypeAndTypeLabel` — single evolve. Asserts the predecessor's own fields first, so a failure indicts `Evolve` rather than `Write`. Fails without the fix: `0x1` vs `0x0`, `"architectural_decision"` vs `""`.
- `TestEvolve_TypeSurvivesSupersedeChain` — three hops, failing at every hop without the fix. A single-hop assertion would still pass if inheritance ever read from a default-filled intermediate, and the compounding case is the one that destroys a long-lived memory.

The assertion that the successor's `Summary` is empty is a **regression guard against re-introducing the inheritance — it does not fail without the fix.** Flagging that explicitly so it isn't mistaken for a teeth-bearing test.

`go build ./...`, `go vet`, `gofmt -l` clean; `./internal/engine/...` green.

### One design note, deliberately not acted on here

This constructor enumerates which predecessor fields to carry, and that shape is what produced both this bug and #622 — it will produce the next one when a field is added to `storage.Engram`. Starting from a copy of the predecessor and overwriting only what evolve genuinely changes would make the failure mode unrepresentable rather than policy-checked. Larger change, more review surface, so this PR stays minimal and matches the existing style. Glad to do it the other way if you prefer.

Two adjacent losses found while checking and deliberately left alone: `Consolidate` writes its merged engram with only a concept and content, dropping all source types, summaries and tags — same class, but many-to-one and out of this issue's scope. `CreatedBy` and `Classification` are dropped too but appear to be dead fields with no writer anywhere in the tree.

### Relationship to #646

That PR carries entity links and relationships across evolve — same constructor, different fields. Independent diffs; whichever lands first, the other should rebase cleanly.
