### PR TITLE
Move GitHub Actions to their Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,6 @@ on:
   pull_request:
     branches: [main, develop]
 
-# Opt into Node.js 24 for all actions now, ahead of the forced migration
-# on June 2, 2026. Silences deprecation warnings for actions/checkout,
-# actions/setup-node, actions/cache, etc.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   # ── Go: build + test ────────────────────────────────────────────────────
   go:
@@ -19,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -43,7 +37,7 @@ jobs:
       # ORT version or model changes. The cache key includes both versions.
       - name: Cache embed assets
         id: asset-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: internal/plugin/embed/assets
           key: embed-assets-ort-1.24.2-bge-small-en-v1.5-linux
@@ -53,7 +47,7 @@ jobs:
         if: steps.asset-cache.outputs.cache-hit != 'true'
         run: make fetch-model _ort-linux-amd64
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -73,7 +67,7 @@ jobs:
         run: go tool cover -func=coverage.out | tail -1
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage
           path: coverage.out
@@ -85,15 +79,15 @@ jobs:
     needs: go
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Restore embed assets from cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: internal/plugin/embed/assets
           key: embed-assets-ort-1.24.2-bge-small-en-v1.5-linux
@@ -105,7 +99,7 @@ jobs:
             make fetch-model _ort-linux-amd64
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -123,16 +117,16 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Cache embed assets (Windows)
         id: asset-cache-win
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: internal/plugin/embed/assets
           key: embed-assets-ort-1.24.2-bge-small-en-v1.5-windows
@@ -163,7 +157,7 @@ jobs:
           Write-Host "DLL size: $((Get-Item 'internal/plugin/embed/assets/onnxruntime_windows_amd64.dll').Length / 1MB) MB"
         shell: pwsh
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -227,15 +221,15 @@ jobs:
     needs: cli-integration  # run after CLI tests so all integration jobs are sequential
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Restore embed assets from cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: internal/plugin/embed/assets
           key: embed-assets-ort-1.24.2-bge-small-en-v1.5-linux
@@ -247,7 +241,7 @@ jobs:
             make fetch-model _ort-linux-amd64
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -275,7 +269,7 @@ jobs:
           curl -sf http://localhost:8750/mcp/health
           curl -sf http://localhost:8476/api/health
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -316,15 +310,15 @@ jobs:
     needs: go
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Restore embed assets from cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: internal/plugin/embed/assets
           key: embed-assets-ort-1.24.2-bge-small-en-v1.5-linux
@@ -335,7 +329,7 @@ jobs:
             make fetch-model _ort-linux-amd64
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -353,7 +347,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: web/playwright-report/
@@ -365,7 +359,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run shellcheck
         run: shellcheck install.sh scripts/check-build-tags.sh
@@ -379,7 +373,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check openapi.yaml exists
         run: |
@@ -390,7 +384,7 @@ jobs:
           fi
           echo "openapi.yaml found ($(wc -c < internal/transport/rest/openapi.yaml) bytes)"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -427,9 +421,9 @@ jobs:
     name: Vulnerability scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -454,9 +448,9 @@ jobs:
     name: Node SDK build & test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: npm

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,13 +30,13 @@ jobs:
             arch: arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -44,13 +44,13 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
 
       - name: Build and push digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -67,7 +67,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digests-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -80,17 +80,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -29,9 +29,9 @@ jobs:
       url: https://pypi.org/p/muninn-python
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -90,9 +90,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,9 @@ jobs:
             cc: ""
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -59,7 +59,7 @@ jobs:
       # never get reused after a version bump.
       - name: Cache embed assets
         id: asset-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: internal/plugin/embed/assets
           key: ${{ matrix.cache_key }}
@@ -68,7 +68,7 @@ jobs:
         if: steps.asset-cache.outputs.cache-hit != 'true'
         run: make fetch-model ${{ matrix.ort_target }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -95,7 +95,7 @@ jobs:
           rm muninn
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: muninn-${{ matrix.goos }}-${{ matrix.goarch }}
           path: |
@@ -108,16 +108,16 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Cache embed assets (Windows)
         id: asset-cache-win
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: internal/plugin/embed/assets
           key: embed-assets-ort-1.24.2-bge-small-en-v1.5-windows-amd64
@@ -139,7 +139,7 @@ jobs:
           Copy-Item $dll.FullName -Destination "internal/plugin/embed/assets/onnxruntime_windows_amd64.dll"
         shell: pwsh
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -159,7 +159,7 @@ jobs:
         shell: pwsh
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: muninn-windows-amd64
           path: |
@@ -172,7 +172,7 @@ jobs:
     needs: [build, build-windows]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           merge-multiple: true
 
@@ -231,7 +231,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout homebrew-tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: scrypster/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
Every action across all four workflows targeted Node 20 and was being force-run on Node 24, producing the deprecation warnings in CI logs.

`ci.yml` had `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` — added deliberately ahead of the forced migration — but it only covered `ci.yml`. `release.yml`, `publish-sdk.yml`, and `docker-publish.yml` had no such env and were riding the runner's default behavior.

## Approach: lowest node24 major, not newest

The goal is to stop depending on a runtime override, not to absorb unrelated majors.

| Action | | | Action | |
|---|---|---|---|---|
| `checkout` | v4 → **v5** | | `setup-python` | v5 → **v6** |
| `setup-node` | v4 → **v5** | | `setup-buildx-action` | v3 → **v4** |
| `setup-go` | v5 → **v6** | | `login-action` | v3 → **v4** |
| `cache` | v4 → **v5** | | `metadata-action` | v5 → **v6** |
| `upload-artifact` | v4 → **v6** | | `build-push-action` | v6 → **v7** |
| `download-artifact` | v4 → **v7** | | | |

Verified by reading `action.yml` at each candidate tag to find the first with `using: node24`, and the release notes to confirm these majors are runtime-only. Worth noting `upload-artifact@v5` and `download-artifact@v5`/`v6` still default to Node 20 despite the version jump — going to "latest minus a bit" would not have fixed the warning.

## Deliberately not taken

**`upload-artifact@v7` and `download-artifact@v8.`** Both migrate to ESM, and v8 additionally makes digest mismatches **fail the run** and skips decompression based on `Content-Type`. Those are real behavior changes on the release path — and `release.yml` only runs on tags, so PR CI can't exercise it. A break would surface mid-release.

v8's fail-on-mismatch default is genuinely worth having (it pairs well with the `#600` checksum work), but as its own change, when someone can watch a release run.

## Caveats

- These majors require **Actions Runner ≥ 2.327.1**. GitHub-hosted runners are well past it; a self-hosted runner would need checking.
- CI validates `ci.yml` only. The `release.yml` / `publish-sdk.yml` / `docker-publish.yml` bumps are tag-triggered and unexercised until the next release — which is exactly why I kept them to runtime-only majors.