### PR TITLE
Pin plasticity preset names across Go and the web console

### DIFF
--- a/docs/internals/drift-and-obligations.md
+++ b/docs/internals/drift-and-obligations.md
@@ -33,6 +33,8 @@ and remain the reviewer's job.
    (`web/static/js/app.js`), and any docs table. Presets are **hand-duplicated** across Go
    and the web UI with no parity test — a known drift surface. If you add a preset, also
    add a `reflect.DeepEqual`-style pinning test if it's derived from another (see #599). 🪝
+   Preset *names* are pinned across Go and all four web sites by
+   `TestPlasticityPresets_WebConsoleParity`; values are still on you.
 
 5. **The embed model or ORT version** (`Makefile`) → update **all** of: `ci.yml` cache keys
    (Linux *and* Windows jobs), `release.yml` matrix cache keys (5 platforms), and the
@@ -79,7 +81,12 @@ and remain the reviewer's job.
 - ~~**`muninn upgrade` has no checksum verification** (#600)~~ — fixed. `selfUpdate` now
   fetches `checksums.txt`, hashes the whole downloaded archive, and verifies before
   anything executes it. Fails closed if the file is unreachable or the asset isn't listed.
-- **Presets are hand-duplicated** Go ↔ web UI with no parity test.
+- ~~**Presets are hand-duplicated** Go ↔ web UI with no parity test.~~ — partially closed.
+  `TestPlasticityPresets_WebConsoleParity` (`internal/auth/`) now pins preset *names* across
+  the Go table and all four web sites. The preset *values* are still hand-duplicated: the
+  radar-chart numbers in `_plasticityData` are hand-tuned for visual separation and are
+  deliberately not asserted (see the test's comment), and the prose in
+  `plasticityPresetDescription` cites values that nothing checks.
 - **SDK type drift is warning-only** — no CI gate keeps Python/Node/PHP in sync with
   `types.go`.
 - ~~**`govulncheck@latest` is unpinned** in CI~~ — fixed, pinned to v1.6.0.

--- a/internal/auth/plasticity_web_parity_test.go
+++ b/internal/auth/plasticity_web_parity_test.go
@@ -1,0 +1,119 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"testing"
+)
+
+// The plasticity presets are hand-duplicated between Go and the web console:
+// the Go table here, and four separate places in web/. Nothing generates one
+// from the other, and until this test nothing checked them, which
+// docs/internals/drift-and-obligations.md tracks as a known drift surface
+// (obligation #4).
+//
+// The failure this catches is adding or renaming a preset in Go and missing one
+// of the UI sites — a preset the console cannot select, or a card that writes a
+// name the engine will silently fall back to `default` for (COG-1). Both look
+// fine in isolation and neither breaks a build.
+//
+// Deliberately NOT checked: the radar-chart numbers in `_plasticityData`. They
+// are hand-tuned for visual separation and are not a faithful rendering of the
+// preset values — e.g. knowledge-graph plots depth 1.00 where HopDepth/8 would
+// be 0.50. Asserting on them would either fail immediately or force the chart
+// to be less legible. If they are ever meant to be derived, that is a change to
+// the chart, not to this test.
+var webPresetSites = []struct {
+	name    string
+	relPath string
+	pattern string // must contain exactly one capture group: the preset name
+}{
+	{"_plasticityData", "web/static/js/app.js", `(?s)_plasticityData:\s*\{(.*?)\}`},
+	{"_plasticityColors", "web/static/js/app.js", `(?s)_plasticityColors:\s*\{(.*?)\n\s*\},`},
+	{"plasticityPresetDescription", "web/static/js/app.js", `(?s)plasticityPresetDescription\(preset\)\s*\{.*?const d = \{(.*?)\n\s*\};`},
+	{"preset cards", "web/templates/index.html", `(?s)(.*)`},
+}
+
+var (
+	jsKeyRe   = regexp.MustCompile(`'([a-z][a-z-]*)':`)
+	cardKeyRe = regexp.MustCompile(`preset\s*=\s*'([a-z][a-z-]*)'`)
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	// This file lives at <root>/internal/auth/.
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("repo root %q has no go.mod — test needs relocating: %v", root, err)
+	}
+	return root
+}
+
+func TestPlasticityPresets_WebConsoleParity(t *testing.T) {
+	root := repoRoot(t)
+
+	want := make([]string, 0, len(plasticityPresets))
+	for name := range plasticityPresets {
+		want = append(want, name)
+	}
+	sort.Strings(want)
+
+	for _, site := range webPresetSites {
+		t.Run(site.name, func(t *testing.T) {
+			path := filepath.Join(root, site.relPath)
+			src, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v (did the web console move? update webPresetSites)", site.relPath, err)
+			}
+
+			section := string(src)
+			if site.pattern != `(?s)(.*)` {
+				m := regexp.MustCompile(site.pattern).FindStringSubmatch(section)
+				if m == nil {
+					t.Fatalf("could not locate %s in %s — the block was renamed or restructured; "+
+						"update the pattern in webPresetSites rather than deleting this check",
+						site.name, site.relPath)
+				}
+				section = m[1]
+			}
+
+			keyRe := jsKeyRe
+			if site.name == "preset cards" {
+				keyRe = cardKeyRe
+			}
+			seen := map[string]bool{}
+			for _, m := range keyRe.FindAllStringSubmatch(section, -1) {
+				seen[m[1]] = true
+			}
+			got := make([]string, 0, len(seen))
+			for k := range seen {
+				got = append(got, k)
+			}
+			sort.Strings(got)
+
+			if len(got) == 0 {
+				t.Fatalf("found no preset names in %s (%s) — the extraction broke, "+
+					"which would make this test silently vacuous", site.name, site.relPath)
+			}
+
+			for _, w := range want {
+				if !seen[w] {
+					t.Errorf("preset %q exists in Go but is missing from %s (%s) — "+
+						"the console cannot offer it", w, site.name, site.relPath)
+				}
+			}
+			for _, g := range got {
+				if _, ok := plasticityPresets[g]; !ok {
+					t.Errorf("%s (%s) offers preset %q which Go does not define — "+
+						"selecting it silently falls back to `default` (COG-1)",
+						site.name, site.relPath, g)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes the first of the two remaining live-drift entries in `docs/internals/drift-and-obligations.md`.

## What drifts

Presets are hand-duplicated between the Go table and **four** separate places in `web/`: `_plasticityData`, `_plasticityColors`, `plasticityPresetDescription`, and the preset cards in `index.html`. Nothing generates one from the other, and nothing checked them (obligation #4).

The failure this catches: add or rename a preset in Go, miss one of the four UI sites. Either the console can't offer a preset that exists, or a card writes a name the engine doesn't know and `ResolvePlasticity` silently falls back to `default` (**COG-1**). Both look fine in isolation and neither breaks a build.

Everything is in sync today — this pins it, it doesn't fix an outstanding bug.

## What is deliberately NOT asserted

**The radar-chart numbers in `_plasticityData`.** They are hand-tuned for visual separation, not derived from the preset values. `_updatePlasticityChart` documents the normalization, and applying it to the Go table doesn't reproduce them:

| preset | `HopDepth/8` | chart plots |
|---|---|---|
| default | 0.25 | 0.50 |
| knowledge-graph | 0.50 | 1.00 |
| reference | 0.375 | 0.375 ✓ |

Asserting on those would fail immediately, and the only "fix" would be making the chart less legible. The test says this explicitly so the next reader doesn't assume the chart is authoritative.

## Scope

**Names only.** The prose in `plasticityPresetDescription` cites real values ("4-hop BFS", "7-day halflife", "0.01 floor") — I verified all of them are accurate today, but nothing checks them. The drift entry is narrowed rather than deleted to reflect that.

## Verification

| Direction | Result |
|---|---|
| Preset added to Go, absent from UI | reported by **all four** sites |
| Preset added to UI, undefined in Go | reported, citing COG-1 fallback |
| Current tree | passes |

Extraction failure is a hard error, not a silent pass — if the web files are restructured the test fails loudly rather than quietly checking nothing, which is how this class of test usually rots.