### PR TITLE
fix(engine): apply meta filters and trust exclusion to entity-boost injected results

### DIFF
--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -1910,6 +1910,18 @@ func computeGatedActivation(vectorScore, normalizedFTS, decayFactor, hebbianBoos
 	return contentRelevance * gate
 }
 
+// PassesMetaFilter evaluates the request's filter predicates against a full
+// engram, for callers outside this package.
+//
+// Phase 6 is the correctness gate for everything the pipeline itself retrieves,
+// but passes that run after Run returns — the entity-boost spread activation in
+// particular — can introduce engrams the pipeline never saw. Those candidates
+// have never been filtered, so they must be checked here before being surfaced
+// (issue #654).
+func PassesMetaFilter(eng *storage.Engram, filters []Filter) bool {
+	return passesMetaFilter(eng, filters)
+}
+
 // passesMetaFilter evaluates filter predicates against a full engram.
 // Accepts *storage.Engram directly — avoids a separate GetMetadata call in phase6.
 func passesMetaFilter(eng *storage.Engram, filters []Filter) bool {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2133,7 +2133,7 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 	// After BFS produces a scored set, any engram sharing a named entity with a
 	// top-N result receives a small boost. This surfaces entity-linked engrams
 	// that have no direct association edge to the query-matching engrams.
-	result.Activations = e.applyEntityBoost(ctx, wsPrefix, result.Activations)
+	result.Activations = e.applyEntityBoost(ctx, wsPrefix, result.Activations, actReq.Filters, actReq.ExcludeUntrusted)
 	// Re-apply MaxResults: entity boost may have appended engrams beyond the limit.
 	// applyEntityBoost re-sorts by score descending, so truncation preserves top-K.
 	if actReq.MaxResults > 0 && len(result.Activations) > actReq.MaxResults {

--- a/internal/engine/engine_entity_boost.go
+++ b/internal/engine/engine_entity_boost.go
@@ -50,6 +50,13 @@ func (e *Engine) applyEntityBoost(ctx context.Context, ws [8]byte, results []act
 		seenInResults[r.Engram.ID] = i
 	}
 
+	// Candidates rejected once stay rejected: the fetch and every exclusion
+	// check depend only on the candidate, never on which seed reached it. A
+	// candidate sharing entities with several seeds would otherwise be
+	// re-fetched and re-checked per seed — common under restrictive filters,
+	// where most of a dense entity neighbourhood is rejected.
+	rejected := make(map[storage.ULID]struct{})
+
 	// For each seed engram, iterate its entity links (0x20 forward index).
 	for _, topEng := range seeds {
 		_ = e.store.ScanEngramEntities(ctx, ws, topEng.Engram.ID, func(entityName string) error {
@@ -67,12 +74,17 @@ func (e *Engine) applyEntityBoost(ctx context.Context, ws [8]byte, results []act
 					// Boost existing result.
 					results[idx].Score += entityBoostFactor
 				} else {
+					if _, wasRejected := rejected[engramID]; wasRejected {
+						return nil
+					}
 					// Fetch engram and add as a new entity-boosted result.
 					eng, err := e.store.GetEngram(ctx, ws, engramID)
 					if err != nil || eng == nil {
+						rejected[engramID] = struct{}{}
 						return nil
 					}
 					if eng.State == storage.StateSoftDeleted || eng.State == storage.StateArchived {
+						rejected[engramID] = struct{}{}
 						return nil
 					}
 					// This engram was never in the pipeline's candidate pool,
@@ -84,9 +96,11 @@ func (e *Engine) applyEntityBoost(ctx context.Context, ws [8]byte, results []act
 					// backward-compat alias for TrustInferred and passes
 					// through, as it does in the pipeline.
 					if excludeUntrusted && eng.Trust == storage.TrustUntrusted {
+						rejected[engramID] = struct{}{}
 						return nil
 					}
 					if !activation.PassesMetaFilter(eng, filters) {
+						rejected[engramID] = struct{}{}
 						return nil
 					}
 					results = append(results, activation.ScoredEngram{

--- a/internal/engine/engine_entity_boost.go
+++ b/internal/engine/engine_entity_boost.go
@@ -26,7 +26,13 @@ const (
 // the 0x23 reverse index. Each such engram receives a score boost of
 // entityBoostFactor (or is added to the result set with that score if it was
 // not already returned by BFS). Results are re-sorted by score descending.
-func (e *Engine) applyEntityBoost(ctx context.Context, ws [8]byte, results []activation.ScoredEngram) []activation.ScoredEngram {
+//
+// filters and excludeUntrusted carry the request's exclusion rules. They must be
+// applied to engrams injected here, because this pass runs after activation.Run
+// has returned and therefore after phase 6, the pipeline's correctness gate.
+// Engrams already in results need no re-check — they passed phase 6 on the way
+// in — so only the injection path consults them (issue #654).
+func (e *Engine) applyEntityBoost(ctx context.Context, ws [8]byte, results []activation.ScoredEngram, filters []activation.Filter, excludeUntrusted bool) []activation.ScoredEngram {
 	if len(results) == 0 {
 		return results
 	}
@@ -67,6 +73,20 @@ func (e *Engine) applyEntityBoost(ctx context.Context, ws [8]byte, results []act
 						return nil
 					}
 					if eng.State == storage.StateSoftDeleted || eng.State == storage.StateArchived {
+						return nil
+					}
+					// This engram was never in the pipeline's candidate pool,
+					// so it has not been through phase 6. Apply the request's
+					// exclusion rules before surfacing it (issue #654).
+					//
+					// The trust check mirrors phase 6 exactly: only
+					// TrustUntrusted is excluded. TrustUnset is the zero-value
+					// backward-compat alias for TrustInferred and passes
+					// through, as it does in the pipeline.
+					if excludeUntrusted && eng.Trust == storage.TrustUntrusted {
+						return nil
+					}
+					if !activation.PassesMetaFilter(eng, filters) {
 						return nil
 					}
 					results = append(results, activation.ScoredEngram{

--- a/internal/engine/engine_entity_boost_test.go
+++ b/internal/engine/engine_entity_boost_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/scrypster/muninndb/internal/engine/activation"
 	"github.com/scrypster/muninndb/internal/storage"
 	"github.com/scrypster/muninndb/internal/transport/mbp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -158,7 +160,7 @@ func TestEntityBoost_ApplyEntityBoostDirect(t *testing.T) {
 	}
 
 	// Apply entity boost.
-	boosted := eng.applyEntityBoost(ctx, ws, initialResults)
+	boosted := eng.applyEntityBoost(ctx, ws, initialResults, nil, false)
 
 	// Build ID set from boosted results.
 	idSet := make(map[storage.ULID]float64, len(boosted))
@@ -234,4 +236,197 @@ func TestEntityBoost_MaxResultsRespectedAfterBoost(t *testing.T) {
 				i, resp.Activations[i].Score, resp.Activations[i-1].Score)
 		}
 	}
+}
+
+// TestEntityBoost_InjectedResultsRespectMetaFilters pins issue #654: engrams
+// injected by the entity-boost pass have never been through phase 6, so the
+// request's meta filters must be applied to them here. Before the fix, a recall
+// scoped by tags_all or created_after returned entity-linked engrams matching
+// neither constraint.
+//
+// The two halves are asserted separately on purpose. Filtering the injection
+// path is the fix; filtering engrams already in results would be a regression,
+// since those passed phase 6 on the way in and dropping them would silently
+// shrink legitimate result sets.
+func TestEntityBoost_InjectedResultsRespectMetaFilters(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "boost-filter-test"
+	ws := eng.store.ResolveVaultPrefix(vault)
+
+	require.NoError(t, eng.store.UpsertEntityRecord(ctx, storage.EntityRecord{
+		Name: "Shared", Type: "concept", Source: "inline",
+	}, "inline"))
+
+	// Seed: in the result set already, carries the tag.
+	seed := &storage.Engram{Concept: "seed", Content: "seed content", Confidence: 0.9, Tags: []string{"keep"}}
+	idSeed, err := eng.store.WriteEngram(ctx, ws, seed)
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, idSeed, "Shared"))
+
+	// Matching: entity-linked and carries the tag. Must still be injected —
+	// the fix must not suppress legitimate injections.
+	match := &storage.Engram{Concept: "match", Content: "tagged neighbour", Confidence: 0.8, Tags: []string{"keep"}}
+	idMatch, err := eng.store.WriteEngram(ctx, ws, match)
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, idMatch, "Shared"))
+
+	// Violating: entity-linked but does NOT carry the tag. Must not appear.
+	violating := &storage.Engram{Concept: "violating", Content: "untagged neighbour", Confidence: 0.8, Tags: []string{"other"}}
+	idViolating, err := eng.store.WriteEngram(ctx, ws, violating)
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, idViolating, "Shared"))
+
+	fullSeed, err := eng.store.GetEngram(ctx, ws, idSeed)
+	require.NoError(t, err)
+	require.NotNil(t, fullSeed)
+
+	filters := []activation.Filter{{Field: "tags_all", Op: "eq", Value: []string{"keep"}}}
+	boosted := eng.applyEntityBoost(ctx, ws,
+		[]activation.ScoredEngram{{Engram: fullSeed, Score: 0.8}}, filters, false)
+
+	got := make(map[storage.ULID]float64, len(boosted))
+	for _, r := range boosted {
+		got[r.Engram.ID] = r.Score
+	}
+
+	_, violatingFound := got[idViolating]
+	assert.False(t, violatingFound,
+		"engram carrying none of the requested tags must not be injected by entity boost (#654)")
+
+	_, matchFound := got[idMatch]
+	assert.True(t, matchFound,
+		"entity-linked engram that satisfies the filter must still be injected")
+
+	_, seedFound := got[idSeed]
+	assert.True(t, seedFound,
+		"engrams already in the result set passed phase 6 and must not be re-filtered out")
+}
+
+// TestEntityBoost_InjectedResultsRespectTimeFilters covers the same bypass on
+// created_after, the form in which it was originally observed on a live daemon:
+// a recall bounded to the current day returned entity-linked engrams from two
+// weeks earlier, each scored purely by entity boost with no content score.
+func TestEntityBoost_InjectedResultsRespectTimeFilters(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "boost-time-filter-test"
+	ws := eng.store.ResolveVaultPrefix(vault)
+
+	require.NoError(t, eng.store.UpsertEntityRecord(ctx, storage.EntityRecord{
+		Name: "Timed", Type: "concept", Source: "inline",
+	}, "inline"))
+
+	now := time.Now()
+	cutoff := now.Add(-24 * time.Hour)
+
+	seed := &storage.Engram{Concept: "seed", Content: "recent seed", Confidence: 0.9, CreatedAt: now}
+	idSeed, err := eng.store.WriteEngram(ctx, ws, seed)
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, idSeed, "Timed"))
+
+	old := &storage.Engram{
+		Concept: "old", Content: "two weeks old", Confidence: 0.8,
+		CreatedAt: now.Add(-14 * 24 * time.Hour),
+	}
+	idOld, err := eng.store.WriteEngram(ctx, ws, old)
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, idOld, "Timed"))
+
+	fullSeed, err := eng.store.GetEngram(ctx, ws, idSeed)
+	require.NoError(t, err)
+	require.NotNil(t, fullSeed)
+
+	filters := []activation.Filter{{Field: "created_after", Op: "gt", Value: cutoff}}
+	boosted := eng.applyEntityBoost(ctx, ws,
+		[]activation.ScoredEngram{{Engram: fullSeed, Score: 0.8}}, filters, false)
+
+	for _, r := range boosted {
+		if r.Engram.ID == idOld {
+			t.Fatalf("engram created %s violates the created_after bound %s but was injected by entity boost (#654)",
+				r.Engram.CreatedAt, cutoff)
+		}
+	}
+}
+
+// TestEntityBoost_InjectedResultsRespectExcludeUntrusted pins the trust half of
+// the same bypass. ExcludeUntrusted is a vault operator's standing posture, not
+// a per-call convenience — the plasticity config documents untrusted engrams as
+// filtered from ACTIVATE results, and the MCP tool surface advertises that to
+// end users. Phase 6 honors it; the injection path did not.
+//
+// The check mirrors phase 6 exactly: only TrustUntrusted is excluded.
+// TrustUnset is the zero-value backward-compat alias for TrustInferred and must
+// still be injected, which the third assertion pins.
+func TestEntityBoost_InjectedResultsRespectExcludeUntrusted(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "boost-trust-test"
+	ws := eng.store.ResolveVaultPrefix(vault)
+
+	require.NoError(t, eng.store.UpsertEntityRecord(ctx, storage.EntityRecord{
+		Name: "Trusted", Type: "concept", Source: "inline",
+	}, "inline"))
+
+	seed := &storage.Engram{Concept: "seed", Content: "seed", Confidence: 0.9, Trust: storage.TrustInferred}
+	idSeed, err := eng.store.WriteEngram(ctx, ws, seed)
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, idSeed, "Trusted"))
+
+	untrusted := &storage.Engram{Concept: "untrusted", Content: "untrusted neighbour", Confidence: 0.8, Trust: storage.TrustUntrusted}
+	idUntrusted, err := eng.store.WriteEngram(ctx, ws, untrusted)
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, idUntrusted, "Trusted"))
+
+	unset := &storage.Engram{Concept: "unset", Content: "unset-trust neighbour", Confidence: 0.8, Trust: storage.TrustUnset}
+	idUnset, err := eng.store.WriteEngram(ctx, ws, unset)
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, idUnset, "Trusted"))
+
+	fullSeed, err := eng.store.GetEngram(ctx, ws, idSeed)
+	require.NoError(t, err)
+	require.NotNil(t, fullSeed)
+
+	// Guard: the fixture really is untrusted, so a failure indicts the boost
+	// pass rather than the write path.
+	predUntrusted, err := eng.store.GetEngram(ctx, ws, idUntrusted)
+	require.NoError(t, err)
+	require.Equal(t, storage.TrustUntrusted, predUntrusted.Trust, "precondition: fixture is untrusted")
+
+	boosted := eng.applyEntityBoost(ctx, ws,
+		[]activation.ScoredEngram{{Engram: fullSeed, Score: 0.8}}, nil, true)
+
+	got := make(map[storage.ULID]struct{}, len(boosted))
+	for _, r := range boosted {
+		got[r.Engram.ID] = struct{}{}
+	}
+
+	_, untrustedFound := got[idUntrusted]
+	assert.False(t, untrustedFound,
+		"TrustUntrusted engram must not be injected when ExcludeUntrusted is set (#654)")
+
+	_, unsetFound := got[idUnset]
+	assert.True(t, unsetFound,
+		"TrustUnset is the backward-compat alias for TrustInferred and must still be injected, as in phase 6")
+
+	// With the posture off, the untrusted engram is injected normally.
+	boostedOff := eng.applyEntityBoost(ctx, ws,
+		[]activation.ScoredEngram{{Engram: fullSeed, Score: 0.8}}, nil, false)
+	offFound := false
+	for _, r := range boostedOff {
+		if r.Engram.ID == idUntrusted {
+			offFound = true
+		}
+	}
+	assert.True(t, offFound,
+		"with ExcludeUntrusted unset the untrusted engram must still be injected")
 }

--- a/internal/engine/engine_entity_boost_test.go
+++ b/internal/engine/engine_entity_boost_test.go
@@ -430,3 +430,90 @@ func TestEntityBoost_InjectedResultsRespectExcludeUntrusted(t *testing.T) {
 	assert.True(t, offFound,
 		"with ExcludeUntrusted unset the untrusted engram must still be injected")
 }
+
+// TestEntityBoost_ActivateWiresRequestFiltersIntoBoost drives the real Activate
+// entry point rather than applyEntityBoost directly. The direct-call tests
+// above prove the function filters correctly; this one proves activateCore
+// actually passes the request's filters into it — un-wiring the call site to
+// (nil, false) leaves every direct-call test green and turns only this red, so
+// a later refactor of activateCore cannot silently reopen #654.
+//
+// Filter values are typed the way activateCore's verbatim conversion delivers
+// them to passesMetaFilter: created_after must be a time.Time — with a string
+// the type assertion fails open and the negative assertion would pass for the
+// wrong reason. The positive assertions guard the same trap from the other
+// side: a filter that is silently ignored (or an injection pass that never
+// ran) cannot produce a false green, because the satisfying neighbour must
+// still arrive via the boost path.
+func TestEntityBoost_ActivateWiresRequestFiltersIntoBoost(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "boost-wiring-test"
+	ws := eng.store.ResolveVaultPrefix(vault)
+
+	now := time.Now()
+	cutoff := now.Add(-24 * time.Hour)
+
+	// Seed: strong FTS match for the query, entity-linked, inside the window.
+	respSeed, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   vault,
+		Concept: "primary database choice",
+		Content: "We use PostgreSQL as the primary relational database for all transactional workloads",
+		Entities: []mbp.InlineEntity{
+			{Name: "PostgreSQL", Type: "database"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Recent neighbour: entity-linked, content deliberately unrelated to the
+	// query so it can only arrive via the boost path. Inside the window.
+	recent := &storage.Engram{
+		Concept: "recent neighbour", Content: "streaming replication failover runbook",
+		Confidence: 0.8, CreatedAt: now.Add(-time.Hour),
+	}
+	idRecent, err := eng.store.WriteEngram(ctx, ws, recent)
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, idRecent, "PostgreSQL"))
+
+	// Old neighbour: entity-linked, outside the window. Before the wiring fix
+	// this came back on a created_after-bounded recall, scored purely by boost.
+	old := &storage.Engram{
+		Concept: "old neighbour", Content: "legacy connection pool sizing notes",
+		Confidence: 0.8, CreatedAt: now.Add(-14 * 24 * time.Hour),
+	}
+	idOld, err := eng.store.WriteEngram(ctx, ws, old)
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, idOld, "PostgreSQL"))
+
+	awaitFTS(t, eng)
+
+	resp, err := eng.Activate(ctx, &mbp.ActivateRequest{
+		Vault:      vault,
+		Context:    []string{"primary relational database"},
+		MaxResults: 20,
+		Threshold:  0.01,
+		Filters: []mbp.Filter{
+			{Field: "created_after", Op: "gt", Value: cutoff},
+		},
+	})
+	require.NoError(t, err)
+
+	got := make(map[string]struct{}, len(resp.Activations))
+	for _, item := range resp.Activations {
+		got[item.ID] = struct{}{}
+	}
+
+	_, seedFound := got[respSeed.ID]
+	require.True(t, seedFound, "seed satisfies the filter and matches the query; its absence means the request itself failed, not the boost pass")
+
+	_, recentFound := got[idRecent.String()]
+	assert.True(t, recentFound,
+		"filter-satisfying entity neighbour must be injected — proves the boost pass ran and the filter was actually evaluated, not ignored")
+
+	_, oldFound := got[idOld.String()]
+	assert.False(t, oldFound,
+		"engram outside the created_after bound must not be injected by entity boost on a real Activate request (#654)")
+}


### PR DESCRIPTION
Fixes #654.

Sent ahead of a maintainer reply on the issue — happy to close it if you would rather take a different approach, particularly the structural alternative at the bottom.

### The change

`applyEntityBoost` runs after `activation.Run` returns, and therefore after phase 6. Its injection path fetched engrams the pipeline had never retrieved and appended them behind a hand-rolled lifecycle check:

```go
if eng.State == storage.StateSoftDeleted || eng.State == storage.StateArchived {
    return nil
}
```

That was the only predicate applied. `tags_all`, `tags_any`, `tag_prefix`, `created_after`, `created_before`, explicit `state` filters and `ExcludeUntrusted` were all skipped. The pass received none of those inputs — it could not have honored them.

This threads the request's filters and `ExcludeUntrusted` through, and gates injected candidates on `activation.PassesMetaFilter`, a thin exported wrapper over the same predicate phase 6 uses so the two cannot drift.

The trust check mirrors phase 6 exactly: only `TrustUntrusted` is excluded, and `TrustUnset` passes through as the backward-compat alias for `TrustInferred`. There is an assertion pinning that, so the fix cannot quietly become an over-exclusion.

**Scope widened from the filed issue, deliberately.** The issue reported the meta-filter bypass; this also fixes `ExcludeUntrusted`. It is a vault operator's standing posture rather than a per-call convenience — `plasticity.go` documents untrusted engrams as filtered from ACTIVATE results, and the MCP tool surface advertises the guarantee to end users — which places it above the meta filters in the contract hierarchy, not below. Fixing the weakest of these contracts while shipping a commit message naming the strongest as still-broken seemed like the wrong trade. Say the word and I will split it back out.

Engrams **already in the result set are deliberately not re-checked.** Every path into `result.Activations` goes through one of phase 6's four gated scoring loops (RRF, CGDN, ACT-R, legacy), so they have already passed these predicates and re-checking would be redundant.

### Tests

All three fail without the fix:

- `TestEntityBoost_InjectedResultsRespectMetaFilters` — `tags_all`. Also asserts a filter-*satisfying* neighbour is still injected and the seed survives, so a fix that merely suppresses injection would not pass.
- `TestEntityBoost_InjectedResultsRespectTimeFilters` — `created_after`, the form originally observed on a live daemon, where a recall bounded to the current day returned entity-linked engrams from two weeks earlier scored purely by entity boost with no content score.
- `TestEntityBoost_InjectedResultsRespectExcludeUntrusted` — trust, plus the `TrustUnset` pin and a with-the-posture-off case.

`go build ./...`, `go vet ./internal/...`, `gofmt -l` clean. `./internal/engine/...`, `./internal/mcp/...`, `./internal/query/...` green, plus `-race` on the entity-boost tests.

### Known residuals — still bypassed, named rather than fixed

Phase 6 applies two further exclusions the injection path still ignores, both pre-existing and neither introduced here:

1. **`StructuredFilter`** — MQL `WHERE` clauses arrive via `ActivateWithStructuredFilter` and are applied inside phase 6 only, so injected engrams bypass the predicate entirely. Needs the structured predicate threaded the same way the meta filters now are.
2. **Foreign live-lease hiding (#548)** — leased-out engrams are injected despite the visibility contract. Needs `CallerOwner` and `IncludeLeased` threaded plus a per-candidate lease read (an extra Pebble read in the hub fan-out, or batching). #576 records the lease as advisory under a cooperative trust model, which is the severity argument for deferring it.

Separately, injected entries carry a flat `entityBoostFactor` and so are not subject to the caller's `threshold`. Mechanically that is the same class, with two differences worth stating: the violation is **visible** in the reported score, unlike a tag or trust violation; and enforcing it is a product decision rather than a patch, since injections score `entityBoostFactor` by construction and enforcing a caller threshold above it would disable injection entirely for those callers.

Happy to take any of the three in a follow-up.

### Relationship to #569 / #570

Distinct. #570 governs *how much* gets injected — rarity weighting, accumulation cap, threshold gate. This is about injected rows escaping the exclusion gates regardless of how many there are. The bypass reproduces on a daemon already running #570, and the diffs touch different lines; whichever lands first, the other should rebase cleanly.

### A structural alternative

Threading exclusions into a post-pipeline pass means there are now two places that must stay in sync with "what phase 6 excludes" — and the residual list above is evidence that this is a real maintenance hazard, not a hypothetical one. The `seedTagCandidates` comment states the intent that phase 6 is the single correctness gate, and moving the entity-boost pass inside `Run` would restore that property instead of adding a second gate that already lags by two exclusions. Substantially larger change, not attempted here — but if you would rather have the invariant than the patch, say so and I will look at it.
