### PR TITLE
Add Worker.Flush and make awaitFTS actually await

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -140,18 +140,27 @@ func (a *ftsTrigAdapter) Search(ctx context.Context, ws [8]byte, query string, t
 	return out, nil
 }
 
-// awaitFTS drains the FTS worker by stopping it (which deterministically
-// processes all queued index jobs) and restarting it with a fresh worker.
-// This is the correct alternative to time.Sleep(300ms) when a test needs
-// to ensure FTS visibility before calling Activate.
-// The restarted worker will be stopped by eng.Stop() during cleanup.
+// awaitFTS blocks until every index job submitted so far has been applied, so a
+// following Activate sees the writes. Use it instead of time.Sleep when a test
+// depends on FTS visibility.
+//
+// It previously stopped the worker and installed a replacement, relying on
+// Stop()'s drain as a flush. That worked but was indirect, and it was silently
+// wrong until #675: a Stop() that raced worker startup skipped the drain, the
+// queued jobs stayed in the discarded worker's buffer, and the replacement began
+// with an empty channel — so the engram was never indexed and recall came back
+// empty. It failed roughly 1 run in 5 under CI load.
+//
+// Flush waits on the worker's pending count instead, which asks the question the
+// tests actually care about, leaves the worker running, and cannot lose a job.
 func awaitFTS(t *testing.T, eng *Engine) {
 	t.Helper()
 	if eng.ftsWorker == nil {
 		return
 	}
-	eng.ftsWorker.Stop()
-	eng.ftsWorker = fts.NewWorker(eng.fts)
+	if err := eng.ftsWorker.Flush(10 * time.Second); err != nil {
+		t.Fatalf("awaitFTS: %v", err)
+	}
 }
 
 // TestHelloVersionCheck ensures the engine accepts the protocol version string

--- a/internal/index/fts/worker.go
+++ b/internal/index/fts/worker.go
@@ -39,11 +39,18 @@ type indexer interface {
 // Stale FTS entries for deleted engrams are harmless: Phase 6 of activation filters
 // nil metadata results, so orphaned posting list entries never surface in results.
 type Worker struct {
-	idx            indexer
-	input          chan IndexJob
-	stopCh         chan struct{}
-	stopped        atomic.Bool
-	dropped        atomic.Int64
+	idx    indexer
+	input  chan IndexJob
+	stopCh chan struct{}
+	// flushNow wakes idle goroutines so Flush does not have to wait out a full
+	// workerInterval tick. Buffered and best-effort: a send that would block is
+	// discarded, because a goroutine that is already awake will flush anyway.
+	flushNow chan struct{}
+	stopped  atomic.Bool
+	dropped  atomic.Int64
+	// pending counts jobs accepted by Submit but not yet handed to the indexer.
+	// Flush waits for it to reach zero.
+	pending        atomic.Int64
 	wg             sync.WaitGroup
 	done           chan struct{}
 	clearingVaults sync.Map // [8]byte → struct{}{}
@@ -74,10 +81,11 @@ func NewWorker(idx *Index) *Worker {
 func newWorkerWithIndex(idx indexer) *Worker {
 	n := runtime.NumCPU()
 	w := &Worker{
-		idx:    idx,
-		input:  make(chan IndexJob, workerBufSize),
-		stopCh: make(chan struct{}),
-		done:   make(chan struct{}),
+		idx:      idx,
+		input:    make(chan IndexJob, workerBufSize),
+		stopCh:   make(chan struct{}),
+		flushNow: make(chan struct{}, 1),
+		done:     make(chan struct{}),
 	}
 	for range n {
 		w.wg.Add(1)
@@ -127,6 +135,7 @@ func (w *Worker) Submit(job IndexJob) bool {
 	}
 	select {
 	case w.input <- job:
+		w.pending.Add(1)
 		return true
 	default:
 		n := w.dropped.Add(1)
@@ -148,6 +157,41 @@ func (w *Worker) Stop() {
 // Dropped returns the cumulative number of jobs dropped due to queue pressure.
 func (w *Worker) Dropped() int64 {
 	return w.dropped.Load()
+}
+
+// Flush blocks until every job accepted by Submit before this call has been
+// handed to the indexer, or until timeout elapses. It does not stop the worker.
+//
+// Use it when a caller needs FTS visibility to be guaranteed rather than
+// eventual — tests asserting on recall results, and any admin path that must
+// not report success while writes are still unsearchable. It is not needed on
+// the normal write path, which is deliberately decoupled from indexing.
+//
+// Jobs rejected by Submit (queue full, or worker stopped) were never counted,
+// so Flush makes no promise about them; check the Submit return value or
+// Dropped() for that.
+func (w *Worker) Flush(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if w.pending.Load() == 0 {
+			return nil
+		}
+		if w.stopped.Load() {
+			// Stop() drains synchronously, so anything still pending here is
+			// never going to be picked up. Report rather than spin to timeout.
+			return fmt.Errorf("fts: flush abandoned, worker stopped with %d jobs pending", w.pending.Load())
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("fts: flush timed out after %s with %d jobs pending", timeout, w.pending.Load())
+		}
+		// Nudge an idle goroutine rather than waiting out the workerInterval
+		// tick. Best-effort: if the buffer is full a wake is already queued.
+		select {
+		case w.flushNow <- struct{}{}:
+		default:
+		}
+		time.Sleep(200 * time.Microsecond)
+	}
 }
 
 func (w *Worker) run() {
@@ -182,6 +226,8 @@ func (w *Worker) run() {
 					return
 				}
 			}
+		case <-w.flushNow:
+			flush()
 		case <-ticker.C:
 			flush()
 		}
@@ -189,16 +235,32 @@ func (w *Worker) run() {
 }
 
 func (w *Worker) flush(jobs []IndexJob) {
+	// Each job decrements pending exactly once, and only after it is fully dealt
+	// with — indexed, failed, or skipped for a clearing vault. Decrementing on
+	// entry instead would let pending reach zero while IndexEngram was still
+	// running for the last batch, so Flush would return before the write was
+	// actually searchable.
+	done := 0
+	defer func() {
+		// IndexEngram panicking aborts the batch (the goroutine then restarts,
+		// see runLoop). Release the counter for the jobs we never reached, or
+		// Flush would wait out its timeout on work that will never happen.
+		if rem := len(jobs) - done; rem > 0 {
+			w.pending.Add(int64(-rem))
+		}
+	}()
+
 	for _, job := range jobs {
-		if _, dropping := w.clearingVaults.Load(job.WS); dropping {
-			continue
+		if _, dropping := w.clearingVaults.Load(job.WS); !dropping {
+			if err := w.idx.IndexEngram(job.WS, job.ID, job.Concept, job.CreatedBy, job.Content, job.Tags); err != nil {
+				slog.Warn("fts: worker failed to index engram",
+					"engram_id", job.ID,
+					"err", err,
+				)
+			}
 		}
-		if err := w.idx.IndexEngram(job.WS, job.ID, job.Concept, job.CreatedBy, job.Content, job.Tags); err != nil {
-			slog.Warn("fts: worker failed to index engram",
-				"engram_id", job.ID,
-				"err", err,
-			)
-		}
+		done++
+		w.pending.Add(-1)
 	}
 }
 

--- a/internal/index/fts/worker_test.go
+++ b/internal/index/fts/worker_test.go
@@ -1,6 +1,7 @@
 package fts
 
 import (
+	"fmt"
 	"runtime"
 	"sync/atomic"
 	"testing"
@@ -88,5 +89,68 @@ func TestWorkerStopDrainsJobsSubmittedBeforeStart(t *testing.T) {
 		if got := stub.indexed.Load(); got != 1 {
 			t.Fatalf("iteration %d: Stop() did not drain the queue — indexed %d jobs, want 1", i, got)
 		}
+	}
+}
+
+// slowIndex blocks each IndexEngram call briefly so jobs are provably still in
+// flight when Flush is called.
+type slowIndex struct {
+	indexed atomic.Int64
+	delay   time.Duration
+}
+
+func (s *slowIndex) IndexEngram(ws [8]byte, id [16]byte, concept, createdBy, content string, tags []string) error {
+	time.Sleep(s.delay)
+	s.indexed.Add(1)
+	return nil
+}
+
+// TestWorkerFlushWaitsForPendingJobs verifies Flush's contract: when it returns
+// nil, every job accepted before the call has reached the indexer.
+func TestWorkerFlushWaitsForPendingJobs(t *testing.T) {
+	const jobs = 200
+	stub := &slowIndex{delay: 50 * time.Microsecond}
+	w := newWorkerWithIndex(stub)
+	defer w.Stop()
+
+	for i := range jobs {
+		if !w.Submit(IndexJob{Concept: fmt.Sprintf("job-%d", i)}) {
+			t.Fatalf("Submit %d rejected", i)
+		}
+	}
+
+	if err := w.Flush(10 * time.Second); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if got := stub.indexed.Load(); got != jobs {
+		t.Errorf("Flush returned with work outstanding: indexed %d, want %d", got, jobs)
+	}
+}
+
+// Flush must not block for the full timeout once the worker is stopped — Stop
+// drains synchronously, so anything still pending will never be picked up.
+func TestWorkerFlushReportsAfterStop(t *testing.T) {
+	w := newWorkerWithIndex(&countingIndex{})
+	w.Stop()
+
+	start := time.Now()
+	err := w.Flush(5 * time.Second)
+	elapsed := time.Since(start)
+
+	// Nothing was queued, so a stopped-but-empty worker still flushes cleanly.
+	if err != nil {
+		t.Fatalf("Flush on a drained stopped worker should succeed, got %v", err)
+	}
+	if elapsed > time.Second {
+		t.Errorf("Flush took %s on an empty stopped worker; should return immediately", elapsed)
+	}
+}
+
+// Flush is a no-op when nothing was ever submitted.
+func TestWorkerFlushNoJobs(t *testing.T) {
+	w := newWorkerWithIndex(&countingIndex{})
+	defer w.Stop()
+	if err := w.Flush(2 * time.Second); err != nil {
+		t.Fatalf("Flush with no jobs: %v", err)
 	}
 }


### PR DESCRIPTION
Follow-up to #675. That PR fixed `Stop()` so its drain guarantee holds; this removes the reason the tests depended on that guarantee at all.

## The problem

`awaitFTS` was named for a wait it didn't perform. It stopped the FTS worker, leaned on `Stop()`'s drain as an implicit flush, and installed a replacement — indirect, discarded a live worker pool **52 times per engine suite run**, and was silently wrong until #675.

## The change

`Worker.Flush(timeout)` blocks until every job accepted by `Submit` before the call has been indexed, without stopping anything. A `pending` counter tracks accepted-but-unindexed jobs; `Flush` waits for zero, nudging idle goroutines via a new `flushNow` channel so it doesn't wait out the 100ms `workerInterval` tick. `awaitFTS` is now one call to it.

Not test-only scaffolding: any admin path that must not report success while writes are still unsearchable wants the same guarantee. The normal write path stays deliberately decoupled from indexing.

## Two things the counter has to get exactly right

Both found by measuring, not by reasoning:

**Decrement after `IndexEngram` returns, not on entry.** My first version decremented on entry, so `pending` hit zero while the last batch was still indexing and `Flush` returned before the write was searchable — **15/15 engine runs failed.** The ordering is now spelled out in a comment so it doesn't get "simplified" back.

**Release the remainder if `IndexEngram` panics.** A panic aborts the batch (the goroutine restarts — see `runLoop`), so un-reached jobs would leak the counter and make `Flush` wait out its full timeout.

## Evidence

| Check | Result |
|---|---|
| `Flush` stubbed to `return nil` | test fails — indexed 0, want 200 |
| Real `Flush` | passes |
| Engine flake stress (`GOMAXPROCS=1 -race -shuffle`) — failed 3/15 pre-#675 | **0 / 20** |
| Full engine suite, `GOMAXPROCS=1 -race -shuffle` | 3/3 clean |
| `internal/index/...`, `internal/storage`, `internal/mcp` with `-race` | pass |
| Engine suite runtime | **31.2s** vs ~33.8s baseline |

Runtime went *down*: waiting on a counter costs less than tearing down and rebuilding a worker pool 52 times.