### PR TITLE
chore(test,docs): use neutral fixtures, remove vault-specific identifiers

### DIFF
--- a/.claude/deep-review/2026-07-29-fts-abstention-design.md
+++ b/.claude/deep-review/2026-07-29-fts-abstention-design.md
@@ -3,8 +3,8 @@
 **Date:** 2026-07-29 · **Step:** DESIGN (no production code) · **Base:** origin/develop @ `cdbe355`
 **Problem:** Recall never abstains. Off-topic/nonsense queries return confident irrelevant
 results because `full_text_relevance` is ~1.0 for *any* single-token match, so no threshold
-can separate nonsense from genuine matches. Measured on the real 3,296-memory simplorium
-vault: `"how to bake sourdough bread"` → "Platform validation methodology", score 1.0,
+can separate nonsense from genuine matches. Measured on a real ~3,300-memory vault
+(the labs clone): `"how to bake sourdough bread"` → "Platform validation methodology", score 1.0,
 full_text_relevance 0.9999, semantic_similarity 0.
 
 ---
@@ -41,7 +41,7 @@ with `idf = ln((N-df+0.5)/(df+0.5) + 1)` (fts.go:536) and field weights **3.0 co
 activation engine unmodified: `c.ftsScore = s.Score` at
 `internal/engine/activation/engine.go:948` (phase3RRF), then tanh'd at the three sites above.
 
-**Real magnitudes for N=3,296 (simplorium):**
+**Real magnitudes for N=3,296 (a real vault):**
 
 | match | idf | bm25 (≈) | tanh |
 |---|---|---|---|
@@ -260,7 +260,7 @@ score plants):
 
 ### Real-vault validation (the honest gate)
 
-Against the labs clone (isolated daemon, REST :9475, vault=simplorium, 3,296 real
+Against the labs clone (isolated daemon, REST :9475, vault=<labs-clone>, 3,296 real
 memories), run the ~12-query probe before and after, default threshold, and report a
 before/after table of (top concept, score, full_text_relevance, semantic_similarity, n):
 

--- a/internal/engine/activation/helpers_test.go
+++ b/internal/engine/activation/helpers_test.go
@@ -1653,7 +1653,7 @@ func TestPhase6Score_FTSOnlyCandidate_NonZeroCosine(t *testing.T) {
 	// candidate), not tag-seeded, not traversed -- but it DOES carry an
 	// embedding that is identical to the query embedding (cosine = 1.0).
 	eng := &storage.Engram{
-		Concept: "RemittanceFile lifecycle", Content: "RemittanceFile lifecycle state machine",
+		Concept: "WidgetPipeline lifecycle", Content: "WidgetPipeline lifecycle state machine",
 		Confidence: 1.0, Stability: 30.0, State: storage.StateActive,
 		Embedding: []float32{1, 0, 0},
 	}
@@ -1664,7 +1664,7 @@ func TestPhase6Score_FTSOnlyCandidate_NonZeroCosine(t *testing.T) {
 	// vector-pool loop sets vectorScore, never the FTS loop.
 	fused := []fusedCandidate{{id: eng.ID, rrfScore: 0.5, ftsScore: 1.0}}
 	p1 := &phase1Result{
-		queryStr:  "RemittanceFile lifecycle state machine",
+		queryStr:  "WidgetPipeline lifecycle state machine",
 		embedding: []float32{1, 0, 0},
 	}
 
@@ -1711,7 +1711,7 @@ func TestPhase6Score_FTSOnlyCandidate_LoaderGap(t *testing.T) {
 	defer e.Close()
 
 	eng := &storage.Engram{
-		Concept: "RemittanceFile lifecycle", Content: "RemittanceFile lifecycle state machine",
+		Concept: "WidgetPipeline lifecycle", Content: "WidgetPipeline lifecycle state machine",
 		Confidence: 1.0, Stability: 30.0, State: storage.StateActive,
 	}
 	// Embedding reachable ONLY via GetEmbedding -- eng.Embedding is nil after
@@ -1720,7 +1720,7 @@ func TestPhase6Score_FTSOnlyCandidate_LoaderGap(t *testing.T) {
 
 	fused := []fusedCandidate{{id: eng.ID, rrfScore: 0.5, ftsScore: 1.0}}
 	p1 := &phase1Result{
-		queryStr:  "RemittanceFile lifecycle state machine",
+		queryStr:  "WidgetPipeline lifecycle state machine",
 		embedding: []float32{1, 0, 0},
 	}
 

--- a/internal/engine/activation/phase6_cosine_realstore_test.go
+++ b/internal/engine/activation/phase6_cosine_realstore_test.go
@@ -64,8 +64,8 @@ func TestPhase6Score_FTSOnlyCandidate_RealStoreLoaderGap(t *testing.T) {
 	queryVec := []float32{0.6, 0.8, 0.0, 0.0}
 
 	eng := &storage.Engram{
-		Concept:   "RemittanceFile lifecycle",
-		Content:   "RemittanceFile lifecycle state machine handles pending, cleared, and reversed states.",
+		Concept:   "WidgetPipeline lifecycle",
+		Content:   "WidgetPipeline lifecycle state machine handles pending, cleared, and reversed states.",
 		Embedding: queryVec, // identical to the query vector => cosine ~= 1.0
 	}
 	id, err := store.WriteEngram(context.Background(), ws, eng)
@@ -110,7 +110,7 @@ func TestPhase6Score_FTSOnlyCandidate_RealStoreLoaderGap(t *testing.T) {
 
 	result, err := eng2.Run(context.Background(), &activation.ActivateRequest{
 		VaultPrefix: ws,
-		Context:     []string{"RemittanceFile lifecycle state machine"},
+		Context:     []string{"WidgetPipeline lifecycle state machine"},
 		Embedding:   queryVec,
 		Threshold:   0.01,
 		MaxResults:  10,

--- a/internal/engine/prospective_harness_test.go
+++ b/internal/engine/prospective_harness_test.go
@@ -141,7 +141,7 @@ func runProspectiveHarness(t *testing.T, enabled bool) harnessResult {
 			// a value that only worked because FTS relevance was tanh-saturated
 			// to ~1.0 for any match; #711 made full_text_relevance an honest
 			// absolute coverage score, so the harness must use the threshold real
-			// callers use. Verified on the real simplorium vault: at 0.1 the Push
+			// callers use. Verified on a real vault: at 0.1 the Push
 			// still fires 15/15 at precision 1.0; 0.35 was riding inflated scores.
 			Threshold: 0.1,
 		})


### PR DESCRIPTION
Replace vault-derived test fixture names and vault-name references with neutral placeholders. No functional change.

## What changed
Real-vault-derived identifiers that leaked into merged code/docs are replaced with neutral synthetic placeholders:

- `internal/engine/activation/helpers_test.go` — test fixture concept/content/query strings renamed from a real vault concept to `WidgetPipeline` (arbitrary fixture text; the test asserts cosine/scoring behavior, not the words).
- `internal/engine/activation/phase6_cosine_realstore_test.go` — same rename to `WidgetPipeline`, sentence structure preserved.
- `internal/engine/prospective_harness_test.go` — comment reference to a specific real vault genericized to "a real vault".
- `.claude/deep-review/2026-07-29-fts-abstention-design.md` — the specific vault name removed everywhere and ties to the owner's exact data softened (e.g. "a real ~3,300-memory vault (the labs clone)", "vault=<labs-clone>"). Technical content — magnitudes, methodology, numbers — is kept intact; only the vault identity is removed.

## Verification
- `go build -tags localassets ./...` clean
- `go vet -tags localassets ./...` clean
- `gofmt -l .` empty
- `go test -tags localassets ./internal/engine/activation/... ./internal/engine/...` green (renamed fixtures pass identically)
- A `git grep -iE` over `'*.go' '*.md'` for the full list of leaked identifiers (vault name, client-domain vocabulary, and fixture-derived terms — the list is kept locally rather than restated here) returns zero matches on the committed tree.

## Note on git history
This PR removes the strings from the current tree only. The old strings remain in already-merged commits in git history; fully purging them would require a destructive force-push history rewrite of a shared public repo, which is intentionally out of scope here.
