### PR TITLE
feat(recall): per-vault exclude-tags knob (#713)

### DIFF
--- a/internal/auth/plasticity.go
+++ b/internal/auth/plasticity.go
@@ -1,5 +1,7 @@
 package auth
 
+import "strings"
+
 // PlasticityConfig is the per-vault cognitive pipeline configuration.
 // A nil PlasticityConfig means "use defaults" (equivalent to Preset: "default").
 // Non-nil pointer fields override the chosen preset value.
@@ -93,6 +95,17 @@ type PlasticityConfig struct {
 	// registry/identity fallback, never silently producing a floor that
 	// abstains everything).
 	SemanticFloor *float64 `json:"semantic_floor,omitempty"`
+
+	// ExcludeTags is a per-vault list of tags excluded from recall RANKING.
+	// A candidate carrying any of these tags is dropped from activation results
+	// (the recall pipeline) before scoring. This is ranking-only: the engram is
+	// NOT deleted, NOT hidden from explicit direct-id or as_of-by-id reads, and
+	// still counts toward the vault. An explicit per-request tag include
+	// (tags_all/tags_any naming an excluded tag) overrides the standing exclude
+	// for that request — caller intent wins. Not preset-varying; default-empty /
+	// opt-in: nil or empty means no exclusion, so a vault without this config
+	// recalls byte-identically to before (#713).
+	ExcludeTags []string `json:"exclude_tags,omitempty"`
 }
 
 // ResolvedPlasticity is the fully-merged configuration after applying preset defaults
@@ -156,6 +169,12 @@ type ResolvedPlasticity struct {
 	// lookup for this vault's semantic-abstention baseline b. nil = no
 	// override (use the per-embedder registry). See PlasticityConfig.SemanticFloor.
 	SemanticFloorOverride *float64 `json:"semantic_floor_override,omitempty"`
+
+	// ExcludeTags is the resolved per-vault recall-ranking tag exclusion list
+	// (see PlasticityConfig.ExcludeTags). nil/empty = no exclusion. Normalized
+	// at resolution: blank entries dropped, duplicates collapsed. Not
+	// preset-varying.
+	ExcludeTags []string `json:"exclude_tags,omitempty"`
 }
 
 type plasticityPreset struct {
@@ -381,6 +400,13 @@ func ResolvePlasticity(cfg *PlasticityConfig) ResolvedPlasticity {
 	// silently here would hide a misconfiguration the caller should see.
 	r.SemanticFloorOverride = cfg.SemanticFloor
 
+	// ExcludeTags is not preset-varying (like SemanticFloor/ReinforceOnRead):
+	// nil/empty = no exclusion. Normalized here so a nil, empty, or
+	// duplicate-laden config all resolve to the same minimal set — and an empty
+	// or all-blank config resolves to nil, byte-identical to "no config" (the
+	// default-empty / opt-in invariant, #713).
+	r.ExcludeTags = resolveExcludeTags(cfg.ExcludeTags)
+
 	// Apply pointer-field overrides
 	if cfg.HebbianEnabled != nil {
 		r.HebbianEnabled = *cfg.HebbianEnabled
@@ -566,6 +592,30 @@ func ResolvePlasticity(cfg *PlasticityConfig) ResolvedPlasticity {
 		r.LTPWeightFloor = v
 	}
 	return r
+}
+
+// resolveExcludeTags normalizes a per-vault exclude-tags list: blank entries
+// are dropped and duplicates collapsed, preserving first-seen order. Returns
+// nil for a nil, empty, or all-blank input so "no config" and "empty config"
+// resolve identically (the default-empty / opt-in invariant, #713).
+func resolveExcludeTags(tags []string) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(tags))
+	var out []string
+	for _, t := range tags {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	return out
 }
 
 var validBehaviorModes = map[string]bool{

--- a/internal/auth/plasticity_exclude_tags_test.go
+++ b/internal/auth/plasticity_exclude_tags_test.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The per-vault exclude-tags knob (#713) is not preset-varying and is
+// default-empty / opt-in: a nil or empty config must resolve to a nil list so
+// recall behaves byte-identically to before. Resolution also normalizes the
+// list (blank entries dropped, duplicates collapsed) and never mutates a
+// preset. All fixtures use invented synthetic tag names.
+
+func TestResolvePlasticity_ExcludeTags_DefaultNil(t *testing.T) {
+	// No config at all: identity — no exclusion.
+	if got := ResolvePlasticity(nil).ExcludeTags; got != nil {
+		t.Errorf("nil config: ExcludeTags = %v, want nil (default-empty / opt-in)", got)
+	}
+	// Empty config with an unrelated preset: still no exclusion.
+	if got := ResolvePlasticity(&PlasticityConfig{Preset: "reference"}).ExcludeTags; got != nil {
+		t.Errorf("preset-only config: ExcludeTags = %v, want nil", got)
+	}
+	// Explicitly empty slice resolves identically to "not set".
+	if got := ResolvePlasticity(&PlasticityConfig{ExcludeTags: []string{}}).ExcludeTags; got != nil {
+		t.Errorf("empty slice: ExcludeTags = %v, want nil", got)
+	}
+}
+
+func TestResolvePlasticity_ExcludeTags_Passthrough(t *testing.T) {
+	r := ResolvePlasticity(&PlasticityConfig{ExcludeTags: []string{"noise-tag", "fixture-log"}})
+	want := []string{"noise-tag", "fixture-log"}
+	if !reflect.DeepEqual(r.ExcludeTags, want) {
+		t.Errorf("ExcludeTags = %v, want %v", r.ExcludeTags, want)
+	}
+}
+
+func TestResolvePlasticity_ExcludeTags_Normalized(t *testing.T) {
+	// Blank entries dropped, duplicates collapsed, first-seen order preserved.
+	r := ResolvePlasticity(&PlasticityConfig{
+		ExcludeTags: []string{"noise-tag", "  ", "fixture-log", "noise-tag", " template-x "},
+	})
+	want := []string{"noise-tag", "fixture-log", "template-x"}
+	if !reflect.DeepEqual(r.ExcludeTags, want) {
+		t.Errorf("normalized ExcludeTags = %v, want %v", r.ExcludeTags, want)
+	}
+}
+
+func TestResolvePlasticity_ExcludeTags_AllBlankResolvesNil(t *testing.T) {
+	// A config of only-blank tags must resolve to nil — byte-identical to "no
+	// config", so it cannot silently diverge from the default recall path.
+	if got := ResolvePlasticity(&PlasticityConfig{ExcludeTags: []string{"", "   "}}).ExcludeTags; got != nil {
+		t.Errorf("all-blank config: ExcludeTags = %v, want nil", got)
+	}
+}

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -214,6 +214,14 @@ type ActivateRequest struct {
 	// ExcludeUntrusted: when true, engrams with TrustUntrusted (0x04) are silently
 	// excluded from activation results. Set by the engine from vault PlasticityConfig.
 	ExcludeUntrusted bool
+	// ExcludeTags: candidates carrying any of these tags are dropped from recall
+	// RANKING (activation results) before scoring. Ranking-only — direct-id and
+	// as_of-by-id reads bypass activation and are unaffected, and the engram
+	// still counts toward the vault. Set by the engine from vault
+	// PlasticityConfig (#713). An explicit per-request tags_all/tags_any naming
+	// an excluded tag overrides the standing exclude for that request (caller
+	// intent wins). nil/empty = no exclusion (identity: unchanged behavior).
+	ExcludeTags []string
 	// CallerOwner is the ownership-lease identity of the recall caller. Engrams
 	// held by a live lease owned by someone else are hidden (work-queue checkout),
 	// unless IncludeLeased is set. Empty means the caller owns no leases.
@@ -1535,6 +1543,29 @@ func (e *ActivationEngine) phase6Score(
 		}
 	}
 
+	// Standing per-vault exclude-tags (#713): drop candidates carrying a
+	// vault-excluded tag from recall RANKING. Ranking-only — the engram is
+	// neither deleted nor hidden from direct-id/as_of-by-id reads, and still
+	// counts toward the vault. An explicit per-request include (tags_all/tags_any
+	// naming the tag) overrides the standing exclude, so a caller can always
+	// reach an excluded tag on purpose. Built once here; nil when the request
+	// carries no exclusions, so the default path is byte-identical to before.
+	var excludeTagSet map[string]struct{}
+	if len(req.ExcludeTags) > 0 {
+		excludeTagSet = make(map[string]struct{}, len(req.ExcludeTags))
+		for _, t := range req.ExcludeTags {
+			excludeTagSet[t] = struct{}{}
+		}
+		// Explicit per-request tag includes override the standing exclude.
+		reqAll, reqAny, _ := extractTagFilters(req.Filters)
+		for _, t := range reqAll {
+			delete(excludeTagSet, t)
+		}
+		for _, t := range reqAny {
+			delete(excludeTagSet, t)
+		}
+	}
+
 	// Filter out soft-deleted engrams (defense-in-depth; HNSW has no delete method).
 	// Also filter untrusted engrams when ExcludeUntrusted is set in the request.
 	var active []*storage.Engram
@@ -1549,6 +1580,11 @@ func (e *ActivationEngine) phase6Score(
 		// TrustUnset (0x00) is intentionally passed through — it is the zero-value
 		// backward-compat alias for TrustInferred, not an "unknown" or untrusted value.
 		if req.ExcludeUntrusted && eng.Trust == storage.TrustUntrusted {
+			continue
+		}
+		// Standing exclude-tags: drop candidates carrying a vault-excluded tag
+		// from ranking (#713). See excludeTagSet construction above.
+		if len(excludeTagSet) > 0 && engramHasExcludedTag(eng, excludeTagSet) {
 			continue
 		}
 		// Work-queue checkout: hide engrams under a live foreign lease.
@@ -2324,6 +2360,17 @@ func PassesMetaFilter(eng *storage.Engram, filters []Filter) bool {
 		}
 	}
 	return true
+}
+
+// engramHasExcludedTag reports whether the engram carries any tag in
+// excludeSet. Used by the phase-6 exclude-tags drop (#713).
+func engramHasExcludedTag(eng *storage.Engram, excludeSet map[string]struct{}) bool {
+	for _, t := range eng.Tags {
+		if _, ok := excludeSet[t]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // tagSet builds a lookup set from an engram's tags.

--- a/internal/engine/activation/exclude_tags_test.go
+++ b/internal/engine/activation/exclude_tags_test.go
@@ -1,0 +1,89 @@
+package activation_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/engine/activation"
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// Unit coverage for the phase-6 exclude-tags drop (#713) exercised through the
+// real activation pipeline (ActivationEngine.Run). Fixtures use invented
+// synthetic tags/content only.
+
+// runExclude runs an activation with the given ExcludeTags / Filters over a
+// two-engram store (one tagged "noise-tag", one tagged "keep-tag") and returns
+// which of the two surfaced. Both engrams enter the pipeline via the recent
+// pool, so the only thing that removes one is the exclude-tags drop.
+func runExclude(t *testing.T, exclude []string, filters []activation.Filter) (noise, keep bool) {
+	t.Helper()
+	store := newStubStore()
+	noiseEng := &storage.Engram{Concept: "alpha", Content: "shared body", Relevance: 0.5, Tags: []string{"noise-tag"}}
+	keepEng := &storage.Engram{Concept: "beta", Content: "shared body", Relevance: 0.5, Tags: []string{"keep-tag"}}
+	store.writeEngram(noiseEng)
+	store.writeEngram(keepEng)
+	store.recent = []storage.ULID{noiseEng.ID, keepEng.ID}
+
+	eng := newTestEngine(store, &stubFTS{}, &emptyHNSW{})
+	result, err := eng.Run(context.Background(), &activation.ActivateRequest{
+		Context:     []string{"anything"},
+		Threshold:   0.0,
+		MaxResults:  10,
+		Weights:     rrfTagWeights(),
+		Filters:     filters,
+		ExcludeTags: exclude,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return containsID(result.Activations, noiseEng.ID), containsID(result.Activations, keepEng.ID)
+}
+
+// TestExcludeTags_DropsCandidate: a candidate carrying an excluded tag is
+// dropped from ranking; the non-excluded candidate still surfaces.
+func TestExcludeTags_DropsCandidate(t *testing.T) {
+	noise, keep := runExclude(t, []string{"noise-tag"}, nil)
+	if noise {
+		t.Error("excluded-tag candidate leaked into ranking (#713 drop failed)")
+	}
+	if !keep {
+		t.Error("non-excluded candidate was dropped — exclusion must be tag-scoped")
+	}
+}
+
+// TestExcludeTags_DefaultIdentity: with no ExcludeTags, both candidates surface
+// (byte-identical to today).
+func TestExcludeTags_DefaultIdentity(t *testing.T) {
+	noise, keep := runExclude(t, nil, nil)
+	if !noise || !keep {
+		t.Errorf("default (nil ExcludeTags) dropped a candidate: noise=%v keep=%v", noise, keep)
+	}
+}
+
+// TestExcludeTags_ExplicitIncludeOverrides: an explicit tags_any include naming
+// the excluded tag overrides the standing exclude.
+func TestExcludeTags_ExplicitIncludeOverrides(t *testing.T) {
+	noise, _ := runExclude(t, []string{"noise-tag"},
+		[]activation.Filter{{Field: "tags_any", Value: []string{"noise-tag"}}})
+	if !noise {
+		t.Error("explicit tags_any include did not override the standing exclude (#713)")
+	}
+}
+
+// TestExcludeTags_UnrelatedIncludeStillDrops: an explicit include of a DIFFERENT
+// tag must not resurrect the excluded candidate — only an include naming the
+// excluded tag overrides.
+func TestExcludeTags_UnrelatedIncludeStillDrops(t *testing.T) {
+	// tags_any names only "keep-tag"; the noise engram lacks it and would fail
+	// that post-filter anyway, so assert on the keep engram's survival plus the
+	// noise engram staying dropped under an unrelated include.
+	noise, keep := runExclude(t, []string{"noise-tag"},
+		[]activation.Filter{{Field: "tags_any", Value: []string{"keep-tag"}}})
+	if noise {
+		t.Error("excluded candidate resurfaced under an unrelated explicit include")
+	}
+	if !keep {
+		t.Error("keep-tag candidate should survive its own explicit include")
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2250,6 +2250,9 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 	actReq.PASEnabled = resolved.PredictiveActivation
 	actReq.PASMaxInjections = resolved.PASMaxInjections
 	actReq.ExcludeUntrusted = resolved.ExcludeUntrusted
+	// Per-vault exclude-tags (#713): candidates carrying a configured tag are
+	// dropped from recall ranking. nil/empty = no exclusion (unchanged behavior).
+	actReq.ExcludeTags = resolved.ExcludeTags
 
 	// Valid-time gate (COG-19): as_of / include_invalid flow into phase-6
 	// filtering; the final gate below re-applies them to entity-boost injections.

--- a/internal/engine/engine_exclude_tags_test.go
+++ b/internal/engine/engine_exclude_tags_test.go
@@ -1,0 +1,155 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/auth"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// End-to-end coverage for the per-vault exclude-tags recall knob (#713):
+// candidates carrying a configured tag are dropped from recall RANKING, while
+// remaining reachable by explicit direct-id read (ranking-only) and by an
+// explicit per-request tag include (caller intent overrides the standing
+// exclude). All fixtures use invented synthetic tags/content only.
+
+// writeTagged writes an engram carrying tag and returns its ID.
+func writeTagged(t *testing.T, eng *Engine, ctx context.Context, vault, concept, tag string) string {
+	t.Helper()
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   vault,
+		Concept: concept,
+		// Distinct per-engram content (concept-prefixed) so the two fixtures do
+		// not collapse under content dedup, while still sharing the query terms
+		// so both are FTS candidates for the shared recall context.
+		Content: concept + " common searchable body text for recall",
+		Tags:    []string{tag},
+	})
+	if err != nil {
+		t.Fatalf("Write(%s): %v", concept, err)
+	}
+	return resp.ID
+}
+
+// recallIDs runs a recall and returns the set of returned engram IDs.
+func recallIDs(t *testing.T, eng *Engine, ctx context.Context, req *mbp.ActivateRequest) map[string]bool {
+	t.Helper()
+	resp, err := eng.Activate(ctx, req)
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	got := make(map[string]bool, len(resp.Activations))
+	for _, a := range resp.Activations {
+		got[a.ID] = true
+	}
+	return got
+}
+
+// TestExcludeTags_DefaultIdentity pins that a vault with NO exclude-tags config
+// returns a tagged engram exactly as before — the default-empty / opt-in
+// invariant. This is the byte-identical-to-today control for the drop test.
+func TestExcludeTags_DefaultIdentity(t *testing.T) {
+	eng, as, _, cleanup := testEnvWithAuth(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "excl-default"
+	if err := as.SetVaultConfig(auth.VaultConfig{Name: vault, Public: true}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+
+	noiseID := writeTagged(t, eng, ctx, vault, "alpha topic", "noise-tag")
+	keepID := writeTagged(t, eng, ctx, vault, "beta topic", "keep-tag")
+	awaitFTS(t, eng)
+
+	got := recallIDs(t, eng, ctx, &mbp.ActivateRequest{
+		Vault:      vault,
+		Context:    []string{"common searchable body text for recall"},
+		MaxResults: 10,
+		Threshold:  0.0,
+	})
+	if !got[noiseID] {
+		t.Errorf("default (no ExcludeTags): tagged engram was dropped — expected identity behavior")
+	}
+	if !got[keepID] {
+		t.Errorf("default (no ExcludeTags): untagged-relative engram missing from recall")
+	}
+}
+
+// TestExcludeTags_DropsFromRanking is the core feature test: a candidate
+// carrying an excluded tag is dropped from recall ranking, a non-excluded
+// candidate still ranks, and the dropped engram remains reachable by explicit
+// direct-id read (exclusion is ranking-only).
+func TestExcludeTags_DropsFromRanking(t *testing.T) {
+	eng, as, _, cleanup := testEnvWithAuth(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "excl-drop"
+	if err := as.SetVaultConfig(auth.VaultConfig{
+		Name:       vault,
+		Public:     true,
+		Plasticity: &auth.PlasticityConfig{ExcludeTags: []string{"noise-tag"}},
+	}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+
+	noiseID := writeTagged(t, eng, ctx, vault, "alpha topic", "noise-tag")
+	keepID := writeTagged(t, eng, ctx, vault, "beta topic", "keep-tag")
+	awaitFTS(t, eng)
+
+	got := recallIDs(t, eng, ctx, &mbp.ActivateRequest{
+		Vault:      vault,
+		Context:    []string{"common searchable body text for recall"},
+		MaxResults: 10,
+		Threshold:  0.0,
+	})
+	if got[noiseID] {
+		t.Errorf("excluded-tag engram leaked into recall ranking (#713 drop failed)")
+	}
+	if !got[keepID] {
+		t.Errorf("non-excluded engram was dropped — exclusion must be tag-scoped, not blanket")
+	}
+
+	// Ranking-only: the excluded engram is still retrievable by direct id.
+	rd, err := eng.Read(ctx, &mbp.ReadRequest{ID: noiseID, Vault: vault})
+	if err != nil {
+		t.Fatalf("Read(excluded id): %v — exclusion must be ranking-only, not a hide", err)
+	}
+	if rd.ID != noiseID {
+		t.Errorf("Read returned id %q, want %q", rd.ID, noiseID)
+	}
+}
+
+// TestExcludeTags_ExplicitIncludeOverrides pins that an explicit per-request tag
+// include (tags_any naming an excluded tag) overrides the standing exclude —
+// the caller can always reach an excluded tag on purpose.
+func TestExcludeTags_ExplicitIncludeOverrides(t *testing.T) {
+	eng, as, _, cleanup := testEnvWithAuth(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "excl-override"
+	if err := as.SetVaultConfig(auth.VaultConfig{
+		Name:       vault,
+		Public:     true,
+		Plasticity: &auth.PlasticityConfig{ExcludeTags: []string{"noise-tag"}},
+	}); err != nil {
+		t.Fatalf("SetVaultConfig: %v", err)
+	}
+
+	noiseID := writeTagged(t, eng, ctx, vault, "alpha topic", "noise-tag")
+	awaitFTS(t, eng)
+
+	got := recallIDs(t, eng, ctx, &mbp.ActivateRequest{
+		Vault:      vault,
+		Context:    []string{"common searchable body text for recall"},
+		MaxResults: 10,
+		Threshold:  0.0,
+		Filters:    []mbp.Filter{{Field: "tags_any", Value: []string{"noise-tag"}}},
+	})
+	if !got[noiseID] {
+		t.Errorf("explicit tags_any include did not override the standing exclude (#713 override failed)")
+	}
+}


### PR DESCRIPTION
Optional per-vault `ExcludeTags` list that drops configured tags from recall **ranking** — the general, per-vault-configurable mechanism for the near-duplicate / auto-generated-tag crowding that hurts recall (and, measured separately, self-knowledge signals like staleness).

## Behavior
- **Default-empty / opt-in** (principle #11): nil or empty resolves identically to no config; a vault without this set recalls byte-identically to before. No tag names hardcoded.
- **Ranking-only**: an excluded-tag engram is not deleted, not hidden from direct-id / as_of-by-id reads, and still counts toward the vault.
- **Caller intent wins**: an explicit per-request `tags_all`/`tags_any` naming an excluded tag overrides the standing exclude for that request.
- Reuses the existing tag-filter extraction path (principle #7); config rides the same `PlasticityConfig` -> `ResolvedPlasticity` resolution as `SemanticFloor`.

## Tests
RED-first coverage across `internal/auth` (resolution/normalization + opt-in identity), `internal/engine/activation` (candidate dropped from ranking; default = no drop; per-request include overrides), and `internal/engine` (wire-up + id/as_of bypass). Build/vet/gofmt clean; `-race` green.

Refs #713.