### PR TITLE
fix(fts): Stop() must drain the queue even before workers are scheduled

### DIFF
--- a/internal/index/fts/worker.go
+++ b/internal/index/fts/worker.go
@@ -89,9 +89,19 @@ func newWorkerWithIndex(idx indexer) *Worker {
 // runLoop is the per-goroutine entry point. It wraps run() in a restart loop:
 // after a non-fatal panic, the goroutine re-enters run() instead of exiting.
 // wg.Done() only fires when the worker is cleanly stopped.
+//
+// run() is entered at least once, before the stopped flag is consulted. That
+// ordering is what makes Stop()'s drain guarantee hold: Stop sets `stopped`
+// and only then closes stopCh, so a goroutine that had not been scheduled yet
+// would — with the check at the top — observe stopped==true, skip run()
+// entirely, and return without draining. Every queued job then sat in the
+// channel buffer forever: durable engrams that were never indexed and so could
+// not be recalled. Entering run() first costs nothing (stopCh is already
+// closed, so run() takes its drain branch and returns immediately) and turns
+// the guarantee into something the code actually enforces.
 func (w *Worker) runLoop() {
 	defer w.wg.Done()
-	for !w.stopped.Load() {
+	for {
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
@@ -103,6 +113,9 @@ func (w *Worker) runLoop() {
 			}()
 			w.run()
 		}()
+		if w.stopped.Load() {
+			return
+		}
 	}
 }
 

--- a/internal/index/fts/worker_test.go
+++ b/internal/index/fts/worker_test.go
@@ -1,6 +1,7 @@
 package fts
 
 import (
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -46,5 +47,46 @@ func TestWorkerRestartsAfterPanic(t *testing.T) {
 
 	if calls := stub.callCount.Load(); calls < 2 {
 		t.Errorf("callCount = %d, want >= 2 (worker must restart after panic)", calls)
+	}
+}
+
+// countingIndex records every engram it is asked to index.
+type countingIndex struct{ indexed atomic.Int64 }
+
+func (c *countingIndex) IndexEngram(ws [8]byte, id [16]byte, concept, createdBy, content string, tags []string) error {
+	c.indexed.Add(1)
+	return nil
+}
+
+// TestWorkerStopDrainsJobsSubmittedBeforeStart is a regression test for jobs
+// silently lost when Stop() runs before the worker goroutines are first
+// scheduled.
+//
+// Stop() is documented to drain the queue. It set `stopped` before closing
+// stopCh, and runLoop checked `!stopped` *before* ever calling run(). If the
+// goroutines had not been scheduled yet, every one of them saw stopped==true,
+// skipped run() entirely, and returned without draining — leaving the job in
+// the channel buffer forever. The engram stayed durable but was never indexed,
+// so recall could not find it.
+//
+// GOMAXPROCS(1) plus an immediate Stop() makes the unscheduled-goroutine window
+// deterministic rather than a rare CI flake.
+func TestWorkerStopDrainsJobsSubmittedBeforeStart(t *testing.T) {
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(1))
+
+	for i := range 50 {
+		stub := &countingIndex{}
+		w := newWorkerWithIndex(stub)
+
+		if !w.Submit(IndexJob{Concept: "indexed-before-stop"}) {
+			t.Fatalf("iteration %d: Submit was rejected", i)
+		}
+		// No sleep on purpose: Stop() must drain regardless of whether the
+		// worker goroutines have run yet.
+		w.Stop()
+
+		if got := stub.indexed.Load(); got != 1 {
+			t.Fatalf("iteration %d: Stop() did not drain the queue — indexed %d jobs, want 1", i, got)
+		}
 	}
 }


### PR DESCRIPTION
Root cause of the intermittent `internal/engine` CI failures — and a real production bug, not a test-only one.

## The defect

`Worker.Stop()` is documented to *"drain the queue and shut down all worker goroutines."* It didn't always drain.

`Stop()` sets `stopped` **and then** closes `stopCh`, while `runLoop` checked the flag at the *top* of its loop:

```go
for !w.stopped.Load() {   // ← checked before run() ever executes
    ... w.run() ...
}
```

A goroutine not yet scheduled therefore observed `stopped == true`, **skipped `run()` entirely, and returned without draining**. When that happened to every goroutine in the pool, nothing consumed `w.input`: queued jobs sat in the channel buffer until the worker was garbage. The engrams stayed durable but were never indexed, so recall could not find them.

`runLoop` now enters `run()` at least once and consults `stopped` afterwards. Free on the shutdown path — `stopCh` is already closed, so `run()` takes its drain branch and returns immediately. Panic-restart behavior is unchanged.

## How it surfaced

`TestRecall_ObserveModeDoesNotPersist` and `TestTemporalFilter_CombinedRange` both write an engram, call the `awaitFTS` helper (which stops the worker and installs a fresh one), then assert recall returns it. With the drain skipped, the job was still in the old worker's buffer while the replacement had a new empty channel — lost, and recall came back empty.

## Evidence, both directions

| Check | Without fix | With fix |
|---|---|---|
| New unit test (`GOMAXPROCS=1`, `Stop()` straight after `Submit`) | **fails iteration 0** — 0 jobs indexed, want 1 | passes ×3 |
| Engine stress, `GOMAXPROCS=1 -race -shuffle=on` | **3 / 15 runs failed** | **0 / 15** |

The unit test pins `GOMAXPROCS` to 1 and stops immediately after submitting, which makes the unscheduled-goroutine window deterministic instead of a rare flake — so this stays caught rather than becoming a retry-until-green.

Also green with `-race`: `internal/engine`, `internal/index/...`, `internal/storage`. `gofmt` and `vet` clean.

## Why this matters beyond CI

Any `Stop()` racing worker startup could lose queued index jobs in production — a durable engram that is silently unsearchable. That is the "silently-wrong result" class `CLAUDE.md` principle 1 calls the project's worst failure mode.

Not addressed here: `awaitFTS` is still named for a wait it doesn't perform (it stops and replaces the worker rather than awaiting visibility). It's correct now that `Stop()` honors its contract, but the name is misleading and worth revisiting separately.