### PR TITLE
fix(mcp): drop the entity-type enum from the write paths (it cost 64pp of entity coverage)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -5,15 +5,42 @@ func allToolDefinitions() []ToolDefinition {
 		"type":        "string",
 		"description": "Vault name to scope the operation (default: 'default'). Optional when authenticating via a vault-pinned mk_ key.",
 	}
-	// entityTypeEnum lists the 14 recognised entity types (the single source of
-	// truth is validEntityTypes in handlers.go). Any other value is coerced to
-	// "other" on every user-facing write path, so advertising the enum lets MCP
-	// clients validate before sending. Keep this in sync with validEntityTypes.
-	entityTypeEnum := []string{
+	// entityTypeDescription advertises the 14 recognised entity types (the single
+	// source of truth is validEntityTypes in handlers.go) as GUIDANCE rather than
+	// as a machine-enforced JSON-Schema `enum`.
+	//
+	// The enum was strictly worse than useless. Server-side it was dead weight —
+	// normalizeEntityType coerces any unrecognised value to "other" on every
+	// user-facing write path, so it never changed what was stored. Client-side it
+	// was a hard rejection: a writer whose entity did not map cleanly onto one of
+	// the 14 buckets (or whose client validates before sending) dropped the
+	// entity, and `required:["name","type"]` meant dropping the type dropped the
+	// whole entity.
+	//
+	// A difference-in-differences control on a real 4,216-engram corpus
+	// (aggregate counts only) attributed an entity-coverage collapse to exactly
+	// this line: muninn_remember_batch never received the enum and held 87.9% ->
+	// 90.2% coverage across the change, while single-write coverage fell 76.2% ->
+	// 12.8% (DiD +65.7pp largest vault, +52.3pp overall). "The enrichment worker
+	// died" is refuted by the same data — summarization and classification ran at
+	// 92-100% throughout while entity coverage sat at 0-25%.
+	//
+	// Entity coverage caps every graph-shaped capability in the product, so an
+	// entity the caller cannot confidently classify is worth strictly more than
+	// no entity at all. Guidance, not a gate. Keep in sync with validEntityTypes.
+	// entityTypeNames is the enforced vocabulary for the CORRECTION paths
+	// (muninn_entity_state / _batch), where the caller is deliberately choosing a
+	// type for an entity that already exists. There is no capture to suppress
+	// there, so an enum is appropriate — unlike the WRITE paths above, where it
+	// cost measured entity coverage. Keep in sync with validEntityTypes.
+	entityTypeNames := []string{
 		"person", "organization", "location", "concept", "technology",
 		"project", "tool", "database", "service", "framework",
 		"language", "product", "event", "other",
 	}
+	const entityTypeDescription = "Entity type. Recognised types: person, organization, location, " +
+		"concept, technology, project, tool, database, service, framework, language, product, event, other. " +
+		"Any other value is accepted and stored as 'other' — always include the entity even if you are unsure of its type."
 	return []ToolDefinition{
 		{
 			Name:        "muninn_remember",
@@ -41,7 +68,7 @@ func allToolDefinitions() []ToolDefinition {
 							"type": "object",
 							"properties": map[string]any{
 								"name": map[string]any{"type": "string", "description": "Entity name (e.g. 'PostgreSQL', 'Auth Service')."},
-								"type": map[string]any{"type": "string", "enum": entityTypeEnum, "description": "Entity type. One of the 14 recognised types (e.g. 'database', 'service', 'person', 'project'); any other value is stored as 'other'."},
+								"type": map[string]any{"type": "string", "description": entityTypeDescription},
 							},
 							"required": []string{"name", "type"},
 						},
@@ -116,12 +143,12 @@ func allToolDefinitions() []ToolDefinition {
 									"items": map[string]any{
 										"type": "object",
 										"properties": map[string]any{
-											"name": map[string]any{"type": "string"},
-											"type": map[string]any{"type": "string"},
+											"name": map[string]any{"type": "string", "description": "Entity name (e.g. 'PostgreSQL', 'Auth Service')."},
+											"type": map[string]any{"type": "string", "description": entityTypeDescription},
 										},
 										"required": []string{"name", "type"},
 									},
-									"description": "Entities mentioned in this memory.",
+									"description": "Entities mentioned in this memory. These populate the knowledge graph that association, traversal, and cross-memory features depend on.",
 								},
 								"relationships": map[string]any{
 									"type": "array",
@@ -570,7 +597,7 @@ func allToolDefinitions() []ToolDefinition {
 							"type": "object",
 							"properties": map[string]any{
 								"name":       map[string]any{"type": "string"},
-								"type":       map[string]any{"type": "string", "enum": entityTypeEnum, "description": "Entity type. One of the 14 recognised types; any other value is stored as 'other'."},
+								"type":       map[string]any{"type": "string", "description": entityTypeDescription},
 								"confidence": map[string]any{"type": "number"},
 							},
 							"required": []string{"name", "type"},
@@ -659,7 +686,7 @@ func allToolDefinitions() []ToolDefinition {
 					"entity_name": map[string]any{"type": "string", "description": "The entity name to update"},
 					"state":       map[string]any{"type": "string", "description": "New state: active, deprecated, merged, or resolved"},
 					"merged_into": map[string]any{"type": "string", "description": "Canonical entity name (required when state=merged)"},
-					"type":        map[string]any{"type": "string", "enum": entityTypeEnum, "description": "Correct the entity type to one of the 14 recognised types (e.g. 'concept', 'technology', 'product'). Any other value is stored as 'other'. Omit to preserve the existing type."},
+					"type":        map[string]any{"type": "string", "enum": entityTypeNames, "description": "Correct the entity type to one of the 14 recognised types (e.g. 'concept', 'technology', 'product'). Any other value is stored as 'other'. Omit to preserve the existing type."},
 					"vault":       vaultProp,
 				},
 				"required": []string{"entity_name", "state"},
@@ -682,7 +709,7 @@ func allToolDefinitions() []ToolDefinition {
 								"entity_name": map[string]any{"type": "string", "description": "Entity name to update"},
 								"state":       map[string]any{"type": "string", "description": "New state: active, deprecated, merged, or resolved"},
 								"merged_into": map[string]any{"type": "string", "description": "Canonical entity name (required when state=merged)"},
-								"type":        map[string]any{"type": "string", "enum": entityTypeEnum, "description": "Correct the entity type to one of the 14 recognised types (e.g. 'concept', 'technology', 'product'). Any other value is stored as 'other'. Omit to preserve existing."},
+								"type":        map[string]any{"type": "string", "enum": entityTypeNames, "description": "Correct the entity type to one of the 14 recognised types (e.g. 'concept', 'technology', 'product'). Any other value is stored as 'other'. Omit to preserve existing."},
 							},
 							"required": []string{"entity_name", "state"},
 						},

--- a/internal/mcp/tools_entity_enum_test.go
+++ b/internal/mcp/tools_entity_enum_test.go
@@ -1,0 +1,155 @@
+package mcp
+
+import (
+	"testing"
+)
+
+// muninn_remember's entities[].type carried a strict 14-value JSON-Schema `enum`
+// (added 2026-06-11). Server-side it is DEAD WEIGHT: normalizeEntityType coerces
+// any unrecognised value to "other" on every user-facing write path, so the enum
+// changes nothing about what is stored. Client-side it is a hard constraint — a
+// writer whose entity does not map cleanly onto one of the 14 buckets, or whose
+// client validates arguments before sending, drops the field.
+//
+// A difference-in-differences control on a real 4,216-engram corpus (aggregate
+// counts only) attributed an entity-coverage collapse to exactly this schema:
+// muninn_remember_batch never received the enum, and across the change
+// batch-shaped writes held at 87.9% -> 90.2% entity coverage while single-write
+// coverage fell 76.2% -> 12.8% (DiD +65.7pp in the largest vault, +52.3pp
+// overall). The rival "enrichment worker died" explanation is refuted by the
+// same data: summarization and classification ran at 92-100% throughout while
+// entity coverage sat at 0-25%.
+//
+// Entity coverage caps every graph-shaped capability in the product (29.9%
+// today; jointly 2.49% with the type gate). So this schema line is load-bearing
+// for far more than one field.
+//
+// The fix keeps the vocabulary DISCOVERABLE in the description — the writer
+// still learns the 14 recognised types and that anything else becomes "other" —
+// while removing the machine-enforced rejection. Guidance, not a gate: an entity
+// the caller cannot classify is worth strictly more than no entity at all.
+func TestRememberSchema_EntityTypeIsNotEnumConstrained(t *testing.T) {
+	items := rememberEntityItemsSchema(t, "muninn_remember")
+	props, ok := items["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("muninn_remember entities.items has no properties")
+	}
+	typeProp, ok := props["type"].(map[string]any)
+	if !ok {
+		t.Fatal("muninn_remember entities.items.properties.type missing")
+	}
+	if _, hasEnum := typeProp["enum"]; hasEnum {
+		t.Errorf("entities[].type must NOT carry a JSON-Schema enum: it is server-side dead weight "+
+			"(normalizeEntityType coerces anyway) and client-side it suppresses the whole field. "+
+			"Measured: it cost ~64pp of entity coverage on the single-write path. got %v", typeProp["enum"])
+	}
+	// The vocabulary must remain DISCOVERABLE even though it is not enforced —
+	// dropping the enum must not degrade into telling the caller nothing.
+	desc, _ := typeProp["description"].(string)
+	if desc == "" {
+		t.Fatal("entities[].type must keep a description naming the recognised types")
+	}
+	for _, name := range []string{"database", "service", "person", "project", "other"} {
+		if !containsFold(desc, name) {
+			t.Errorf("entities[].type description must still name the recognised type %q so the "+
+				"vocabulary stays discoverable without being enforced; got %q", name, desc)
+		}
+	}
+}
+
+// The two write paths must not disagree about how entities are described. The
+// enum was only ever added to the single-write path, which is precisely why the
+// batch path served as the natural control — but that divergence is itself the
+// drift this pins shut, in both directions.
+func TestRememberSchema_BatchAndSingleAgreeOnEntityType(t *testing.T) {
+	for _, tool := range []string{"muninn_remember", "muninn_remember_batch"} {
+		items := rememberEntityItemsSchema(t, tool)
+		props, _ := items["properties"].(map[string]any)
+		typeProp, ok := props["type"].(map[string]any)
+		if !ok {
+			t.Fatalf("%s: entities.items.properties.type missing", tool)
+		}
+		if _, hasEnum := typeProp["enum"]; hasEnum {
+			t.Errorf("%s: entities[].type must not be enum-constrained on ANY write path", tool)
+		}
+		if desc, _ := typeProp["description"].(string); desc == "" {
+			t.Errorf("%s: entities[].type must carry a description on every write path "+
+				"(the batch path historically carried none, which is its own capture gap)", tool)
+		}
+	}
+}
+
+// rememberEntityItemsSchema digs out entities.items for a named tool, failing
+// loudly rather than silently returning an empty map if the shape drifts.
+func rememberEntityItemsSchema(t *testing.T, toolName string) map[string]any {
+	t.Helper()
+	var schema map[string]any
+	for _, td := range allToolDefinitions() {
+		if td.Name == toolName {
+			s, ok := td.InputSchema.(map[string]any)
+			if !ok {
+				t.Fatalf("%s: InputSchema is not a map[string]any (%T)", toolName, td.InputSchema)
+			}
+			schema = s
+			break
+		}
+	}
+	if schema == nil {
+		t.Fatalf("tool %q not found in allToolDefinitions()", toolName)
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s: schema has no properties", toolName)
+	}
+	// remember_batch nests per-memory properties under memories.items.
+	if toolName == "muninn_remember_batch" {
+		mem, ok := props["memories"].(map[string]any)
+		if !ok {
+			t.Fatalf("%s: no memories property", toolName)
+		}
+		memItems, ok := mem["items"].(map[string]any)
+		if !ok {
+			t.Fatalf("%s: memories has no items", toolName)
+		}
+		props, ok = memItems["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("%s: memories.items has no properties", toolName)
+		}
+	}
+	ents, ok := props["entities"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s: no entities property", toolName)
+	}
+	items, ok := ents["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s: entities has no items", toolName)
+	}
+	return items
+}
+
+func containsFold(haystack, needle string) bool {
+	return len(needle) > 0 && len(haystack) >= len(needle) &&
+		indexFold(haystack, needle) >= 0
+}
+
+func indexFold(s, substr string) int {
+	lower := func(b byte) byte {
+		if b >= 'A' && b <= 'Z' {
+			return b + 32
+		}
+		return b
+	}
+	for i := 0; i+len(substr) <= len(s); i++ {
+		match := true
+		for j := 0; j < len(substr); j++ {
+			if lower(s[i+j]) != lower(substr[j]) {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## The bug

`muninn_remember`'s `entities[].type` carried a strict 14-value JSON-Schema `enum` (added 2026-06-11).

Server-side it is **dead weight**: `normalizeEntityType` (`handlers.go:1558-1567`) coerces any unrecognized value to `"other"` on every user-facing write path, so the enum never changed what was stored.

Client-side it is a **hard rejection**. A writer whose entity doesn't map cleanly onto one of the 14 buckets — or whose client validates arguments before sending — drops the field. And `required:["name","type"]` means dropping the type drops the **whole entity**.

## Measured, not assumed

`muninn_remember_batch` **never received the enum**, which makes it a natural control sitting in existing data. Difference-in-differences over a real 4,216-engram corpus (aggregate counts only; no content, concepts, entity names, or vault names left the machine):

| write path | baseline (pre 06-08) | treatment (post 06-15) | |
|---|---|---|---|
| batch-shaped (no enum) | 87.9% | **90.2%** | unchanged |
| single (enum'd) | 76.2% | **12.8%** | collapsed |

**DiD: +65.7pp** in the largest vault, **+52.3pp** overall. The collapse is confined to the path that received the enum.

The rival *"the enrichment worker died"* explanation is **refuted by the same data**: summarization and classification ran at 92–100% throughout while entity coverage sat at 0–25%.

### Why it matters beyond one field

Entity coverage caps every graph-shaped capability in the product — 29.9% today, and 2.49% jointly with the memory-type gate. An associative-surfacing feature was measured firing **0 times on 37,296 real candidate edges** for exactly this reason.

## The change

The vocabulary stays **discoverable** as a description on both write paths — the caller still learns the 14 recognized types and that anything else is stored as `"other"`. The *enforcement* is what goes, not the guidance. An entity the caller cannot confidently classify is worth strictly more than no entity at all.

- `muninn_remember` — enum → description.
- `muninn_remember_batch` — same description, plus the `name`/`type` field descriptions it never had.
- `muninn_apply_enrichment` — relaxed too; it is a capture path with the identical failure mode.
- `muninn_entity_state` / `_batch` — **keep the enum**. Those correct the type of an entity that already exists, so there is no capture to suppress.

## Honest caveats

- The write-path label is a **ULID-millisecond clustering proxy**, not a recorded fact — batch members share a timestamp inside one `WriteEngramBatch` loop, while two `muninn_remember` calls are separated by an LLM round trip. Error is one-sided and conservative (size-1 batches fall into *solo*, never the reverse).
- Baseline solo sample is small (n=35 overall).
- DiD controls for time-invariant writer differences, not for a writer who changed behavior that same week for an unrelated reason. What it does establish: data age is not the cause, and enrichment outage is not the cause.

## Pre-committed kill threshold

If four weeks after landing the low-coverage vaults have **not** gained ≥15 percentage points of entity coverage, the hypothesis is refuted — revert this and write it up as a negative result. A second kill: if coverage rises but distinct-entity count grows faster than mention count (the graph filling with singletons), it is producing junk and should be reverted regardless.

## Verification

- **RED-sanity checked**: both new tests fail with the schema change reverted, pass with it restored.
- Tests pin that no write path is enum-constrained, that the vocabulary stays discoverable, and that the two write paths agree — closing the single-vs-batch drift that caused this in the first place.
- `go build`/`go vet -tags localassets ./...` clean, `gofmt -l` clean, full `internal/mcp` package green including the registry smoke test.
- Branched off `origin/develop` (5c111f9).
