### PR TITLE
docs: calibration is per-vault and self-derived, never hardcoded (principle #11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,19 @@ Distilled from real decisions across the project's history (each traced to its P
 10. **Honest negative results and scope discipline are first-class.** #609 reported that
     ambient-push memory had zero uptake and killed the idea — that's valued, not dismissed.
 
+11. **Calibration is per-vault and self-derived, never hardcoded from one dataset.** A
+    threshold, baseline, or vocabulary a feature needs must be derived from each vault's OWN
+    data (self-calibrating, like #711's per-corpus IDF) or exposed as a per-vault override —
+    with model/cold-start defaults as hints only, never fixed constants that define someone
+    else's data for them. A number tuned on one sample vault imposes that vault's shape on
+    every other (a code vault versions with git SHAs; a notes app has no version tags; a
+    medical vault is different again) where it is wrong or a silent no-op. A sample vault
+    (e.g. a maintainer's own) is for FINDING bugs and VALIDATING generalization on messy real
+    data — never for tuning a constant into the product. Everyone calibrates their own vault;
+    we ship mechanisms and hints, not their answers. (The semantic-abstention floor self-
+    measures each vault's embedding-anisotropy baseline instead of shipping bge-small's; #712
+    currency was held partly because its version-marker vocabulary was one-vault-specific.)
+
 ---
 
 ## 3. How we work

--- a/docs/internals/decision-record.md
+++ b/docs/internals/decision-record.md
@@ -155,3 +155,23 @@ candidates (`ActivationEngine.seedTagCandidates` / `storage.ScanRawTagRange`); p
 0x2B for the key layout. **Principle: "stays a post-filter" is a permanent verdict only
 until the seeding mechanism it was rejected for becomes cheap to build — re-litigate
 when the cost equation changes, don't let an old call block a index built for it.**
+
+### Calibration is per-vault, self-derived, never hardcoded from a sample vault (semantic floor / #712, 2026-07-29)
+
+Reliable-colleague work surfaced a recurring trap: tuning a threshold/baseline/vocabulary on the
+maintainer's own vault and shipping that constant as the universal default. #712 currency
+(version-cluster) failed this twice — v1's entity anchor didn't fire on the entity-sparse real
+vault, and v2's tag-marker vocabulary (`four-bucket`, `v2`, `final`) + document-frequency
+thresholds were tuned to one vault's pricing history (and still false-positived on it, telling a
+shipped fact it was superseded by an aspirational "planned" one). The semantic-abstention floor's
+`b = μ+2σ` was derived from that vault's embedding anisotropy — a value that fits bge-small on that
+corpus but misfloors a different vault or model. The maintainer's framing: *"you can calibrate my
+vault to get better results, everyone can calibrate their own vault, but we shouldn't be defining
+the calibration for others."* A maintainer/sample vault is for FINDING bugs and VALIDATING that a
+feature survives messy real data — never for baking a constant into the product; a feature that
+shines on the sample vault and does nothing (or misfires) elsewhere is a failure even when the
+sample passes. **Principle (CLAUDE.md #11): a feature that needs a number derives it from each
+vault's OWN data (self-calibrating — #711 weights IDF from the vault's own corpus; the semantic
+floor should self-measure each vault's anisotropy baseline over its own embeddings) or exposes a
+per-vault override; model/cold-start defaults are hints, never fixed law. Ship mechanisms and
+hints, not other people's answers.**


### PR DESCRIPTION
Documents the calibration/generalization lesson from the reliable-colleague work as a first-class principle.

**Principle #11 (CLAUDE.md):** a feature that needs a threshold/baseline/vocabulary derives it from each vault's OWN data (self-calibrating, like #711's per-corpus IDF) or exposes a per-vault override — model/cold-start defaults are hints, never fixed constants that impose one sample vault's shape on all others. A sample vault is for finding bugs and validating generalization, never for tuning a constant into the product.

Traced examples in the decision-record: the semantic-abstention floor should self-measure each vault's embedding-anisotropy baseline (not ship bge-small's constant); #712 currency held partly for a one-vault-specific version-marker vocabulary.

Docs-only.