### PR TITLE
feat(recall): self-knowledge surface — staleness + contradiction annotations

### DIFF
--- a/internal/cognitive/contradictext/contradictext.go
+++ b/internal/cognitive/contradictext/contradictext.go
@@ -1,0 +1,344 @@
+// Package contradictext is a model-free, pure-function text contradiction
+// detector. Given two short statements it decides whether they carry an
+// ACTUAL conflict signal — not whether they are similar. This distinction is
+// the whole point: two statements can be embedding-near-identical paraphrases
+// and NOT conflict ("returns 200 on success" vs "responds OK when it
+// succeeds"), while two dissimilar-looking statements DO ("auth tokens never
+// expire" vs "auth tokens expire after 24 hours"). Similarity is never
+// consulted here.
+//
+// It is deliberately separate from internal/cognitive/contradict.go, which
+// detects contradictions between association RELATION TYPES over the
+// association matrix (Supports vs Contradicts, etc.). That mechanism operates
+// on graph edges; this one operates on raw text and has no storage or engine
+// dependency. Both the recall self-knowledge surface and the Push consume this
+// text detector.
+//
+// Two detectors are ported (matching the proven Python miner: precision 1.00,
+// recall 0.93, paraphrase false-positive rate 0.000):
+//
+//  1. Polarity / negation flip — same-subject statements where one negates the
+//     other (a negation cue in scope over a shared predicate) or asserts a
+//     known antonym of the other ("enabled" vs "disabled").
+//  2. Numeric / value mismatch — same-subject statements that assert a
+//     genuinely SWAPPED value in a comparable slot (100 vs 250; true vs false).
+//     A swap requires a value present in A but not B AND a value present in B
+//     but not A, so "returns 200 on success" vs "responds OK ..." (only one
+//     side has a value) is never flagged.
+//
+// Both detectors are gated on a shared-subject test so unrelated statements are
+// never compared. Everything is deterministic, allocation-light, and cheap
+// enough to run across a full recall result set (~190 pairs) in well under a
+// millisecond.
+package contradictext
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Kind classifies which detector fired. Empty when there is no conflict.
+const (
+	KindNone     = ""
+	KindPolarity = "polarity"
+	KindNumeric  = "numeric"
+)
+
+// Detector holds the (English, hand-built) lexicons and the enable flags for
+// each detector. The zero value is not useful; construct one with New (or use
+// the package-level Conflict, which shares a single default Detector). Callers
+// may build a Detector with New and extend its exported maps before first use;
+// the maps are read-only during detection so a configured Detector is safe to
+// share across goroutines.
+type Detector struct {
+	// Stopwords are dropped when computing the shared-subject overlap.
+	Stopwords map[string]struct{}
+	// Negations are cues that flip polarity ("not", "never", "no", ...).
+	Negations map[string]struct{}
+	// Antonyms maps a word to its polarity opposite, both directions.
+	Antonyms map[string]string
+	// Booleans maps recognised boolean literals to a canonical value so
+	// "true"/"false" and "yes"/"no" participate in the numeric swap test.
+	Booleans map[string]string
+
+	// EnableNumeric / EnablePolarity toggle the individual detectors. Both
+	// default true; they exist so tests can prove each detector is load-bearing
+	// (disable it and the case it uniquely catches must stop being flagged).
+	EnableNumeric  bool
+	EnablePolarity bool
+}
+
+// numberRe matches integers, decimals and percentages, with an optional sign.
+// Compiled once; FindAllString is the only per-call allocation of note.
+var numberRe = regexp.MustCompile(`[-+]?\d+(?:\.\d+)?%?`)
+
+// tokenRe splits on any run of non-alphanumeric characters (so "req/s" ->
+// "req","s" and "24h" stays "24h"); it is used for word-level tokenisation.
+var wordSplit = func(r rune) bool {
+	return !(r >= 'a' && r <= 'z' || r >= '0' && r <= '9')
+}
+
+// New returns a Detector with the default lexicons and both detectors enabled.
+func New() *Detector {
+	d := &Detector{
+		Stopwords:      make(map[string]struct{}),
+		Negations:      make(map[string]struct{}),
+		Antonyms:       make(map[string]string),
+		Booleans:       make(map[string]string),
+		EnableNumeric:  true,
+		EnablePolarity: true,
+	}
+	for _, w := range defaultStopwords {
+		d.Stopwords[w] = struct{}{}
+	}
+	for _, w := range defaultNegations {
+		d.Negations[w] = struct{}{}
+	}
+	for _, p := range defaultAntonymPairs {
+		d.Antonyms[p[0]] = p[1]
+		d.Antonyms[p[1]] = p[0]
+	}
+	for k, v := range defaultBooleans {
+		d.Booleans[k] = v
+	}
+	return d
+}
+
+// std is the shared default Detector backing the package-level Conflict.
+var std = New()
+
+// Conflict reports whether a and b carry an actual contradiction signal, using
+// the package default Detector. See Detector.Conflict.
+func Conflict(a, b string) (isConflict bool, reason, kind string) {
+	return std.Conflict(a, b)
+}
+
+// Conflict reports whether a and b carry an actual contradiction signal.
+// It returns (false, "", KindNone) when there is no conflict — including for
+// paraphrases, which are similar but not conflicting. When a conflict is found
+// kind is KindNumeric or KindPolarity and reason is a short human explanation.
+func (d *Detector) Conflict(a, b string) (isConflict bool, reason, kind string) {
+	ta := d.tokenize(a)
+	tb := d.tokenize(b)
+
+	// Shared-subject gate: the two statements must be about the same thing
+	// before any conflict signal is meaningful. This is what keeps unrelated
+	// pairs (even ones that both happen to contain numbers) from being flagged.
+	if !d.sameSubject(ta, tb) {
+		return false, "", KindNone
+	}
+
+	// Numeric / value swap first (concrete), then polarity.
+	if d.EnableNumeric {
+		if ok, why := d.numericConflict(ta, tb); ok {
+			return true, why, KindNumeric
+		}
+	}
+	if d.EnablePolarity {
+		if ok, why := d.polarityConflict(ta, tb); ok {
+			return true, why, KindPolarity
+		}
+	}
+	return false, "", KindNone
+}
+
+// tokens is the parsed view of one statement.
+type tokens struct {
+	words   []string            // all lowercased alphanumeric words, in order
+	set     map[string]struct{} // set of words
+	subject map[string]struct{} // words minus stopwords/negations/numbers/booleans
+	values  map[string]struct{} // numeric literals + canonical boolean values
+	negated bool                // statement contains a negation cue
+}
+
+func (d *Detector) tokenize(s string) tokens {
+	s = strings.ToLower(s)
+	words := strings.FieldsFunc(s, wordSplit)
+
+	t := tokens{
+		words:   words,
+		set:     make(map[string]struct{}, len(words)),
+		subject: make(map[string]struct{}, len(words)),
+		values:  make(map[string]struct{}),
+	}
+	for _, w := range words {
+		t.set[w] = struct{}{}
+		if _, isNeg := d.Negations[w]; isNeg {
+			t.negated = true
+		}
+		if bv, isBool := d.Booleans[w]; isBool {
+			t.values[bv] = struct{}{}
+		}
+	}
+	// Numeric literals come straight off the raw (lowercased) string so signs,
+	// decimals and percentages survive the alphanumeric split.
+	for _, n := range numberRe.FindAllString(s, -1) {
+		t.values[n] = struct{}{}
+	}
+	// Subject words: drop stopwords, negation cues, pure numbers and booleans so
+	// the differing signal words don't distort the overlap.
+	for _, w := range words {
+		if _, ok := d.Stopwords[w]; ok {
+			continue
+		}
+		if _, ok := d.Negations[w]; ok {
+			continue
+		}
+		if _, ok := d.Booleans[w]; ok {
+			continue
+		}
+		if isNumberWord(w) {
+			continue
+		}
+		t.subject[w] = struct{}{}
+	}
+	return t
+}
+
+// sameSubject requires at least two shared subject words. Two is enough to bind
+// the statements to a common referent while still rejecting unrelated pairs.
+func (d *Detector) sameSubject(a, b tokens) bool {
+	shared := 0
+	// Iterate the smaller set.
+	small, large := a.subject, b.subject
+	if len(large) < len(small) {
+		small, large = large, small
+	}
+	for w := range small {
+		if _, ok := large[w]; ok {
+			shared++
+			if shared >= 2 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// numericConflict fires on a genuine value SWAP: some value asserted by a is
+// absent from b AND some value asserted by b is absent from a. This models
+// "different value in the same slot" without flagging a mere extra number.
+func (d *Detector) numericConflict(a, b tokens) (bool, string) {
+	if len(a.values) == 0 || len(b.values) == 0 {
+		return false, ""
+	}
+	onlyA := diff(a.values, b.values)
+	onlyB := diff(b.values, a.values)
+	if len(onlyA) == 0 || len(onlyB) == 0 {
+		return false, ""
+	}
+	return true, "value mismatch: " + strings.Join(onlyA, ",") + " vs " + strings.Join(onlyB, ",")
+}
+
+// polarityConflict fires when the two same-subject statements carry opposite
+// polarity: either a known antonym pair spans them, or exactly one of them
+// negates a shared predicate (negation XOR over a common subject word).
+func (d *Detector) polarityConflict(a, b tokens) (bool, string) {
+	// Antonym across the pair.
+	for w := range a.set {
+		if opp, ok := d.Antonyms[w]; ok {
+			if _, present := b.set[opp]; present {
+				return true, "antonym pair: " + w + "/" + opp
+			}
+		}
+	}
+	// Negation XOR over a shared subject predicate. Exactly one side negates,
+	// and (via the subject gate already passed) they share a predicate word, so
+	// one asserts what the other denies.
+	if a.negated != b.negated {
+		if pred, ok := firstShared(a.subject, b.subject); ok {
+			return true, "negation flip on shared predicate: " + pred
+		}
+	}
+	return false, ""
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func isNumberWord(w string) bool {
+	// A word is numeric if it is fully consumed by numberRe.
+	loc := numberRe.FindString(w)
+	return loc == w
+}
+
+// diff returns the sorted members of x not present in y.
+func diff(x, y map[string]struct{}) []string {
+	var out []string
+	for v := range x {
+		if _, ok := y[v]; !ok {
+			out = append(out, v)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// firstShared returns a deterministic shared member of a and b, if any.
+func firstShared(a, b map[string]struct{}) (string, bool) {
+	small, large := a, b
+	if len(large) < len(small) {
+		small, large = large, small
+	}
+	var shared []string
+	for w := range small {
+		if _, ok := large[w]; ok {
+			shared = append(shared, w)
+		}
+	}
+	if len(shared) == 0 {
+		return "", false
+	}
+	sort.Strings(shared)
+	return shared[0], true
+}
+
+// --- default lexicons ------------------------------------------------------
+
+var defaultStopwords = []string{
+	"a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+	"to", "of", "on", "in", "for", "when", "it", "its", "at", "by", "as",
+	"and", "or", "with", "that", "this", "these", "those", "after", "before",
+	"will", "has", "have", "had", "does", "do", "did", "than", "then", "so",
+	"but", "if", "into", "over", "per", "from", "up",
+}
+
+var defaultNegations = []string{
+	"not", "no", "never", "none", "neither", "nor", "without", "cannot",
+	"cant", "wont", "dont", "doesnt", "isnt", "arent", "wasnt", "werent",
+	"nt", "unable", "fails", "fail",
+}
+
+// defaultAntonymPairs are hand-built polarity opposites. Kept small and
+// English-only; a caller may extend Detector.Antonyms for its domain. "on/off"
+// is deliberately omitted because "on" is a stopword.
+var defaultAntonymPairs = [][2]string{
+	{"enabled", "disabled"},
+	{"enable", "disable"},
+	{"active", "inactive"},
+	{"allowed", "denied"},
+	{"allow", "deny"},
+	{"valid", "invalid"},
+	{"present", "absent"},
+	{"granted", "revoked"},
+	{"locked", "unlocked"},
+	{"online", "offline"},
+	{"mutable", "immutable"},
+	{"public", "private"},
+	{"required", "optional"},
+	{"mandatory", "optional"},
+	{"permanent", "temporary"},
+	{"success", "failure"},
+	{"open", "closed"},
+}
+
+// defaultBooleans map boolean literals to a canonical value so a true/false
+// flip registers as a numeric-style value swap.
+// The canonical values contain ':' so they can never collide with a numeric
+// literal (numberRe never emits ':') or an ordinary word token.
+var defaultBooleans = map[string]string{
+	"true":  "bool:true",
+	"false": "bool:false",
+	"yes":   "bool:true",
+	"no":    "bool:false",
+}

--- a/internal/cognitive/contradictext/contradictext_test.go
+++ b/internal/cognitive/contradictext/contradictext_test.go
@@ -1,0 +1,185 @@
+package contradictext
+
+import "testing"
+
+// PRIVACY: every string in this file is INVENTED. None of it is derived from
+// any real vault, memory, tag, entity, or vault name. The fixtures are generic
+// software-config assertions chosen only to exercise the detectors.
+
+func TestConflict(t *testing.T) {
+	cases := []struct {
+		name     string
+		a        string
+		b        string
+		wantHit  bool
+		wantKind string
+	}{
+		// --- contradictions that MUST be detected -----------------------------
+		{
+			name:     "numeric mismatch: rate limit value swap",
+			a:        "Rate limit is 100 req/s",
+			b:        "Rate limit is 250 req/s",
+			wantHit:  true,
+			wantKind: KindNumeric,
+		},
+		{
+			name:     "numeric mismatch: percentage swap across tense",
+			a:        "Error rate was 50%",
+			b:        "Error rate is 2%",
+			wantHit:  true,
+			wantKind: KindNumeric,
+		},
+		{
+			name:     "boolean flip: true vs false",
+			a:        "Payload validation is true",
+			b:        "Payload validation is false",
+			wantHit:  true,
+			wantKind: KindNumeric,
+		},
+		{
+			name:     "polarity flip: negation over shared predicate",
+			a:        "Auth tokens never expire",
+			b:        "Auth tokens expire after 24 hours",
+			wantHit:  true,
+			wantKind: KindPolarity,
+		},
+		{
+			name:     "polarity flip: antonym enabled vs disabled",
+			a:        "Feature flag beta is enabled",
+			b:        "Feature flag beta is disabled",
+			wantHit:  true,
+			wantKind: KindPolarity,
+		},
+		{
+			name:     "polarity flip: antonym allowed vs denied",
+			a:        "Anonymous access is allowed",
+			b:        "Anonymous access is denied",
+			wantHit:  true,
+			wantKind: KindPolarity,
+		},
+
+		// --- paraphrases that MUST NOT be flagged (the decisive property) -----
+		// Embedding-similar, semantically equivalent, zero conflict signal.
+		{
+			name:    "paraphrase: 200-on-success vs responds-OK",
+			a:       "returns 200 on success",
+			b:       "responds OK when it succeeds",
+			wantHit: false,
+		},
+		{
+			name:    "paraphrase: deploy-on-merge reworded",
+			a:       "deploys on merge to main",
+			b:       "merging to main triggers a deploy",
+			wantHit: false,
+		},
+
+		// --- unrelated pairs: no shared subject, never flagged ---------------
+		{
+			name:    "unrelated: cache ttl vs upload size (both have numbers)",
+			a:       "Cache TTL is 60 seconds",
+			b:       "Max upload size is 10 megabytes",
+			wantHit: false,
+		},
+		{
+			name:    "unrelated: no shared subject, opposite-sounding words",
+			a:       "The scheduler is active",
+			b:       "The mailbox is inactive",
+			wantHit: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason, kind := Conflict(tc.a, tc.b)
+			if got != tc.wantHit {
+				t.Fatalf("Conflict(%q, %q) hit=%v want %v (reason=%q kind=%q)",
+					tc.a, tc.b, got, tc.wantHit, reason, kind)
+			}
+			if tc.wantHit && kind != tc.wantKind {
+				t.Fatalf("Conflict(%q, %q) kind=%q want %q (reason=%q)",
+					tc.a, tc.b, kind, tc.wantKind, reason)
+			}
+			if got && reason == "" {
+				t.Fatalf("Conflict(%q, %q) reported a hit with an empty reason", tc.a, tc.b)
+			}
+			if !got && (reason != "" || kind != KindNone) {
+				t.Fatalf("Conflict(%q, %q) no hit but reason=%q kind=%q", tc.a, tc.b, reason, kind)
+			}
+		})
+	}
+}
+
+// TestKnownLimits pins the honest failure modes the proven miner documented, so
+// a future change that alters them is a deliberate, visible decision rather than
+// silent drift. These assert CURRENT behaviour, not desired behaviour.
+func TestKnownLimits(t *testing.T) {
+	// KNOWN LIMIT 1 — existential present-vs-absent MISS (a false negative,
+	// consistent with the miner's recall 0.93). "was removed" carries no lexical
+	// conflict signal (no negation cue, no antonym, no value swap), so a genuine
+	// semantic contradiction is not detected. Model-free is the trade.
+	if hit, _, _ := Conflict(
+		"The service exposes a metrics endpoint",
+		"The metrics endpoint was removed last quarter",
+	); hit {
+		t.Fatalf("known-limit existential present/absent unexpectedly flagged; the miss is expected")
+	}
+
+	// KNOWN LIMIT 2 — mixed historical state FALSE POSITIVE. Both statements can
+	// be simultaneously true when separated in time ("was 50%" during an
+	// incident, "is 2%" now), but the detector is tense-blind: it sees a value
+	// swap over a shared subject and flags it. A time/tense-aware caller must
+	// resolve this; the text detector cannot.
+	if hit, _, kind := Conflict(
+		"Error rate was 50%",
+		"Error rate is 2%",
+	); !hit || kind != KindNumeric {
+		t.Fatalf("known-limit mixed-historical: want numeric hit (tense-blind), got hit=%v kind=%q", hit, kind)
+	}
+}
+
+// TestNumericDetectorIsLoadBearing is a RED-sanity check: disable the numeric
+// detector and the pure-numeric case must stop being flagged. If this still
+// passed with EnableNumeric=false, the numeric detector would be dead code and
+// something else would be (wrongly) catching the case.
+func TestNumericDetectorIsLoadBearing(t *testing.T) {
+	a, b := "Rate limit is 100 req/s", "Rate limit is 250 req/s"
+
+	d := New()
+	if hit, _, kind := d.Conflict(a, b); !hit || kind != KindNumeric {
+		t.Fatalf("with numeric enabled: want numeric hit, got hit=%v kind=%q", hit, kind)
+	}
+
+	d.EnableNumeric = false
+	if hit, _, _ := d.Conflict(a, b); hit {
+		t.Fatalf("numeric detector disabled but numeric case still flagged — detector is not load-bearing")
+	}
+}
+
+// TestPolarityDetectorIsLoadBearing is the same RED-sanity check for polarity.
+func TestPolarityDetectorIsLoadBearing(t *testing.T) {
+	a, b := "Feature flag beta is enabled", "Feature flag beta is disabled"
+
+	d := New()
+	if hit, _, kind := d.Conflict(a, b); !hit || kind != KindPolarity {
+		t.Fatalf("with polarity enabled: want polarity hit, got hit=%v kind=%q", hit, kind)
+	}
+
+	d.EnablePolarity = false
+	if hit, _, _ := d.Conflict(a, b); hit {
+		t.Fatalf("polarity detector disabled but polarity case still flagged — detector is not load-bearing")
+	}
+}
+
+// TestDeterministic guards the cheap-and-repeatable contract: identical inputs
+// yield identical verdicts across runs (maps are read-only during detection).
+func TestDeterministic(t *testing.T) {
+	a, b := "Auth tokens never expire", "Auth tokens expire after 24 hours"
+	firstHit, firstReason, firstKind := Conflict(a, b)
+	for i := 0; i < 50; i++ {
+		hit, reason, kind := Conflict(a, b)
+		if hit != firstHit || reason != firstReason || kind != firstKind {
+			t.Fatalf("non-deterministic verdict on run %d: (%v,%q,%q) != (%v,%q,%q)",
+				i, hit, reason, kind, firstHit, firstReason, firstKind)
+		}
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2590,6 +2590,14 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 	}
 	wg.Wait()
 
+	// Self-knowledge contradiction surface (gated): run the model-free text
+	// detector over every pair of the RETURNED (post-truncation) set and stamp
+	// each conflicting result with the other's ID. Only ContradictsIDs is
+	// touched, so result order/membership is unchanged — see annotateContradictions.
+	if req.SelfKnowledge {
+		annotateContradictions(items)
+	}
+
 	// Persist the surfaced set as a recall event (issue #573): the engrams
 	// this recall actually returned (post entity-boost, post truncation),
 	// keyed by a time-ordered event ULID. Skipped in observe mode — a pure

--- a/internal/engine/engine_selfknowledge.go
+++ b/internal/engine/engine_selfknowledge.go
@@ -1,0 +1,51 @@
+package engine
+
+import (
+	"github.com/scrypster/muninndb/internal/cognitive/contradictext"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// annotateContradictions is the "agent feels it" conflict surface (increment 1
+// of the self-knowledge wiring). It runs the model-free contradictext detector
+// over every pair of the RETURNED result set and stamps each conflicting item
+// with the other's ID in ContradictsIDs.
+//
+// Cost: O(k^2) pair comparisons where k is the (already truncated) result
+// count, so k <= MaxResults — at the default 20 that is at most ~190 pairs, and
+// each contradictext.Conflict call is deterministic, allocation-light and
+// sub-microsecond, so the whole pass runs in well under a millisecond. The
+// caller gates it behind req.SelfKnowledge so recalls that don't ask never pay.
+//
+// INVARIANT — annotations never reorder results: this pass mutates only each
+// item's ContradictsIDs slice. It never reorders, inserts, or removes an item,
+// so the response's result order and membership are byte-for-byte identical to
+// a recall that skipped it (the ContradictsIDs field is omitempty). It must run
+// POST-TRUNCATION so the pairs it compares are exactly the results the caller
+// sees — a conflict is only meaningful against another surfaced result.
+//
+// Comparison text is concept + content: the concept binds the shared subject
+// (contradictext's same-subject gate needs >=2 shared subject words) and the
+// content carries the asserted value/polarity the detector flips on.
+//
+// This is the pure-text, returned-set-bounded detection. Merging already-
+// persisted explicit RelContradicts edges (both ends in the returned set) is a
+// separate, store-reading concern still served by the annotate=true path's
+// ConflictsWith; folding it into this flat surface is a follow-on increment.
+//
+// TODO(self-knowledge): vault-wide predictive staleness — for each returned
+// result, is there a NEWER, highly-similar result ANYWHERE in the vault that
+// supersedes it — is a later increment. Increment 1 ships explicit-supersession
+// staleness only (SupersededBy != "", always-on from applySupersession) plus
+// this returned-set contradiction pass; neither does a vault-wide lookup.
+func annotateContradictions(items []mbp.ActivationItem) {
+	for i := 0; i < len(items); i++ {
+		ti := items[i].Concept + " " + items[i].Content
+		for j := i + 1; j < len(items); j++ {
+			tj := items[j].Concept + " " + items[j].Content
+			if conflict, _, _ := contradictext.Conflict(ti, tj); conflict {
+				items[i].ContradictsIDs = append(items[i].ContradictsIDs, items[j].ID)
+				items[j].ContradictsIDs = append(items[j].ContradictsIDs, items[i].ID)
+			}
+		}
+	}
+}

--- a/internal/engine/engine_selfknowledge_test.go
+++ b/internal/engine/engine_selfknowledge_test.go
@@ -1,0 +1,126 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// All fixtures below are INVENTED synthetic memories — no real vault content,
+// tags, entities, or IDs. The contradiction detector is pure text, so these
+// exercise the wiring without any stored data.
+
+func item(id, concept, content string) mbp.ActivationItem {
+	return mbp.ActivationItem{ID: id, Concept: concept, Content: content}
+}
+
+// contradictsSet returns item i's ContradictsIDs as a set for order-independent
+// assertions.
+func contradictsSet(it mbp.ActivationItem) map[string]bool {
+	s := make(map[string]bool, len(it.ContradictsIDs))
+	for _, id := range it.ContradictsIDs {
+		s[id] = true
+	}
+	return s
+}
+
+// TestAnnotateContradictions_NumericSwap: two returned results that assert a
+// swapped value in the same slot must each name the other in ContradictsIDs.
+func TestAnnotateContradictions_NumericSwap(t *testing.T) {
+	items := []mbp.ActivationItem{
+		item("id-a", "widget batch limit", "the widget batch limit is 100 per request"),
+		item("id-b", "widget batch limit", "the widget batch limit is 250 per request"),
+	}
+	annotateContradictions(items)
+
+	if !contradictsSet(items[0])["id-b"] {
+		t.Fatalf("expected id-a to contradict id-b, got %v", items[0].ContradictsIDs)
+	}
+	if !contradictsSet(items[1])["id-a"] {
+		t.Fatalf("expected id-b to contradict id-a, got %v", items[1].ContradictsIDs)
+	}
+}
+
+// TestAnnotateContradictions_PolarityFlip: an antonym pair over a shared subject
+// (enabled vs disabled) must be flagged both ways.
+func TestAnnotateContradictions_PolarityFlip(t *testing.T) {
+	items := []mbp.ActivationItem{
+		item("id-a", "beta gadget flag", "the beta gadget flag is enabled for all tenants"),
+		item("id-b", "beta gadget flag", "the beta gadget flag is disabled for all tenants"),
+	}
+	annotateContradictions(items)
+
+	if !contradictsSet(items[0])["id-b"] || !contradictsSet(items[1])["id-a"] {
+		t.Fatalf("expected mutual contradiction, got a=%v b=%v",
+			items[0].ContradictsIDs, items[1].ContradictsIDs)
+	}
+}
+
+// TestAnnotateContradictions_ParaphraseNotFlagged is the decisive privacy-safe
+// case: two same-subject paraphrases that agree must NOT be flagged. This is the
+// property that separates "conflict" from mere "similar".
+func TestAnnotateContradictions_ParaphraseNotFlagged(t *testing.T) {
+	items := []mbp.ActivationItem{
+		item("id-a", "sprocket cache policy", "the sprocket cache holds session tokens"),
+		item("id-b", "sprocket cache policy", "the sprocket cache stores session tokens"),
+	}
+	annotateContradictions(items)
+
+	if len(items[0].ContradictsIDs) != 0 || len(items[1].ContradictsIDs) != 0 {
+		t.Fatalf("paraphrases must not be flagged, got a=%v b=%v",
+			items[0].ContradictsIDs, items[1].ContradictsIDs)
+	}
+}
+
+// TestAnnotateContradictions_UnrelatedNotFlagged: results about different
+// subjects, even both carrying numbers, are never compared (shared-subject gate).
+func TestAnnotateContradictions_UnrelatedNotFlagged(t *testing.T) {
+	items := []mbp.ActivationItem{
+		item("id-a", "doohickey timeout", "the doohickey timeout is 30 seconds"),
+		item("id-b", "gizmo retry count", "the gizmo retry count is 5 attempts"),
+	}
+	annotateContradictions(items)
+
+	if len(items[0].ContradictsIDs) != 0 || len(items[1].ContradictsIDs) != 0 {
+		t.Fatalf("unrelated results must not be flagged, got a=%v b=%v",
+			items[0].ContradictsIDs, items[1].ContradictsIDs)
+	}
+}
+
+// TestAnnotateContradictions_OrderInvariant is the HARD invariant: the pass must
+// never change result order, membership, or count — it only appends to
+// ContradictsIDs. We snapshot the ID sequence, run the pass over a mixed set
+// (one conflicting pair, one unrelated), and assert the sequence is identical.
+func TestAnnotateContradictions_OrderInvariant(t *testing.T) {
+	items := []mbp.ActivationItem{
+		item("id-0", "flange torque spec", "the flange torque spec is 40 newton meters"),
+		item("id-1", "unrelated topic alpha", "the alpha module ships on tuesday"),
+		item("id-2", "flange torque spec", "the flange torque spec is 55 newton meters"),
+		item("id-3", "unrelated topic beta", "the beta module ships on friday"),
+	}
+	before := make([]string, len(items))
+	for i, it := range items {
+		before[i] = it.ID
+	}
+
+	annotateContradictions(items)
+
+	if len(items) != len(before) {
+		t.Fatalf("count changed: %d -> %d", len(before), len(items))
+	}
+	for i, it := range items {
+		if it.ID != before[i] {
+			t.Fatalf("order changed at %d: %q != %q", i, it.ID, before[i])
+		}
+	}
+	// Sanity: the conflicting pair WAS detected (so the test isn't vacuous).
+	if !contradictsSet(items[0])["id-2"] || !contradictsSet(items[2])["id-0"] {
+		t.Fatalf("expected id-0<->id-2 conflict to be detected, got 0=%v 2=%v",
+			items[0].ContradictsIDs, items[2].ContradictsIDs)
+	}
+	// And the unrelated items were left clean.
+	if len(items[1].ContradictsIDs) != 0 || len(items[3].ContradictsIDs) != 0 {
+		t.Fatalf("unrelated items should be clean, got 1=%v 3=%v",
+			items[1].ContradictsIDs, items[3].ContradictsIDs)
+	}
+}

--- a/internal/mcp/convert.go
+++ b/internal/mcp/convert.go
@@ -80,6 +80,19 @@ func activationToMemory(item *mbp.ActivationItem) Memory {
 	return m
 }
 
+// attachSelfKnowledge builds the "agent feels it" self_knowledge block onto a
+// recall Memory from its ActivationItem. Called only when muninn_recall was
+// invoked with self_knowledge=true. Staleness/current_version reuse the
+// always-on supersession fields (item.SupersededBy/CurrentVersion); contradicts_ids
+// is the returned-set contradiction detection the engine computed under the flag.
+func attachSelfKnowledge(m *Memory, item *mbp.ActivationItem) {
+	m.SelfKnowledge = &SelfKnowledge{
+		Stale:          item.SupersededBy != "",
+		CurrentVersion: item.CurrentVersion,
+		ContradictsIDs: item.ContradictsIDs,
+	}
+}
+
 // readResponseToMemory converts a ReadResponse to a Memory for the muninn_read tool.
 // Returns the full content without truncation, and maps Summary when present.
 // Entities and EntityRelationships are included when populated by the engine.

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -521,6 +521,12 @@ func (s *MCPServer) handleRecall(ctx context.Context, w http.ResponseWriter, id 
 
 	annotate, _ := args["annotate"].(bool)
 
+	// self_knowledge gates the O(k^2) returned-set contradiction pass in the
+	// engine (staleness is always-on and needs no flag). Plumbed onto the engine
+	// request so the detection runs once, on the surfaced set, inside Activate.
+	selfKnowledge, _ := args["self_knowledge"].(bool)
+	req.SelfKnowledge = selfKnowledge
+
 	resp, err := s.engine.Activate(ctx, req)
 	if err != nil {
 		sendError(w, id, -32000, "tool error: "+err.Error())
@@ -544,6 +550,15 @@ func (s *MCPServer) handleRecall(ctx context.Context, w http.ResponseWriter, id 
 			// activationToMemory already attached, so superseded_by/current_version
 			// from the ranking phase are preserved.
 			augmentAnnotations(&memories[i], &item, ann)
+		}
+	}
+
+	// The felt self-knowledge block: stale/current_version (from the always-on
+	// supersession fields) and contradicts_ids (the engine's returned-set
+	// contradiction pass). Only present when the caller asked for it.
+	if selfKnowledge {
+		for i := range resp.Activations {
+			attachSelfKnowledge(&memories[i], &resp.Activations[i])
 		}
 	}
 

--- a/internal/mcp/selfknowledge_test.go
+++ b/internal/mcp/selfknowledge_test.go
@@ -1,0 +1,76 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// All fixtures below are INVENTED synthetic values — no real vault data.
+
+// TestAttachSelfKnowledge_Stale: a result carrying a supersession stamp yields
+// stale=true and surfaces its current_version in the self_knowledge block.
+func TestAttachSelfKnowledge_Stale(t *testing.T) {
+	item := mbp.ActivationItem{
+		ID:             "id-old",
+		SupersededBy:   "id-mid",
+		CurrentVersion: "id-head",
+	}
+	m := activationToMemory(&item)
+	attachSelfKnowledge(&m, &item)
+
+	if m.SelfKnowledge == nil {
+		t.Fatal("expected self_knowledge block")
+	}
+	if !m.SelfKnowledge.Stale {
+		t.Error("expected stale=true for a superseded result")
+	}
+	if m.SelfKnowledge.CurrentVersion != "id-head" {
+		t.Errorf("current_version = %q, want id-head", m.SelfKnowledge.CurrentVersion)
+	}
+}
+
+// TestAttachSelfKnowledge_NotStale: a result with no supersession is not stale.
+func TestAttachSelfKnowledge_NotStale(t *testing.T) {
+	item := mbp.ActivationItem{ID: "id-fresh"}
+	m := activationToMemory(&item)
+	attachSelfKnowledge(&m, &item)
+
+	if m.SelfKnowledge == nil {
+		t.Fatal("expected self_knowledge block")
+	}
+	if m.SelfKnowledge.Stale {
+		t.Error("expected stale=false for a non-superseded result")
+	}
+}
+
+// TestAttachSelfKnowledge_Contradicts: contradicts_ids carried on the
+// ActivationItem is surfaced into the self_knowledge block.
+func TestAttachSelfKnowledge_Contradicts(t *testing.T) {
+	item := mbp.ActivationItem{ID: "id-a", ContradictsIDs: []string{"id-b"}}
+	m := activationToMemory(&item)
+	attachSelfKnowledge(&m, &item)
+
+	if m.SelfKnowledge == nil || len(m.SelfKnowledge.ContradictsIDs) != 1 ||
+		m.SelfKnowledge.ContradictsIDs[0] != "id-b" {
+		t.Fatalf("expected contradicts_ids=[id-b], got %+v", m.SelfKnowledge)
+	}
+}
+
+// TestSelfKnowledge_OmittedWhenNotAttached is the backward-compat guard: a
+// Memory built WITHOUT attachSelfKnowledge (flag off) must serialize with no
+// self_knowledge key at all — old clients see today's exact response.
+func TestSelfKnowledge_OmittedWhenNotAttached(t *testing.T) {
+	item := mbp.ActivationItem{ID: "id-x", ContradictsIDs: []string{"id-y"}}
+	m := activationToMemory(&item) // flag off: attachSelfKnowledge NOT called
+
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "self_knowledge") {
+		t.Fatalf("self_knowledge must be absent when flag off, got: %s", b)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -230,6 +230,10 @@ func allToolDefinitions() []ToolDefinition {
 						"type":        "boolean",
 						"description": "When true, each result includes an annotations object with staleness, conflict, and supersession metadata. Default false.",
 					},
+					"self_knowledge": map[string]any{
+						"type":        "boolean",
+						"description": "When true, each result includes a self_knowledge block: stale (superseded by a newer fact), current_version (the fact to consult now), and contradicts_ids (IDs of OTHER results in this response that this one actually conflicts with — a value swap or polarity flip). The contradiction pass compares only the returned set. Default false.",
+					},
 					"caller": map[string]any{
 						"type":        "string",
 						"description": "Your ownership-lease identity (conventionally '{host}:{session}'). Memories checked out by a live lease owned by someone else are hidden; your own leased memories are returned normally. See muninn_claim.",

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -121,6 +121,30 @@ type Memory struct {
 	// are always set when the memory is superseded; the rest of the fields
 	// (stale, conflicts_with, last_verified) only when annotate=true.
 	Annotations *MemoryAnnotations `json:"annotations,omitempty"`
+
+	// SelfKnowledge is the "agent feels it" block, populated only when
+	// muninn_recall is called with self_knowledge=true. It groups the felt
+	// signals about THIS result relative to the returned set: whether it is
+	// stale (superseded by a newer fact), what the current version is, and which
+	// other returned results it contradicts. Absent when the flag is off, so an
+	// old client sees today's exact response.
+	SelfKnowledge *SelfKnowledge `json:"self_knowledge,omitempty"`
+}
+
+// SelfKnowledge is muninn_recall's felt self-assessment of one result, emitted
+// only under self_knowledge=true. Stale/CurrentVersion mirror the always-on
+// supersession annotation (surfaced here so the whole felt picture is in one
+// block); ContradictsIDs is the returned-set contradiction detection.
+type SelfKnowledge struct {
+	// Stale is true when this result is superseded by a newer active fact
+	// (SupersededBy != ""): the explicit-supersession staleness signal.
+	Stale bool `json:"stale"`
+	// CurrentVersion is the chain head — the fact to consult now — when stale.
+	CurrentVersion string `json:"current_version,omitempty"`
+	// ContradictsIDs are the IDs of other results in THIS response that carry an
+	// actual contradiction signal against this one (value swap or polarity flip
+	// over a shared subject). Empty/absent when this result conflicts with none.
+	ContradictsIDs []string `json:"contradicts_ids,omitempty"`
 }
 
 // MemoryAnnotations contains contextual metadata about a recalled memory.

--- a/internal/transport/mbp/types.go
+++ b/internal/transport/mbp/types.go
@@ -223,6 +223,14 @@ type ActivateRequest struct {
 	// IncludeInvalid disables the valid-time gate entirely (show history):
 	// expired facts are returned, annotated with expired=true.
 	IncludeInvalid bool `json:"include_invalid,omitempty" msgpack:"include_invalid,omitempty"`
+	// SelfKnowledge, when true, asks recall to compute the "agent feels it"
+	// contradiction surface: the model-free contradictext detector is run over
+	// every pair of the RETURNED result set (post-ranking, post-truncation) and
+	// each conflicting result is stamped with the other's ID in ContradictsIDs.
+	// Gated because it is O(k^2) in the returned count; the staleness signal
+	// (SupersededBy/CurrentVersion) is always-on and needs no flag. Additive and
+	// omitempty, so an old client that never sets it gets today's exact response.
+	SelfKnowledge bool `json:"self_knowledge,omitempty" msgpack:"self_knowledge,omitempty"`
 }
 
 // Weights defines scoring weight distribution.
@@ -318,6 +326,15 @@ type ActivationItem struct {
 	// Importance is the STORED caller-asserted importance (0 = unset; the
 	// presentation layer derives the effective value — see ReadResponse).
 	Importance float32 `msgpack:"importance,omitempty" json:"importance,omitempty"`
+	// ContradictsIDs lists the IDs of OTHER results in this same recall response
+	// that this result carries an actual contradiction signal against — a value
+	// swap ("limit is 100" vs "limit is 250") or a polarity flip ("enabled" vs
+	// "disabled") over a shared subject, from the model-free contradictext
+	// detector. It is the "agent feels it" conflict surface: computed over the
+	// returned set only (never a vault-wide scan), post-ranking so it never
+	// changes result order, and only when the request sets SelfKnowledge (the
+	// O(k^2) pass is gated for cost). Empty/absent when off or no conflict.
+	ContradictsIDs []string `msgpack:"contradicts_ids,omitempty" json:"contradicts_ids,omitempty"`
 }
 
 // ScoreComponents breaks down the activation score.


### PR DESCRIPTION
First increment of the recall **self-knowledge surface**: a recall with `self_knowledge: true` returns each result annotated with whether it is **stale** (superseded by a newer memory) and which other results it **contradicts** — so an agent gets its answers *with* the memory's own read on them.

## What it adds
- **Response shape (additive, `omitempty` — old clients get byte-identical responses):**
  - `mbp.ActivationItem` += `ContradictsIDs []string`; `ActivateRequest` += `SelfKnowledge bool` (REST inherits via type alias).
  - MCP `Memory` += a `self_knowledge` block `{stale, current_version, contradicts_ids}`, emitted only under the flag; `muninn_recall` gains a `self_knowledge` arg.
- **Staleness** — reuses `applySupersession`'s existing always-on `superseded_by`/`current_version` (explicit `RelSupersedes`). `stale = superseded_by != ""`. (Vault-wide *predictive* staleness is a flagged follow-on.)
- **Contradiction** — a new pure-function text detector (`internal/cognitive/contradictext/`, polarity + numeric conflict, separate from the association-matrix detector) run over the **returned, post-truncation** set, gated behind `self_knowledge` (the O(k²) part; k≤MaxResults, sub-ms).

## Invariants
- **Ranking is never changed** — the pass only appends to `ContradictsIDs`; `TestAnnotateContradictions_OrderInvariant` asserts the result order is identical with vs without it (and non-vacuously that the conflict was still found).
- **Backward-compatible** — flag off ⇒ no detection ⇒ `omitempty` drops the fields; `TestSelfKnowledge_OmittedWhenNotAttached`.
- **Paraphrases are not flagged as contradictions** (the decisive case): `TestAnnotateContradictions_ParaphraseNotFlagged`.

## Notes for review
- **Tier-3 (wire format):** the new `msgpack`/`json` fields on the MBP/REST surface — additive/`omitempty`. gRPC/proto fields deferred.
- Drift follow-on (additive, non-gating): `openapi.yaml` + SDK field parity.
- Build/vet/gofmt clean; `-race` green on engine/mcp/cognitive.

Refs the self-knowledge capability work.