### PR TITLE
fix(mcp): report the stored concept in evolve/decide/explain/contradictions responses (#721)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   though REST's equivalent adapter has set it correctly all along. Scoped to
   the MCP surface only — REST's explain adapter already sets `Concept`.
   (#721)
+- **`muninn_contradictions` reported `concept_a`/`concept_b` as `""` for
+  every pair.** A fourth instance of the same defect shape: REST's
+  equivalent (`GetContradictions` in
+  `internal/transport/rest/engine_adapter.go`) has always read both
+  engrams back to populate `ConceptA`/`ConceptB`; the MCP adapter shipped
+  `ContradictionPair{IDa, IDb}` only. Fixed with a single batched read
+  (`Engine.GetEngramsBatch`, one Pebble iterator for every ID referenced by
+  any pair) rather than a per-pair lookup, since this tool can return every
+  contradiction in the vault. A missing or unreadable engram degrades that
+  side to `""` rather than failing the call. Scoped to the MCP surface
+  only — REST already gets this right. `detected_at` remains unpopulated;
+  the 0x0A marker persists only the pair, with no severity/type/provenance
+  to report. (#721)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,12 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `WriteResult.Warnings`, which already existed. Scoped to the MCP surface
   only. (#721)
 - **The `muninn_explain` MCP tool's response also dropped `concept`.** A
-  third instance of the same defect shape: the adapter copied eight score-
-  breakdown fields off the engine's `ExplainData` but never copied
-  `Concept`, so `muninn_explain` always reported `concept: ""` on MCP even
-  though REST's equivalent adapter has set it correctly all along. Scoped to
-  the MCP surface only — REST's explain adapter already sets `Concept`.
-  (#721)
+  third instance of the same defect shape: the adapter copied five of the
+  engine's `ExplainData`'s six fields (every field except `Concept`) into
+  the response, so `muninn_explain` always reported `concept: ""` on MCP
+  even though REST's equivalent adapter has set it correctly all along.
+  Scoped to the MCP surface only — REST's explain adapter already sets
+  `Concept`. (#721)
 - **`muninn_contradictions` reported `concept_a`/`concept_b` as `""` for
   every pair.** A fourth instance of the same defect shape: REST's
   equivalent (`GetContradictions` in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   concept was set correctly — the same defect class already fixed for
   `muninn_remember` in #172, but evolve never got the equivalent fix. The
   response now returns the caller's `concept` when supplied, or reads back
-  the freshly-written engram to report the inherited concept. The
-  `muninn_decide` MCP tool had the identical defect and is fixed alongside
-  it. Scoped to the MCP surface only — REST's `EvolveResponse` has no
-  `concept` field. (#721)
+  the freshly-written engram to report the inherited concept. Scoped to the
+  MCP surface only — REST's `EvolveResponse` has no `concept` field. (#721)
+- **The `muninn_decide` MCP tool had the identical empty-`concept` defect,
+  plus a second bug once the first fix landed.** A naive fix (echo the
+  caller's `decision` text) is wrong when two decisions submit identical
+  rationale text: `engine.Decide` writes through the content-hash dedup
+  path, which returns a pre-existing engram's ID, so the response would
+  report the *second* call's decision text against the *first* call's
+  engram. The response now reads the concept back from the stored engram,
+  the same way evolve does, so it never echoes text the returned engram
+  doesn't actually have. Scoped to the MCP surface only — REST's
+  `DecideResponse` is `{ID, Warnings}` and has no `concept` field. (#721)
+- **The `muninn_explain` MCP tool's response also dropped `concept`.** A
+  third instance of the same defect shape: the adapter copied eight score-
+  breakdown fields off the engine's `ExplainData` but never copied
+  `Concept`, so `muninn_explain` always reported `concept: ""` on MCP even
+  though REST's equivalent adapter has set it correctly all along. Scoped to
+  the MCP surface only — REST's explain adapter already sets `Concept`.
+  (#721)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same way evolve does, so it never echoes text the returned engram
   doesn't actually have. Scoped to the MCP surface only — REST's
   `DecideResponse` is `{ID, Warnings}` and has no `concept` field. (#721)
+- **`muninn_decide` now warns when content-hash dedup substitutes an
+  existing engram.** The read-back fix above stopped the response from
+  lying, but a caller whose rationale collided with an existing engram
+  still got back someone else's concept with nothing flagging that their
+  own decision text was never written — silent substitution. The response
+  now appends a `warnings` entry naming both the stored concept and the
+  requested decision text whenever they differ. No new field: reuses
+  `WriteResult.Warnings`, which already existed. Scoped to the MCP surface
+  only. (#721)
 - **The `muninn_explain` MCP tool's response also dropped `concept`.** A
   third instance of the same defect shape: the adapter copied eight score-
   breakdown fields off the engine's `ExplainData` but never copied

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`muninn_evolve` response no longer reports an empty `concept`.** The
-  field was always serialized as `""`, even when the concept was set
-  correctly — the same defect class already fixed for `muninn_remember` in
-  #172, but evolve never got the equivalent fix. The response now returns
-  the caller's `concept` when supplied, or reads back the freshly-written
-  engram to report the inherited concept. (#721)
+- **The `muninn_evolve` MCP tool's response no longer reports an empty
+  `concept`.** The field was always serialized as `""`, even when the
+  concept was set correctly — the same defect class already fixed for
+  `muninn_remember` in #172, but evolve never got the equivalent fix. The
+  response now returns the caller's `concept` when supplied, or reads back
+  the freshly-written engram to report the inherited concept. The
+  `muninn_decide` MCP tool had the identical defect and is fixed alongside
+  it. Scoped to the MCP surface only — REST's `EvolveResponse` has no
+  `concept` field. (#721)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- **`muninn_evolve` response no longer reports an empty `concept`.** The
+  field was always serialized as `""`, even when the concept was set
+  correctly — the same defect class already fixed for `muninn_remember` in
+  #172, but evolve never got the equivalent fix. The response now returns
+  the caller's `concept` when supplied, or reads back the freshly-written
+  engram to report the inherited concept. (#721)
 
 ---
 

--- a/cmd/muninn/smoke_exhaustive_test.go
+++ b/cmd/muninn/smoke_exhaustive_test.go
@@ -452,6 +452,27 @@ func TestSmoke_AllMCPTools(t *testing.T) {
 		if errVal, hasErr := result["error"]; hasErr {
 			t.Errorf("muninn_evolve returned error field: %v", errVal)
 		}
+		// #721: with `concept` omitted, EvolveAt inherits the predecessor's
+		// label, so the response must report the inherited one — not "".
+		// Asserting only "no error field" is what let #721 ship.
+		if got, _ := result["concept"].(string); got != "Alice the explorer" {
+			t.Errorf("evolve response concept = %q, want the inherited %q", got, "Alice the explorer")
+		}
+		evolvedID, _ := result["id"].(string)
+		if evolvedID == "" {
+			t.Fatalf("muninn_evolve: expected non-empty id, got: %v", result)
+		}
+		// An explicit concept must be echoed back verbatim.
+		renamed := mcpTool(t, tok, "muninn_evolve", map[string]any{
+			"vault":       vault,
+			"id":          evolvedID,
+			"new_content": "Alice explored the ancient ruins, found a map, and drew the first chart.",
+			"reason":      "relabel while updating content",
+			"concept":     "Alice the cartographer",
+		})
+		if got, _ := renamed["concept"].(string); got != "Alice the cartographer" {
+			t.Errorf("evolve response concept = %q, want the supplied %q", got, "Alice the cartographer")
+		}
 	})
 
 	t.Run("muninn_consolidate", func(t *testing.T) {

--- a/cmd/muninn/smoke_exhaustive_test.go
+++ b/cmd/muninn/smoke_exhaustive_test.go
@@ -524,6 +524,12 @@ func TestSmoke_AllMCPTools(t *testing.T) {
 		if errVal, hasErr := result["error"]; hasErr {
 			t.Errorf("muninn_decide returned error field: %v", errVal)
 		}
+		// Same defect class as #721: the decide response must echo the
+		// decision text as its concept, not "". Asserting only "no error
+		// field" is exactly the coverage shape that let #721 ship.
+		if got, _ := result["concept"].(string); got != "explore the eastern ruins now" {
+			t.Errorf("decide response concept = %q, want the decision text %q", got, "explore the eastern ruins now")
+		}
 	})
 
 	t.Run("muninn_restore", func(t *testing.T) {

--- a/cmd/muninn/smoke_exhaustive_test.go
+++ b/cmd/muninn/smoke_exhaustive_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 // allMCPTools is the canonical list of every MCP tool the server must expose.
@@ -572,13 +573,42 @@ func TestSmoke_AllMCPTools(t *testing.T) {
 	})
 
 	t.Run("muninn_explain", func(t *testing.T) {
-		result := mcpTool(t, tok, "muninn_explain", map[string]any{
+		// Deliberately explains idB, not idA: by this point in the suite
+		// idA has already been superseded and soft-deleted by the
+		// muninn_evolve subtest above, so ExplainData.WouldReturn is false
+		// by construction for idA and Concept is never set (engine.Explain,
+		// internal/engine/query.go, only fills Concept inside the
+		// WouldReturn branch) — asserting concept on idA here would either
+		// be vacuous (gated on a would_return that's always false) or
+		// outright fail. idB was never evolved, so its concept survives.
+		//
+		// FTS indexing of idB's write is async (cmd/muninn has no access to
+		// the engine's internal drain hooks across the daemon process
+		// boundary — see docs/internals/testing-hermeticity.md), so poll
+		// with a hard deadline exactly like waitForIDs
+		// (cmd/muninn/integration_test.go) rather than asserting once.
+		args := map[string]any{
 			"vault":     vault,
-			"engram_id": idA,
-			"query":     []string{"Alice explorer ruins"},
-		})
-		if errVal, hasErr := result["error"]; hasErr {
-			t.Errorf("muninn_explain returned error field: %v", errVal)
+			"engram_id": idB,
+			"query":     []string{"EntityB", "ruins", "Alice"},
+		}
+		deadline := time.Now().Add(10 * time.Second)
+		var result map[string]any
+		for {
+			result = mcpTool(t, tok, "muninn_explain", args)
+			if errVal, hasErr := result["error"]; hasErr {
+				t.Fatalf("muninn_explain returned error field: %v", errVal)
+			}
+			if wr, _ := result["would_return"].(bool); wr {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("muninn_explain: would_return never became true within the readiness deadline (last result: %v)", result)
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+		if got, _ := result["concept"].(string); got != "EntityB discovery" {
+			t.Errorf("explain response concept = %q, want %q", got, "EntityB discovery")
 		}
 	})
 

--- a/internal/engine/append_mode_test.go
+++ b/internal/engine/append_mode_test.go
@@ -38,6 +38,7 @@ var appendReadOnly = map[string]bool{
 	"Explain": true, "ExportGraph": true, "ExportVault": true, "FindByEntity": true,
 	"FindSimilarEntities": true, "GetAnnotations": true, "GetAssociations": true,
 	"GetAssociationsBatch": true, "GetContradictions": true, "GetEngram": true,
+	"GetEngramsBatch":         true,
 	"GetEnrichmentCandidates": true, "GetEnrichmentMode": true, "GetEntityAggregate": true,
 	"GetEntityClusters": true, "GetEntityTimeline": true, "GetNoveltyDrops": true,
 	"GetProcessorStats": true, "GetProvenance": true, "GetVaultEmbedDim": true, "GetVaultJob": true,

--- a/internal/engine/query.go
+++ b/internal/engine/query.go
@@ -84,6 +84,15 @@ func (e *Engine) GetContradictions(ctx context.Context, vault string) ([][2]stor
 	return e.store.GetContradictions(ctx, ws)
 }
 
+// GetEngramsBatch resolves vault to a workspace prefix and batch-reads ids in
+// one call — a single Pebble iterator (storage.PebbleStore.GetEngrams) instead
+// of one point lookup per ID, same batching pattern as GetAssociationsBatch
+// above. Missing entries come back nil at their index; callers must guard.
+func (e *Engine) GetEngramsBatch(ctx context.Context, vault string, ids []storage.ULID) ([]*storage.Engram, error) {
+	ws := e.store.ResolveVaultPrefix(vault)
+	return e.store.GetEngrams(ctx, ws, ids)
+}
+
 // ResolveContradiction removes the contradiction marker for the pair (idA, idB)
 // and updates the vault coherence counters.
 func (e *Engine) ResolveContradiction(ctx context.Context, vault, idA, idB string) error {

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -113,6 +113,7 @@ func (a *mcpEngineAdapter) Evolve(ctx context.Context, vault, oldID, newContent,
 		Concept: resolveEvolveConcept(concept, func() string {
 			eng, gerr := a.eng.GetEngram(ctx, vault, id)
 			if gerr != nil || eng == nil {
+				slog.Warn("evolve: failed to read back concept", "id", id.String(), "err", gerr)
 				return ""
 			}
 			return eng.Concept

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -89,12 +89,35 @@ func (a *mcpEngineAdapter) GetContradictions(ctx context.Context, vault string) 
 	}
 	return result, nil
 }
+
+// resolveEvolveConcept decides which concept an evolve response reports.
+// An explicit caller value always wins. When the caller omitted `concept`,
+// EvolveAt inherited the predecessor's, so the only truthful answer requires
+// reading the new version back — readBack returns "" if that read fails, and
+// an empty result is correct-to-degrade-to: the write has already committed,
+// so a failed read-back must not turn a successful evolve into an error.
+func resolveEvolveConcept(callerConcept string, readBack func() string) string {
+	if callerConcept != "" {
+		return callerConcept
+	}
+	return readBack()
+}
+
 func (a *mcpEngineAdapter) Evolve(ctx context.Context, vault, oldID, newContent, reason string, embedding []float32, concept string, entities []mbp.InlineEntity, importance *float32, effectiveAt time.Time) (*WriteResult, error) {
 	id, err := a.eng.EvolveAt(ctx, vault, oldID, newContent, reason, embedding, concept, entities, importance, effectiveAt)
 	if err != nil {
 		return nil, err
 	}
-	return &WriteResult{ID: id.String()}, nil
+	return &WriteResult{
+		ID: id.String(),
+		Concept: resolveEvolveConcept(concept, func() string {
+			eng, gerr := a.eng.GetEngram(ctx, vault, id)
+			if gerr != nil || eng == nil {
+				return ""
+			}
+			return eng.Concept
+		}),
+	}, nil
 }
 func (a *mcpEngineAdapter) Consolidate(ctx context.Context, vault string, ids []string, merged string) (*ConsolidateResult, error) {
 	res, err := a.eng.Consolidate(ctx, vault, ids, merged)

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -103,21 +103,39 @@ func resolveEvolveConcept(callerConcept string, readBack func() string) string {
 	return readBack()
 }
 
+// readBackConcept fetches id's stored Concept for use as the read-back
+// resolution in a WriteResult. Shared by Evolve (via resolveEvolveConcept)
+// and Decide, whose dedup path (see Decide below) means the caller-supplied
+// text can name a different engram's content than the one actually returned.
+//
+// GetEngram, not Read, deliberately: Read bumps AccessCount when the vault's
+// ReinforceOnRead plasticity is enabled (COG-12 amendment, S2/#682,
+// docs/internals/invariants.md), and formatting a response is not a
+// caller-intended access — reading back what we just wrote to report it
+// truthfully must not itself inflate ACT-R base-level activation. GetEngram
+// is a plain point lookup with no such side effect.
+//
+// The failure arm only ever fires on a genuine error: storage.PebbleStore's
+// GetEngram never returns (nil, nil) on success — a missing key takes the
+// err != nil branch (internal/storage/engram.go) — so there is no
+// eng == nil-with-nil-err case to additionally guard against here.
+func (a *mcpEngineAdapter) readBackConcept(ctx context.Context, vault string, id storage.ULID, op string) string {
+	eng, gerr := a.eng.GetEngram(ctx, vault, id)
+	if gerr != nil {
+		slog.Warn(op+": failed to read back concept", "id", id.String(), "err", gerr)
+		return ""
+	}
+	return eng.Concept
+}
+
 func (a *mcpEngineAdapter) Evolve(ctx context.Context, vault, oldID, newContent, reason string, embedding []float32, concept string, entities []mbp.InlineEntity, importance *float32, effectiveAt time.Time) (*WriteResult, error) {
 	id, err := a.eng.EvolveAt(ctx, vault, oldID, newContent, reason, embedding, concept, entities, importance, effectiveAt)
 	if err != nil {
 		return nil, err
 	}
 	return &WriteResult{
-		ID: id.String(),
-		Concept: resolveEvolveConcept(concept, func() string {
-			eng, gerr := a.eng.GetEngram(ctx, vault, id)
-			if gerr != nil || eng == nil {
-				slog.Warn("evolve: failed to read back concept", "id", id.String(), "err", gerr)
-				return ""
-			}
-			return eng.Concept
-		}),
+		ID:      id.String(),
+		Concept: resolveEvolveConcept(concept, func() string { return a.readBackConcept(ctx, vault, id, "evolve") }),
 	}, nil
 }
 func (a *mcpEngineAdapter) Consolidate(ctx context.Context, vault string, ids []string, merged string) (*ConsolidateResult, error) {
@@ -147,10 +165,22 @@ func (a *mcpEngineAdapter) Decide(ctx context.Context, vault, decision, rational
 	if err != nil {
 		return nil, err
 	}
-	// Concept is unconditionally the caller's decision text — engine.Decide
-	// writes Concept: decision verbatim (internal/engine/engine.go), so there
-	// is no store read-back precedence to apply here, unlike Evolve.
-	return &WriteResult{ID: res.ID.String(), Concept: decision, Warnings: res.Warnings}, nil
+	// Concept must NOT be the caller's decision text unconditionally.
+	// engine.Decide routes through e.Write, whose content-hash dedup
+	// short-circuit (engine.go, content-hash dedup block) returns a
+	// PRE-EXISTING engram's ID with Hint: "duplicate_content" when two
+	// decisions submit identical content (same rationale + alternatives).
+	// DecideResult carries only {ID, Warnings} — the dedup hint is dropped —
+	// so two Decide calls with the same rationale collapse onto one engram,
+	// and res.ID can name an engram whose stored Concept is an EARLIER
+	// call's decision text, not this call's. Read the concept back from the
+	// store, exactly like Evolve, so the response never echoes text the
+	// returned engram doesn't actually have.
+	return &WriteResult{
+		ID:       res.ID.String(),
+		Concept:  a.readBackConcept(ctx, vault, res.ID, "decide"),
+		Warnings: res.Warnings,
+	}, nil
 }
 
 func (a *mcpEngineAdapter) Restore(ctx context.Context, vault, id string) (*RestoreResult, error) {

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -237,6 +237,7 @@ func (a *mcpEngineAdapter) Explain(ctx context.Context, vault string, req *Expla
 	}
 	return &ExplainResult{
 		EngramID:    data.EngramID,
+		Concept:     data.Concept,
 		WouldReturn: data.WouldReturn,
 		Threshold:   data.Threshold,
 		FinalScore:  data.FinalScore,

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -220,10 +220,34 @@ func (a *mcpEngineAdapter) Decide(ctx context.Context, vault, decision, rational
 	// call's decision text, not this call's. Read the concept back from the
 	// store, exactly like Evolve, so the response never echoes text the
 	// returned engram doesn't actually have.
+	concept := a.readBackConcept(ctx, vault, res.ID, "decide")
+	warnings := res.Warnings
+	// The read-back above is now truthful, but a caller whose rationale
+	// collided with an existing engram still gets back someone else's
+	// concept with no signal that their own decision text was never
+	// written. That's silent substitution (CLAUDE.md principles 1/2) even
+	// though it's no longer a lie. Surface it as a warning rather than
+	// adding engine.DecideResult.Hint (deliberately deferred) — WriteResult
+	// already has a Warnings field for exactly this.
+	//
+	// Detected by comparing the read-back concept to the caller's decision
+	// text, NOT by checking res.Warnings == nil — engine.Decide's own
+	// warnings are about evidence-linking failures, an unrelated concern,
+	// so either could be present independent of the other.
+	//
+	// Guarded on concept != "": a failed read-back already degrades to ""
+	// via readBackConcept's own WARN path, and "" will always differ from a
+	// non-empty decision, which would otherwise misreport a read failure as
+	// a dedup substitution.
+	if concept != "" && concept != decision {
+		warnings = append(warnings, fmt.Sprintf(
+			"decision stored against an existing engram with matching content: reports concept %q instead of the requested %q",
+			concept, decision))
+	}
 	return &WriteResult{
 		ID:       res.ID.String(),
-		Concept:  a.readBackConcept(ctx, vault, res.ID, "decide"),
-		Warnings: res.Warnings,
+		Concept:  concept,
+		Warnings: warnings,
 	}, nil
 }
 

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -146,7 +146,10 @@ func (a *mcpEngineAdapter) Decide(ctx context.Context, vault, decision, rational
 	if err != nil {
 		return nil, err
 	}
-	return &WriteResult{ID: res.ID.String(), Warnings: res.Warnings}, nil
+	// Concept is unconditionally the caller's decision text — engine.Decide
+	// writes Concept: decision verbatim (internal/engine/engine.go), so there
+	// is no store read-back precedence to apply here, unlike Evolve.
+	return &WriteResult{ID: res.ID.String(), Concept: decision, Warnings: res.Warnings}, nil
 }
 
 func (a *mcpEngineAdapter) Restore(ctx context.Context, vault, id string) (*RestoreResult, error) {

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -78,14 +78,58 @@ func (a *mcpEngineAdapter) NoticesForRemember(ctx context.Context, vault string,
 	return a.eng.NoticesForRemember(ctx, vault, focal, createdID, sessionSeen)
 }
 
+// GetContradictions reports every contradiction pair in vault, with each
+// side's Concept read back from the store — the fourth instance of the
+// #721 defect shape: REST's equivalent (internal/transport/rest/engine_adapter.go,
+// GetContradictions) has always enriched ConceptA/ConceptB by reading both
+// engrams back; this adapter shipped ContradictionPair{IDa, IDb} only, so
+// concept_a/concept_b serialized as "" on every MCP response.
+//
+// Batched, not per-pair: GetContradictions scans the vault's entire 0x0A
+// keyspace with no cap (storage/association.go), so a tool call can return
+// every pair in the vault. Reading each side individually, as REST does,
+// would cost 2N point lookups; GetEngramsBatch instead opens a single Pebble
+// iterator for the whole ID set (storage.PebbleStore.GetEngrams), same
+// mechanism GetAssociationsBatch already uses for a batch of forward edges.
+//
+// GetEngramsBatch, not Read: it is a plain point-style lookup with no access
+// accounting, so formatting this response never bumps AccessCount/LastAccess
+// (COG-12, docs/internals/invariants.md) — the same discipline readBackConcept
+// already documents for Evolve/Decide.
+//
+// A missing or unreadable engram degrades that side to "" (mirrors REST's
+// per-side `if errX == nil && engX != nil` guards) rather than failing the
+// whole call — DetectedAt is left alone; it is genuinely unpopulatable (the
+// 0x0A marker persists only the pair, no severity/type/provenance).
 func (a *mcpEngineAdapter) GetContradictions(ctx context.Context, vault string) ([]ContradictionPair, error) {
 	pairs, err := a.eng.GetContradictions(ctx, vault)
 	if err != nil {
 		return nil, err
 	}
+	ids := make([]storage.ULID, 0, len(pairs)*2)
+	for _, p := range pairs {
+		ids = append(ids, p[0], p[1])
+	}
+	engrams, err := a.eng.GetEngramsBatch(ctx, vault, ids)
+	if err != nil {
+		// GetEngramsBatch degrades internally rather than erroring in the
+		// current implementation, but guard anyway: a batch failure must
+		// still return every pair's IDs, just with both concepts blank.
+		slog.Warn("contradictions: batch concept read-back failed, concepts will be empty", "err", err)
+		engrams = nil
+	}
 	result := make([]ContradictionPair, len(pairs))
 	for i, p := range pairs {
 		result[i] = ContradictionPair{IDa: p[0].String(), IDb: p[1].String()}
+		if len(engrams) != len(ids) {
+			continue
+		}
+		if eng := engrams[2*i]; eng != nil {
+			result[i].ConceptA = eng.Concept
+		}
+		if eng := engrams[2*i+1]; eng != nil {
+			result[i].ConceptB = eng.Concept
+		}
 	}
 	return result, nil
 }

--- a/internal/mcp/engine_adapter_concept_test.go
+++ b/internal/mcp/engine_adapter_concept_test.go
@@ -27,10 +27,14 @@ import (
 // newConceptAdapterEnv wires a real *engine.Engine (live PebbleStore + FTS)
 // using only exported constructors — the same shape as
 // rest.newRESTRetryEnrichEnv and grpc's newConfidenceAdapterEnv. AuthStore is
-// required: the write path resolves vault plasticity and, for a vault with no
-// explicit config, logs a WARN and proceeds — that WARN is expected here, not
-// a failure. Shared with engine_adapter_decide_concept_test.go, whose
-// muninn_decide regression test needs the identical harness.
+// NOT required: Engine.ResolveVaultPlasticity falls back to defaults when
+// authStore is nil (internal/engine/engine.go). What auth.NewStore(db) buys
+// here is the expected WARN line: auth.Store.GetVaultConfig logs "vault has
+// no explicit config — defaulting to locked access (fail-closed)" for a
+// vault with no explicit config (internal/auth/vault_config.go), and that
+// WARN in test output is expected, not a failure. Shared with
+// engine_adapter_decide_concept_test.go, whose muninn_decide regression test
+// needs the identical harness.
 func newConceptAdapterEnv(t *testing.T) (*mcpEngineAdapter, func()) {
 	t.Helper()
 

--- a/internal/mcp/engine_adapter_concept_test.go
+++ b/internal/mcp/engine_adapter_concept_test.go
@@ -1,0 +1,101 @@
+package mcp
+
+// Adapter-level regression coverage for #721: muninn_evolve's response must
+// report the memory's concept back to the caller.
+//
+// TestResolveEvolveConcept (engine_adapter_test.go) pins the precedence rule
+// inside resolveEvolveConcept but never calls mcpEngineAdapter.Evolve, so it
+// stayed green even when the adapter never wired the helper's result into
+// WriteResult.Concept at all — the actual #721 bug. This test stands up a
+// real *engine.Engine and goes through the adapter method end-to-end so the
+// wiring itself is under test, not just the helper.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/auth"
+	"github.com/scrypster/muninndb/internal/engine"
+	"github.com/scrypster/muninndb/internal/engine/activation"
+	"github.com/scrypster/muninndb/internal/engine/trigger"
+	"github.com/scrypster/muninndb/internal/index/fts"
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// newConceptAdapterEnv wires a real *engine.Engine (live PebbleStore + FTS)
+// using only exported constructors — the same shape as
+// rest.newRESTRetryEnrichEnv and grpc's newConfidenceAdapterEnv. AuthStore is
+// required: the write path resolves vault plasticity and, for a vault with no
+// explicit config, logs a WARN and proceeds — that WARN is expected here, not
+// a failure. Shared with engine_adapter_decide_concept_test.go, whose
+// muninn_decide regression test needs the identical harness.
+func newConceptAdapterEnv(t *testing.T) (*mcpEngineAdapter, func()) {
+	t.Helper()
+
+	db, err := storage.OpenPebble(t.TempDir(), storage.DefaultOptions())
+	if err != nil {
+		t.Fatalf("OpenPebble: %v", err)
+	}
+
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 128})
+	ftsIdx := fts.New(db)
+	embedder := activation.NewNoopEmbedder()
+	actEngine := activation.New(store, activation.NewFTSAdapter(ftsIdx), nil, embedder)
+	trigSystem := trigger.New(store, trigger.NewFTSAdapter(ftsIdx), nil, embedder)
+	eng := engine.NewEngine(engine.EngineConfig{
+		Store:            store,
+		AuthStore:        auth.NewStore(db),
+		FTSIndex:         ftsIdx,
+		ActivationEngine: actEngine,
+		TriggerSystem:    trigSystem,
+		Embedder:         embedder,
+	})
+
+	return &mcpEngineAdapter{eng: eng}, func() {
+		eng.Stop()
+		store.Close()
+	}
+}
+
+// TestMCPEngineAdapterEvolve_SetsConcept is the adapter-level regression guard
+// for #721: muninn_evolve's response must report the stored concept, whether
+// it was inherited from the predecessor engram (caller omitted `concept`) or
+// supplied explicitly on the evolve call.
+func TestMCPEngineAdapterEvolve_SetsConcept(t *testing.T) {
+	a, cleanup := newConceptAdapterEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	seed, err := a.eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   "default",
+		Concept: "Alice the explorer",
+		Content: "Alice is planning a trip to the Andes",
+	})
+	if err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+
+	t.Run("inherited concept", func(t *testing.T) {
+		got, err := a.Evolve(ctx, "default", seed.ID, "Alice postponed the trip to next spring",
+			"schedule slipped", nil, "", nil, nil, time.Time{})
+		if err != nil {
+			t.Fatalf("Evolve: %v", err)
+		}
+		if got.Concept != "Alice the explorer" {
+			t.Errorf("Concept = %q, want inherited %q", got.Concept, "Alice the explorer")
+		}
+	})
+
+	t.Run("explicit concept", func(t *testing.T) {
+		got, err := a.Evolve(ctx, "default", seed.ID, "Alice is now planning for the Alps instead",
+			"destination changed", nil, "Alice the mountaineer", nil, nil, time.Time{})
+		if err != nil {
+			t.Fatalf("Evolve: %v", err)
+		}
+		if got.Concept != "Alice the mountaineer" {
+			t.Errorf("Concept = %q, want explicit %q", got.Concept, "Alice the mountaineer")
+		}
+	})
+}

--- a/internal/mcp/engine_adapter_contradictions_concept_test.go
+++ b/internal/mcp/engine_adapter_contradictions_concept_test.go
@@ -1,0 +1,91 @@
+package mcp
+
+// TestMCPEngineAdapterContradictions_SetsConcepts guards the muninn_contradictions
+// sibling of #721/#172 — the fourth live instance of the same defect shape
+// (after Evolve, Decide, Explain): internal/mcp/engine_adapter.go's
+// GetContradictions method built ContradictionPair{IDa, IDb} straight off the
+// engine's [2]storage.ULID pairs and never populated ConceptA/ConceptB, so
+// concept_a/concept_b always serialized as "" on MCP even though REST's
+// equivalent (internal/transport/rest/engine_adapter.go, GetContradictions)
+// has read both engrams back to populate them all along.
+//
+// engine.Engine has no public API that flags a contradiction — it is only
+// ever written via storage.PebbleStore.FlagContradiction (the 0x0A marker),
+// which production code never calls automatically. Seeding one here mirrors
+// the exact pattern internal/engine/prospective_test.go's contradiction-notice
+// test and internal/engine/engine_test.go's TestEngineGetContradictions
+// already use: eng.Store().ResolveVaultPrefix + eng.Store().FlagContradiction,
+// both exported. That is the narrowest available seeding path; there is no
+// narrower one through the adapter or MCP surface.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+func TestMCPEngineAdapterContradictions_SetsConcepts(t *testing.T) {
+	a, cleanup := newConceptAdapterEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	seedA, err := a.eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   "default",
+		Concept: "Deploys ship on Fridays",
+		Content: "The team decided deploys are fine on Fridays given the on-call rotation",
+	})
+	if err != nil {
+		t.Fatalf("seed Write A: %v", err)
+	}
+	seedB, err := a.eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   "default",
+		Concept: "Deploys never ship on Fridays",
+		Content: "The team decided Friday deploys are banned after last quarter's incident",
+	})
+	if err != nil {
+		t.Fatalf("seed Write B: %v", err)
+	}
+
+	idA, err := storage.ParseULID(seedA.ID)
+	if err != nil {
+		t.Fatalf("ParseULID(a): %v", err)
+	}
+	idB, err := storage.ParseULID(seedB.ID)
+	if err != nil {
+		t.Fatalf("ParseULID(b): %v", err)
+	}
+	ws := a.eng.Store().ResolveVaultPrefix("default")
+	if err := a.eng.Store().FlagContradiction(ctx, ws, idA, idB); err != nil {
+		t.Fatalf("FlagContradiction: %v", err)
+	}
+
+	pairs, err := a.GetContradictions(ctx, "default")
+	if err != nil {
+		t.Fatalf("GetContradictions: %v", err)
+	}
+	if len(pairs) != 1 {
+		t.Fatalf("GetContradictions: got %d pairs, want 1 (pairs=%+v)", len(pairs), pairs)
+	}
+
+	p := pairs[0]
+	// FlagContradiction stores both directions and GetContradictions
+	// canonicalizes by ULID ordering, so which of idA/idB lands in IDa vs
+	// IDb is not under this test's control — assert by matching ID, not by
+	// position.
+	wantConcept := map[string]string{
+		seedA.ID: "Deploys ship on Fridays",
+		seedB.ID: "Deploys never ship on Fridays",
+	}
+	got := map[string]string{p.IDa: p.ConceptA, p.IDb: p.ConceptB}
+	for id, wantC := range wantConcept {
+		gotC, ok := got[id]
+		if !ok {
+			t.Fatalf("pair %+v does not reference expected id %s", p, id)
+		}
+		if gotC != wantC {
+			t.Errorf("concept for id %s = %q, want %q", id, gotC, wantC)
+		}
+	}
+}

--- a/internal/mcp/engine_adapter_decide_concept_test.go
+++ b/internal/mcp/engine_adapter_decide_concept_test.go
@@ -11,9 +11,16 @@ package mcp
 // identical content (same rationale). The "dedup" subtest proves the
 // response must report the STORED engram's concept, not the second caller's
 // decision text, which a plain assignment gets wrong.
+//
+// The dedup subtest also asserts a Warnings entry: the read-back fix makes
+// the response truthful, but a caller whose rationale collided with an
+// existing engram still gets back someone else's concept with nothing
+// flagging that their own decision text was never written — silent
+// substitution, not a lie, but still something the caller should be told.
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/scrypster/muninndb/internal/storage"
@@ -65,6 +72,18 @@ func TestMCPEngineAdapterDecide_SetsConcept(t *testing.T) {
 		}
 		if r2.Concept != "Use PostgreSQL" {
 			t.Errorf("Concept = %q, want %q (the first call's decision — dedup returned that engram, not r2's \"Use MySQL\")", r2.Concept, "Use PostgreSQL")
+		}
+
+		found := false
+		for _, w := range r2.Warnings {
+			if strings.Contains(w, "Use PostgreSQL") && strings.Contains(w, "Use MySQL") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Warnings = %v, want an entry naming both the stored concept %q and the requested decision %q",
+				r2.Warnings, "Use PostgreSQL", "Use MySQL")
 		}
 	})
 }

--- a/internal/mcp/engine_adapter_decide_concept_test.go
+++ b/internal/mcp/engine_adapter_decide_concept_test.go
@@ -3,15 +3,20 @@ package mcp
 // TestMCPEngineAdapterDecide_SetsConcept guards the muninn_decide sibling of
 // #721: internal/mcp/engine_adapter.go's Decide method returned
 // &WriteResult{ID: ..., Warnings: ...} without ever setting Concept, so every
-// muninn_decide response also reported concept: "". Unlike Evolve there is no
-// store read-back precedence to apply — engine.Decide writes
-// Concept: decision verbatim (internal/engine/engine.go) — so a plain field
-// assignment in the adapter is the entire fix, and this test is what proves
-// the wiring, not just the intent.
+// muninn_decide response also reported concept: "". A plain field assignment
+// of the caller's decision text looked like the entire fix, and the
+// "fresh write" subtest below still passes under that simpler fix — but
+// engine.Decide routes through e.Write, whose content-hash dedup
+// short-circuit returns a PRE-EXISTING engram's ID when two decisions submit
+// identical content (same rationale). The "dedup" subtest proves the
+// response must report the STORED engram's concept, not the second caller's
+// decision text, which a plain assignment gets wrong.
 
 import (
 	"context"
 	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
 )
 
 func TestMCPEngineAdapterDecide_SetsConcept(t *testing.T) {
@@ -19,12 +24,47 @@ func TestMCPEngineAdapterDecide_SetsConcept(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
-	got, err := a.Decide(ctx, "default", "Use PostgreSQL for the primary store",
-		"It handles our write throughput and has good ecosystem support", nil, nil)
-	if err != nil {
-		t.Fatalf("Decide: %v", err)
-	}
-	if got.Concept != "Use PostgreSQL for the primary store" {
-		t.Errorf("Concept = %q, want %q", got.Concept, "Use PostgreSQL for the primary store")
-	}
+
+	t.Run("fresh write", func(t *testing.T) {
+		got, err := a.Decide(ctx, "default", "Use PostgreSQL for the primary store",
+			"It handles our write throughput and has good ecosystem support", nil, nil)
+		if err != nil {
+			t.Fatalf("Decide: %v", err)
+		}
+		if got.Concept != "Use PostgreSQL for the primary store" {
+			t.Errorf("Concept = %q, want %q", got.Concept, "Use PostgreSQL for the primary store")
+		}
+	})
+
+	t.Run("dedup returns the stored engram's concept, not the second caller's decision text", func(t *testing.T) {
+		const rationale = "It is the option the team already has operational experience running"
+
+		r1, err := a.Decide(ctx, "default", "Use PostgreSQL", rationale, nil, nil)
+		if err != nil {
+			t.Fatalf("Decide (first): %v", err)
+		}
+		r2, err := a.Decide(ctx, "default", "Use MySQL", rationale, nil, nil)
+		if err != nil {
+			t.Fatalf("Decide (second): %v", err)
+		}
+		if r2.ID != r1.ID {
+			t.Fatalf("expected content-hash dedup to collapse onto the same engram, got r1.ID=%s r2.ID=%s", r1.ID, r2.ID)
+		}
+
+		storedID, err := storage.ParseULID(r2.ID)
+		if err != nil {
+			t.Fatalf("ParseULID(%q): %v", r2.ID, err)
+		}
+		stored, err := a.eng.GetEngram(ctx, "default", storedID)
+		if err != nil {
+			t.Fatalf("GetEngram: %v", err)
+		}
+
+		if r2.Concept != stored.Concept {
+			t.Errorf("Concept = %q, want the stored engram's concept %q", r2.Concept, stored.Concept)
+		}
+		if r2.Concept != "Use PostgreSQL" {
+			t.Errorf("Concept = %q, want %q (the first call's decision — dedup returned that engram, not r2's \"Use MySQL\")", r2.Concept, "Use PostgreSQL")
+		}
+	})
 }

--- a/internal/mcp/engine_adapter_decide_concept_test.go
+++ b/internal/mcp/engine_adapter_decide_concept_test.go
@@ -1,0 +1,30 @@
+package mcp
+
+// TestMCPEngineAdapterDecide_SetsConcept guards the muninn_decide sibling of
+// #721: internal/mcp/engine_adapter.go's Decide method returned
+// &WriteResult{ID: ..., Warnings: ...} without ever setting Concept, so every
+// muninn_decide response also reported concept: "". Unlike Evolve there is no
+// store read-back precedence to apply — engine.Decide writes
+// Concept: decision verbatim (internal/engine/engine.go) — so a plain field
+// assignment in the adapter is the entire fix, and this test is what proves
+// the wiring, not just the intent.
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMCPEngineAdapterDecide_SetsConcept(t *testing.T) {
+	a, cleanup := newConceptAdapterEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	got, err := a.Decide(ctx, "default", "Use PostgreSQL for the primary store",
+		"It handles our write throughput and has good ecosystem support", nil, nil)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if got.Concept != "Use PostgreSQL for the primary store" {
+		t.Errorf("Concept = %q, want %q", got.Concept, "Use PostgreSQL for the primary store")
+	}
+}

--- a/internal/mcp/engine_adapter_explain_concept_test.go
+++ b/internal/mcp/engine_adapter_explain_concept_test.go
@@ -1,0 +1,77 @@
+package mcp
+
+// TestMCPEngineAdapterExplain_SetsConcept guards a third live instance of the
+// #721 shape (after Evolve and Decide): internal/mcp/engine_adapter.go's
+// Explain method copied eight fields off engine.ExplainData into ExplainResult
+// but dropped Concept, so muninn_explain always reported concept: "" on MCP
+// even though REST's equivalent adapter (internal/transport/rest/engine_adapter.go)
+// has set it correctly all along. ExplainResult.Concept has no `omitempty`
+// (internal/mcp/types.go), so the zero value serializes as an explicit
+// concept: "" on the wire.
+//
+// engine.ExplainData.Concept is only populated inside engine.Explain's
+// WouldReturn branch (internal/engine/query.go) — it walks the activation
+// results looking for the requested engram ID and only fills Concept (and the
+// rest of the score breakdown) if it finds it there. So this test must seed a
+// query that genuinely matches the engram, not just assert WouldReturn==true
+// as a side effect.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+func TestMCPEngineAdapterExplain_SetsConcept(t *testing.T) {
+	a, cleanup := newConceptAdapterEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	seed, err := a.eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   "default",
+		Concept: "Bob the baker",
+		Content: "Bob bakes sourdough bread every morning at the corner bakery",
+	})
+	if err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+
+	req := &ExplainRequest{
+		EngramID: seed.ID,
+		Query:    []string{"sourdough", "bakery"},
+	}
+
+	// The environment's embedder is a noop (activation.NewNoopEmbedder in
+	// newConceptAdapterEnv), so FTS is the only path that can make
+	// WouldReturn true here (docs/internals/testing-hermeticity.md, async
+	// source #3) — and FTS indexing runs off an async worker, not inline
+	// with Write. package mcp has no access to the unexported
+	// engine.waitWriteTimeIdle drain (white-box, package engine/activation
+	// only), so this polls Explain's WouldReturn with a hard deadline
+	// instead. This is a bounded READINESS wait, not a synchronization
+	// primitive — it does not order two goroutines, it just bounds how long
+	// we tolerate the indexer being behind, and it fails loudly (t.Fatalf)
+	// rather than silently asserting on a stale/empty result if the deadline
+	// is reached.
+	deadline := time.Now().Add(5 * time.Second)
+	var got *ExplainResult
+	for {
+		got, err = a.Explain(ctx, "default", req)
+		if err != nil {
+			t.Fatalf("Explain: %v", err)
+		}
+		if got.WouldReturn {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Explain: WouldReturn never became true within the readiness deadline (last result: %+v)", got)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got.Concept != "Bob the baker" {
+		t.Errorf("Concept = %q, want %q", got.Concept, "Bob the baker")
+	}
+}

--- a/internal/mcp/engine_adapter_explain_concept_test.go
+++ b/internal/mcp/engine_adapter_explain_concept_test.go
@@ -2,12 +2,13 @@ package mcp
 
 // TestMCPEngineAdapterExplain_SetsConcept guards a third live instance of the
 // #721 shape (after Evolve and Decide): internal/mcp/engine_adapter.go's
-// Explain method copied eight fields off engine.ExplainData into ExplainResult
-// but dropped Concept, so muninn_explain always reported concept: "" on MCP
-// even though REST's equivalent adapter (internal/transport/rest/engine_adapter.go)
-// has set it correctly all along. ExplainResult.Concept has no `omitempty`
-// (internal/mcp/types.go), so the zero value serializes as an explicit
-// concept: "" on the wire.
+// Explain method copied five of engine.ExplainData's six fields
+// (EngramID, FinalScore, WouldReturn, Threshold, Components — skipping only
+// Concept) into ExplainResult, so muninn_explain always reported
+// concept: "" on MCP even though REST's equivalent adapter
+// (internal/transport/rest/engine_adapter.go) has set it correctly all
+// along. ExplainResult.Concept has no `omitempty` (internal/mcp/types.go),
+// so the zero value serializes as an explicit concept: "" on the wire.
 //
 // engine.ExplainData.Concept is only populated inside engine.Explain's
 // WouldReturn branch (internal/engine/query.go) — it walks the activation

--- a/internal/mcp/engine_adapter_test.go
+++ b/internal/mcp/engine_adapter_test.go
@@ -373,3 +373,34 @@ func TestWhereLeftOffEntryFromEngramImportance(t *testing.T) {
 		t.Errorf("derived entry = (%v, %q), want (0.6, derived)", derived.Importance, derived.ImportanceSource)
 	}
 }
+
+// TestResolveEvolveConcept pins the precedence rule behind the evolve
+// response's `concept` field (#721). Before the fix the adapter never
+// populated WriteResult.Concept at all, so every evolve response reported
+// `"concept": ""` — a caller reading it concluded the label had been wiped
+// and "repaired" it with another evolve, churning ULIDs for nothing.
+func TestResolveEvolveConcept(t *testing.T) {
+	t.Run("caller value wins without a read-back", func(t *testing.T) {
+		got := resolveEvolveConcept("explicit label", func() string {
+			t.Fatal("read-back must not run when the caller supplied a concept")
+			return ""
+		})
+		if got != "explicit label" {
+			t.Errorf("got %q, want %q", got, "explicit label")
+		}
+	})
+
+	t.Run("omitted concept reports the inherited one", func(t *testing.T) {
+		got := resolveEvolveConcept("", func() string { return "inherited label" })
+		if got != "inherited label" {
+			t.Errorf("got %q, want %q", got, "inherited label")
+		}
+	})
+
+	t.Run("failed read-back degrades to empty, never panics", func(t *testing.T) {
+		got := resolveEvolveConcept("", func() string { return "" })
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes #721.

`muninn_evolve`'s MCP response always reported `concept: ""` — the same defect as
#172, which was fixed for `muninn_remember` only. Chasing it turned up **four**
instances of one pattern in `internal/mcp/engine_adapter.go`: the engine populates
a field, the adapter constructs the wire struct without copying it, and because none
of these fields carry `omitempty`, every response ships a confidently-empty value.

| Tool | Field(s) dropped |
|---|---|
| `muninn_evolve` | `concept` |
| `muninn_decide` | `concept` |
| `muninn_explain` | `concept` |
| `muninn_contradictions` | `concept_a`, `concept_b` |

REST already populates `concept_a`/`concept_b` (`internal/transport/rest/engine_adapter.go`),
so the MCP surface was the outlier, not the feature.

This is the project's worst failure class (`CLAUDE.md` principle 1/2): the call
succeeds, the response looks well-formed, and the caller has no signal that a field
it is reading was never filled in.

## Implementation notes

- **`muninn_evolve`** — `resolveEvolveConcept(callerConcept string, readBack func() string) string`.
  A caller-supplied `concept` wins (it is what was just written); otherwise the stored
  concept is read back. A failed read-back logs a `slog.Warn` rather than silently
  returning `""`.

- **`muninn_decide`** — the concept is resolved by **reading the engram back**, not by
  echoing the `decision` argument. `e.Write`'s content-hash dedup can return a
  *pre-existing* engram's ULID, in which case echoing `decision` would produce a
  self-consistent-looking falsehood — a worse outcome than the empty string. When the
  read-back concept differs from `decision`, the substitution is surfaced through the
  already-plumbed `WriteResult.Warnings`, so dedup is loud rather than merely truthful.
  No new field on `engine.DecideResult`.

- **`muninn_contradictions`** — this tool can return every pair in the vault, so the
  concepts are fetched with one batched read rather than 2N point lookups. A missing or
  unreadable engram degrades to `""` for that side only, mirroring REST's per-side
  guards, rather than failing the whole call.

- **Read path honors COG-12.** All read-backs use the non-access-accounting
  `Engine.GetEngram`, never `Engine.Read`, so shaping a response cannot inflate
  `AccessCount` and perturb ACT-R base-level activation.

- **`DetectedAt` deliberately left empty.** Per COG-23 the `0x0A` contradiction marker
  persists only the engram pair — there is no stored timestamp to report. Filed
  separately rather than invented here.

## Testing

- `go build ./...` ✓ &nbsp; `go vet ./...` ✓ &nbsp; `gofmt -l .` clean ✓
- `go test ./internal/mcp/... ./internal/engine/... ./cmd/muninn/...` ✓
- `go test -race ./internal/mcp/...` ✓
- One real-engine adapter regression test per instance
  (`engine_adapter_concept_test.go`, `_decide_`, `_explain_`, `_contradictions_`),
  each **RED-verified**: reverted the fix, confirmed the test fails on its intended
  assertion with the empty value — not on a compile error or an unrelated check.
- `cmd/muninn/smoke_exhaustive_test.go` extended to assert the concept end-to-end
  against a live server for evolve, decide, and explain. The explain assertion is
  guarded on `would_return`, since the engram it explains has already been superseded
  by the evolve subtest.

## Scope

MCP surface only. The sibling gaps this work surfaced — REST `/api/explain` dropping
its `Components` breakdown, REST `/api/traverse` dropping `rel_type`, and the wire
fields nothing populates on any surface — are being filed as separate issues rather
than folded in here.

## Related PRs

- #730 — independent (both branch off `develop` and can merge in either order), but both add `[Unreleased]` entries, so whichever lands second needs a trivial `CHANGELOG.md` conflict resolution.
