### PR TITLE
feat(provenance): record the real write verb instead of hardcoded "create"

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -3561,7 +3561,7 @@ func (e *Engine) EvolveAt(ctx context.Context, vault, oldID, newContent, reason 
 	batch := e.store.NewBatch()
 	defer batch.Discard()
 
-	if err := batch.WriteEngram(ctx, wsPrefix, newEng); err != nil {
+	if err := batch.WriteEngramOp(ctx, wsPrefix, newEng, "evolve"); err != nil {
 		return storage.ULID{}, fmt.Errorf("evolve: batch write new engram: %w", err)
 	}
 	if err := batch.WriteAssociation(ctx, wsPrefix, newULID, oldULID, supersedes); err != nil {

--- a/internal/provenance/types.go
+++ b/internal/provenance/types.go
@@ -20,6 +20,6 @@ type ProvenanceEntry struct {
 	Timestamp time.Time
 	Source    SourceType
 	AgentID   string // e.g. "user:mj", "ollama:llama3.2", "consolidation-worker"
-	Operation string // "create", "update-relevance", "update-meta", "merge", "promote"
+	Operation string // "create", "evolve", "update-relevance", "update-meta", "update-trust", "stamp-valid-until", "merge", "promote"
 	Note      string // optional free text
 }

--- a/internal/storage/batch.go
+++ b/internal/storage/batch.go
@@ -39,8 +39,9 @@ type pebbleStoreBatch struct {
 // batchPendingItem holds the data required for post-commit vault counter and
 // provenance work for a single engram queued into the batch.
 type batchPendingItem struct {
-	wsPrefix [8]byte
-	eng      *Engram
+	wsPrefix  [8]byte
+	eng       *Engram
+	operation string // provenance verb: "create" (default), "evolve", etc.
 }
 
 // NewBatch returns a new StoreBatch that queues engram writes atomically.
@@ -54,7 +55,19 @@ func (ps *PebbleStore) NewBatch() StoreBatch {
 
 // WriteEngram queues all keys for eng into the batch (does not commit).
 // It applies the same defaulting and encoding logic as PebbleStore.WriteEngram.
+// The provenance entry records Operation "create" — use WriteEngramOp for
+// batch writes that are not creating a brand-new engram.
 func (b *pebbleStoreBatch) WriteEngram(ctx context.Context, wsPrefix [8]byte, eng *Engram) error {
+	return b.WriteEngramOp(ctx, wsPrefix, eng, "create")
+}
+
+// WriteEngramOp queues all keys for eng into the batch exactly like
+// WriteEngram, except the eventual provenance entry (written post-commit,
+// see Commit below) records operation as the originating verb instead of
+// always "create". Evolve's successor engram is queued through this so its
+// provenance reads "evolve", not "create" (the write-path verb was
+// previously discarded — see issue tracked in the provenance-verb work).
+func (b *pebbleStoreBatch) WriteEngramOp(ctx context.Context, wsPrefix [8]byte, eng *Engram, operation string) error {
 	// Apply defaults — same as PebbleStore.WriteEngram.
 	if eng.ID == (ULID{}) {
 		if !eng.CreatedAt.IsZero() {
@@ -144,7 +157,7 @@ func (b *pebbleStoreBatch) WriteEngram(ctx context.Context, wsPrefix [8]byte, en
 	laKey := keys.LastAccessIndexKey(wsPrefix, laMillis, id16)
 	b.batch.Set(laKey, nil, nil)
 
-	b.pendingItems = append(b.pendingItems, batchPendingItem{wsPrefix: wsPrefix, eng: eng})
+	b.pendingItems = append(b.pendingItems, batchPendingItem{wsPrefix: wsPrefix, eng: eng, operation: operation})
 	return nil
 }
 
@@ -342,11 +355,15 @@ func (b *pebbleStoreBatch) Commit() error {
 		}
 
 		if b.ps.provWork != nil {
+			op := item.operation
+			if op == "" {
+				op = "create" // defensive default; WriteEngram/WriteEngramOp always set this
+			}
 			b.ps.provWork.Submit(ws, eng.ID, provenance.ProvenanceEntry{
 				Timestamp: eng.CreatedAt,
 				Source:    provenance.SourceHuman,
 				AgentID:   eng.CreatedBy,
-				Operation: "create",
+				Operation: op,
 			})
 		}
 	}

--- a/internal/storage/batch_test.go
+++ b/internal/storage/batch_test.go
@@ -155,3 +155,74 @@ func TestStoreBatch_DefaultsApplied(t *testing.T) {
 		t.Error("CreatedAt should not be zero")
 	}
 }
+
+// TestStoreBatch_WriteEngramOp_RecordsRealOperation verifies that the
+// originating verb (e.g. "evolve") is threaded into the provenance entry
+// instead of being hardcoded to "create". Evolve queues its successor engram
+// through the batch (see Engine.EvolveAt), so a batch-committed engram is not
+// always a "create" — the caller must be able to say what it actually is.
+func TestStoreBatch_WriteEngramOp_RecordsRealOperation(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStoreForBatch(t)
+	ws := store.VaultPrefix("batch-op-test")
+
+	eng := &Engram{Concept: "Successor", Content: "evolved content"}
+
+	batch := store.NewBatch()
+	defer batch.Discard()
+
+	if err := batch.WriteEngramOp(ctx, ws, eng, "evolve"); err != nil {
+		t.Fatalf("WriteEngramOp: %v", err)
+	}
+	if err := batch.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// provWork.Submit is async (non-blocking channel send) — drain before reading.
+	store.provWork.Drain()
+
+	entries, err := store.ProvenanceStore().Get(ctx, ws, [16]byte(eng.ID))
+	if err != nil {
+		t.Fatalf("ProvenanceStore().Get: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 provenance entry, got %d", len(entries))
+	}
+	if entries[0].Operation != "evolve" {
+		t.Errorf("Operation = %q, want %q (the batch write must record the real originating verb, not a hardcoded \"create\")", entries[0].Operation, "evolve")
+	}
+}
+
+// TestStoreBatch_WriteEngram_StillRecordsCreate is a non-regression pin:
+// the plain WriteEngram entry point (used by remember_tree / add_child, which
+// genuinely create engrams) must keep recording "create".
+func TestStoreBatch_WriteEngram_StillRecordsCreate(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStoreForBatch(t)
+	ws := store.VaultPrefix("batch-op-test-create")
+
+	eng := &Engram{Concept: "Child", Content: "created content"}
+
+	batch := store.NewBatch()
+	defer batch.Discard()
+
+	if err := batch.WriteEngram(ctx, ws, eng); err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+	if err := batch.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	store.provWork.Drain()
+
+	entries, err := store.ProvenanceStore().Get(ctx, ws, [16]byte(eng.ID))
+	if err != nil {
+		t.Fatalf("ProvenanceStore().Get: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 provenance entry, got %d", len(entries))
+	}
+	if entries[0].Operation != "create" {
+		t.Errorf("Operation = %q, want %q", entries[0].Operation, "create")
+	}
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -23,8 +23,14 @@ type OrdinalEntry struct {
 // StoreBatch is a write-only handle for atomic multi-write operations.
 // Callers must call Commit or Discard exactly once.
 type StoreBatch interface {
-	// WriteEngram queues an engram write into the batch.
+	// WriteEngram queues an engram write into the batch. Its provenance entry
+	// records Operation "create" — use WriteEngramOp when the batch is not
+	// creating a brand-new engram (e.g. Evolve's successor).
 	WriteEngram(ctx context.Context, wsPrefix [8]byte, eng *Engram) error
+	// WriteEngramOp queues an engram write into the batch exactly like
+	// WriteEngram, except the provenance entry records operation as the
+	// originating verb (e.g. "evolve") instead of the hardcoded "create".
+	WriteEngramOp(ctx context.Context, wsPrefix [8]byte, eng *Engram, operation string) error
 	// WriteAssociation queues association forward (0x03), reverse (0x04) keys into the batch.
 	WriteAssociation(ctx context.Context, wsPrefix [8]byte, src, dst ULID, assoc *Association) error
 	// WriteOrdinal queues the ordinal key for (parentID, childID) into the batch.


### PR DESCRIPTION
Every write recorded provenance `Operation: "create"`, discarding the originating verb. `muninn_evolve` in particular recorded `"create"` for its successor engram.

## Change
- Add `StoreBatch.WriteEngramOp(ctx, ws, eng, operation)` so the verb threads through; `EvolveAt` now records `"evolve"`. Plain `remember`/tree writes stay `"create"` (genuine creates).
- Additive, **non-behavioral outside the provenance record** (traced `WriteEngram`→`WriteEngramOp`→`Commit`: never touches engram bytes / WAL / counter / recall / ranking).

## Safety
No migration, no keyspace change; future evolve-writes simply record a more accurate verb. Cleanly revertible.

## Verification
Adversarial review: **APPROVE**. RED-first (behaviorally verified: patch the fix out → test fails `"create", want "evolve"`), `-race` green.