### PR TITLE
fix(recall): deterministic top-N ordering — ULID tie-break at equal scores (#698)

### DIFF
--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -1,6 +1,7 @@
 package activation
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -1562,7 +1563,12 @@ func (e *ActivationEngine) phase6Score(
 				hopPath: c.hopPath,
 			})
 		}
-		sort.Slice(scored, func(i, j int) bool { return scored[i].final > scored[j].final })
+		sort.Slice(scored, func(i, j int) bool {
+			if scored[i].final != scored[j].final {
+				return scored[i].final > scored[j].final
+			}
+			return bytes.Compare(scored[i].id[:], scored[j].id[:]) < 0
+		})
 		goto cgdnDone
 	}
 
@@ -1641,7 +1647,12 @@ func (e *ActivationEngine) phase6Score(
 			}
 		}
 
-		sort.Slice(scored, func(i, j int) bool { return scored[i].final > scored[j].final })
+		sort.Slice(scored, func(i, j int) bool {
+			if scored[i].final != scored[j].final {
+				return scored[i].final > scored[j].final
+			}
+			return bytes.Compare(scored[i].id[:], scored[j].id[:]) < 0
+		})
 		goto cgdnDone
 	}
 
@@ -1691,7 +1702,12 @@ func (e *ActivationEngine) phase6Score(
 			cc.components.Final = final
 			scored = append(scored, scoredItem{id: cc.id, final: final, components: cc.components, hopPath: cc.hopPath})
 		}
-		sort.Slice(scored, func(i, j int) bool { return scored[i].final > scored[j].final })
+		sort.Slice(scored, func(i, j int) bool {
+			if scored[i].final != scored[j].final {
+				return scored[i].final > scored[j].final
+			}
+			return bytes.Compare(scored[i].id[:], scored[j].id[:]) < 0
+		})
 		goto cgdnDone
 	}
 
@@ -1710,7 +1726,12 @@ func (e *ActivationEngine) phase6Score(
 		}
 		scored = append(scored, scoredItem{id: c.id, final: final, components: components, hopPath: c.hopPath})
 	}
-	sort.Slice(scored, func(i, j int) bool { return scored[i].final > scored[j].final })
+	sort.Slice(scored, func(i, j int) bool {
+		if scored[i].final != scored[j].final {
+			return scored[i].final > scored[j].final
+		}
+		return bytes.Compare(scored[i].id[:], scored[j].id[:]) < 0
+	})
 
 cgdnDone:
 	totalFound := len(scored)

--- a/internal/engine/activation/tiebreak_determinism_test.go
+++ b/internal/engine/activation/tiebreak_determinism_test.go
@@ -1,0 +1,192 @@
+package activation
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// ---------------------------------------------------------------------------
+// TestPhase6Score_TieBreakDeterministic (#698)
+//
+// sort.Slice is NOT a stable sort, and until this fix the final-ordering
+// comparators in phase6Score compared ONLY on `final` score with no secondary
+// key. When many candidates share the same final score -- routine under
+// weighted-sum blend-cap saturation (0.400) and in cold vaults where every
+// candidate has zero access history -- the order among tied candidates (and
+// therefore which ones survive a small MaxResults cutoff) tracked the input
+// slice order rather than being a deterministic function of the candidate
+// set itself.
+//
+// This test builds a candidate set where every candidate scores identically
+// under all four scoring paths (RRF, CGDN, ACT-R, legacy weighted-sum), feeds
+// phase6Score the SAME set in many different (shuffled) input orders, and
+// asserts the surviving top-N ordering is always identical -- and equal to
+// ascending-ULID order, per the documented tie-break rule.
+//
+// RED (pre-fix): output order tracks input order, so different shuffles of
+// the same tied candidate set produce different top-N results/orderings.
+// GREEN (post-fix): output order is independent of input order.
+// ---------------------------------------------------------------------------
+
+func buildTiedCandidates(t *testing.T, store *internalStubStore, n int) []fusedCandidate {
+	t.Helper()
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	fused := make([]fusedCandidate, 0, n)
+	for i := 0; i < n; i++ {
+		eng := &storage.Engram{
+			Concept:     "tied engram",
+			Content:     "identical content for every tied candidate",
+			Confidence:  1.0,
+			Stability:   30.0,
+			Relevance:   0.8,
+			State:       storage.StateActive,
+			CreatedAt:   created,
+			LastAccess:  created,
+			AccessCount: 3,
+		}
+		// Force a fresh random ID (not time-derived) so ties aren't
+		// accidentally broken by monotonic ULID generation order.
+		eng.ID = storage.NewULID()
+		store.addEngram(eng)
+		fused = append(fused, fusedCandidate{
+			id:          eng.ID,
+			rrfScore:    0.5,
+			ftsScore:    1.0,
+			vectorScore: 0.8,
+		})
+	}
+	return fused
+}
+
+func shuffledCopy(seed int64, in []fusedCandidate) []fusedCandidate {
+	out := make([]fusedCandidate, len(in))
+	copy(out, in)
+	r := rand.New(rand.NewSource(seed))
+	r.Shuffle(len(out), func(i, j int) { out[i], out[j] = out[j], out[i] })
+	return out
+}
+
+func ascendingIDOrder(fused []fusedCandidate) []storage.ULID {
+	ids := make([]storage.ULID, len(fused))
+	for i, c := range fused {
+		ids[i] = c.id
+	}
+	// simple insertion sort ascending by ULID bytes
+	for i := 1; i < len(ids); i++ {
+		for j := i; j > 0 && ulidLess(ids[j], ids[j-1]); j-- {
+			ids[j], ids[j-1] = ids[j-1], ids[j]
+		}
+	}
+	return ids
+}
+
+func ulidLess(a, b storage.ULID) bool {
+	for i := range a {
+		if a[i] != b[i] {
+			return a[i] < b[i]
+		}
+	}
+	return false
+}
+
+func runPhase6ScoreTieBreak(t *testing.T, weights *Weights) {
+	t.Helper()
+
+	const n = 12
+	const maxResults = 5
+	const runs = 50
+
+	store := newInternalStubStore()
+	e := newTestActivationEngine(store)
+	defer e.Close()
+
+	base := buildTiedCandidates(t, store, n)
+	wantOrder := ascendingIDOrder(base)[:maxResults]
+
+	var firstOrder []storage.ULID
+	for run := 0; run < runs; run++ {
+		fused := shuffledCopy(int64(run), base)
+		p1 := &phase1Result{queryStr: "test"}
+		result, err := e.phase6Score(context.Background(), &ActivateRequest{
+			MaxResults: maxResults,
+			Threshold:  0.0,
+			Weights:    weights,
+		}, [8]byte{}, fused, nil, p1)
+		if err != nil {
+			t.Fatalf("run %d: phase6Score: %v", run, err)
+		}
+		if len(result.Activations) != maxResults {
+			t.Fatalf("run %d: got %d activations, want %d", run, len(result.Activations), maxResults)
+		}
+		gotOrder := make([]storage.ULID, len(result.Activations))
+		for i, a := range result.Activations {
+			gotOrder[i] = a.Engram.ID
+		}
+
+		if run == 0 {
+			firstOrder = gotOrder
+			continue
+		}
+		if !ulidSliceEqual(gotOrder, firstOrder) {
+			t.Fatalf("run %d: top-%d order changed across input shuffles (nondeterministic tie-break)\n  run 0: %v\n  run %d: %v",
+				run, maxResults, ulidStrings(firstOrder), run, ulidStrings(gotOrder))
+		}
+	}
+
+	if !ulidSliceEqual(firstOrder, wantOrder) {
+		t.Fatalf("stable order did not match ascending-ULID tie-break rule\n  got:  %v\n  want: %v",
+			ulidStrings(firstOrder), ulidStrings(wantOrder))
+	}
+}
+
+func ulidSliceEqual(a, b []storage.ULID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func ulidStrings(ids []storage.ULID) []string {
+	out := make([]string, len(ids))
+	for i, id := range ids {
+		out[i] = id.String()
+	}
+	return out
+}
+
+func TestPhase6Score_TieBreakDeterministic_Legacy(t *testing.T) {
+	runPhase6ScoreTieBreak(t, &Weights{
+		DisableACTR:        true,
+		SemanticSimilarity: 0.35,
+		FullTextRelevance:  0.25,
+		DecayFactor:        0.20,
+		HebbianBoost:       0.10,
+		AccessFrequency:    0.05,
+		Recency:            0.05,
+	})
+}
+
+func TestPhase6Score_TieBreakDeterministic_ACTR(t *testing.T) {
+	runPhase6ScoreTieBreak(t, &Weights{UseACTR: true})
+}
+
+func TestPhase6Score_TieBreakDeterministic_CGDN(t *testing.T) {
+	runPhase6ScoreTieBreak(t, &Weights{
+		UseCGDN:            true,
+		SemanticSimilarity: 0.5,
+		FullTextRelevance:  0.3,
+	})
+}
+
+func TestPhase6Score_TieBreakDeterministic_RRF(t *testing.T) {
+	runPhase6ScoreTieBreak(t, &Weights{UseRRFFusion: true})
+}

--- a/internal/engine/engine_entity_boost.go
+++ b/internal/engine/engine_entity_boost.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"math"
 	"sort"
@@ -281,6 +282,17 @@ func (e *Engine) applyEntityBoost(ctx context.Context, ws [8]byte, vaultSize int
 		})
 	}
 
-	sort.SliceStable(results, func(i, j int) bool { return results[i].Score > results[j].Score })
+	// Deterministic order (#698): SliceStable on Score alone is NOT enough here —
+	// pass 2b appends injections in Go map-iteration order, so tied boost totals
+	// (equal EntityBoost·idf) would survive MaxResults truncation in an arbitrary
+	// subset. Break ties by ULID so the output is independent of map order.
+	// Mirrors applySupersession's tiebreak (engine_supersession.go).
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].Score != results[j].Score {
+			return results[i].Score > results[j].Score
+		}
+		a, b := results[i].Engram.ID, results[j].Engram.ID
+		return bytes.Compare(a[:], b[:]) < 0
+	})
 	return results
 }

--- a/internal/engine/tiebreak_entityboost_test.go
+++ b/internal/engine/tiebreak_entityboost_test.go
@@ -1,0 +1,96 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/engine/activation"
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEntityBoost_TiedInjectionsDeterministic guards #698 on the entity-boost
+// injection path. Eight target engrams share one rare entity with the seed, so
+// each receives an identical boost (entityBoostFactor × idf) and ties. Before the
+// ULID tie-break, applyEntityBoost appended injections in Go map-iteration order
+// (pass 2b), so repeated calls on the SAME input produced different orderings and
+// an arbitrary subset survived a MaxResults cutoff. This test runs applyEntityBoost
+// 40× on identical input and requires the tied-injection order to be identical every
+// run and equal to ascending-ULID. It is RED without the tie-break at
+// engine_entity_boost.go's final sort.
+func TestEntityBoost_TiedInjectionsDeterministic(t *testing.T) {
+	t.Parallel()
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "boost-tie-determinism"
+	ws := eng.store.ResolveVaultPrefix(vault)
+
+	// One rare entity, upserted once → df=1.
+	require.NoError(t, eng.store.UpsertEntityRecord(ctx, storage.EntityRecord{
+		Name: "SharedEntity", Type: "topic", Source: "inline",
+	}, "inline"))
+
+	// Seed, linked to SharedEntity — the BFS result that triggers the boost.
+	seed := &storage.Engram{Concept: "seed", Content: "seed about SharedEntity", Confidence: 0.9}
+	idSeed, err := eng.store.WriteEngram(ctx, ws, seed)
+	require.NoError(t, err)
+	require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, idSeed, "SharedEntity"))
+	fullSeed, err := eng.store.GetEngram(ctx, ws, idSeed)
+	require.NoError(t, err)
+
+	// Eight targets, each linked ONLY to SharedEntity → identical idf, identical
+	// boost, all tie.
+	const nTargets = 8
+	targetSet := make(map[storage.ULID]struct{}, nTargets)
+	for i := 0; i < nTargets; i++ {
+		tg := &storage.Engram{Concept: fmt.Sprintf("t%d", i), Content: fmt.Sprintf("target %d re SharedEntity", i), Confidence: 0.8}
+		id, err := eng.store.WriteEngram(ctx, ws, tg)
+		require.NoError(t, err)
+		require.NoError(t, eng.store.WriteEntityEngramLink(ctx, ws, id, "SharedEntity"))
+		targetSet[id] = struct{}{}
+	}
+
+	initial := []activation.ScoredEngram{{Engram: fullSeed, Score: 0.8}}
+	req := &activation.ActivateRequest{Threshold: 0.05}
+
+	orderOfTargets := func(res []activation.ScoredEngram) ([]storage.ULID, float64) {
+		var ids []storage.ULID
+		var tieScore float64
+		for _, r := range res {
+			if _, ok := targetSet[r.Engram.ID]; ok {
+				ids = append(ids, r.Engram.ID)
+				tieScore = r.Score
+			}
+		}
+		return ids, tieScore
+	}
+
+	var first []storage.ULID
+	for run := 0; run < 40; run++ {
+		res := eng.applyEntityBoost(ctx, ws, 10, initial, req)
+		got, tieScore := orderOfTargets(res)
+		require.Len(t, got, nTargets, "run %d: all %d tied targets should be injected", run, nTargets)
+		// Confirm the targets genuinely tie — else this wouldn't exercise the
+		// tie-break (a same-score block is the whole point of #698).
+		for _, r := range res {
+			if _, ok := targetSet[r.Engram.ID]; ok {
+				require.Equal(t, tieScore, r.Score, "run %d: targets must share one boost score to test tie-break", run)
+			}
+		}
+		if run == 0 {
+			first = got
+		} else {
+			require.Equal(t, first, got, "run %d: tied-injection order changed across identical calls (nondeterministic map-order)", run)
+		}
+	}
+
+	// The deterministic order must be ascending ULID (the tie-break key).
+	want := append([]storage.ULID(nil), first...)
+	sort.Slice(want, func(i, j int) bool { return bytes.Compare(want[i][:], want[j][:]) < 0 })
+	require.Equal(t, want, first, "tied injections must be ordered by ascending ULID")
+}


### PR DESCRIPTION
## The bug (#698)
Recall ordered results with `sort.Slice(scored, final > final)` — **unstable, no tie-break** — at all four scoring modes (RRF/CGDN/ACT-R/legacy weighted-sum) in `internal/engine/activation/engine.go`. When scores tie — routine under weighted-sum **blend-cap saturation (0.400)** and in cold vaults — the order among equal-score results, and thus which survive a small `MaxResults` cutoff, was **nondeterministic across runs and under concurrent worker load**. Identical stored state could return a different top-N each time.

This surfaced when the prospective self-focality fix (#693) removed a self-trigger that had been masking it: acceptance recall swung 6–10/15 purely from tie-order instability (precision stayed 1.000).

## The fix
Deterministic secondary sort key (engram ULID) at every final-ordering site: descending `final`, ascending ULID on exact ties. Two layers, both proven:

1. **phase6 (4 scoring modes)** — `activation/engine.go` RRF/CGDN/ACT-R/legacy. RED-proven: a shuffle-stability test fails in all four modes without the tie-break, stable at `-count=20` after.
2. **Entity-boost injections** — found by the Tier-3 refute of layer 1: `engine_entity_boost.go` appended injections in **map-iteration order** then `SliceStable`-sorted by Score only, laundering map randomness into the output (under default ACT-R scoring; 8 distinct orderings in 40 identical calls, PoC-proven). Fixed with the same ULID tie-break, mirroring `applySupersession`. RED-checked (`TestEntityBoost_TiedInjectionsDeterministic`).

Tie-break key mirrors the pre-existing `applySupersession` rule, so the codebase has one consistent tie policy. Only equal-`final` ordering changes — distinct scores are untouched (verified: existing `scoring_invariants_test.go`/`rrf_scoring_test.go` pass unchanged).

## Verification
`go build/vet -tags localassets ./...` clean, `gofmt` clean; `go test ./internal/engine/... ./internal/storage/...` green; `-race` green on engine + activation; both determinism tests stable at `-count=10/20`. Refute verdict on layer 1: DEFECT (entity-boost) → fixed here → clean.

Closes #698.