### PR TITLE
test(engine): entity-boost lease-fail-closed coverage (#570 follow-up)

### DIFF
--- a/internal/engine/engine_entity_boost.go
+++ b/internal/engine/engine_entity_boost.go
@@ -52,6 +52,16 @@ const (
 	entityBoostNoiseFloor = 0.001
 )
 
+// getLeaseForInjection reads the lease sidecar consulted by applyEntityBoost's
+// pass 2b fail-closed guard. It defaults to the store's real GetLease; tests
+// covering the fail-closed behavior on a lease-read error reassign it for the
+// duration of a single test (save/restore) since the real store only errors
+// on a genuine read/decode failure, never on a missing lease. Production code
+// must never reassign this var.
+var getLeaseForInjection = func(ctx context.Context, s *storage.PebbleStore, wsPrefix [8]byte, id storage.ULID) (storage.Lease, error) {
+	return s.GetLease(ctx, wsPrefix, id)
+}
+
 // entityIDF returns the inverse-document-frequency weight for an entity:
 // ln(n/df) / ln(n), clamped to [0, 1]. n is the RECALLED VAULT's engram count
 // (vault-local — the flood #569 guards against is a vault-local phenomenon)
@@ -246,7 +256,7 @@ func (e *Engine) applyEntityBoost(ctx context.Context, ws [8]byte, vaultSize int
 		// possibly-checked-out engram is worse than dropping an optional
 		// enrichment. A missing lease record is not an error on either path.
 		if !req.IncludeLeased {
-			l, err := e.store.GetLease(ctx, ws, id)
+			l, err := getLeaseForInjection(ctx, e.store, ws, id)
 			if err != nil {
 				continue
 			}

--- a/internal/engine/engine_entity_boost_test.go
+++ b/internal/engine/engine_entity_boost_test.go
@@ -945,6 +945,75 @@ func TestEntityBoost_InjectionRespectsLeaseVisibility(t *testing.T) {
 		"a released lease must not hide the injection")
 }
 
+// TestEntityBoost_InjectionFailsClosedOnLeaseReadError verifies the pass 2b
+// fail-closed guard (#570 follow-up): when the lease read itself errors
+// (distinct from a missing lease, which yields a zero Lease and no error),
+// the candidate must NOT be injected. The real store's GetLease only errors
+// on a genuine Pebble read/decode failure — never on an absent lease record —
+// so this test injects the fault via getLeaseForInjection, the seam added
+// solely to make this failure mode reachable in a test.
+func TestEntityBoost_InjectionFailsClosedOnLeaseReadError(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "lease-fault-test"
+	ws := eng.store.ResolveVaultPrefix(vault)
+
+	upsertEntityTimes(t, eng, "LeaseFaultEnt", 2)
+
+	seedID, err := eng.store.WriteEngram(ctx, ws, &storage.Engram{
+		Concept:    "lease-fault-seed",
+		Content:    "seed content",
+		Confidence: 0.9,
+	})
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, seedID, "LeaseFaultEnt"))
+
+	target, err := eng.store.WriteEngram(ctx, ws, &storage.Engram{
+		Concept:    "lease-fault-target",
+		Content:    "work item content sharing the entity",
+		Confidence: 0.9,
+	})
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, target, "LeaseFaultEnt"))
+
+	fullSeed, err := eng.store.GetEngram(ctx, ws, seedID)
+	require.NoError(t, err)
+	seedResults := []activation.ScoredEngram{{Engram: fullSeed, Score: 0.8}}
+	inSet := func(rs []activation.ScoredEngram) bool {
+		for _, r := range rs {
+			if r.Engram.ID == target {
+				return true
+			}
+		}
+		return false
+	}
+
+	// No lease record exists yet: the real store returns a zero Lease and no
+	// error, so the candidate is injected. This is the control proving the
+	// fault below — not the guard itself — is what suppresses the injection.
+	require.True(t, inSet(eng.applyEntityBoost(ctx, ws, 100, seedResults,
+		&activation.ActivateRequest{Threshold: 0.05, CallerOwner: "me"})),
+		"control: with no lease record, the candidate is injected")
+
+	// Fault-inject a lease-read error for this target only; every other id
+	// (including calls from other concurrently-running tests) is unaffected.
+	faultyID := target
+	orig := getLeaseForInjection
+	getLeaseForInjection = func(ctx context.Context, s *storage.PebbleStore, wsPrefix [8]byte, id storage.ULID) (storage.Lease, error) {
+		if id == faultyID {
+			return storage.Lease{}, fmt.Errorf("simulated lease read failure")
+		}
+		return orig(ctx, s, wsPrefix, id)
+	}
+	defer func() { getLeaseForInjection = orig }()
+
+	require.False(t, inSet(eng.applyEntityBoost(ctx, ws, 100, seedResults,
+		&activation.ActivateRequest{Threshold: 0.05, CallerOwner: "me"})),
+		"a lease-read error must fail closed: the candidate must not be injected")
+}
+
 // TestEntityBoost_InjectionRespectsValidity verifies that injections honor the
 // COG-19 valid-time gate: an engram whose ValidUntil has passed must not be
 // injected (the final gate in activateCore would drop it anyway, but gating at


### PR DESCRIPTION
## Summary

PR #570's entity-boost injection guard (`applyEntityBoost`'s pass 2b, `internal/engine/engine_entity_boost.go`) fails closed when the lease read (`e.store.GetLease`) errors on a candidate — the candidate is not injected. Both the primary review and an Opus Tier-3 refute confirmed the guard is correct, but flagged it had no covering test: a mutation to fail OPEN on error stayed green. This is that follow-up, as committed.

- The real store's `GetLease` only errors on a genuine Pebble read/decode failure — a missing lease record returns a zero `Lease` with `nil` error — so exercising the error path needs fault injection, not just an absent lease.
- Adds `getLeaseForInjection`, a minimal package-level func var in `engine_entity_boost.go` that defaults to the real `e.store.GetLease` call and is the sole seam `applyEntityBoost` now calls through. Tests reassign it (save/restore) to force an error for one target id; production code never reassigns it.
- New test: `TestEntityBoost_InjectionFailsClosedOnLeaseReadError` in `internal/engine/engine_entity_boost_test.go`, mirroring the existing `TestEntityBoost_InjectionRespectsLeaseVisibility` harness (shared rare entity, above-threshold seed, trusted). Control leg confirms the candidate is injected with no lease record; fault leg confirms it is NOT injected once `GetLease` is made to error.

Test-only change — no production behavior differs. `getLeaseForInjection`'s default body is byte-for-byte the prior direct call.

## RED → GREEN proof

Temporarily mutated the guard to fail OPEN (`if err == nil && l.Live(...) ...` instead of `continue` on error):

```
--- FAIL: TestEntityBoost_InjectionFailsClosedOnLeaseReadError (0.06s)
    Error: Should be false
    Messages: a lease-read error must fail closed: the candidate must not be injected
```

Restored the guard; the same test passes, along with the full `EntityBoost` suite and `-race` on the new test.

## Test plan

- [x] `go build -tags localassets ./...`
- [x] `go vet -tags localassets ./internal/engine/`
- [x] `gofmt -l .` clean
- [x] `go test -tags localassets -run 'EntityBoost' ./internal/engine/` — all green, including the new test
- [x] `go test -tags localassets -race -run 'TestEntityBoost_InjectionFailsClosedOnLeaseReadError' ./internal/engine/` — green
- [x] RED-checked: test fails against a fail-open mutation of the guard, passes against the real (fail-closed) guard