### PR TITLE
feat(guide): curator reflex — treat MuninnDB as living memory, reconcile at write

### DIFF
--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -17,8 +17,9 @@ const mcpInstructions = `MuninnDB is a long-term memory server for AI agents. ` 
 	`in a shared vault it is vault-global, so use muninn_recall scoped to your per-user tag instead ` +
 	`(muninn_guide states whether this vault is shared, under Vault Configuration). ` +
 	`Store with muninn_remember (include type, summary, entities). ` +
-	`Update with muninn_evolve, not forget+remember. ` +
-	`Keep memories atomic — one concept each. ` +
+	`You are this memory's curator, not a static store: the moment you write is the moment you know something, so it is the moment to reconcile. ` +
+	`Before adding a fact, recall what's related — if your new knowledge corrects, sharpens, or supersedes an existing memory, muninn_evolve that one instead of adding a rival copy (evolve supersedes and retires the old version; a second muninn_remember leaves a stale duplicate competing in recall). ` +
+	`Reserve muninn_remember for genuinely new facts. Keep memories atomic — one concept each. ` +
 	`Call muninn_guide for the full reference.`
 
 // apiKeyValidator is the subset of auth.Store used by MCP for vault key auth.

--- a/internal/mcp/guide.go
+++ b/internal/mcp/guide.go
@@ -152,6 +152,7 @@ func generateGuide(vaultName string, resolved auth.ResolvedPlasticity, stats eng
 	b.WriteString("  1. \"Decided on JWTs with 15-minute expiry for authentication\" (type: decision)\n")
 	b.WriteString("  2. \"Tom is implementing the auth system\" (type: task)\n")
 	b.WriteString("  3. \"API rate limit set to 100 requests/second per client\" (type: decision)\n\n")
+	b.WriteString("**You are the curator, not a filing cabinet.** MuninnDB is living memory, not a static database. The moment you write is the moment you know something — so it is the moment to reconcile. Before storing a fact, recall its neighborhood; if what you now know corrects, clarifies, or replaces something already there, *evolve* that memory rather than leaving a stale rival copy to compete in recall. Curating as you write is how the vault stays true over time instead of accreting contradictions — and it costs nothing extra, because you already had the knowledge in hand.\n\n")
 	b.WriteString("**Updating vs. creating.** If you are re-asserting or updating a fact that changes or replaces a prior version of the same thing ")
 	b.WriteString("(a re-run score, a corrected status, a fact that went stale), call `muninn_evolve(id, new_content, reason)` — not `muninn_remember`. ")
 	b.WriteString("Evolve links the new engram to the old one with a `supersedes` association and soft-deletes the predecessor, so the old version ")


### PR DESCRIPTION
Primes every connecting LLM to use MuninnDB as **living memory, not a static store** — so the vault stays true over time instead of accreting near-duplicates and contradictions.

## What changes (guidance text only — no logic)
- **`internal/mcp/context.go`** (the auto-surfaced MCP `initialize` instructions — every client sees this on connect, no tool call): adds the *curator reflex* — "the moment you write is the moment you know something, so it's the moment to reconcile: before adding a fact, recall what's related; if it corrects/sharpens/supersedes an existing memory, `muninn_evolve` that one instead of adding a rival copy."
- **`muninn_guide`**: a "you are the curator, not a filing cabinet" lead-in before the existing evolve-vs-remember mechanics.

## Principle-safe by construction
- **Universal-surface-first:** the reflex ships in the on-connect instructions, so the behavior does **not** depend on any skill or harness.
- **Honest don't-over-reach guard** baked in: never `evolve` away a fact you can't confidently call superseded; genuinely-coexisting variants stay. Keeps the nudge from causing the silently-wrong failure (hiding a live fact).
- Guidance text only — no code logic, no regression, no keyspace, cleanly reversible.

## Follow-up (deferred, not in this PR)
An optional `muninn-curator` **skill** (same reflex as an invokable workflow) is drafted but held — we'll A/B the guide-only lift first to see whether the skill is even needed, per the measure-before-build discipline.