### PR TITLE
fix(mcp): never silently swallow an unrecognized memory type

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -158,7 +158,7 @@ func (s *MCPServer) handleRemember(ctx context.Context, w http.ResponseWriter, i
 	} else if imp != nil {
 		req.Importance = imp
 	}
-	applyTypeArgs(args, req)
+	unknownType := applyTypeArgs(args, req)
 	if t, ok := args["trust"].(string); ok {
 		req.Trust = t
 	}
@@ -196,6 +196,15 @@ func (s *MCPServer) handleRemember(ctx context.Context, w http.ResponseWriter, i
 		}
 		result.Hint += fmt.Sprintf("%d entity item(s) were malformed (expected {\"name\":\"...\",\"type\":\"...\"} objects) and were skipped.", malformed)
 	}
+	// An unrecognised `type` is still accepted and stored — but never silently.
+	// Tell the writer it was downgraded to "fact" while they still have the
+	// context to correct it (principle #1, degrade-loudly form).
+	if h := unknownTypeHint(unknownType); h != "" {
+		if result.Hint != "" {
+			result.Hint += " "
+		}
+		result.Hint += h
+	}
 	// THE PUSH: prospective notices — focal set is the caller-supplied inline
 	// entities; the created engram is the self-echo guard. Inert unless
 	// MUNINN_PROSPECTIVE=1.
@@ -216,6 +225,9 @@ func (s *MCPServer) handleRememberBatch(ctx context.Context, w http.ResponseWrit
 
 	reqs := make([]*mbp.WriteRequest, 0, len(memoriesAny))
 	malformedCounts := make([]int, 0, len(memoriesAny))
+	// Per-item unrecognised `type` values, reported on that item's hint so a
+	// batch write is never a place where a type is silently swallowed.
+	unknownTypes := make([]string, 0, len(memoriesAny))
 	for i, mAny := range memoriesAny {
 		m, ok := mAny.(map[string]any)
 		if !ok {
@@ -270,7 +282,7 @@ func (s *MCPServer) handleRememberBatch(ctx context.Context, w http.ResponseWrit
 		} else if imp != nil {
 			req.Importance = imp
 		}
-		applyTypeArgs(m, req)
+		unknownTypes = append(unknownTypes, applyTypeArgs(m, req))
 		if t, ok := m["trust"].(string); ok {
 			req.Trust = t
 		}
@@ -308,6 +320,12 @@ func (s *MCPServer) handleRememberBatch(ctx context.Context, w http.ResponseWrit
 		}
 		if malformedCounts[i] > 0 {
 			results[i].Hint = fmt.Sprintf("%d entity item(s) were malformed (expected {\"name\":\"...\",\"type\":\"...\"} objects) and were skipped.", malformedCounts[i])
+		}
+		if h := unknownTypeHint(unknownTypes[i]); h != "" {
+			if results[i].Hint != "" {
+				results[i].Hint += " "
+			}
+			results[i].Hint += h
 		}
 	}
 	sendResult(w, id, textContent(mustJSON(map[string]any{
@@ -1511,7 +1529,44 @@ func (s *MCPServer) handleExportGraph(ctx context.Context, w http.ResponseWriter
 
 // applyTypeArgs parses the "type" and "type_label" arguments from an MCP call
 // and sets MemoryType + TypeLabel on the WriteRequest accordingly.
-func applyTypeArgs(args map[string]any, req *mbp.WriteRequest) {
+// memoryTypeNames is the caller-facing vocabulary ParseMemoryType accepts. It is
+// the single source of truth for what unknownTypeHint offers, so a new
+// MemoryType cannot be added to the enum without the nudge learning to name it
+// (pinned by TestApplyTypeArgs_NoValidTypeIsEverReportedUnknown).
+var memoryTypeNames = []string{
+	"fact", "decision", "observation", "preference", "issue", "bugfix",
+	"bug_report", "task", "procedure", "event", "experience", "goal", "constraint",
+}
+
+// unknownTypeHint renders the loud-but-graceful notice for a `type` value that
+// is not a recognised MemoryType. Empty rejected value → empty hint (nothing was
+// discarded, so there is nothing to report).
+func unknownTypeHint(rejected string) string {
+	if rejected == "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Note: type %q is not a recognised memory type, so this memory was stored as \"fact\" and %q was kept only as a display label. "+
+			"Typed memories participate in recall and graph features that plain facts do not. Valid types: %s.",
+		rejected, rejected, strings.Join(memoryTypeNames, ", "))
+}
+
+// applyTypeArgs maps the caller's `type`/`type_label` arguments onto the write
+// request, and RETURNS the `type` value if it was not a recognised MemoryType.
+//
+// The storage behaviour is deliberately unchanged — an unrecognised type is
+// still accepted and still stored as TypeFact with the caller's string kept as
+// TypeLabel, so no existing writer breaks and no memory is ever rejected. What
+// changed is that the substitution is no longer SILENT: callers surface the
+// returned value via unknownTypeHint so the writer learns their type was
+// discarded while they still have the context to correct it.
+//
+// This is the project's first principle applied to the write path ("explicit
+// config is never silently substituted") in its degrade-loudly form (#578/#740):
+// accept and continue, but never pretend nothing happened. A real-corpus census
+// found 66.3% of memories typed by their writer but untyped by the type system
+// as a direct result of the previous silent behaviour.
+func applyTypeArgs(args map[string]any, req *mbp.WriteRequest) (unknownType string) {
 	typeStr, _ := args["type"].(string)
 	explicitLabel, _ := args["type_label"].(string)
 
@@ -1522,16 +1577,19 @@ func applyTypeArgs(args map[string]any, req *mbp.WriteRequest) {
 				req.TypeLabel = typeStr
 			}
 		} else {
-			// Not a known enum name — store as free-form label, default to Fact.
+			// Not a known enum name — store as free-form label, default to Fact,
+			// and report it so the caller can be told (never silently swallowed).
 			req.MemoryType = uint8(storage.TypeFact)
 			if explicitLabel == "" {
 				req.TypeLabel = typeStr
 			}
+			unknownType = typeStr
 		}
 	}
 	if explicitLabel != "" {
 		req.TypeLabel = explicitLabel
 	}
+	return unknownType
 }
 
 // validEntityTypes is the single source of truth for the 14 recognised entity

--- a/internal/mcp/handlers_typenotice_test.go
+++ b/internal/mcp/handlers_typenotice_test.go
@@ -1,0 +1,138 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// A caller-supplied `type` that is not one of the recognised MemoryType enum
+// names was SILENTLY downgraded to TypeFact: the value was kept as a cosmetic
+// TypeLabel, the memory was filed as a plain fact, and nothing told the writer
+// their type had been discarded. That is a direct violation of the project's
+// first principle — "explicit config is never silently substituted" — applied to
+// the one argument that decides whether a memory can ever participate in a
+// typed/graph capability.
+//
+// Measured blast radius on a real 4,216-engram corpus (2026-07-28 census,
+// aggregate counts only): 66.3% of all memories were typed by their writer but
+// untyped by the type system, TypeGoal and TypeIdentity were 0 corpus-wide, and
+// only 4.2% of memories cleared a decision/constraint/goal gate at all. The loss
+// is unrecoverable after the fact — the discarded labels encode topic, not kind,
+// so no normalisation pass rebuilds them (a salvage attempt recovered 1.1%).
+//
+// The fix does not reject the write and does not change what is stored: it makes
+// the miss LOUD, returning a hint that names the valid types at the only moment
+// the writer still has the context to correct it. That is the same
+// degrade-loudly-never-silently-wrong shape as #578/#740, delivered over the
+// Hint channel already used to nudge about malformed entities.
+func TestApplyTypeArgs_UnknownTypeIsReportedNotSwallowed(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantType    uint8
+		wantLabel   string
+		wantUnknown string // the value the caller should be told was not recognised
+	}{
+		{
+			// THE BUG: a plausible-but-unrecognised kind. Silently became "fact".
+			name:        "unrecognised type is reported",
+			args:        map[string]any{"type": "insight"},
+			wantType:    uint8(storage.TypeFact),
+			wantLabel:   "insight",
+			wantUnknown: "insight",
+		},
+		{
+			// A valid enum name must stay silent — no false alarm.
+			name:        "valid type is silent",
+			args:        map[string]any{"type": "decision"},
+			wantType:    uint8(storage.TypeDecision),
+			wantLabel:   "decision",
+			wantUnknown: "",
+		},
+		{
+			// Omitting type entirely is not a miss; it is the documented default.
+			name:        "absent type is silent",
+			args:        map[string]any{},
+			wantType:    0,
+			wantLabel:   "",
+			wantUnknown: "",
+		},
+		{
+			// An explicit type_label is a display concern and must not suppress
+			// the report — the TYPE was still discarded.
+			name:        "unrecognised type still reported when type_label given",
+			args:        map[string]any{"type": "insight", "type_label": "my_label"},
+			wantType:    uint8(storage.TypeFact),
+			wantLabel:   "my_label",
+			wantUnknown: "insight",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &mbp.WriteRequest{}
+			gotUnknown := applyTypeArgs(tc.args, req)
+			if gotUnknown != tc.wantUnknown {
+				t.Errorf("unknown type reported = %q, want %q", gotUnknown, tc.wantUnknown)
+			}
+			if req.MemoryType != tc.wantType {
+				t.Errorf("MemoryType = %d, want %d (storage behaviour must not change)", req.MemoryType, tc.wantType)
+			}
+			if req.TypeLabel != tc.wantLabel {
+				t.Errorf("TypeLabel = %q, want %q (storage behaviour must not change)", req.TypeLabel, tc.wantLabel)
+			}
+		})
+	}
+}
+
+// The hint must actually name the valid types — a bare "unrecognised type"
+// leaves the writer no better off, and the whole point is that the correction is
+// possible at the moment of the miss.
+func TestUnknownTypeHint_NamesTheValidTypes(t *testing.T) {
+	hint := unknownTypeHint("insight")
+	if hint == "" {
+		t.Fatal("unknownTypeHint returned empty for an unrecognised type")
+	}
+	if !strings.Contains(hint, "insight") {
+		t.Errorf("hint must quote the rejected value so the writer knows what was dropped; got %q", hint)
+	}
+	// Every enum name ParseMemoryType accepts must be offered.
+	for _, name := range []string{
+		"fact", "decision", "observation", "preference", "issue", "bugfix",
+		"bug_report", "task", "procedure", "event", "experience", "goal", "constraint",
+	} {
+		if !strings.Contains(hint, name) {
+			t.Errorf("hint must list the valid type %q so the writer can correct it; got %q", name, hint)
+		}
+	}
+	// And it must say the type was not stored, not merely that it was odd.
+	if !strings.Contains(strings.ToLower(hint), "fact") {
+		t.Errorf("hint must state what the memory was stored as; got %q", hint)
+	}
+	if unknownTypeHint("") != "" {
+		t.Error("unknownTypeHint must be empty when nothing was rejected")
+	}
+}
+
+// Every name ParseMemoryType accepts must round-trip through applyTypeArgs
+// WITHOUT being reported as unknown. This is the anti-drift pin: if someone adds
+// a MemoryType to the enum, the hint text and this test force it to be handled
+// rather than silently becoming a new class of swallowed write.
+func TestApplyTypeArgs_NoValidTypeIsEverReportedUnknown(t *testing.T) {
+	for _, name := range []string{
+		"fact", "decision", "observation", "preference", "issue", "bugfix",
+		"bug_report", "task", "procedure", "event", "experience", "goal", "constraint",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, ok := storage.ParseMemoryType(name); !ok {
+				t.Fatalf("test vocabulary drifted: ParseMemoryType rejects %q", name)
+			}
+			req := &mbp.WriteRequest{}
+			if got := applyTypeArgs(map[string]any{"type": name}, req); got != "" {
+				t.Errorf("valid type %q was reported unknown (%q) — false alarm", name, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

An explicit `type` argument that is not a recognized `MemoryType` enum name was **silently** downgraded to `TypeFact`. The caller's string was kept as a cosmetic `TypeLabel`, the memory was filed as a plain fact, and nothing told the writer their type had been discarded.

`internal/mcp/handlers.go` (before):

```go
} else {
    // Not a known enum name — store as free-form label, default to Fact.
    req.MemoryType = uint8(storage.TypeFact)
```

This is principle #1 — *"explicit config is never silently substituted"* — violated on the one argument that decides whether a memory can ever participate in a typed or graph capability.

## Why it matters (measured, not asserted)

A read-only census of a real 4,216-engram corpus (aggregate counts only; no content, concepts, entity names, or vault names left the machine):

| | |
|---|---|
| Memories typed by their writer but untyped by the type system | **66.3%** |
| Memories clearing a `decision`/`constraint`/`goal` gate | **4.2%** |
| `TypeGoal` / `TypeIdentity` engrams corpus-wide | **0** |
| Memories usable by any graph feature (typed **and** entity-bearing) | **2.49%** |
| Memories with a co-activation edge | 99.9% |

The last two rows are the story: the Hebbian graph is in excellent shape, and the features built on it starve anyway because almost nothing carries the labels they gate on.

The loss is **unrecoverable after the fact**. A salvage attempt that token-normalized the discarded labels recovered 1.1% of them — the labels encode *topic*, not *kind*, so there is no normalization pass that rebuilds the type. The only place this is fixable is at the moment of the write.

This was found while investigating why an associative-surfacing feature fired **0 times on 37,296 real candidate edges**. Removing the type gate entirely did not help; the substrate simply is not there.

## The change

Storage behavior is **deliberately unchanged** — the write is still accepted, still stored as `TypeFact`, still keeps the label — so no existing writer breaks and no memory is ever rejected. What changes is that the substitution is no longer silent:

- `applyTypeArgs` now returns the unrecognized value.
- Both write paths surface it via the **existing** `Hint` channel already used for malformed entities: `muninn_remember`, and `muninn_remember_batch` per-item.
- The hint quotes the rejected value, states the memory was stored as `fact`, and names all 13 valid types — so the correction is possible at the only moment the writer still has the context to make it.

Degrade loudly, never silently-wrong (#578 / #740). Extends a proven in-tree mechanism rather than inventing one (principle #7).

`memoryTypeNames` is the single source of truth for the offered vocabulary, pinned by a test asserting no `ParseMemoryType`-valid name is ever reported unknown — so adding an enum member cannot silently create a new class of swallowed write (principle #6).

## Verification

- **RED-sanity checked**: the tests fail to build/pass with the handler change stashed, and pass with it restored. Shown both ways.
- `go build -tags localassets ./...`, `go vet -tags localassets ./...`, `gofmt -l` — all clean.
- Full `internal/mcp` package green; MCP registry smoke test green (drift obligation for touching a handler).
- Branched off `origin/develop` (5c111f9) in a fresh worktree.

## Scope / what this does not do

- Does not backfill or repair existing memories — the discarded types are gone. Forward-looking only.
- Does not touch the entity-coverage gap, which is the larger cap (29.9% vs 4.2%) and gets its own change.
- Does not reject any write or alter what is stored.
