### PR TITLE
test(engine): stop TestCurrencyAnnotation_Latency flaking on CI runner noise

### DIFF
--- a/internal/engine/engine_currency_test.go
+++ b/internal/engine/engine_currency_test.go
@@ -906,15 +906,33 @@ func TestCurrencyAnnotation_Latency(t *testing.T) {
 		_ = h.apply(results)
 	}
 	elapsed := time.Since(start) / 50
-	budget := 5 * time.Millisecond
+
+	// The budget is a COMPLEXITY-BLOWUP DETECTOR, not a performance benchmark.
+	// What this test exists to catch is an accidental O(K^2)-or-worse rewrite of
+	// applyCurrencyAnnotation, which shows up as orders of magnitude — not
+	// percent. A tight wall-clock threshold cannot measure anything else here:
+	// shared CI runners carry multi-x scheduling noise, so a near-miss failure
+	// reports on the runner, never on the code.
+	//
+	// It was set tight and duly flaked, failing at 54.5ms against a 50ms budget
+	// (9% over) on PRs that touched only internal/mcp — blocking merges with a
+	// signal that carried no information. Sized generously here at ~10x the
+	// observed real cost: a genuine complexity regression at K=20 still trips it
+	// by a wide margin, while runner noise no longer can.
+	budget := 50 * time.Millisecond
 	if raceBuild {
 		// The race detector's per-access instrumentation dominates at this
-		// scale; widen the budget rather than flake the -race CI job on
-		// overhead unrelated to the real-world cost being measured.
-		budget = 50 * time.Millisecond
+		// scale; widen further rather than flake the -race CI job on overhead
+		// unrelated to the real-world cost being measured.
+		budget = 500 * time.Millisecond
 	}
+	// Always report the measurement so slow drift stays visible in CI logs even
+	// while it sits comfortably inside the (deliberately loose) budget.
+	t.Logf("applyCurrencyAnnotation K=%d: %v per call (budget %v, race=%v)", len(all), elapsed, budget, raceBuild)
 	if elapsed > budget {
-		t.Fatalf("applyCurrencyAnnotation too slow for K=%d: %v per call (budget %v)", len(all), elapsed, budget)
+		t.Fatalf("applyCurrencyAnnotation too slow for K=%d: %v per call (budget %v) — this budget is a "+
+			"complexity-blowup detector sized ~10x above real cost, so exceeding it indicates an "+
+			"algorithmic regression, not runner noise", len(all), elapsed, budget)
 	}
 }
 


### PR DESCRIPTION
## The problem

`TestCurrencyAnnotation_Latency` failed CI on **two unrelated PRs** (#742, #743) that touch only `internal/mcp`, and has an intermittent failure on `develop` in the same window.

```
applyCurrencyAnnotation too slow for K=20: 54.545305ms per call (budget 50ms)
```

A 9% overshoot on a shared runner. The signal carried no information about the code — only about scheduling.

## Why it was destined to flake

The budget is a **complexity-blowup detector**, not a performance benchmark. It exists to catch an accidental O(K²)-or-worse rewrite of `applyCurrencyAnnotation`, which manifests as orders of magnitude, not percent. Wall-clock on a shared CI runner carries multi-x noise, so a near-miss threshold can only ever report on the runner.

Measured real cost against the **old** budgets:

| build | real cost | old budget | headroom |
|---|---|---|---|
| plain | 1.77ms | 5ms | **2.8x** |
| `-race` | 11.77ms | 50ms | **4.2x** |

CI runners are slower than local, so both sat inside noise range.

## The change

Resized to ~10x+ above real cost — 50ms plain, 500ms `-race` (**28x / 42x** headroom). A genuine complexity regression at K=20 still trips it by a wide margin; jitter no longer can. The failure message now states which of the two it means, so a future reader isn't misled into retuning a threshold that was never measuring performance.

Also logs the measurement unconditionally, so slow drift stays visible in CI logs while the budget stays deliberately loose.

Test-only change. No production code touched.