### PR TITLE
docs(guide): use muninn_evolve, not repeated remember, for superseding facts

### DIFF
--- a/internal/mcp/guide.go
+++ b/internal/mcp/guide.go
@@ -151,7 +151,16 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 	b.WriteString("**Good:** Three separate memories:\n")
 	b.WriteString("  1. \"Decided on JWTs with 15-minute expiry for authentication\" (type: decision)\n")
 	b.WriteString("  2. \"Tom is implementing the auth system\" (type: task)\n")
-	b.WriteString("  3. \"API rate limit set to 100 requests/second per client\" (type: decision)\n")
+	b.WriteString("  3. \"API rate limit set to 100 requests/second per client\" (type: decision)\n\n")
+	b.WriteString("**Updating vs. creating.** If you are re-asserting or updating a fact that changes or replaces a prior version of the same thing ")
+	b.WriteString("(a re-run score, a corrected status, a fact that went stale), call `muninn_evolve(id, new_content, reason)` — not `muninn_remember`. ")
+	b.WriteString("Evolve links the new engram to the old one with a `supersedes` association and soft-deletes the predecessor, so the old version ")
+	b.WriteString("drops out of present-tense recall entirely (it is never destroyed — `as_of` still sees it). Calling `muninn_remember` again for the ")
+	b.WriteString("same fact instead creates a brand-new, unlinked engram: nothing tells recall the old one is stale, so every prior copy stays fully ")
+	b.WriteString("active and keeps competing for rank. Reserve `muninn_remember` for genuinely NEW atomic facts; use `muninn_evolve` for anything that ")
+	b.WriteString("supersedes what's already stored. This matters most for bulk or repeated-write pipelines that re-run over the same entities (periodic ")
+	b.WriteString("re-scoring, re-auditing, status polling): re-remembering on every run silently accumulates near-duplicate copies that crowd out other ")
+	b.WriteString("results in recall — evolving keeps the vault at one live version per fact.\n")
 
 	// Hierarchical memory
 	b.WriteString("\n## Hierarchical Memory\n\n")
@@ -225,7 +234,7 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 	b.WriteString("- Use muninn_recall with mode='deep' for thorough searches across the memory graph.\n")
 	b.WriteString("- Use muninn_link to connect related memories and strengthen the knowledge graph.\n")
 	b.WriteString("- Use muninn_decide to record decisions — they automatically link to supporting evidence.\n")
-	b.WriteString("- Use muninn_evolve instead of forget+remember when updating existing information.\n")
+	b.WriteString("- Use muninn_evolve instead of forget+remember (or repeated muninn_remember) when updating existing information — only evolve's supersedes link removes the old version from present-tense recall; repeated remember leaves every stale copy fully active and crowds recall with near-duplicates.\n")
 	b.WriteString("- Use muninn_remember_batch when storing multiple memories from the same conversation.\n")
 
 	return b.String()

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -17,7 +17,7 @@ func allToolDefinitions() []ToolDefinition {
 	return []ToolDefinition{
 		{
 			Name:        "muninn_remember",
-			Description: "Store a new piece of information (engram) in long-term memory. IMPORTANT: Keep each memory atomic — one concept, decision, or fact per memory. If a conversation covers multiple topics, use muninn_remember_batch to store them as separate memories. Atomic memories produce sharper recall, better associations, and more accurate contradiction detection. TIP: Provide ‘entities’ and ‘entity_relationships’ whenever you can identify them — this builds the knowledge graph immediately without requiring background enrichment. NOTE: If the exact same content already exists in the vault, the existing memory ID is returned instead of creating a duplicate.",
+			Description: "Store a new piece of information (engram) in long-term memory. IMPORTANT: Keep each memory atomic — one concept, decision, or fact per memory. If a conversation covers multiple topics, use muninn_remember_batch to store them as separate memories. Atomic memories produce sharper recall, better associations, and more accurate contradiction detection. TIP: Provide ‘entities’ and ‘entity_relationships’ whenever you can identify them — this builds the knowledge graph immediately without requiring background enrichment. NOTE: If the exact same content already exists in the vault, the existing memory ID is returned instead of creating a duplicate. CAUTION: If this call is RE-ASSERTING or UPDATING a fact you already stored (a re-run score, a refreshed status), use muninn_evolve(id, ...) on the prior engram instead — calling muninn_remember repeatedly for the same evolving fact leaves every stale copy fully active and crowds recall with near-duplicates.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -320,7 +320,7 @@ func allToolDefinitions() []ToolDefinition {
 		},
 		{
 			Name:        "muninn_evolve",
-			Description: "Update a memory with new information. Creates a new version and archives the old one.",
+			Description: "Update a memory with new information. Creates a new version linked to the old one by a supersedes association, and soft-deletes the old version so it drops out of present-tense recall (never destroyed — as_of still sees it). Use this — not a repeated muninn_remember — whenever a new call is re-asserting or replacing a fact you already stored; otherwise every stale copy stays fully active and crowds recall with near-duplicates.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{


### PR DESCRIPTION
## Problem (measured this session, on a real production vault)

50% of that vault is templated/near-duplicate/bookmark pollution. The
biggest single cluster — 310 near-duplicate engrams re-asserting one periodically-recomputed
score — traces to one root
cause: a bulk pipeline called `muninn_remember` repeatedly to re-assert an evolving fact
(the recomputed score), instead of `muninn_evolve`. Measured impact: ~40% top-10 crowding
in recall from this cluster alone.

## Root cause (verified against the actual code before writing any guidance)

- `muninn_evolve` (`internal/engine/engine.go:EvolveAt`) writes the new engram, a
  `RelSupersedes` association pointing at the old one, and **soft-deletes the old engram
  in the same atomic batch** (`SupersedeEngram` → `State = StateSoftDeleted` +
  `ValidUntil` stamp). The old version drops out of present-tense recall entirely — not
  merely demoted — while remaining visible under `as_of` for history. This is stronger
  than the demotion path.
- `internal/engine/engine_supersession.go` (`applySupersession`) is a *separate*, softer
  mechanism: it demotes (never deletes) a candidate only when a `RelSupersedes` edge
  exists **and the predecessor is still active** (i.e. a manual link created without going
  through evolve). Evolve's own soft-deleted predecessors never reach this phase — they're
  already excluded by the state filter before scoring runs.
- Calling `muninn_remember` again for the same fact creates a brand-new, **unlinked**
  engram. No `RelSupersedes` edge is created, so neither the soft-delete-on-evolve path nor
  `applySupersession`'s demotion has anything to act on. Every re-assertion stays fully
  active and independently rankable forever — that's the 310-copy cluster.

## Fix: write-path guidance only (the free half of #713)

This PR is docs/guidance only — no engine or storage change. It adds a precise
"updating vs. creating" rule to the agent-facing guidance surfaces so agents and bulk
pipelines route re-asserted/updated facts through `muninn_evolve` (which structurally
prevents the pollution) instead of `muninn_remember` (which doesn't):

- `internal/mcp/guide.go` — new subsection under "Writing Effective Memories" explaining
  the evolve-vs-remember distinction, the exact supersedes/soft-delete mechanism, and an
  explicit callout that bulk/repeated-write pipelines re-running over the same entities
  must evolve, not re-remember, or they accumulate near-duplicate pollution that crowds
  recall. Also strengthened the existing Tips bullet.
- `internal/mcp/tools.go` — added a CAUTION clause to the `muninn_remember` tool
  description pointing at `muninn_evolve` for re-asserted/updated facts, and corrected
  the `muninn_evolve` description ("archives" → precise supersedes + soft-delete +
  as_of-preserved semantics) so the tool descriptions themselves carry the rule at the
  point of tool selection.

The other half of #713 — a per-vault exclude-tags knob to filter templated/bookmark
pollution that isn't fact-supersession-shaped — is a separate build increment, not
included here.

## Test plan

- [x] `go build -tags localassets ./...` clean
- [x] `go vet -tags localassets ./...` clean
- [x] `gofmt -l .` empty
- [x] `go test -tags localassets ./internal/mcp/...` passes
