### PR TITLE
fix(recall): restore post-load cosine — GetEngrams omits ERF v2 embeddings (#714)

### DIFF
--- a/internal/engine/activation/activation_test.go
+++ b/internal/engine/activation/activation_test.go
@@ -122,6 +122,16 @@ func (s *stubStore) EngramLastAccessNs(_ [8]byte, _ storage.ULID) int64 {
 	return 0
 }
 
+// GetEmbedding mirrors PebbleStore.GetEmbedding for this in-memory stub: since
+// stubStore keeps Embedding inline on the engram (it never models the ERF v2
+// separate-key split), the fallback simply reads it back off the same record.
+func (s *stubStore) GetEmbedding(_ context.Context, _ [8]byte, id storage.ULID) ([]float32, error) {
+	if e, ok := s.engrams[id]; ok {
+		return e.Embedding, nil
+	}
+	return nil, nil
+}
+
 func (s *stubStore) EngramIDsByCreatedRange(_ context.Context, _ [8]byte, since, until time.Time, limit int) ([]storage.ULID, error) {
 	var ids []storage.ULID
 	for _, id := range s.recent {

--- a/internal/engine/activation/activation_test.go
+++ b/internal/engine/activation/activation_test.go
@@ -132,6 +132,19 @@ func (s *stubStore) GetEmbedding(_ context.Context, _ [8]byte, id storage.ULID) 
 	return nil, nil
 }
 
+// GetEmbeddings mirrors PebbleStore.GetEmbeddings for this in-memory stub: same
+// inline-Embedding source as GetEmbedding, just returned positionally for a batch
+// of ids in one call.
+func (s *stubStore) GetEmbeddings(_ context.Context, _ [8]byte, ids []storage.ULID) ([][]float32, error) {
+	out := make([][]float32, len(ids))
+	for i, id := range ids {
+		if e, ok := s.engrams[id]; ok {
+			out[i] = e.Embedding
+		}
+	}
+	return out, nil
+}
+
 func (s *stubStore) EngramIDsByCreatedRange(_ context.Context, _ [8]byte, since, until time.Time, limit int) ([]storage.ULID, error) {
 	var ids []storage.ULID
 	for _, id := range s.recent {

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -358,6 +358,10 @@ type ActivationEngine struct {
 	logCh     chan logItem
 	logDone   chan struct{}
 	closeOnce sync.Once
+	// logWG tracks in-flight logCh items (Add before enqueue, Done after
+	// drainLog applies the entry to assocLog) so tests can await full log
+	// visibility. See WaitLogIdle.
+	logWG sync.WaitGroup
 }
 
 // New creates a new ActivationEngine.
@@ -418,7 +422,37 @@ func (e *ActivationEngine) drainLog() {
 			EngramIDs: ids,
 			Scores:    scores,
 		})
+		e.logWG.Done()
 	}
+}
+
+// WaitLogIdle blocks until every activation-log entry submitted so far (via
+// the logCh <- logItem send in Run()) has been applied to assocLog by
+// drainLog. Test-only synchronization helper, mirroring autoassoc.Worker's
+// WaitIdle pattern: production callers never await this — phase4HebbianBoost
+// tolerates the drainer's eventual consistency by design (comment on
+// drainLog: "the log may lag by ~1ms but Hebbian decay half-life is 3600s —
+// irrelevant"). That assumption fails in a scripted back-to-back test harness
+// (calls a few ms apart): under -race/CPU contention the drainer goroutine
+// can still be applying call N's entry when call N+1 runs phase4HebbianBoost,
+// so the same candidate nondeterministically scores with or without the
+// Hebbian boost from a just-finished activation — flipping which of two
+// near-tied candidates ranks first. Exported only because the caller
+// (engine.Engine.waitWriteTimeIdle, itself unexported/test-only) lives in a
+// different package — same visibility trade-off as autoassoc.Worker.WaitIdle.
+func (e *ActivationEngine) WaitLogIdle() {
+	e.logWG.Wait()
+}
+
+// ResetLog discards assocLog's recorded activation events for vaultID.
+// Test-only: see ActivationLog.ResetVault for the full rationale (a scripted
+// back-to-back harness modeling separate agent sessions compresses real
+// elapsed time, defeating the recency half-life that normally bounds
+// cross-call priming). Callers MUST call WaitLogIdle first if a just-run
+// Activate() may still have an entry in flight, or the drainer can
+// re-populate the vault's log immediately after this call clears it.
+func (e *ActivationEngine) ResetLog(vaultID uint32) {
+	e.assocLog.ResetVault(vaultID)
 }
 
 // SetTransitionStore sets the PAS transition store for candidate injection.
@@ -548,6 +582,7 @@ func (e *ActivationEngine) Run(ctx context.Context, req *ActivateRequest) (*Acti
 	// The drainer extracts ids/scores off the critical path.
 	// Non-blocking: drops if channel full (Hebbian half-life=3600s, 1ms lag is negligible).
 	if !req.ReadOnly && len(result.Activations) > 0 {
+		e.logWG.Add(1) // Add FIRST — visible to WaitLogIdle() (test-only); undone below on drop
 		select {
 		case e.logCh <- logItem{vaultID: req.VaultID, activations: result.Activations}:
 			// Yield to allow the drainer goroutine to process immediately.
@@ -555,6 +590,7 @@ func (e *ActivationEngine) Run(ctx context.Context, req *ActivateRequest) (*Acti
 			// drainer queue depth in production under bursty load.
 			runtime.Gosched()
 		default: // channel full — drop; eventual consistency accepted
+			e.logWG.Done()
 		}
 	}
 

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -275,6 +275,11 @@ type ActivationStore interface {
 	// storage.PebbleStore.GetEmbedding and the identical fallback in
 	// internal/consolidation/dedup.go and orient.go.
 	GetEmbedding(ctx context.Context, wsPrefix [8]byte, id storage.ULID) ([]float32, error)
+	// GetEmbeddings batch-reads the standalone embeddings (0x18 keys, ERF v2) for
+	// multiple engrams in one round-trip -- see storage.PebbleStore.GetEmbeddings.
+	// The returned slice is positionally aligned with ids; an id with no stored
+	// embedding gets a nil/empty entry, never an error.
+	GetEmbeddings(ctx context.Context, wsPrefix [8]byte, ids []storage.ULID) ([][]float32, error)
 	// GetLeases batch-reads ownership leases, one per id in order (zero Lease for
 	// unleased engrams). Used for work-queue recall visibility filtering.
 	GetLeases(ctx context.Context, wsPrefix [8]byte, ids []storage.ULID) ([]storage.Lease, error)
@@ -1540,6 +1545,14 @@ func (e *ActivationEngine) phase6Score(
 	// A non-zero vectorScore from the HNSW pool is never overwritten.
 	// ftsScore is left at zero: BM25 requires corpus-level IDF statistics unavailable here.
 	if len(p1.embedding) > 0 {
+		// Two passes: first collect the embeddings already available (eng.Embedding
+		// non-empty) and the ids that need a fallback read; then fetch all fallback
+		// ids in ONE GetEmbeddings round-trip instead of one GetEmbedding point-read
+		// per candidate (#714 batch follow-up). Bounded to exactly this needsCosine
+		// candidate set, never the full result set.
+		embeds := make([]([]float32), len(all))
+		var fallbackIdx []int
+		var fallbackIDs []storage.ULID
 		for i := range all {
 			needsCosine := all[i].isTraversed || (all[i].vectorScore == 0 && (all[i].inTagPool || all[i].ftsScore > 0))
 			if !needsCosine {
@@ -1549,21 +1562,28 @@ func (e *ActivationEngine) phase6Score(
 			if eng == nil {
 				continue
 			}
-			embed := eng.Embedding
-			if len(embed) == 0 {
-				// ERF v2 stores embeddings in a separate 0x18 key, so GetEngrams()
-				// above returns nil embeddings. Fall back to GetEmbedding() in
-				// that case -- same pattern as internal/consolidation/dedup.go
-				// and orient.go. Bounded to exactly this needsCosine candidate
-				// set, never the full result set.
-				// TODO(#714): if needsCosine pools grow, a batch
-				// GetEmbeddings([]ULID) would collapse these per-candidate point
-				// reads into one round-trip. Fine sequentially at current pool sizes.
-				if loaded, err := e.store.GetEmbedding(ctx, ws, eng.ID); err == nil && len(loaded) > 0 {
-					embed = loaded
+			if len(eng.Embedding) > 0 {
+				embeds[i] = eng.Embedding
+				continue
+			}
+			// ERF v2 stores embeddings in a separate 0x18 key, so GetEngrams()
+			// above returns nil embeddings. Fall back to a batched GetEmbeddings()
+			// read in that case -- same pattern as internal/consolidation/dedup.go
+			// and orient.go, collapsed into one round-trip.
+			fallbackIdx = append(fallbackIdx, i)
+			fallbackIDs = append(fallbackIDs, eng.ID)
+		}
+		if len(fallbackIDs) > 0 {
+			if loaded, err := e.store.GetEmbeddings(ctx, ws, fallbackIDs); err == nil {
+				for j, idx := range fallbackIdx {
+					if j < len(loaded) && len(loaded[j]) > 0 {
+						embeds[idx] = loaded[j]
+					}
 				}
 			}
-			if len(embed) > 0 {
+		}
+		for i := range all {
+			if embed := embeds[i]; len(embed) > 0 {
 				all[i].vectorScore = float64(cosineSimilarity32(p1.embedding, embed))
 			}
 		}

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -1521,16 +1521,20 @@ func (e *ActivationEngine) phase6Score(
 	}
 
 	// Compute vectorScore for candidates that entered the pipeline without an HNSW
-	// score now that engrams are loaded. Two cases need this:
+	// score now that engrams are loaded. Three cases need this:
 	//   - BFS-traversed candidates (never in the HNSW pool).
 	//   - Tag-seeded candidates that appear in no other pool (vectorScore == 0):
 	//     without this, ACT-R/CGDN/legacy contentMatch is zero and the tag hit is
 	//     threshold-dropped one layer below the seeding fix (caveat 1 of #607).
+	//   - FTS-only candidates (vectorScore == 0, ftsScore > 0): a lexical match that
+	//     never ranked into the HNSW top-K otherwise keeps vectorScore=0 forever,
+	//     silently dropping its entire semantic evidence term from the ACT-R blend
+	//     even though the engram's embedding is right there once loaded (#714-A2).
 	// A non-zero vectorScore from the HNSW pool is never overwritten.
 	// ftsScore is left at zero: BM25 requires corpus-level IDF statistics unavailable here.
 	if len(p1.embedding) > 0 {
 		for i := range all {
-			needsCosine := all[i].isTraversed || (all[i].inTagPool && all[i].vectorScore == 0)
+			needsCosine := all[i].isTraversed || (all[i].vectorScore == 0 && (all[i].inTagPool || all[i].ftsScore > 0))
 			if !needsCosine {
 				continue
 			}

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -268,6 +268,13 @@ type ActivateResponseFrame struct {
 type ActivationStore interface {
 	GetMetadata(ctx context.Context, wsPrefix [8]byte, ids []storage.ULID) ([]*storage.EngramMeta, error)
 	GetEngrams(ctx context.Context, wsPrefix [8]byte, ids []storage.ULID) ([]*storage.Engram, error)
+	// GetEmbedding reads the standalone embedding (0x18 key, ERF v2) for a single
+	// engram. GetEngrams does NOT join this key (embeddings are large and the
+	// join is a hot-path cost not every caller needs), so any post-load cosine
+	// fixup that finds eng.Embedding empty must fall back to this — see
+	// storage.PebbleStore.GetEmbedding and the identical fallback in
+	// internal/consolidation/dedup.go and orient.go.
+	GetEmbedding(ctx context.Context, wsPrefix [8]byte, id storage.ULID) ([]float32, error)
 	// GetLeases batch-reads ownership leases, one per id in order (zero Lease for
 	// unleased engrams). Used for work-queue recall visibility filtering.
 	GetLeases(ctx context.Context, wsPrefix [8]byte, ids []storage.ULID) ([]storage.Lease, error)
@@ -1538,8 +1545,23 @@ func (e *ActivationEngine) phase6Score(
 			if !needsCosine {
 				continue
 			}
-			if eng := engramByID[all[i].id]; eng != nil && len(eng.Embedding) > 0 {
-				all[i].vectorScore = float64(cosineSimilarity32(p1.embedding, eng.Embedding))
+			eng := engramByID[all[i].id]
+			if eng == nil {
+				continue
+			}
+			embed := eng.Embedding
+			if len(embed) == 0 {
+				// ERF v2 stores embeddings in a separate 0x18 key, so GetEngrams()
+				// above returns nil embeddings. Fall back to GetEmbedding() in
+				// that case -- same pattern as internal/consolidation/dedup.go
+				// and orient.go. Bounded to exactly this needsCosine candidate
+				// set, never the full result set.
+				if loaded, err := e.store.GetEmbedding(ctx, ws, eng.ID); err == nil && len(loaded) > 0 {
+					embed = loaded
+				}
+			}
+			if len(embed) > 0 {
+				all[i].vectorScore = float64(cosineSimilarity32(p1.embedding, embed))
 			}
 		}
 	}

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -1556,6 +1556,9 @@ func (e *ActivationEngine) phase6Score(
 				// that case -- same pattern as internal/consolidation/dedup.go
 				// and orient.go. Bounded to exactly this needsCosine candidate
 				// set, never the full result set.
+				// TODO(#714): if needsCosine pools grow, a batch
+				// GetEmbeddings([]ULID) would collapse these per-candidate point
+				// reads into one round-trip. Fine sequentially at current pool sizes.
 				if loaded, err := e.store.GetEmbedding(ctx, ws, eng.ID); err == nil && len(loaded) > 0 {
 					embed = loaded
 				}

--- a/internal/engine/activation/helpers_test.go
+++ b/internal/engine/activation/helpers_test.go
@@ -404,6 +404,11 @@ type internalStubStore struct {
 	assocs       map[storage.ULID][]storage.Association
 	recent       []storage.ULID
 	lastAccessNs map[storage.ULID]int64
+	// embeddings holds vectors reachable ONLY via GetEmbedding, modeling the
+	// ERF v2 separate 0x18 key. addEngramSeparateEmbedding populates this and
+	// strips eng.Embedding, faithfully reproducing the production GetEngrams/
+	// GetEmbedding loader split (see TestPhase6Score_FTSOnlyCandidate_LoaderGap).
+	embeddings map[storage.ULID][]float32
 }
 
 func newInternalStubStore() *internalStubStore {
@@ -411,7 +416,18 @@ func newInternalStubStore() *internalStubStore {
 		engrams:      make(map[storage.ULID]*storage.Engram),
 		assocs:       make(map[storage.ULID][]storage.Association),
 		lastAccessNs: make(map[storage.ULID]int64),
+		embeddings:   make(map[storage.ULID][]float32),
 	}
+}
+
+// addEngramSeparateEmbedding stores eng with its Embedding field stripped and
+// the vector filed away under embeddings instead -- reproducing ERF v2's
+// storage split where GetEngrams() never joins the 0x18 embedding key and
+// only GetEmbedding() can retrieve it.
+func (s *internalStubStore) addEngramSeparateEmbedding(eng *storage.Engram, embedding []float32) {
+	eng.Embedding = nil
+	s.addEngram(eng)
+	s.embeddings[eng.ID] = embedding
 }
 
 func (s *internalStubStore) addEngram(eng *storage.Engram) {
@@ -494,6 +510,13 @@ func (s *internalStubStore) VaultPrefix(_ string) [8]byte { return [8]byte{} }
 
 func (s *internalStubStore) EngramLastAccessNs(_ [8]byte, id storage.ULID) int64 {
 	return s.lastAccessNs[id]
+}
+
+// GetEmbedding returns the vector filed away under the separate embeddings
+// map (see addEngramSeparateEmbedding), mirroring PebbleStore.GetEmbedding's
+// 0x18-key read that GetEngrams never joins.
+func (s *internalStubStore) GetEmbedding(_ context.Context, _ [8]byte, id storage.ULID) ([]float32, error) {
+	return s.embeddings[id], nil
 }
 
 func (s *internalStubStore) EngramIDsByCreatedRange(_ context.Context, _ [8]byte, since, until time.Time, limit int) ([]storage.ULID, error) {
@@ -1540,6 +1563,67 @@ func TestPhase6Score_TraversedCandidateACTR_NonZeroScore(t *testing.T) {
 	}
 }
 
+// TestPhase6Score_TraversedCandidate_LoaderGap confirms the #714-A2 fix (fall
+// back to GetEmbedding when GetEngrams returns an empty Embedding) restores
+// cosine for the PRE-EXISTING BFS-traversed case too, not just the new
+// FTS-only case -- both share the exact same needsCosine fixup and the exact
+// same dead guard. Reproduces the ERF v2 loader split via
+// addEngramSeparateEmbedding, same as TestPhase6Score_FTSOnlyCandidate_LoaderGap.
+func TestPhase6Score_TraversedCandidate_LoaderGap(t *testing.T) {
+	store := newInternalStubStore()
+	e := newTestActivationEngine(store)
+	defer e.Close()
+
+	eng1 := &storage.Engram{
+		Concept: "microservices", Content: "Project Alpha uses microservices",
+		Confidence: 1.0, Stability: 30.0, State: storage.StateActive,
+		Embedding: []float32{1, 0, 0},
+	}
+	eng2 := &storage.Engram{
+		Concept: "scaling issues", Content: "Microservices cause scaling issues in our infrastructure",
+		Confidence: 1.0, Stability: 30.0, State: storage.StateActive,
+	}
+	store.addEngram(eng1)
+	// Traversed engram's embedding reachable ONLY via GetEmbedding, mirroring
+	// a real ERF v2 record loaded through GetEngrams.
+	store.addEngramSeparateEmbedding(eng2, []float32{0.6, 0.8, 0})
+
+	fused := []fusedCandidate{{id: eng1.ID, rrfScore: 0.5, vectorScore: 1.0, ftsScore: 1.5}}
+	traversed := []traversedCandidate{{
+		id:         eng2.ID,
+		propagated: 0.3,
+		hopPath:    []storage.ULID{eng1.ID, eng2.ID},
+		relType:    uint16(storage.RelSupports),
+	}}
+	p1 := &phase1Result{
+		queryStr:  "risks for Project Alpha",
+		embedding: []float32{1, 0, 0},
+	}
+
+	result, err := e.phase6Score(context.Background(), &ActivateRequest{
+		MaxResults: 10,
+		Threshold:  0.01,
+	}, [8]byte{}, fused, traversed, p1)
+	if err != nil {
+		t.Fatalf("phase6Score: %v", err)
+	}
+
+	var found bool
+	for _, a := range result.Activations {
+		if a.Engram.ID == eng2.ID {
+			found = true
+			if a.Components.SemanticSimilarity <= 0 {
+				t.Errorf("traversed candidate SemanticSimilarity = %v, want > 0 -- the GetEmbedding "+
+					"fallback must restore cosine for the traversed case exactly as it does for FTS-only",
+					a.Components.SemanticSimilarity)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("traversed candidate did not survive to the final result set")
+	}
+}
+
 // TestPhase6Score_FTSOnlyCandidate_NonZeroCosine is the RED-first repro for
 // scrypster/muninndb#714-A2: a candidate that enters the pool ONLY via the FTS
 // path (ftsScore > 0, never ranked into the HNSW top-K, not tag-seeded, not
@@ -1587,6 +1671,65 @@ func TestPhase6Score_FTSOnlyCandidate_NonZeroCosine(t *testing.T) {
 			found = true
 			if a.Components.SemanticSimilarity <= 0 {
 				t.Errorf("FTS-only candidate SemanticSimilarity = %v, want > 0 (real cosine against the query embedding, bug #714-A2)", a.Components.SemanticSimilarity)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("FTS-only candidate did not survive to the final result set")
+	}
+}
+
+// TestPhase6Score_FTSOnlyCandidate_LoaderGap is the RED-first repro for the
+// REAL #714-A2 bug: TestPhase6Score_FTSOnlyCandidate_NonZeroCosine above pre-
+// populates eng.Embedding directly on the stub, so it never exercises the
+// production loader split and passed even though production was broken.
+//
+// On real ERF v2 vaults, storage.PebbleStore.GetEngrams() does NOT join the
+// separate 0x18 embedding key -- it returns Embedding empty -- and only
+// storage.PebbleStore.GetEmbedding() can retrieve the vector (confirmed by a
+// standalone probe against a real vault). This test reproduces that split
+// exactly: the engram is stored via addEngramSeparateEmbedding, so GetEngrams
+// returns eng.Embedding == nil and only GetEmbedding(id) returns the vector.
+//
+// Before the fix (needsCosine guard checks only eng.Embedding, never falls
+// back to GetEmbedding), this FAILS: SemanticSimilarity == 0 despite a
+// perfect embedding match. After the fix it PASSES.
+func TestPhase6Score_FTSOnlyCandidate_LoaderGap(t *testing.T) {
+	store := newInternalStubStore()
+	e := newTestActivationEngine(store)
+	defer e.Close()
+
+	eng := &storage.Engram{
+		Concept: "RemittanceFile lifecycle", Content: "RemittanceFile lifecycle state machine",
+		Confidence: 1.0, Stability: 30.0, State: storage.StateActive,
+	}
+	// Embedding reachable ONLY via GetEmbedding -- eng.Embedding is nil after
+	// this call, exactly like a GetEngrams() load of an ERF v2 record.
+	store.addEngramSeparateEmbedding(eng, []float32{1, 0, 0})
+
+	fused := []fusedCandidate{{id: eng.ID, rrfScore: 0.5, ftsScore: 1.0}}
+	p1 := &phase1Result{
+		queryStr:  "RemittanceFile lifecycle state machine",
+		embedding: []float32{1, 0, 0},
+	}
+
+	result, err := e.phase6Score(context.Background(), &ActivateRequest{
+		MaxResults: 10,
+		Threshold:  0.01,
+	}, [8]byte{}, fused, nil, p1)
+	if err != nil {
+		t.Fatalf("phase6Score: %v", err)
+	}
+
+	var found bool
+	for _, a := range result.Activations {
+		if a.Engram.ID == eng.ID {
+			found = true
+			if a.Components.SemanticSimilarity <= 0 {
+				t.Errorf("FTS-only candidate SemanticSimilarity = %v, want > 0 -- GetEngrams returned an "+
+					"empty Embedding (as it does for real ERF v2 records) and the fixup must fall back to "+
+					"GetEmbedding() to find it, exactly as internal/consolidation/dedup.go and orient.go do",
+					a.Components.SemanticSimilarity)
 			}
 		}
 	}

--- a/internal/engine/activation/helpers_test.go
+++ b/internal/engine/activation/helpers_test.go
@@ -519,6 +519,17 @@ func (s *internalStubStore) GetEmbedding(_ context.Context, _ [8]byte, id storag
 	return s.embeddings[id], nil
 }
 
+// GetEmbeddings mirrors GetEmbedding but batched, returning vectors from the
+// same separate-embeddings map positionally aligned with ids -- faithfully
+// reproducing the ERF v2 split for a batch of ids in one call.
+func (s *internalStubStore) GetEmbeddings(_ context.Context, _ [8]byte, ids []storage.ULID) ([][]float32, error) {
+	out := make([][]float32, len(ids))
+	for i, id := range ids {
+		out[i] = s.embeddings[id]
+	}
+	return out, nil
+}
+
 func (s *internalStubStore) EngramIDsByCreatedRange(_ context.Context, _ [8]byte, since, until time.Time, limit int) ([]storage.ULID, error) {
 	return nil, nil
 }

--- a/internal/engine/activation/helpers_test.go
+++ b/internal/engine/activation/helpers_test.go
@@ -1540,6 +1540,61 @@ func TestPhase6Score_TraversedCandidateACTR_NonZeroScore(t *testing.T) {
 	}
 }
 
+// TestPhase6Score_FTSOnlyCandidate_NonZeroCosine is the RED-first repro for
+// scrypster/muninndb#714-A2: a candidate that enters the pool ONLY via the FTS
+// path (ftsScore > 0, never ranked into the HNSW top-K, not tag-seeded, not
+// BFS-traversed) keeps vectorScore=0 for its entire life in the pipeline unless
+// something computes it post-load. Before the fix, needsCosine only covered
+// isTraversed and inTagPool candidates, so an FTS-only match with a perfectly
+// good, highly-similar embedding silently reports semantic_similarity=0 — its
+// entire semantic evidence term is dropped from the ACT-R blend even though the
+// embedding was sitting right there once the engram was loaded.
+func TestPhase6Score_FTSOnlyCandidate_NonZeroCosine(t *testing.T) {
+	store := newInternalStubStore()
+	e := newTestActivationEngine(store)
+	defer e.Close()
+
+	// FTS-matched engram: not in the HNSW pool (vectorScore=0 in the fused
+	// candidate), not tag-seeded, not traversed -- but it DOES carry an
+	// embedding that is identical to the query embedding (cosine = 1.0).
+	eng := &storage.Engram{
+		Concept: "RemittanceFile lifecycle", Content: "RemittanceFile lifecycle state machine",
+		Confidence: 1.0, Stability: 30.0, State: storage.StateActive,
+		Embedding: []float32{1, 0, 0},
+	}
+	store.addEngram(eng)
+
+	// ftsScore > 0 (came from FTS), vectorScore left at its zero value exactly
+	// as phase3RRF's FTS loop (engine.go ~L971-975) produces it: only the
+	// vector-pool loop sets vectorScore, never the FTS loop.
+	fused := []fusedCandidate{{id: eng.ID, rrfScore: 0.5, ftsScore: 1.0}}
+	p1 := &phase1Result{
+		queryStr:  "RemittanceFile lifecycle state machine",
+		embedding: []float32{1, 0, 0},
+	}
+
+	result, err := e.phase6Score(context.Background(), &ActivateRequest{
+		MaxResults: 10,
+		Threshold:  0.01, // non-zero: proves score > 0, not just "engram passed nil-check"
+	}, [8]byte{}, fused, nil, p1)
+	if err != nil {
+		t.Fatalf("phase6Score: %v", err)
+	}
+
+	var found bool
+	for _, a := range result.Activations {
+		if a.Engram.ID == eng.ID {
+			found = true
+			if a.Components.SemanticSimilarity <= 0 {
+				t.Errorf("FTS-only candidate SemanticSimilarity = %v, want > 0 (real cosine against the query embedding, bug #714-A2)", a.Components.SemanticSimilarity)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("FTS-only candidate did not survive to the final result set")
+	}
+}
+
 // TestPhase6Score_TraversedCandidateACTR_NoEmbedding verifies backward compatibility:
 // traversed candidates without embeddings (or without a query embedding) still pass
 // through at threshold=0.0, preserving existing behaviour for deployments without HNSW.

--- a/internal/engine/activation/log.go
+++ b/internal/engine/activation/log.go
@@ -38,6 +38,22 @@ func (l *ActivationLog) getOrCreate(vaultID uint32) *vaultLog {
 	return v.(*vaultLog)
 }
 
+// ResetVault discards all recorded activation events for vaultID. Test-only:
+// production callers never call this — phase4HebbianBoost's cross-activation
+// priming ("was this candidate's associated target recently activated") is
+// intentional, unbounded spreading activation across a vault's real timeline.
+// A scripted test harness that fires many calls back-to-back to model
+// SEPARATE, independently-dedup'd agent sessions (see prospective_harness_test.go)
+// compresses what would be minutes/hours of real elapsed time into
+// milliseconds, so the recency-weighted half-life (3600s) never meaningfully
+// decays between "sessions" — every prior scripted call's results stay
+// maximally "recently activated" for the rest of the run, letting an armed
+// intention's own engram silently accumulate Hebbian boost from unrelated
+// earlier calls and outscore its own corroborator. See ActivationEngine.ResetLog.
+func (l *ActivationLog) ResetVault(vaultID uint32) {
+	l.vaults.Delete(vaultID)
+}
+
 // Record appends a new activation event to the vault-scoped ring buffer.
 func (l *ActivationLog) Record(entry LogEntry) {
 	vl := l.getOrCreate(entry.VaultID)

--- a/internal/engine/activation/phase6_cosine_realstore_test.go
+++ b/internal/engine/activation/phase6_cosine_realstore_test.go
@@ -47,12 +47,15 @@ func TestPhase6Score_FTSOnlyCandidate_RealStoreLoaderGap(t *testing.T) {
 		os.RemoveAll(dir)
 		t.Fatal(err)
 	}
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 128})
 	t.Cleanup(func() {
-		db.Close()
+		// Close the store (which closes the underlying db) rather than the raw
+		// db directly, so the counter-flush and other background workers stop
+		// before Pebble closes -- otherwise the flush goroutine races the db
+		// close and logs a recovered "unexpected panic in counter flush" WARN.
+		store.Close()
 		os.RemoveAll(dir)
 	})
-
-	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 128})
 	idx := fts.New(db)
 
 	ws := store.VaultPrefix("fts-cosine-loader-gap")

--- a/internal/engine/activation/phase6_cosine_realstore_test.go
+++ b/internal/engine/activation/phase6_cosine_realstore_test.go
@@ -1,0 +1,136 @@
+package activation_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/engine/activation"
+	"github.com/scrypster/muninndb/internal/index/fts"
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// TestPhase6Score_FTSOnlyCandidate_RealStoreLoaderGap is the RED-first repro
+// for the REAL #714-A2 bug against the ACTUAL production loader path -- no
+// stub. TestPhase6Score_FTSOnlyCandidate_NonZeroCosine (helpers_test.go) and
+// its stub-double companion TestPhase6Score_FTSOnlyCandidate_LoaderGap both
+// use in-memory stores; this test proves the bug against a real
+// *storage.PebbleStore, the same store type production wires into
+// activation.New (see muninn.go, cmd/muninn/server.go).
+//
+// Root cause: an engram written with WriteEngram(ctx, ws, eng) (eng.Embedding
+// set) lands as an ERF v2 record -- the 0x01 engram key holds no embedding
+// bytes at all; the vector goes to the separate 0x18 key
+// (storage.PebbleStore.WriteEngram, keys.EmbeddingKey). storage.PebbleStore.
+// GetEngrams (the hot-path bulk loader phase6Score uses) never joins 0x18 --
+// it returns Embedding empty for every engram, always. Only
+// storage.PebbleStore.GetEmbedding does the 0x18 read.
+//
+// This engram is made an FTS-only candidate: it is indexed into a real
+// fts.Index and no HNSW is wired (nil), so it can only ever enter the
+// candidate pool via the FTS path with vectorScore == 0. The query embedding
+// is supplied directly via ActivateRequest.Embedding (identical to the
+// engram's own embedding => cosine ~= 1.0 after int8 quantization), bypassing
+// the need for a real embedder.
+//
+// Before the fix, needsCosine's fixup reads eng.Embedding straight off the
+// GetEngrams result -- empty on a real store -- and never calls
+// GetEmbedding(), so SemanticSimilarity stays 0. This FAILS on current code
+// (guard dead) and PASSES once phase6Score falls back to GetEmbedding().
+func TestPhase6Score_FTSOnlyCandidate_RealStoreLoaderGap(t *testing.T) {
+	dir, err := os.MkdirTemp("", "muninndb-fts-cosine-loader-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := storage.OpenPebble(dir, storage.DefaultOptions())
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.RemoveAll(dir)
+	})
+
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 128})
+	idx := fts.New(db)
+
+	ws := store.VaultPrefix("fts-cosine-loader-gap")
+
+	// A distinctive query embedding -- what "the query" would have embedded to.
+	queryVec := []float32{0.6, 0.8, 0.0, 0.0}
+
+	eng := &storage.Engram{
+		Concept:   "RemittanceFile lifecycle",
+		Content:   "RemittanceFile lifecycle state machine handles pending, cleared, and reversed states.",
+		Embedding: queryVec, // identical to the query vector => cosine ~= 1.0
+	}
+	id, err := store.WriteEngram(context.Background(), ws, eng)
+	if err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+	eng.ID = id
+
+	// Sanity: confirm the production loader split actually holds on this
+	// vault BEFORE running the engine, so a future storage change that starts
+	// joining embeddings into GetEngrams doesn't make this test meaningless.
+	loaded, err := store.GetEngrams(context.Background(), ws, []storage.ULID{id})
+	if err != nil {
+		t.Fatalf("GetEngrams: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0] == nil {
+		t.Fatalf("GetEngrams: expected exactly one engram back, got %d", len(loaded))
+	}
+	if len(loaded[0].Embedding) != 0 {
+		t.Fatalf("GetEngrams unexpectedly returned a non-empty Embedding (len=%d) -- this test's premise "+
+			"(GetEngrams never joins the 0x18 key) no longer holds; re-verify against the current storage layer",
+			len(loaded[0].Embedding))
+	}
+	direct, err := store.GetEmbedding(context.Background(), ws, id)
+	if err != nil {
+		t.Fatalf("GetEmbedding: %v", err)
+	}
+	if len(direct) == 0 {
+		t.Fatalf("GetEmbedding returned no vector -- the embedding is not retrievable through ANY loader; " +
+			"this would be a different, deeper problem than the GetEngrams join gap")
+	}
+
+	if err := idx.IndexEngram(ws, [16]byte(id), eng.Concept, "", eng.Content, eng.Tags); err != nil {
+		t.Fatalf("IndexEngram: %v", err)
+	}
+
+	// No HNSW (nil): the candidate can only ever be FTS-only, vectorScore == 0
+	// in the fused pool. No embedder needed: the query embedding is supplied
+	// directly via ActivateRequest.Embedding.
+	eng2 := activation.New(store, activation.NewFTSAdapter(idx), nil, activation.NewNoopEmbedder())
+	defer eng2.Close()
+
+	result, err := eng2.Run(context.Background(), &activation.ActivateRequest{
+		VaultPrefix: ws,
+		Context:     []string{"RemittanceFile lifecycle state machine"},
+		Embedding:   queryVec,
+		Threshold:   0.01,
+		MaxResults:  10,
+		IncludeWhy:  true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var found bool
+	for _, a := range result.Activations {
+		if a.Engram.ID == id {
+			found = true
+			if a.Components.SemanticSimilarity <= 0 {
+				t.Errorf("FTS-only candidate (real PebbleStore) SemanticSimilarity = %v, want > 0 -- "+
+					"GetEngrams returned an empty Embedding for this ERF v2 record and phase6Score's "+
+					"fixup must fall back to GetEmbedding() to recover it",
+					a.Components.SemanticSimilarity)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("FTS-only candidate did not survive to the final result set; full result count=%d",
+			len(result.Activations))
+	}
+}

--- a/internal/engine/autoassoc/autoassoc.go
+++ b/internal/engine/autoassoc/autoassoc.go
@@ -65,6 +65,11 @@ type Worker struct {
 	fts     FTSIndex
 	metrics *Metrics
 	wg      sync.WaitGroup
+	// jobWG tracks in-flight+queued jobs (Add on successful Enqueue, Done
+	// after processJob returns). Separate from wg (which tracks the fixed
+	// pool of NumWorkers goroutines). Lets WaitIdle() block until the queue
+	// has been fully drained without stopping the worker pool.
+	jobWG   sync.WaitGroup
 	stopCtx context.Context
 }
 
@@ -88,12 +93,22 @@ func New(ctx context.Context, store Store, fts FTSIndex) *Worker {
 // Enqueue submits a job to the worker pool. If the queue is full, the job
 // is dropped (non-blocking) and the Dropped counter is incremented.
 func (w *Worker) Enqueue(job Job) {
+	w.jobWG.Add(1) // Add BEFORE the send so a concurrent WaitIdle() can't observe a false-idle gap.
 	select {
 	case w.jobs <- job:
 		w.metrics.Enqueued.Add(1)
 	default:
+		w.jobWG.Done() // never queued — nothing to wait for
 		w.metrics.Dropped.Add(1)
 	}
+}
+
+// WaitIdle blocks until every job enqueued so far has finished processing
+// (completed or errored). Test-only synchronization helper: production
+// callers never await this — write-time association is fire-and-forget by
+// design. It does not stop or otherwise alter the worker pool's scheduling.
+func (w *Worker) WaitIdle() {
+	w.jobWG.Wait()
 }
 
 // Stop drains all pending jobs and waits for in-flight work to complete.
@@ -123,6 +138,7 @@ func (w *Worker) run() {
 			w.metrics.Completed.Add(1)
 		}
 		cancel()
+		w.jobWG.Done()
 	}
 }
 

--- a/internal/engine/autoassoc/autoassoc.go
+++ b/internal/engine/autoassoc/autoassoc.go
@@ -130,15 +130,25 @@ func (w *Worker) GetMetrics() (enqueued, completed, dropped, errors int64) {
 func (w *Worker) run() {
 	defer w.wg.Done()
 	for job := range w.jobs {
-		ctx, cancel := context.WithTimeout(w.stopCtx, JobTimeout)
-		if err := w.processJob(ctx, job); err != nil {
-			w.metrics.Errors.Add(1)
-			slog.Warn("autoassoc job failed", "err", err)
-		} else {
-			w.metrics.Completed.Add(1)
-		}
-		cancel()
-		w.jobWG.Done()
+		w.runJob(job)
+	}
+}
+
+// runJob processes a single job. Done() and cancel() are deferred (rather
+// than called as plain statements after processJob returns) so they still
+// fire if processJob ever panics — otherwise a panicking job would leak an
+// un-Done() jobWG entry and hang a subsequent WaitIdle() forever. This does
+// not add a recover(): a panic still propagates and crashes the process,
+// it only makes the bookkeeping robust if one unwinds through here.
+func (w *Worker) runJob(job Job) {
+	defer w.jobWG.Done()
+	ctx, cancel := context.WithTimeout(w.stopCtx, JobTimeout)
+	defer cancel()
+	if err := w.processJob(ctx, job); err != nil {
+		w.metrics.Errors.Add(1)
+		slog.Warn("autoassoc job failed", "err", err)
+	} else {
+		w.metrics.Completed.Add(1)
 	}
 }
 

--- a/internal/engine/autoassoc/goal.go
+++ b/internal/engine/autoassoc/goal.go
@@ -92,11 +92,17 @@ func (w *GoalLinkWorker) run() {
 	defer w.wg.Done()
 	for job := range w.jobs {
 		w.process(job)
-		w.jobWG.Done()
 	}
 }
 
+// process handles a single job. jobWG.Done() is deferred here (rather than
+// called as a plain statement in run() after process returns) so it still
+// fires if process ever panics — otherwise a panicking job would leak an
+// un-Done() jobWG entry and hang a subsequent WaitIdle() forever. This does
+// not add a recover(): a panic still propagates and crashes the process, it
+// only makes the bookkeeping robust if one unwinds through here.
 func (w *GoalLinkWorker) process(job GoalJob) {
+	defer w.jobWG.Done()
 	if w.hnsw == nil {
 		slog.Warn("goal_link: hnsw index not initialized, skipping", "id", storage.ULID(job.ID).String())
 		return

--- a/internal/engine/autoassoc/goal.go
+++ b/internal/engine/autoassoc/goal.go
@@ -41,10 +41,13 @@ type GoalHNSW interface {
 // For each new TypeGoal engram, it queries HNSW for topK=5 neighbors with
 // cosine similarity >= 0.6 and creates RelSupports associations.
 type GoalLinkWorker struct {
-	jobs    chan GoalJob
-	store   GoalStore
-	hnsw    GoalHNSW
-	wg      sync.WaitGroup
+	jobs  chan GoalJob
+	store GoalStore
+	hnsw  GoalHNSW
+	wg    sync.WaitGroup
+	// jobWG tracks in-flight+queued jobs; see Worker.jobWG in autoassoc.go
+	// for the same pattern. Lets WaitIdle() block deterministically.
+	jobWG   sync.WaitGroup
 	stopCtx context.Context
 }
 
@@ -64,11 +67,19 @@ func NewGoalLinkWorker(ctx context.Context, store GoalStore, hnswIdx GoalHNSW) *
 
 // EnqueueGoalJob submits a job. If the queue is full, the job is dropped silently.
 func (w *GoalLinkWorker) EnqueueGoalJob(job GoalJob) {
+	w.jobWG.Add(1) // Add BEFORE the send so a concurrent WaitIdle() can't observe a false-idle gap.
 	select {
 	case w.jobs <- job:
 	default:
+		w.jobWG.Done() // never queued — nothing to wait for
 		slog.Warn("goal_link: job queue full, dropping", "id", storage.ULID(job.ID).String())
 	}
+}
+
+// WaitIdle blocks until every job enqueued so far has finished processing.
+// Test-only synchronization helper; see Worker.WaitIdle in autoassoc.go.
+func (w *GoalLinkWorker) WaitIdle() {
+	w.jobWG.Wait()
 }
 
 // Stop drains the queue and waits for the worker to finish.
@@ -81,6 +92,7 @@ func (w *GoalLinkWorker) run() {
 	defer w.wg.Done()
 	for job := range w.jobs {
 		w.process(job)
+		w.jobWG.Done()
 	}
 }
 

--- a/internal/engine/autoassoc/neighbor.go
+++ b/internal/engine/autoassoc/neighbor.go
@@ -123,15 +123,25 @@ func (w *NeighborWorker) GetNeighborMetrics() (enqueued, completed, dropped, err
 func (w *NeighborWorker) run() {
 	defer w.wg.Done()
 	for job := range w.jobs {
-		ctx, cancel := context.WithTimeout(w.stopCtx, neighborJobTimeout)
-		if err := w.processNeighborJob(ctx, job); err != nil {
-			w.metrics.Errors.Add(1)
-			slog.Warn("neighbor worker job failed", "err", err)
-		} else {
-			w.metrics.Completed.Add(1)
-		}
-		cancel()
-		w.jobWG.Done()
+		w.runJob(job)
+	}
+}
+
+// runJob processes a single job. Done() and cancel() are deferred (rather
+// than called as plain statements after processNeighborJob returns) so they
+// still fire if the job ever panics — otherwise a panicking job would leak
+// an un-Done() jobWG entry and hang a subsequent WaitIdle() forever. This
+// does not add a recover(): a panic still propagates and crashes the
+// process, it only makes the bookkeeping robust if one unwinds through here.
+func (w *NeighborWorker) runJob(job NeighborJob) {
+	defer w.jobWG.Done()
+	ctx, cancel := context.WithTimeout(w.stopCtx, neighborJobTimeout)
+	defer cancel()
+	if err := w.processNeighborJob(ctx, job); err != nil {
+		w.metrics.Errors.Add(1)
+		slog.Warn("neighbor worker job failed", "err", err)
+	} else {
+		w.metrics.Completed.Add(1)
 	}
 }
 

--- a/internal/engine/autoassoc/neighbor.go
+++ b/internal/engine/autoassoc/neighbor.go
@@ -56,6 +56,9 @@ type NeighborWorker struct {
 	hnsw    NeighborHNSW
 	metrics *NeighborMetrics
 	wg      sync.WaitGroup
+	// jobWG tracks in-flight+queued jobs; see Worker.jobWG in autoassoc.go
+	// for the same pattern. Lets WaitIdle() block deterministically.
+	jobWG   sync.WaitGroup
 	stopCtx context.Context
 }
 
@@ -81,16 +84,24 @@ func NewNeighborWorker(ctx context.Context, store NeighborStore, hnsw NeighborHN
 // the job is dropped (non-blocking) and the Dropped counter is incremented.
 // Drops are logged at powers of 2.
 func (w *NeighborWorker) EnqueueNeighborJob(job NeighborJob) {
+	w.jobWG.Add(1) // Add BEFORE the send so a concurrent WaitIdle() can't observe a false-idle gap.
 	select {
 	case w.jobs <- job:
 		w.metrics.Enqueued.Add(1)
 	default:
+		w.jobWG.Done() // never queued — nothing to wait for
 		dropped := w.metrics.Dropped.Add(1)
 		// Log at powers of 2: 1, 2, 4, 8, 16, ...
 		if dropped&(dropped-1) == 0 {
 			slog.Warn("neighbor worker queue full, dropping job", "dropped", dropped)
 		}
 	}
+}
+
+// WaitIdle blocks until every job enqueued so far has finished processing.
+// Test-only synchronization helper; see Worker.WaitIdle in autoassoc.go.
+func (w *NeighborWorker) WaitIdle() {
+	w.jobWG.Wait()
 }
 
 // Stop drains all pending jobs and waits for in-flight work to complete.
@@ -120,6 +131,7 @@ func (w *NeighborWorker) run() {
 			w.metrics.Completed.Add(1)
 		}
 		cancel()
+		w.jobWG.Done()
 	}
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -757,21 +757,25 @@ func (e *Engine) spawnJob(fn func()) bool {
 	return true
 }
 
-// waitWriteTimeAssocWorkersIdle blocks until the three write-time
-// association workers (autoAssoc, neighborWorker, goalLinkWorker) have
-// finished every job enqueued so far. These run fire-and-forget off the
-// Write() hot path (see the Intend/Write enqueue sites) and normal callers
-// never await them — recall tolerates their eventual consistency by design.
+// waitWriteTimeIdle blocks until every write-time async worker has finished
+// the work enqueued so far: the three association workers (autoAssoc,
+// neighborWorker, goalLinkWorker) AND the FTS indexer (ftsWorker), all of
+// which run off the Write() hot path (see the Intend/Write enqueue sites) so
+// normal callers never await them — recall tolerates their eventual
+// consistency by design.
 //
 // Test-only synchronization helper: the prospective acceptance harness arms
 // intentions via Intend() (which calls Write()) and then immediately runs
-// scripted Activate() calls whose BFS candidate pool depends on associations
-// (e.g. RelSupports) these workers create. Without draining, the harness was
-// racing the same fire-and-forget workers production code is allowed to race
-// — but the harness must observe steady state before asserting recall.
-// Production scheduling/dispatch behavior is unchanged; this only adds the
-// ability to await it.
-func (e *Engine) waitWriteTimeAssocWorkersIdle() {
+// scripted Activate() calls that depend both on associations these workers
+// create (RelSupports for the BFS pool) AND on the intention being FTS-indexed
+// (the only recall path with the harness's noop zero-vector embeddings). Async
+// FTS indexing is decoupled from the write hot path (ftsWorker), so without
+// flushing it a scripted call can run before its intention is searchable and
+// the intention silently "does not fire" — the residual harness flake under
+// -race/CPU contention. Draining all of it makes the harness observe steady
+// state before asserting recall. Production scheduling/dispatch is unchanged;
+// this only adds the ability to await it.
+func (e *Engine) waitWriteTimeIdle() {
 	if e.autoAssoc != nil {
 		e.autoAssoc.WaitIdle()
 	}
@@ -780,6 +784,11 @@ func (e *Engine) waitWriteTimeAssocWorkersIdle() {
 	}
 	if e.goalLinkWorker != nil {
 		e.goalLinkWorker.WaitIdle()
+	}
+	if e.ftsWorker != nil {
+		// Best-effort in a test helper; the timeout is generous enough that it
+		// never trips for the handful of intentions the harness arms.
+		_ = e.ftsWorker.Flush(10 * time.Second)
 	}
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -745,6 +745,32 @@ func (e *Engine) spawnJob(fn func()) bool {
 	return true
 }
 
+// waitWriteTimeAssocWorkersIdle blocks until the three write-time
+// association workers (autoAssoc, neighborWorker, goalLinkWorker) have
+// finished every job enqueued so far. These run fire-and-forget off the
+// Write() hot path (see the Intend/Write enqueue sites) and normal callers
+// never await them — recall tolerates their eventual consistency by design.
+//
+// Test-only synchronization helper: the prospective acceptance harness arms
+// intentions via Intend() (which calls Write()) and then immediately runs
+// scripted Activate() calls whose BFS candidate pool depends on associations
+// (e.g. RelSupports) these workers create. Without draining, the harness was
+// racing the same fire-and-forget workers production code is allowed to race
+// — but the harness must observe steady state before asserting recall.
+// Production scheduling/dispatch behavior is unchanged; this only adds the
+// ability to await it.
+func (e *Engine) waitWriteTimeAssocWorkersIdle() {
+	if e.autoAssoc != nil {
+		e.autoAssoc.WaitIdle()
+	}
+	if e.neighborWorker != nil {
+		e.neighborWorker.WaitIdle()
+	}
+	if e.goalLinkWorker != nil {
+		e.goalLinkWorker.WaitIdle()
+	}
+}
+
 // beginVaultOp tracks synchronous vault-operation setup work that can still
 // touch Pebble before handing off to a tracked background job. Returns false if
 // the engine is shutting down and the caller should fail fast.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -726,6 +726,18 @@ func (e *Engine) spawnFireAndForget(fn func()) bool {
 	return true
 }
 
+// waitFireAndForgetIdle blocks until every fire-and-forget goroutine spawned
+// so far (RecordFeedback's scoring/TouchAccess writes, Read's reinforcement
+// signal) has finished. Test-only synchronization helper, mirroring
+// autoassoc.Worker.WaitIdle: production callers never await this —
+// fire-and-forget work is deliberately unawaited on the request path.
+// Safe to call only when the caller knows no *other* concurrent request on
+// this Engine is still spawning fire-and-forget work, since the WaitGroup is
+// shared across all callers of spawnFireAndForget.
+func (e *Engine) waitFireAndForgetIdle() {
+	e.fireAndForgetWG.Wait()
+}
+
 // spawnJob tracks fn in the engine's job WaitGroup and launches it as a
 // goroutine. Returns false without spawning if the engine is shutting down.
 // Callers MUST fail the associated job immediately when false is returned.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -762,7 +762,9 @@ func (e *Engine) spawnJob(fn func()) bool {
 // neighborWorker, goalLinkWorker) AND the FTS indexer (ftsWorker), all of
 // which run off the Write() hot path (see the Intend/Write enqueue sites) so
 // normal callers never await them — recall tolerates their eventual
-// consistency by design.
+// consistency by design. It also drains the activation engine's async log
+// drainer (see below) — not a write-time worker, but folded in here so the
+// harness has a single drain call to make between scripted steps.
 //
 // Test-only synchronization helper: the prospective acceptance harness arms
 // intentions via Intend() (which calls Write()) and then immediately runs
@@ -775,6 +777,18 @@ func (e *Engine) spawnJob(fn func()) bool {
 // -race/CPU contention. Draining all of it makes the harness observe steady
 // state before asserting recall. Production scheduling/dispatch is unchanged;
 // this only adds the ability to await it.
+//
+// activation.WaitLogIdle (drainLog/logCh): Run() submits each activation's
+// result set to a buffered channel that a single goroutine drains into
+// assocLog, which phase4HebbianBoost reads on the NEXT call to boost
+// candidates associated with something recently activated. The drainer's
+// eventual consistency ("~1ms lag, half-life 3600s — irrelevant", per its
+// doc comment) is production-safe but breaks a scripted back-to-back
+// harness: call N's log entry can still be in flight when call N+1 runs
+// phase4HebbianBoost, so the same candidate nondeterministically scores with
+// or without that boost — flipping which of two near-tied candidates ranks
+// first (and, downstream, whether NoticesForRecall sees the corroborator or
+// the intention's own engram at rank 0). Refs #722.
 func (e *Engine) waitWriteTimeIdle() {
 	if e.autoAssoc != nil {
 		e.autoAssoc.WaitIdle()
@@ -790,6 +804,22 @@ func (e *Engine) waitWriteTimeIdle() {
 		// never trips for the handful of intentions the harness arms.
 		_ = e.ftsWorker.Flush(10 * time.Second)
 	}
+	if e.activation != nil {
+		e.activation.WaitLogIdle()
+	}
+}
+
+// resetActivationLogForVault clears the activation engine's recorded recent-
+// activations for vault (see activation.ActivationLog.ResetVault). Test-only:
+// callers MUST have already called waitWriteTimeIdle (or otherwise know no
+// Activate() on this vault has an entry still in flight to the log drainer),
+// or the reset can be immediately undone by a late-arriving drain.
+func (e *Engine) resetActivationLogForVault(vault string) {
+	if e.activation == nil {
+		return
+	}
+	ws := e.store.ResolveVaultPrefix(vault)
+	e.activation.ResetLog(wsVaultID(ws))
 }
 
 // beginVaultOp tracks synchronous vault-operation setup work that can still

--- a/internal/engine/engine_reinforcement_test.go
+++ b/internal/engine/engine_reinforcement_test.go
@@ -127,8 +127,10 @@ func TestRead_ReadOnly_NoReinforce(t *testing.T) {
 		}
 	}
 
-	// Give any (incorrectly) spawned fire-and-forget goroutine time to land.
-	time.Sleep(200 * time.Millisecond)
+	// Give any (incorrectly) spawned fire-and-forget goroutine time to land,
+	// deterministically rather than via a fixed sleep (flakes under CPU
+	// contention).
+	eng.waitFireAndForgetIdle()
 
 	resp, err := eng.Read(ctx, &mbp.ReadRequest{Vault: "reinforce-readonly", ID: w.ID, ReadOnly: true})
 	if err != nil {
@@ -153,6 +155,11 @@ func TestFeedbackUseful_BumpsAccessCount(t *testing.T) {
 	if err := eng.RecordFeedback(ctx, "feedback-touch", wTrue.ID, true); err != nil {
 		t.Fatalf("RecordFeedback(true): %v", err)
 	}
+	// RecordFeedback's TouchAccess write rides a fire-and-forget goroutine
+	// (#682); await it deterministically instead of polling with a fixed
+	// deadline, which flakes under CPU contention (constrained CI cores,
+	// -race) when the goroutine isn't scheduled in time.
+	eng.waitFireAndForgetIdle()
 	got := pollAccessCount(t, eng, "feedback-touch", wTrue.ID, 1, 2*time.Second)
 	if got != 1 {
 		t.Fatalf("AccessCount after RecordFeedback(true) = %d, want 1", got)
@@ -165,7 +172,10 @@ func TestFeedbackUseful_BumpsAccessCount(t *testing.T) {
 	if err := eng.RecordFeedback(ctx, "feedback-touch", wFalse.ID, false); err != nil {
 		t.Fatalf("RecordFeedback(false): %v", err)
 	}
-	time.Sleep(200 * time.Millisecond)
+	// useful=false still spawns a fire-and-forget scoring-signal goroutine
+	// (just no TouchAccess); await it deterministically rather than sleeping
+	// a fixed duration before asserting the negative (AccessCount == 0).
+	eng.waitFireAndForgetIdle()
 	resp, err := eng.Read(ctx, &mbp.ReadRequest{Vault: "feedback-touch", ID: wFalse.ID, ReadOnly: true})
 	if err != nil {
 		t.Fatalf("Read: %v", err)
@@ -199,7 +209,9 @@ func TestRecall_DoesNotReinforce(t *testing.T) {
 		}
 	}
 
-	time.Sleep(200 * time.Millisecond)
+	// Deterministic wait for any (incorrectly) spawned fire-and-forget
+	// reinforcement goroutine, instead of a fixed sleep (flakes under load).
+	eng.waitFireAndForgetIdle()
 	resp, err := eng.Read(ctx, &mbp.ReadRequest{Vault: "recall-noreinforce", ID: w.ID, ReadOnly: true})
 	if err != nil {
 		t.Fatalf("Read: %v", err)
@@ -245,7 +257,10 @@ func TestReinforce_DoesNotEscalateTrust(t *testing.T) {
 	}
 
 	pollAccessCount(t, eng, "trust-noescalate", w.ID, 1, 2*time.Second)
-	time.Sleep(200 * time.Millisecond)
+	// pollAccessCount only guarantees the FIRST reinforcement landed; wait
+	// deterministically for all 10 RecordFeedback fire-and-forget goroutines
+	// to finish before asserting trust never moved, instead of a fixed sleep.
+	eng.waitFireAndForgetIdle()
 
 	final, err := eng.GetEngram(ctx, "trust-noescalate", mustParseULID(t, w.ID))
 	if err != nil {

--- a/internal/engine/prospective_harness_test.go
+++ b/internal/engine/prospective_harness_test.go
@@ -148,6 +148,26 @@ func runProspectiveHarness(t *testing.T, enabled bool) harnessResult {
 		if err != nil {
 			t.Fatalf("call %d Activate: %v", ci, err)
 		}
+		// Drain this call's activation-log submission (drainLog/logCh, see
+		// waitWriteTimeIdle) and then clear it before the NEXT scripted call
+		// runs. phase4HebbianBoost reads the activation log for "was this
+		// candidate's associated target recently activated" — real sessions
+		// are minutes/hours apart, so the log's 3600s recency half-life
+		// normally decays this to ~0 between them. This harness fires 60
+		// calls back-to-back in milliseconds, so without resetting, every
+		// prior call's results stay maximally "recent" for the rest of the
+		// run: an armed intention shares its "prospective" tag with the
+		// other 11 (autoassoc.go links same-tagged engrams), so once ANY
+		// sibling intention has appeared in an earlier call's results, later
+		// intentions accumulate Hebbian boost from that unrelated call and
+		// can outscore their OWN corroborator — which, via the #693
+		// self-focality guard, silently drops their own notice. Draining
+		// (so no in-flight entry survives the reset) then resetting models
+		// the harness's own stated "separate agent session" per call
+		// (see the file doc comment) instead of leaking priming across
+		// them — the residual #722 flake this closes.
+		eng.waitWriteTimeIdle()
+		eng.resetActivationLogForVault(vault)
 
 		dumpResults := func() string {
 			s := ""
@@ -190,7 +210,7 @@ func runProspectiveHarness(t *testing.T, enabled bool) harnessResult {
 			if hit {
 				res.shouldFireHit++
 			} else if enabled {
-				t.Logf("call %d (%q): expected intention %d did not fire (results=%d)", ci, call.Context, call.Want, len(resp.Activations))
+				t.Logf("call %d (%q): expected intention %d did not fire (results=%d) real:%s", ci, call.Context, call.Want, len(resp.Activations), dumpResults())
 			}
 		case "trap":
 			for _, n := range notices {

--- a/internal/engine/prospective_harness_test.go
+++ b/internal/engine/prospective_harness_test.go
@@ -129,7 +129,7 @@ func runProspectiveHarness(t *testing.T, enabled bool) harnessResult {
 	// harness nondeterministically raced its own async write-time workers
 	// under scheduler pressure (flaky under -race/CPU load on every branch,
 	// not specific to any feature change) — see #722.
-	eng.waitWriteTimeAssocWorkersIdle()
+	eng.waitWriteTimeIdle()
 
 	var res harnessResult
 	for ci, call := range sc.Calls {

--- a/internal/engine/prospective_harness_test.go
+++ b/internal/engine/prospective_harness_test.go
@@ -120,6 +120,17 @@ func runProspectiveHarness(t *testing.T, enabled bool) harnessResult {
 		intentionIDs[i] = id
 	}
 
+	// Deterministically drain the write-time association workers (autoAssoc,
+	// neighborWorker, goalLinkWorker) before the scripted calls. Intend()
+	// writes each intention through the normal Write() path, which enqueues
+	// fire-and-forget jobs to those workers; the BFS candidate pool the
+	// scripted Activate() calls traverse depends on associations (e.g.
+	// RelSupports from goalLinkWorker) those jobs create. Without this the
+	// harness nondeterministically raced its own async write-time workers
+	// under scheduler pressure (flaky under -race/CPU load on every branch,
+	// not specific to any feature change) — see #722.
+	eng.waitWriteTimeAssocWorkersIdle()
+
 	var res harnessResult
 	for ci, call := range sc.Calls {
 		resp, err := eng.Activate(ctx, &mbp.ActivateRequest{

--- a/internal/storage/engram.go
+++ b/internal/storage/engram.go
@@ -857,6 +857,39 @@ func (ps *PebbleStore) GetEmbedding(ctx context.Context, wsPrefix [8]byte, id UL
 	return erf.Dequantize(quantized, params), nil
 }
 
+// GetEmbeddings reads the quantized embeddings from the 0x18 standalone keys (ERF v2)
+// for a batch of engrams in a single round-trip (via MultiGet), instead of one
+// point-read per id. The returned slice is positionally aligned with ids: entry i
+// is the dequantized vector for ids[i], or nil if no embedding is stored for that
+// id. An unknown id is treated exactly like a missing embedding (nil, no error) --
+// GetEmbedding's own convention -- never an error for a single absent id.
+func (ps *PebbleStore) GetEmbeddings(ctx context.Context, wsPrefix [8]byte, ids []ULID) ([][]float32, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	keyList := make([][]byte, len(ids))
+	for i, id := range ids {
+		keyList[i] = keys.EmbeddingKey(wsPrefix, [16]byte(id))
+	}
+	vals, err := MultiGet(ps.db, keyList)
+	if err != nil {
+		return nil, fmt.Errorf("get embeddings: %w", err)
+	}
+	out := make([][]float32, len(ids))
+	for i, val := range vals {
+		if val == nil || len(val) < 8 {
+			continue // no embedding stored
+		}
+		params := erf.DecodeQuantizeParams([8]byte(val[:8]))
+		quantized := make([]int8, len(val)-8)
+		for j := range quantized {
+			quantized[j] = int8(val[8+j])
+		}
+		out[i] = erf.Dequantize(quantized, params)
+	}
+	return out, nil
+}
+
 // GetConfidence reads the confidence value from 0x02 metadata for an engram.
 func (ps *PebbleStore) GetConfidence(ctx context.Context, wsPrefix [8]byte, id ULID) (float32, error) {
 	key := keys.MetaKey(wsPrefix, [16]byte(id))

--- a/internal/storage/engram_test.go
+++ b/internal/storage/engram_test.go
@@ -291,6 +291,104 @@ func TestGetEmbedding_Roundtrip(t *testing.T) {
 	}
 }
 
+// TestGetEmbeddings_MatchesIndividualReads writes several engrams (some with
+// embeddings, some without, via ERF v2), then confirms GetEmbeddings returns
+// vectors positionally aligned with the requested ids and equal to what N
+// individual GetEmbedding calls would return -- including a nil/empty slot for
+// an id with no stored embedding and an unknown id mixed into the batch.
+func TestGetEmbeddings_MatchesIndividualReads(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("getembeddings-batch")
+
+	vecA := []float32{0.1, 0.5, -0.3, 0.9, -0.7}
+	vecB := []float32{-0.2, 0.4, 0.6, -0.8, 0.1}
+
+	idA, err := store.WriteEngram(ctx, ws, &Engram{Concept: "a", Content: "a-content", Embedding: vecA})
+	if err != nil {
+		t.Fatalf("WriteEngram A: %v", err)
+	}
+	idB, err := store.WriteEngram(ctx, ws, &Engram{Concept: "b", Content: "b-content", Embedding: vecB})
+	if err != nil {
+		t.Fatalf("WriteEngram B: %v", err)
+	}
+	// No embedding at all.
+	idNoEmbed := writeTestEngram(t, store, ws, "no-embed", "no-embed-content")
+	// Never written -- unknown id.
+	idUnknown := NewULID()
+
+	ids := []ULID{idA, idNoEmbed, idB, idUnknown}
+	batch, err := store.GetEmbeddings(ctx, ws, ids)
+	if err != nil {
+		t.Fatalf("GetEmbeddings: %v", err)
+	}
+	if len(batch) != len(ids) {
+		t.Fatalf("GetEmbeddings returned %d entries, want %d", len(batch), len(ids))
+	}
+
+	// Positional checks against individual GetEmbedding calls.
+	for i, id := range ids {
+		individual, err := store.GetEmbedding(ctx, ws, id)
+		if err != nil {
+			t.Fatalf("GetEmbedding(%d): %v", i, err)
+		}
+		if len(batch[i]) != len(individual) {
+			t.Fatalf("id %d: batch len %d != individual len %d", i, len(batch[i]), len(individual))
+		}
+		for j := range individual {
+			if batch[i][j] != individual[j] {
+				t.Errorf("id %d component %d: batch %v != individual %v", i, j, batch[i][j], individual[j])
+			}
+		}
+	}
+
+	// idNoEmbed and idUnknown must both be nil/empty, never an error.
+	if len(batch[1]) != 0 {
+		t.Errorf("expected empty embedding for engram with no embedding, got len %d", len(batch[1]))
+	}
+	if len(batch[3]) != 0 {
+		t.Errorf("expected empty embedding for unknown id, got len %d", len(batch[3]))
+	}
+
+	// idA and idB must round-trip within quantization tolerance.
+	const tolerance = 0.02
+	for _, pair := range []struct {
+		got, want []float32
+	}{
+		{batch[0], vecA},
+		{batch[2], vecB},
+	} {
+		if len(pair.got) != len(pair.want) {
+			t.Fatalf("length mismatch: got %d, want %d", len(pair.got), len(pair.want))
+		}
+		for i := range pair.want {
+			diff := pair.got[i] - pair.want[i]
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff > tolerance {
+				t.Errorf("component %d: got %v, want %v (diff > tolerance)", i, pair.got[i], pair.want[i])
+			}
+		}
+	}
+}
+
+// TestGetEmbeddings_Empty verifies GetEmbeddings handles an empty id slice
+// without error.
+func TestGetEmbeddings_Empty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("getembeddings-empty")
+
+	got, err := store.GetEmbeddings(ctx, ws, nil)
+	if err != nil {
+		t.Fatalf("GetEmbeddings(nil): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty result for empty id slice, got len %d", len(got))
+	}
+}
+
 // ---------------------------------------------------------------------------
 // DeleteEngram
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`storage.PebbleStore.GetEngrams` — the hot-path bulk loader `activation.phase6Score` uses — never joins the separate `0x18` embedding key for **ERF v2** records (the current standard on-disk format). It returns `Embedding` empty for every engram, always.

Because `phase6Score`'s post-load cosine fixup is guarded on `len(eng.Embedding) > 0`, that guard was **permanently false in production**, so the entire fixup was dead for **all** post-load cosine cases — FTS-only, tag-pool, *and* traversed candidates. Those candidates silently scored `semantic_similarity = 0`, dropping their whole semantic term from the ACT-R content gate (COG-5) — a silently-wrong recall result, the project's worst failure class.

This was found by measuring an earlier paper-correct version on the real vault: it passed its unit test (a stub store pre-populated `Embedding`, never exercising the real loader) yet changed nothing on real data.

## Fix

Follow the existing in-tree precedent (`internal/consolidation/dedup.go`, `orient.go`, which already work around exactly this): add `GetEmbedding` to the `ActivationStore` interface and, in the `needsCosine` loop, fall back to `store.GetEmbedding(ctx, ws, id)` when `eng.Embedding` is empty. Bounded strictly to the `needsCosine` candidate set (never the full result set). `GetEngrams` itself is untouched — its lazy-load is intentional (embeddings are large; it's a hot path).

## Evidence (measured on a 3,296-memory real vault clone, control @ `bcb713f` vs fix)

- **Target candidate**: `semantic_similarity` **0 → 0.571**, rank ~47th → #6, nothing displaced.
- Broad restoration across FTS-only candidates (e.g. database-schema 0 → 0.191, session-management 0 → 0.160/0.156).
- **No genuine right-answer demoted** below a distractor. One correctly-directed reorder (a candidate whose *real* restored cosine is ~0 fell; one with real 0.156 rose).
- **Zero new abstention-floor breaches** — all nonsense queries behave identically to control.
- Genuine-vs-nonsense score gap **widens** (schema 0.297 → 0.589, session 0.468 → 0.735) or holds; never narrows.

## Tests (RED-first, all shown to fail without the fix)

- `TestPhase6Score_FTSOnlyCandidate_RealStoreLoaderGap` — real `*storage.PebbleStore` + real `fts.Index`, writes through `WriteEngram` so the record lands as ERF v2, with an in-test guard that fails loudly if a future storage change ever starts joining `0x18` into `GetEngrams` (so the repro can't silently rot).
- `TestPhase6Score_FTSOnlyCandidate_LoaderGap` — stub double faithfully reproducing the `GetEngrams`-empty / `GetEmbedding`-returns-vector split.
- `TestPhase6Score_TraversedCandidate_LoaderGap` — confirms the pre-existing traversed case is restored too.

`go build/vet -tags localassets ./...` clean, `gofmt` clean, `-race` clean on activation + storage.

Refs #714.
