### PR TITLE
Ignore the third maintainer-private skill directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,8 @@ sdk/php/vendor/
 .claude/maintainer/
 .claude/skills/triage-issue/
 .claude/skills/review-pr/
+.claude/skills/merge-orchestration/
+
+# scratch browser-automation / screenshot output (workspace convention keeps these
+# at the workspace root; this is a backstop in case a tool writes into the repo)
+.artifacts/


### PR DESCRIPTION
`.gitignore` listed `.claude/maintainer/`, `.claude/skills/triage-issue/`, and `.claude/skills/review-pr/` — but not `.claude/skills/merge-orchestration/`.

That skill was covered only by `.git/info/exclude`, which is local-only and doesn't survive a fresh clone. A re-cloned working copy would have offered it to the next `git add -A`. It's the same tier as the other two (maintainer voice, contributor history, merge sequencing), so it belongs in the same list.

Also adds `.artifacts/` as a backstop — the workspace convention keeps scratch browser-automation output and screenshots at the workspace root rather than inside any project, but nothing enforced that from within this repo.

**No behaviour change for contributors:** none of these paths exist in a clone. This only affects a maintainer working copy that has the private tier present.

Found while moving the main checkout back onto `develop` after the dependency sweep.