### PR TITLE
fix(recall): degrade loudly on embedding failure (semantic_degraded)

### DIFF
--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -260,6 +260,14 @@ type ActivateResult struct {
 	LatencyMs     float64
 	ProfileUsed   string        // resolved traversal profile name (e.g. "default", "causal")
 	RestoredEdges []mbp.EdgeRef // edges lazily restored from archive during Phase 4.75
+	// SemanticDegraded is true when the vector/semantic signal for this
+	// activation could not be trusted -- embed backend unreachable, an
+	// err==nil embed call returning an empty/all-zero vector for a
+	// non-trivial query, or the phase6 post-load cosine fallback failing to
+	// read stored embeddings. Recall still returns results (BM25/decay/
+	// Hebbian survive), but callers should surface this to the user/agent
+	// rather than silently trusting a zeroed vectorScore (principle #2).
+	SemanticDegraded bool
 }
 
 // ActivateResponseFrame is one streaming frame of results.
@@ -619,6 +627,31 @@ type phase1Result struct {
 	embedding []float32
 	tokens    []string
 	queryStr  string
+	// semanticDegraded is set whenever the semantic (vector) signal could not be
+	// produced or trusted for this query -- embed backend unreachable, or an
+	// err==nil embed call that returned an empty/all-zero vector for a
+	// non-trivial query (normalized embedders such as bge-small never emit an
+	// all-zero L2-normed vector for real text, so that shape is itself a silent
+	// degradation, not a valid embedding). Threaded through to
+	// ActivateResult.SemanticDegraded so callers get a loud signal instead of a
+	// silently-zeroed vectorScore (principle #2, "degrade loudly-but-gracefully").
+	semanticDegraded bool
+}
+
+// isZeroVector reports whether vec is empty or every component is exactly
+// zero. A properly L2-normalized embedding (e.g. bge-small) can never be the
+// zero vector for non-trivial input, so this shape signals a degraded/garbage
+// embedding rather than a legitimate one.
+func isZeroVector(vec []float32) bool {
+	if len(vec) == 0 {
+		return true
+	}
+	for _, v := range vec {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func (e *ActivationEngine) phase1(ctx context.Context, req *ActivateRequest) (*phase1Result, error) {
@@ -647,6 +680,7 @@ func (e *ActivationEngine) phase1(ctx context.Context, req *ActivateRequest) (*p
 			// takes the FTS-only path when len(embedding)==0.
 			slog.Warn("activation: embed backend unreachable, degrading to BM25-only recall",
 				"vault", req.VaultID, "error", err)
+			result.semanticDegraded = true
 			return result, nil
 		}
 		// Embed returns a flat len(texts)*dim slice — each phrase's vector
@@ -658,6 +692,19 @@ func (e *ActivationEngine) phase1(ctx context.Context, req *ActivateRequest) (*p
 			vec = meanPoolEmbeddings(vec, n)
 		}
 		result.embedding = vec
+
+		// Sanity check: err == nil is not proof of a usable embedding. A
+		// normalized embedder (bge-small, L2-normed) never emits an all-zero
+		// vector for real text, so an empty/all-zero result for a non-trivial
+		// query is itself a silent degradation -- same failure class as the
+		// connection-refused case above, just without an error to catch it.
+		// Without this, phase2/phase6 silently fall back to FTS-only /
+		// vectorScore=0 with no signal at all that semantic recall is broken.
+		if strings.TrimSpace(result.queryStr) != "" && isZeroVector(result.embedding) {
+			slog.Warn("activation: embed backend returned empty/zero vector for non-trivial query, degrading to BM25-only recall",
+				"vault", req.VaultID, "query_len", len(result.queryStr))
+			result.semanticDegraded = true
+		}
 	}
 	return result, nil
 }
@@ -1435,6 +1482,12 @@ func (e *ActivationEngine) phase6Score(
 
 	w := resolveWeights(req.Weights, e.weights)
 
+	// semanticDegraded accumulates any semantic-signal failure discovered
+	// during scoring (post-load cosine fallback read errors), OR'd with
+	// whatever phase1 already found (embed backend unreachable / zero
+	// vector) so the final ActivateResult carries one loud, honest signal.
+	semanticDegraded := p1.semanticDegraded
+
 	// Guard: RRF and CGDN are mutually exclusive scoring paths.
 	// If both are enabled, RRF takes precedence (checked first below).
 	// Log the conflict so operators can fix their plasticity config.
@@ -1652,6 +1705,15 @@ func (e *ActivationEngine) phase6Score(
 						embeds[idx] = loaded[j]
 					}
 				}
+			} else {
+				// Fallback read failed: these candidates stay at vectorScore=0
+				// (SemanticSimilarity==0, never a crash), but that must never be
+				// silent -- without this WARN + flag, a storage hiccup here looks
+				// identical to "no semantic evidence exists", which is a
+				// plausible-looking wrong answer (principle #2).
+				slog.Warn("activation: phase6 post-load cosine fallback failed, candidates degraded to vectorScore=0",
+					"vault", req.VaultID, "candidates", len(fallbackIDs), "error", err)
+				semanticDegraded = true
 			}
 		}
 		for i := range all {
@@ -1941,9 +2003,10 @@ cgdnDone:
 	}
 
 	return &ActivateResult{
-		QueryID:     newQueryID(),
-		Activations: activations,
-		TotalFound:  totalFound,
+		QueryID:          newQueryID(),
+		Activations:      activations,
+		TotalFound:       totalFound,
+		SemanticDegraded: semanticDegraded,
 	}, nil
 }
 

--- a/internal/engine/activation/semantic_degraded_test.go
+++ b/internal/engine/activation/semantic_degraded_test.go
@@ -1,0 +1,196 @@
+package activation
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// warnCaptureHandler is a minimal slog.Handler that records every record's
+// level/message/attrs so a test can assert a specific WARN was actually
+// logged, not merely that behavior happened to change.
+type warnCaptureHandler struct {
+	mu      sync.Mutex
+	records []string
+}
+
+func (h *warnCaptureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *warnCaptureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var sb strings.Builder
+	sb.WriteString(r.Level.String())
+	sb.WriteString(": ")
+	sb.WriteString(r.Message)
+	r.Attrs(func(a slog.Attr) bool {
+		sb.WriteString(" ")
+		sb.WriteString(a.Key)
+		sb.WriteString("=")
+		sb.WriteString(a.Value.String())
+		return true
+	})
+	h.records = append(h.records, sb.String())
+	return nil
+}
+
+func (h *warnCaptureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *warnCaptureHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *warnCaptureHandler) contains(substr string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, rec := range h.records {
+		if strings.Contains(rec, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// erroringEmbeddingsStore wraps internalStubStore and forces GetEmbeddings to
+// fail, modeling a storage hiccup on the phase6 post-load cosine fallback
+// (e.g. the batched 0x18-key read timing out or hitting a corrupt block).
+type erroringEmbeddingsStore struct {
+	*internalStubStore
+	err error
+}
+
+func (s *erroringEmbeddingsStore) GetEmbeddings(_ context.Context, _ [8]byte, ids []storage.ULID) ([][]float32, error) {
+	return nil, s.err
+}
+
+// TestPhase6Score_FallbackGetEmbeddingsError_SemanticDegraded is the RED-first
+// repro for the "degrade silently" bug: when the phase6 post-load cosine
+// fallback's GetEmbeddings call errors, candidates silently stayed at
+// vectorScore=0 with NO warning and no signal anywhere in the result that
+// semantic recall degraded.
+//
+// Before the fix: no SemanticDegraded field exists on ActivateResult at all
+// (this test fails to compile / fails the assertion), and no WARN is logged
+// for the fallback error -- the error is swallowed by `if ... err == nil`
+// with no else branch. After the fix: phase6Score logs a WARN naming the
+// vault, candidate count, and error, and result.SemanticDegraded is true.
+//
+// SemanticSimilarity must still be 0 (safe default, no crash) -- the fix is
+// entirely about the loud signal, not changing the score value.
+func TestPhase6Score_FallbackGetEmbeddingsError_SemanticDegraded(t *testing.T) {
+	base := newInternalStubStore()
+	store := &erroringEmbeddingsStore{internalStubStore: base, err: context.DeadlineExceeded}
+
+	handler := &warnCaptureHandler{}
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	defer slog.SetDefault(oldLogger)
+
+	e := newTestActivationEngine(store)
+	defer e.Close()
+
+	eng := &storage.Engram{
+		Concept: "WidgetPipeline lifecycle", Content: "WidgetPipeline lifecycle state machine",
+		Confidence: 1.0, Stability: 30.0, State: storage.StateActive,
+	}
+	// Embedding reachable ONLY via GetEmbeddings in production (ERF v2 split);
+	// here GetEmbeddings is wired to always fail instead.
+	store.addEngramSeparateEmbedding(eng, []float32{1, 0, 0})
+
+	fused := []fusedCandidate{{id: eng.ID, rrfScore: 0.5, ftsScore: 1.0}}
+	p1 := &phase1Result{
+		queryStr:  "WidgetPipeline lifecycle state machine",
+		embedding: []float32{1, 0, 0},
+	}
+
+	result, err := e.phase6Score(context.Background(), &ActivateRequest{
+		VaultID:    7,
+		MaxResults: 10,
+		Threshold:  0.01,
+	}, [8]byte{}, fused, nil, p1)
+	if err != nil {
+		t.Fatalf("phase6Score: %v", err)
+	}
+
+	var found bool
+	for _, a := range result.Activations {
+		if a.Engram.ID == eng.ID {
+			found = true
+			if a.Components.SemanticSimilarity != 0 {
+				t.Errorf("SemanticSimilarity = %v, want exactly 0 -- a failed fallback read must never "+
+					"fabricate a score, only degrade loudly", a.Components.SemanticSimilarity)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("FTS-only candidate did not survive to the final result set")
+	}
+
+	if !result.SemanticDegraded {
+		t.Errorf("ActivateResult.SemanticDegraded = false, want true -- the phase6 post-load cosine " +
+			"fallback failed (GetEmbeddings returned an error) and that must surface as a loud signal, " +
+			"not silently leave vectorScore=0 with no trace")
+	}
+
+	if !handler.contains("phase6 post-load cosine fallback failed") {
+		t.Errorf("expected a WARN log naming the phase6 fallback failure; got records: %v", handler.records)
+	}
+	if !handler.contains("vault=7") {
+		t.Errorf("expected the WARN to include the vault ID; got records: %v", handler.records)
+	}
+}
+
+// TestPhase1_ZeroVectorEmbed_SemanticDegraded is the RED-first repro for the
+// second silent-degradation case: an embedder call that returns err == nil
+// but an empty/all-zero vector for a non-trivial query. A normalized
+// embedder (bge-small, L2-normed) never legitimately produces the zero
+// vector for real text, so this shape must be treated as a degradation, not
+// a valid (if uninformative) embedding.
+func TestPhase1_ZeroVectorEmbed_SemanticDegraded(t *testing.T) {
+	handler := &warnCaptureHandler{}
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	defer slog.SetDefault(oldLogger)
+
+	store := newInternalStubStore()
+	e := newTestActivationEngine(store)
+	defer e.Close()
+	e.embedder = &zeroVectorEmbedder{}
+	e.hnsw = &nilAwareHNSW{}
+
+	p1, err := e.phase1(context.Background(), &ActivateRequest{
+		VaultID: 9,
+		Context: []string{"a real, non-trivial query"},
+	})
+	if err != nil {
+		t.Fatalf("phase1: %v", err)
+	}
+
+	if !p1.semanticDegraded {
+		t.Errorf("phase1Result.semanticDegraded = false, want true -- embedder returned an all-zero " +
+			"vector with err==nil for a non-trivial query, which is a silent degradation, not a legitimate embedding")
+	}
+	if !handler.contains("embed backend returned empty/zero vector") {
+		t.Errorf("expected a WARN log naming the zero-vector degradation; got records: %v", handler.records)
+	}
+}
+
+// zeroVectorEmbedder always succeeds but returns an all-zero vector,
+// simulating a broken/misconfigured embed backend that responds without
+// erroring (e.g. a proxy returning a zeroed placeholder).
+type zeroVectorEmbedder struct{}
+
+func (zeroVectorEmbedder) Embed(_ context.Context, texts []string) ([]float32, error) {
+	return []float32{0, 0, 0}, nil
+}
+func (zeroVectorEmbedder) Tokenize(text string) []string { return strings.Fields(text) }
+
+// nilAwareHNSW is a minimal HNSWIndex stub -- phase1 only computes an
+// embedding at all when e.hnsw != nil, so a non-nil (if unused here) index is
+// required to exercise the embed call path.
+type nilAwareHNSW struct{}
+
+func (nilAwareHNSW) Search(_ context.Context, _ [8]byte, _ []float32, _ int) ([]ScoredID, error) {
+	return nil, nil
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2746,11 +2746,12 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 	metrics.ActivateDuration.WithLabelValues(req.Vault).Observe(d.Seconds())
 
 	return &mbp.ActivateResponse{
-		QueryID:     queryID,
-		TotalFound:  result.TotalFound,
-		Activations: items,
-		LatencyMs:   result.LatencyMs,
-		Brief:       briefSentences,
+		QueryID:          queryID,
+		TotalFound:       result.TotalFound,
+		Activations:      items,
+		LatencyMs:        result.LatencyMs,
+		Brief:            briefSentences,
+		SemanticDegraded: result.SemanticDegraded,
 	}, nil
 }
 

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -551,6 +551,14 @@ func (s *MCPServer) handleRecall(ctx context.Context, w http.ResponseWriter, id 
 		"memories": memories,
 		"total":    resp.TotalFound,
 	}
+	// SemanticDegraded: the vector signal for this recall could not be
+	// trusted (embed backend unreachable, an all-zero embedding, or a
+	// failed post-load cosine fallback read). Recall still returns results
+	// via BM25/decay/Hebbian, but the caller should know semantic ranking
+	// was compromised rather than silently trusting it (principle #2).
+	if resp.SemanticDegraded {
+		result["semantic_degraded"] = true
+	}
 	// THE PUSH: prospective notices — focal set derives from the RETURNED
 	// results; readOnly (COG-11) suppresses the fired-marker write. Omitted
 	// when empty; inert unless MUNINN_PROSPECTIVE=1.

--- a/internal/transport/grpc/engine_adapter.go
+++ b/internal/transport/grpc/engine_adapter.go
@@ -127,6 +127,11 @@ func (a *grpcEngineAdapter) Activate(ctx context.Context, req *pb.ActivateReques
 			Score: item.Score, Why: item.Why,
 		}
 	}
+	// NOTE (deferred): resp.SemanticDegraded is intentionally NOT mapped here —
+	// pb.ActivateResponse has no such field. Wiring it needs a proto field + regen
+	// (a separate drift obligation); tracked as a follow-up so this stays a minimal
+	// increment. Until then gRPC callers do not receive the degrade-loudly signal
+	// that MBP/REST/MCP carry.
 	return &pb.ActivateResponse{
 		QueryID: resp.QueryID, TotalFound: int32(resp.TotalFound),
 		Activations: items, LatencyMs: resp.LatencyMs,

--- a/internal/transport/mbp/types.go
+++ b/internal/transport/mbp/types.go
@@ -270,6 +270,13 @@ type ActivateResponse struct {
 	Frame       int              `msgpack:"frame,omitempty"        json:"frame,omitempty"`
 	TotalFrames int              `msgpack:"total_frames,omitempty" json:"total_frames,omitempty"`
 	Brief       []BriefSentence  `msgpack:"brief,omitempty"        json:"brief,omitempty"` // extractive activation brief
+	// SemanticDegraded is true when the vector/semantic signal for this
+	// activation could not be trusted -- embed backend unreachable, an
+	// err==nil embed call returning an empty/all-zero vector, or the phase6
+	// post-load cosine fallback failing to read stored embeddings. Recall
+	// still returns results (BM25/decay/Hebbian survive), but callers should
+	// not silently trust a zeroed vectorScore (principle #2: degrade loudly).
+	SemanticDegraded bool `msgpack:"semantic_degraded,omitempty" json:"semantic_degraded,omitempty"`
 }
 
 // ActivationItem is a single activated engram.

--- a/internal/transport/mbp/types.go
+++ b/internal/transport/mbp/types.go
@@ -276,6 +276,12 @@ type ActivateResponse struct {
 	// post-load cosine fallback failing to read stored embeddings. Recall
 	// still returns results (BM25/decay/Hebbian survive), but callers should
 	// not silently trust a zeroed vectorScore (principle #2: degrade loudly).
+	// Query-granular and COARSE: set on ANY such failure this recall, even if the
+	// primary HNSW vector search produced real scores and only a secondary
+	// post-load fetch failed (over-warn beats under-warn on a correctness signal).
+	// Caller-supplied embeddings are not zero-checked (only embed-backend paths).
+	// Carried on MBP + REST (alias) + MCP muninn_recall; gRPC does NOT yet map it
+	// (pb.ActivateResponse has no field — a documented deferral, tracked separately).
 	SemanticDegraded bool `msgpack:"semantic_degraded,omitempty" json:"semantic_degraded,omitempty"`
 }
 

--- a/internal/transport/rest/openapi.yaml
+++ b/internal/transport/rest/openapi.yaml
@@ -423,6 +423,14 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BriefSentence"
+        semantic_degraded:
+          type: boolean
+          description: >-
+            True when semantic (vector) scoring degraded during this recall — the
+            embed backend was unreachable, returned an empty/all-zero query vector,
+            or a post-load embedding fetch failed — so semantic_similarity may be
+            understated. Query-granular and coarse (set on any such failure even if
+            the primary vector search produced real scores). Omitted when false.
 
     # ── Link ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes a **degrade-silently** violation (principle #2): `phase6Score`'s post-load cosine fallback swallowed `GetEmbeddings` errors (candidates left at `vectorScore=0`, no WARN); `phase1` treated an `err==nil` empty/all-zero query vector like a valid one.

## Change
- WARN on both paths + a `SemanticDegraded` flag threaded to `mbp.ActivateResponse` → REST (alias) + MCP `muninn_recall` (`semantic_degraded`).
- `SemanticSimilarity` stays `0` — the point is the **loud signal**, not a value change. Ranking byte-identical.
- REST `openapi.yaml` updated; gRPC mapping is an explicit documented deferral (needs a proto field + regen — kept out to stay a minimal increment).

## Safety
Runtime flag only — no persistence, no on-disk change. Cleanly revertible.

## Verification
Adversarial review verdict addressed (openapi + gRPC deferral + doc tightening applied). RED-first (behaviorally verified), `-tags localassets` green.