### PR TITLE
fix(trigger): carry the full 8-byte vault prefix on trigger events (#692)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -471,7 +471,7 @@ func NewEngine(cfg EngineConfig) *Engine {
 	if e.hebbianWorker != nil && e.triggers != nil {
 		e.hebbianWorker.OnWeightUpdate = func(ws [8]byte, id [16]byte, field string, old, new float64) {
 			vaultID := wsVaultID(ws)
-			e.triggers.NotifyCognitive(vaultID, storage.ULID(id), field, float32(old), float32(new))
+			e.triggers.NotifyCognitive(vaultID, ws, storage.ULID(id), field, float32(old), float32(new))
 		}
 	}
 	// Fix 5: Load persisted coherence counters for known vaults.
@@ -1354,7 +1354,7 @@ func (e *Engine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteRe
 			Associations: contraAssocs,
 			OnFound: func(ev cognitive.ContradictionEvent) {
 				if e.triggers != nil {
-					e.triggers.NotifyContradiction(wsVaultID(wsPrefix), storage.ULID(ev.EngramA), storage.ULID(ev.EngramB), ev.Severity, "semantic")
+					e.triggers.NotifyContradiction(wsVaultID(wsPrefix), wsPrefix, storage.ULID(ev.EngramA), storage.ULID(ev.EngramB), ev.Severity, "semantic")
 				}
 				_, _, cw := e.cogWorkers()
 				if cw != nil {
@@ -1898,7 +1898,7 @@ func (e *Engine) WriteBatch(ctx context.Context, reqs []*mbp.WriteRequest) ([]*m
 				Associations: contraAssocs,
 				OnFound: func(ev cognitive.ContradictionEvent) {
 					if e.triggers != nil {
-						e.triggers.NotifyContradiction(wsVaultID(wsPrefix), storage.ULID(ev.EngramA), storage.ULID(ev.EngramB), ev.Severity, "semantic")
+						e.triggers.NotifyContradiction(wsVaultID(wsPrefix), wsPrefix, storage.ULID(ev.EngramA), storage.ULID(ev.EngramB), ev.Severity, "semantic")
 					}
 					_, _, cw := e.cogWorkers()
 					if cw != nil {
@@ -2654,6 +2654,7 @@ func (e *Engine) SubscribeWithDeliver(ctx context.Context, req *mbp.SubscribeReq
 	sub := &trigger.Subscription{
 		ID:             subID,
 		VaultID:        vaultID,
+		WSPrefix:       wsPrefix,
 		Context:        req.Context,
 		Threshold:      float64(req.Threshold),
 		TTL:            time.Duration(req.TTL) * time.Second,
@@ -2760,7 +2761,7 @@ func (e *Engine) Link(ctx context.Context, req *mbp.LinkRequest) (*mbp.LinkRespo
 				},
 				OnFound: func(ev cognitive.ContradictionEvent) {
 					if e.triggers != nil {
-						e.triggers.NotifyContradiction(wsVaultID(wsPrefix), storage.ULID(ev.EngramA), storage.ULID(ev.EngramB), ev.Severity, "explicit_link")
+						e.triggers.NotifyContradiction(wsVaultID(wsPrefix), wsPrefix, storage.ULID(ev.EngramA), storage.ULID(ev.EngramB), ev.Severity, "explicit_link")
 					}
 					_, _, cw := e.cogWorkers()
 					if cw != nil {
@@ -3051,7 +3052,7 @@ func (e *Engine) SetCognitiveWorkers(
 	if heb != nil && e.triggers != nil {
 		heb.OnWeightUpdate = func(ws [8]byte, id [16]byte, field string, old, new float64) {
 			vaultID := wsVaultID(ws)
-			e.triggers.NotifyCognitive(vaultID, storage.ULID(id), field, float32(old), float32(new))
+			e.triggers.NotifyCognitive(vaultID, ws, storage.ULID(id), field, float32(old), float32(new))
 		}
 	}
 	e.hebbianWorker = heb

--- a/internal/engine/trigger/coverage_test.go
+++ b/internal/engine/trigger/coverage_test.go
@@ -245,32 +245,6 @@ func TestActiveVaults_AfterRemoveAll(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// vaultWS — vault workspace ID conversion
-// ---------------------------------------------------------------------------
-
-func TestVaultWS(t *testing.T) {
-	registry := newRegistry()
-	w := &TriggerWorker{registry: registry}
-
-	ws := w.vaultWS(0x01020304)
-	expected := [8]byte{0x01, 0x02, 0x03, 0x04, 0, 0, 0, 0}
-	if ws != expected {
-		t.Errorf("vaultWS(0x01020304) = %v, want %v", ws, expected)
-	}
-
-	ws0 := w.vaultWS(0)
-	if ws0 != [8]byte{} {
-		t.Errorf("vaultWS(0) = %v, want zero", ws0)
-	}
-
-	wsMax := w.vaultWS(0xFFFFFFFF)
-	expectedMax := [8]byte{0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0}
-	if wsMax != expectedMax {
-		t.Errorf("vaultWS(0xFFFFFFFF) = %v, want %v", wsMax, expectedMax)
-	}
-}
-
-// ---------------------------------------------------------------------------
 // handleCognitive — cognitive event processing
 // ---------------------------------------------------------------------------
 
@@ -672,7 +646,7 @@ func TestSweepVault_NoEmbedding_UsesEmbedder(t *testing.T) {
 		contraEvents: make(chan ContradictEvent, 1),
 	}
 
-	ws := worker.vaultWS(9)
+	ws := [8]byte{0, 0, 0, 9, 0, 0, 0, 0}
 	subs := registry.ForVault(9)
 	worker.sweepVault(context.Background(), 9, ws, subs)
 
@@ -739,7 +713,7 @@ func TestSweepVault_SkipsSoftDeleted(t *testing.T) {
 		contraEvents: make(chan ContradictEvent, 1),
 	}
 
-	ws := worker.vaultWS(11)
+	ws := [8]byte{0, 0, 0, 11, 0, 0, 0, 0}
 	subs := registry.ForVault(11)
 	worker.sweepVault(context.Background(), 11, ws, subs)
 

--- a/internal/engine/trigger/realstore_test.go
+++ b/internal/engine/trigger/realstore_test.go
@@ -1,0 +1,118 @@
+package trigger
+
+// Regression test for #692: TriggerWorker.vaultWS() reconstructed the 8-byte
+// Pebble workspace prefix from only the 4-byte routing VaultID, zeroing bytes
+// 4-7. Real vault prefixes are the full 8-byte SipHash output of
+// keys.VaultPrefix (see internal/storage/keys/keys.go), so any vault whose
+// prefix has non-zero trailing bytes caused every trigger consumer that does a
+// store lookup (handleCognitive, handleContradiction, handleSweep) to look up
+// the WRONG key and silently deliver nothing.
+//
+// The fake/mock TriggerStore used elsewhere in this package ignores the ws
+// argument entirely, so it cannot catch this class of bug. This test uses a
+// real *storage.PebbleStore on a temp dir instead.
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// findVaultWithNonZeroTail returns a vault name whose real 8-byte SipHash
+// prefix (storage.PebbleStore.VaultPrefix) has at least one non-zero byte in
+// [4:8]. vaultWS() always zeroed that range, so such a name is required to
+// distinguish "reconstructed from uint32" from "the real prefix".
+func findVaultWithNonZeroTail(t *testing.T, store *storage.PebbleStore) (name string, ws [8]byte) {
+	t.Helper()
+	for i := 0; i < 10000; i++ {
+		name = "trig-vault-" + storage.NewULID().String()
+		ws = store.VaultPrefix(name)
+		for _, b := range ws[4:] {
+			if b != 0 {
+				return name, ws
+			}
+		}
+	}
+	t.Fatal("could not find a vault name with a non-zero tail in its SipHash prefix after 10000 tries")
+	return "", [8]byte{}
+}
+
+// TestNotifyCognitive_RealStore_UsesFullVaultPrefix is the RED-first
+// regression test for #692. Against unfixed code it fails: handleCognitive
+// derives its store lookup key from vaultWS(event.VaultID), which zeroes
+// bytes 4-7 of the real prefix, so GetMetadata misses and no push is
+// delivered.
+func TestNotifyCognitive_RealStore_UsesFullVaultPrefix(t *testing.T) {
+	dir, err := os.MkdirTemp("", "muninndb-trigger-realstore-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := storage.OpenPebble(dir, storage.DefaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 1000})
+	defer store.Close()
+
+	vaultName, ws := findVaultWithNonZeroTail(t, store)
+	vaultID := binary.BigEndian.Uint32(ws[:4])
+
+	ctx := context.Background()
+	eng := &storage.Engram{
+		Concept:    "trigger regression",
+		Content:    "content for #692",
+		Confidence: 0.9,
+		Relevance:  0.9,
+		LastAccess: time.Now(),
+		State:      storage.StateActive,
+	}
+	id, err := store.WriteEngram(ctx, ws, eng)
+	if err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+
+	ts := New(store, &stubTrigFTS{}, &stubTrigHNSW{}, &stubTrigEmbedder{})
+
+	received := make(chan *ActivationPush, 1)
+	sub := &Subscription{
+		ID:        "red-692-sub",
+		VaultID:   vaultID,
+		Threshold: 0.0, // always fires once metadata is found
+		Deliver: func(_ context.Context, push *ActivationPush) error {
+			received <- push
+			return nil
+		},
+	}
+	if err := ts.Subscribe(sub); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ts.Start(runCtx)
+
+	_ = vaultName
+	// Pass the REAL 8-byte prefix through explicitly — this is the fix for
+	// #692. Before the fix, NotifyCognitive had no ws parameter at all and
+	// handleCognitive reconstructed (and truncated) the prefix internally
+	// from vaultID; see git history / PR description for the RED failure
+	// this test produced against that code.
+	ts.NotifyCognitive(vaultID, ws, id, "relevance", 0.1, 0.9)
+
+	select {
+	case push := <-received:
+		if push == nil {
+			t.Fatal("received nil push")
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("#692 regression: no push delivered — handleCognitive's store lookup used a " +
+			"truncated 8-byte prefix (bytes 4-7 zeroed by vaultWS) instead of the real vault " +
+			"prefix, so GetMetadata missed the engram written under the real SipHash prefix")
+	}
+}

--- a/internal/engine/trigger/system.go
+++ b/internal/engine/trigger/system.go
@@ -61,8 +61,14 @@ type ActivationPush struct {
 
 // Subscription is one active context subscription.
 type Subscription struct {
-	ID             string
-	VaultID        uint32
+	ID      string
+	VaultID uint32
+	// WSPrefix is the real 8-byte Pebble workspace prefix for VaultID's vault
+	// (storage.PebbleStore.VaultPrefix / ResolveVaultPrefix). VaultID alone is
+	// only a compact routing key (registry bucketing) derived from its first 4
+	// bytes; store lookups (used by the periodic sweep) must use the full
+	// prefix, not a value reconstructed from VaultID (#692).
+	WSPrefix       [8]byte
 	Context        []string
 	Threshold      float64
 	TTL            time.Duration
@@ -97,8 +103,11 @@ type EngramEvent struct {
 }
 
 // CognitiveEvent fires when a cognitive worker changes an engram's score.
+// WSPrefix is the real 8-byte vault prefix used for the store lookup in
+// handleCognitive — VaultID alone is not sufficient (#692).
 type CognitiveEvent struct {
 	VaultID  uint32
+	WSPrefix [8]byte
 	EngramID storage.ULID
 	Field    string
 	OldValue float32
@@ -107,8 +116,11 @@ type CognitiveEvent struct {
 }
 
 // ContradictEvent fires when a contradiction is detected.
+// WSPrefix is the real 8-byte vault prefix used for the store lookup in
+// handleContradiction — VaultID alone is not sufficient (#692).
 type ContradictEvent struct {
 	VaultID  uint32
+	WSPrefix [8]byte
 	EngramA  storage.ULID
 	EngramB  storage.ULID
 	Severity float64
@@ -505,8 +517,9 @@ func (ts *TriggerSystem) NotifyEmbed(vaultID uint32, eng *storage.Engram, vec []
 	}
 }
 
-// NotifyCognitive sends a cognitive change event.
-func (ts *TriggerSystem) NotifyCognitive(vaultID uint32, id storage.ULID, field string, old, new float32) {
+// NotifyCognitive sends a cognitive change event. ws is the real 8-byte vault
+// prefix (not reconstructible from vaultID alone — see CognitiveEvent, #692).
+func (ts *TriggerSystem) NotifyCognitive(vaultID uint32, ws [8]byte, id storage.ULID, field string, old, new float32) {
 	delta := new - old
 	if delta < 0 {
 		delta = -delta
@@ -515,7 +528,7 @@ func (ts *TriggerSystem) NotifyCognitive(vaultID uint32, id storage.ULID, field 
 		return
 	}
 	select {
-	case ts.CognitiveEvents <- CognitiveEvent{VaultID: vaultID, EngramID: id, Field: field, OldValue: old, NewValue: new, Delta: delta}:
+	case ts.CognitiveEvents <- CognitiveEvent{VaultID: vaultID, WSPrefix: ws, EngramID: id, Field: field, OldValue: old, NewValue: new, Delta: delta}:
 	default:
 	}
 }
@@ -532,10 +545,11 @@ func (ts *TriggerSystem) PruneExpired() int {
 	return ts.registry.PruneExpired()
 }
 
-// NotifyContradiction sends a contradiction event.
-func (ts *TriggerSystem) NotifyContradiction(vaultID uint32, a, b storage.ULID, severity float64, typ string) {
+// NotifyContradiction sends a contradiction event. ws is the real 8-byte
+// vault prefix (not reconstructible from vaultID alone — see ContradictEvent, #692).
+func (ts *TriggerSystem) NotifyContradiction(vaultID uint32, ws [8]byte, a, b storage.ULID, severity float64, typ string) {
 	select {
-	case ts.ContradictEvents <- ContradictEvent{VaultID: vaultID, EngramA: a, EngramB: b, Severity: severity, Type: typ}:
+	case ts.ContradictEvents <- ContradictEvent{VaultID: vaultID, WSPrefix: ws, EngramA: a, EngramB: b, Severity: severity, Type: typ}:
 	default:
 	}
 }

--- a/internal/engine/trigger/trigger_test.go
+++ b/internal/engine/trigger/trigger_test.go
@@ -619,13 +619,17 @@ func TestNotifyCognitiveEnqueues(t *testing.T) {
 	ts := newTestTriggerSystem()
 
 	id := storage.NewULID()
+	ws := [8]byte{0, 0, 0, 42, 9, 9, 9, 9}
 	// Delta = 0.5 — above the 0.001 filter.
-	ts.NotifyCognitive(42, id, "association_weight", 0.1, 0.6)
+	ts.NotifyCognitive(42, ws, id, "association_weight", 0.1, 0.6)
 
 	select {
 	case ev := <-ts.CognitiveEvents:
 		if ev.VaultID != 42 {
 			t.Errorf("VaultID = %d, want 42", ev.VaultID)
+		}
+		if ev.WSPrefix != ws {
+			t.Errorf("WSPrefix = %v, want %v (must carry the full 8-byte prefix, not just VaultID, #692)", ev.WSPrefix, ws)
 		}
 		if ev.EngramID != id {
 			t.Errorf("EngramID mismatch")
@@ -653,7 +657,7 @@ func TestNotifyCognitiveSubThresholdDropped(t *testing.T) {
 
 	id := storage.NewULID()
 	// Delta = 0.0005 — below 0.001 filter → should NOT be enqueued.
-	ts.NotifyCognitive(1, id, "relevance", 0.5000, 0.5005)
+	ts.NotifyCognitive(1, [8]byte{0, 0, 0, 1}, id, "relevance", 0.5000, 0.5005)
 
 	select {
 	case ev := <-ts.CognitiveEvents:
@@ -672,12 +676,16 @@ func TestNotifyContradictionEnqueues(t *testing.T) {
 
 	a := storage.NewULID()
 	b := storage.NewULID()
-	ts.NotifyContradiction(7, a, b, 0.85, "semantic")
+	ws := [8]byte{0, 0, 0, 7, 3, 3, 3, 3}
+	ts.NotifyContradiction(7, ws, a, b, 0.85, "semantic")
 
 	select {
 	case ev := <-ts.ContradictEvents:
 		if ev.VaultID != 7 {
 			t.Errorf("VaultID = %d, want 7", ev.VaultID)
+		}
+		if ev.WSPrefix != ws {
+			t.Errorf("WSPrefix = %v, want %v (must carry the full 8-byte prefix, not just VaultID, #692)", ev.WSPrefix, ws)
 		}
 		if ev.EngramA != a {
 			t.Error("EngramA mismatch")

--- a/internal/engine/trigger/worker.go
+++ b/internal/engine/trigger/worker.go
@@ -99,15 +99,6 @@ func (w *TriggerWorker) Run(ctx context.Context) error {
 	}
 }
 
-func (w *TriggerWorker) vaultWS(vaultID uint32) [8]byte {
-	var ws [8]byte
-	ws[0] = byte(vaultID >> 24)
-	ws[1] = byte(vaultID >> 16)
-	ws[2] = byte(vaultID >> 8)
-	ws[3] = byte(vaultID)
-	return ws
-}
-
 func (w *TriggerWorker) handleWrite(ctx context.Context, event *EngramEvent) {
 	if !event.IsNew {
 		return
@@ -239,7 +230,7 @@ func (w *TriggerWorker) handleCognitive(ctx context.Context, event CognitiveEven
 		return
 	}
 
-	ws := w.vaultWS(event.VaultID)
+	ws := event.WSPrefix
 	metas, err := w.store.GetMetadata(ctx, ws, []storage.ULID{event.EngramID})
 	if err != nil || len(metas) == 0 {
 		return
@@ -294,7 +285,7 @@ func (w *TriggerWorker) handleContradiction(ctx context.Context, event Contradic
 		return
 	}
 
-	ws := w.vaultWS(event.VaultID)
+	ws := event.WSPrefix
 	engrams, err := w.store.GetEngrams(ctx, ws, []storage.ULID{event.EngramA, event.EngramB})
 	if err != nil || len(engrams) == 0 {
 		return
@@ -400,7 +391,10 @@ func (w *TriggerWorker) handleSweep(ctx context.Context) {
 		if len(subs) == 0 {
 			continue
 		}
-		ws := w.vaultWS(vaultID)
+		// All subscriptions in a registry bucket share the same VaultID and
+		// therefore the same real vault prefix; take it from any subscription
+		// rather than reconstructing it from the uint32 routing key (#692).
+		ws := subs[0].WSPrefix
 		w.sweepVault(ctx, vaultID, ws, subs)
 	}
 }


### PR DESCRIPTION
## The bug (#692)
The trigger worker reconstructed an 8-byte vault prefix from a `uint32` (`vaultWS` — bytes 0–3 from the uint32, **bytes 4–7 zeroed**), but real Pebble keys use the full 8-byte SipHash prefix (`keys.VaultPrefix`). So every trigger handler that does a store lookup — `handleCognitive`, `handleContradiction`, and `handleSweep` (including its **HNSW `hnsw.Search`**) — missed against a real `PebbleStore` and **silently delivered nothing**. Contradiction and threshold-crossed pushes were dead in production on REST/gRPC/MBP. `new_write` was unaffected (it reads the engram off the event, no lookup). Masked because the trigger test fakes ignore the `ws` argument.

This is the worst failure class in the project (silently-wrong / silently-empty, principle #2) — the tagline's "push when it matters" third clause, broken on the store-lookup paths.

## The fix
Carry the full `[8]byte` `WSPrefix` on `Subscription`, `CognitiveEvent`, and `ContradictEvent`; delete `vaultWS`; every handler uses the real prefix. All 5 emit sites already had the real `wsPrefix`/`ws` in scope and now pass it. **In-memory event plumbing only — no keyspace, on-disk, or wire-format change.** Registry routing is unchanged: subscriptions still bucket by the pre-existing `wsVaultID(ws) = BigEndian.Uint32(ws[:4])`, and every emit site passes the same derivation, so no bucket-miss regression.

## Verification (RED-first, real store)
- New `TestNotifyCognitive_RealStore_UsesFullVaultPrefix` uses a **real `PebbleStore`** (the fakes ignore `ws` and are why this shipped silently) and a vault whose SipHash tail bytes [4:8] are structurally non-zero, so it genuinely discriminates truncated vs. real. **RED on the truncation, GREEN after** — reproduced independently by re-injecting the truncation (`--- FAIL … no push delivered`) and restoring.
- Tier-3 Fable refute: **STANDS** — all emit sites verified, routing consistent, `new_write` path unchanged, 4-byte bucket-collision residual bounded (≈10⁻⁵, pre-existing, strictly improved by this fix).
- `go build/vet -tags localassets ./...` clean, `gofmt` clean; `-race` green on engine + trigger; REST/gRPC/MBP transport tests green.

## Deferred (#696, non-blocking)
Sweep-path real-store test (also covers the HNSW lookup) + a decision-record line bounding the bucket-collision residual + a trivial test tidy.

Closes #692.