### PR TITLE
Run the web console's vitest suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,3 +467,34 @@ jobs:
       - name: Unit tests
         run: npm test
         working-directory: sdk/node
+
+  # ── Web console: unit tests ───────────────────────────────────────────
+  # web/ has carried vitest suites for a while (time-utils, plugin-config-utils,
+  # and now worker-status-utils) that nothing ever ran. `npm run test:e2e`
+  # covers Playwright, but plain `npm test` was never wired up, so the JS unit
+  # coverage was decorative. Two things had to be true before this job could
+  # exist: vitest had to stop globbing the Playwright specs (fixed by the
+  # test.exclude in web/vite.config.js), and the suite had to be green.
+  #
+  # Kept separate from the Go job rather than appended to it, so a failing JS
+  # assertion reports as a web failure instead of "Go build & test". It runs in
+  # parallel and needs no server, no Go toolchain, and no embed assets.
+  web-unit:
+    name: Web console unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install
+        run: npm ci --ignore-scripts
+        working-directory: web
+
+      - name: Unit tests
+        run: npm test
+        working-directory: web

--- a/docs/internals/drift-and-obligations.md
+++ b/docs/internals/drift-and-obligations.md
@@ -103,17 +103,20 @@ wall-clock. Jobs (from `.github/workflows/ci.yml`, real recent timings):
 | Job | ~duration | Notes |
 |---|---|---|
 | `go` (build & test) | 3.5–4 min | gofmt gate, embed-asset cache, web build, `go build -tags localassets`, `go vet`, **`go test -race -tags localassets ./...`**, coverage |
-| `windows` (build & smoke) | 2.5–3 min | parallel to `go`; **wrong-model drift, see above** |
+| `windows` (build & smoke) | 2–3 min | parallel to `go`; now fetches the same bge-small-en-v1.5 the release ships |
 | `shellcheck` | 10–45s | lints scripts + runs `check-build-tags.sh` |
 | `api-spec-validation` | 15–20s | Redocly lint + informational route-count diff |
-| `vuln-check` | 30–90s | `govulncheck` (unpinned) |
+| `vuln-check` | 15–60s | `govulncheck`, pinned to v1.6.0 |
 | `cli-integration` | 1.5–2 min | **runs after `go`** (sequential); this is where the MCP registry-parity smoke test runs |
 | `playwright-e2e` | 1.5–2 min | management-console E2E (thin: ~5 specs) |
-| `python-sdk` | 1.5–2 min | **serialized after `cli-integration`** "so integration jobs are sequential" — this coupling is not a real data dependency and costs ~1.5 min of avoidable critical path |
+| `python-sdk` | 1–2 min | **serialized after `cli-integration`** "so integration jobs are sequential" — this coupling is not a real data dependency and costs ~1.5 min of avoidable critical path |
+| `node-sdk` | 15–20s | `npm ci` + `tsc` + vitest for `sdk/node`. Before it existed the SDK was first compiled by `publish-sdk.yml` at tag time |
+| `web-unit` | 15–25s | `npm test` for `web/`. Before it existed the vitest suites there ran nowhere |
 
 Critical path: `go` → (`cli-integration` ∥ `playwright-e2e`) → `python-sdk`. What's cached:
-embed assets (~130MB, keyed by ORT+model+platform), Go module cache. npm is **not** cached
-(re-`npm ci` in four jobs). Race detector runs only in the `go` job.
+embed assets (~130MB, keyed by ORT+model+platform), Go module cache, and npm for the two
+lockfile-scoped jobs (`node-sdk`, `web-unit`). npm is **not** cached in the jobs that build
+the web bundle as a side effect. Race detector runs only in the `go` job.
 
 **When adding tests:** unit + invariant tests are nearly free — prefer them. Integration,
 Playwright, `-race`, and asset-gated tests cost real minutes. Reach for end-to-end


### PR DESCRIPTION
`web/` has carried vitest suites for a while — `time-utils`, `plugin-config-utils`, and `worker-status-utils` arriving in #645 — that **nothing ever executed**. CI runs `npm run test:e2e` for Playwright but never plain `npm test`.

Surfaced while reviewing #645, whose new JS tests would have landed in the same unrun suite. That would have been the third file in a row providing coverage nobody was collecting.

## Why it wasn't wired up before

Vitest used to glob the Playwright specs, so `npm test` reported `5 failed | 2 passed` next to `33 passed (33)` — a red result that meant nothing. The `test.exclude` added in #676 fixed that, so this is now a four-line job.

## Shape

Its own job rather than appended to the Go job, which already runs `npm ci && npm run build` for `web/`. Sharing would be marginally cheaper, but a failing JS assertion would report as **"Go build & test"** — exactly the kind of misattributed signal people learn to ignore. Runs in parallel, needs no Go toolchain, no server, no embed assets. ~15-25s, so the ~10 minute budget is unaffected.

## Verification

Not vacuous — breaking one assertion in `time-utils.test.js` turns the job red:

```
FAIL  time-utils.test.js > secondsToMillis > converts epoch seconds to milliseconds
Test Files  1 failed | 1 passed (2)
```

Restoring it returns `2 passed (2)` / `33 passed (33)`.

## Also: the CI map had drifted

`drift-and-obligations.md`'s job table still described `govulncheck` as unpinned and flagged the Windows wrong-model issue — both fixed in #666 — and predated the `node-sdk` job from #672. Refreshed to match reality, including both new jobs and the corrected npm-caching note.