### PR TITLE
Correct two stale code comments; close out fixed drift entries

### DIFF
--- a/docs/internals/drift-and-obligations.md
+++ b/docs/internals/drift-and-obligations.md
@@ -82,9 +82,11 @@ and remain the reviewer's job.
 - **Presets are hand-duplicated** Go ↔ web UI with no parity test.
 - **SDK type drift is warning-only** — no CI gate keeps Python/Node/PHP in sync with
   `types.go`.
-- **`govulncheck@latest` is unpinned** in CI — non-reproducible vuln-check runs.
-- **Doc drift**: `middleware.go` claims write-mode keys can't authenticate to MCP (false);
-  a `toolset.go` comment says "39 tools" (now 42).
+- ~~**`govulncheck@latest` is unpinned** in CI~~ — fixed, pinned to v1.6.0.
+- ~~**Doc drift**: `middleware.go` claims write-mode keys can't authenticate to MCP (false);
+  a `toolset.go` comment says "39 tools"~~ — both corrected. The real count is **43**
+  (context.go's classification table and `allMCPTools` agree), and MCP does accept
+  write-mode keys, restricting them by tool rather than rejecting them.
 
 ## CI map and budget
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -162,8 +162,13 @@ func WriteOnlyFromContext(ctx context.Context) bool {
 //
 //	mux.HandleFunc("GET /api/engrams/{id}", s.withMiddleware(auth.WriteOnlyGuard(s.handleGetEngram)))
 //
-// Scope: this guard applies to the REST API only. The MCP server uses a separate
-// static-token auth model; write-only API keys cannot authenticate to MCP at all.
+// Scope: this guard applies to the REST API only. MCP enforces the same modes
+// through its own path — see the ModeObserve/ModeWrite/ModeFull switch in
+// internal/mcp/server.go, which gates tools by isMutatingTool/isReadOnlyTool.
+// A write-mode key does authenticate to MCP; it is restricted there, not
+// rejected. (This comment previously claimed such keys "cannot authenticate to
+// MCP at all", which was never true and is exactly the kind of stale
+// security-boundary note that misleads a reviewer.)
 func WriteOnlyGuard(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if WriteOnlyFromContext(r.Context()) {

--- a/internal/mcp/toolset.go
+++ b/internal/mcp/toolset.go
@@ -13,8 +13,10 @@ import (
 // export, entity surgery, tree memory, consolidation, ...) remains fully
 // callable via tools/call — the toolset only filters what tools/list
 // ADVERTISES, because advertised schemas ride in every MCP client's context
-// window whether or not they are used (~41KB / ~10k tokens for the full
-// 39-tool surface, vs ~1/4 of that for this set).
+// window whether or not they are used (~10k tokens for the full 43-tool
+// surface, vs ~1/4 of that for this set). The count tracks the classification
+// table in context.go and allMCPTools in cmd/muninn/smoke_exhaustive_test.go —
+// obligation #1 in docs/internals/drift-and-obligations.md.
 var coreToolNames = map[string]bool{
 	"muninn_recall":         true,
 	"muninn_remember":       true,


### PR DESCRIPTION
Comments only, no behavior change. Each verified against the code rather than taken from the drift list on faith.

**`internal/auth/middleware.go`** claimed write-only API keys *"cannot authenticate to MCP at all."* False — `internal/mcp/server.go:218-228` switches on `ModeObserve`/`ModeWrite`/`ModeFull` and gates tools via `isMutatingTool`/`isReadOnlyTool`. A write-mode key authenticates and is *restricted*, not rejected. A stale comment about an auth boundary is worse than none, so it now points at the enforcement it describes.

**`internal/mcp/toolset.go`** said "39-tool surface". Real count is **43** — `context.go`'s classification table and `allMCPTools` in `cmd/muninn/smoke_exhaustive_test.go` both agree, and `TestToolClassification_CoversAllRegisteredHandlers` enforces it. (The drift doc guessed 42; it was also out of date.)

**`drift-and-obligations.md`** — marks the `govulncheck` pin (landed in #666) and this doc-drift entry as fixed.

That leaves two genuinely open items on the live-drift list, both needing real work rather than a doc edit: preset parity Go↔web, and an SDK type-drift CI gate.

Verified: build, vet, gofmt clean; `internal/auth` and `internal/mcp` pass with `-race`.