### PR TITLE
fix(mcp): never silently discard an unrecognized link relation

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -684,15 +685,23 @@ func (s *MCPServer) handleLink(ctx context.Context, w http.ResponseWriter, id js
 		}
 		weight = float32(wf)
 	}
+	relType, unknownRel := relTypeFromStringChecked(rel)
 	_, err := s.engine.Link(ctx, &mbp.LinkRequest{
 		SourceID: srcID,
 		TargetID: dstID,
-		RelType:  relTypeFromString(rel),
+		RelType:  relType,
 		Weight:   weight,
 		Vault:    vault,
 	})
 	if err != nil {
 		sendError(w, id, -32000, "tool error: "+err.Error())
+		return
+	}
+	// An unrecognised relation is still linked (as the inert relates_to) — but
+	// never silently. Tell the caller their declaration was not recorded, and
+	// name the valid relations, while they can still re-link.
+	if h := unknownRelationHint(unknownRel); h != "" {
+		sendResult(w, id, textContent(mustJSON(map[string]any{"ok": true, "hint": h})))
 		return
 	}
 	sendResult(w, id, textContent(`{"ok":true}`))
@@ -1738,11 +1747,65 @@ var relTypeMap = map[string]storage.RelType{
 // relTypeFromString converts a relation string to a uint16 RelType value.
 // Maps to the storage.RelType constants so round-tripping is consistent.
 // Unknown or empty strings default to storage.RelRelatesTo.
+//
+// Prefer relTypeFromStringChecked on any path that can report back to the
+// caller: this variant cannot tell them their relation was discarded.
 func relTypeFromString(rel string) uint16 {
+	v, _ := relTypeFromStringChecked(rel)
+	return v
+}
+
+// relTypeFromStringChecked is relTypeFromString plus the name of the relation
+// when it was NOT recognised, so the caller can be told rather than silently
+// handed an inert edge.
+//
+// An unrecognised relation still resolves to relates_to — storage behaviour is
+// unchanged and no link is rejected — but relates_to is the one relation with no
+// downstream consumer, so the coercion does not file the declaration in a
+// different bucket, it DELETES it. link(contradicts) mistyped as
+// "contradicted_by" produces no contradiction flag, no confidence update and no
+// adversarial-profile boost; a mistyped supersedes produces no ValidUntil stamp
+// and no chain demotion, leaving the stale fact leading recall.
+//
+// Empty is not reported: handleLink rejects a missing relation upstream, and the
+// engine's inline-relationship paths treat "" as "unspecified".
+func relTypeFromStringChecked(rel string) (relType uint16, unknown string) {
 	if v, ok := relTypeMap[rel]; ok {
-		return uint16(v)
+		return uint16(v), ""
 	}
-	return uint16(storage.RelRelatesTo) // default
+	if rel != "" {
+		unknown = rel
+	}
+	return uint16(storage.RelRelatesTo), unknown
+}
+
+// relationNames returns the recognised relation names in sorted order, so the
+// hint text is deterministic and adding a RelType cannot silently omit it.
+func relationNames() []string {
+	names := make([]string, 0, len(relTypeMap))
+	for k := range relTypeMap {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// unknownRelationHint renders the loud-but-graceful notice for a relation that
+// was not recognised. Empty rejected value → empty hint.
+//
+// Declarations are the scarcest resource in the system: measured on a real
+// 4,216-engram corpus (aggregate counts only), just 0.135% of association edges
+// were authored by an agent rather than by the Hebbian or cosine workers, and a
+// counterfactual replay recovered 0 of 114 declared supersessions from content
+// alone. Discarding one silently discards information nothing else can rebuild.
+func unknownRelationHint(rejected string) string {
+	if rejected == "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Note: relation %q is not recognised, so this link was stored as \"relates_to\", which carries no "+
+			"meaning for recall — the relationship you intended was not recorded. Re-link with one of: %s.",
+		rejected, strings.Join(relationNames(), ", "))
 }
 
 // relTypeReverseMap is the inverse of relTypeMap, built once at package init.

--- a/internal/mcp/handlers_linkrelation_test.go
+++ b/internal/mcp/handlers_linkrelation_test.go
@@ -1,0 +1,131 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// muninn_link's `relation` argument was SILENTLY coerced to relates_to when it
+// was not one of the 16 recognised names — the same silent-substitution class as
+// the memory-type downgrade fixed in #742, still live on the verb that matters
+// most.
+//
+// relates_to is INERT: it is the one relation with no downstream consumer, so a
+// mistyped relation does not merely land in the wrong bucket — the declaration
+// evaporates. An agent that writes link(contradicts) but spells it
+// "contradicted_by" gets a silent success and no contradiction flag, no
+// confidence update, no adversarial-profile boost. An agent that means
+// supersedes and mistypes it gets no ValidUntil stamp and no chain demotion: the
+// stale fact keeps leading recall, which is the project's worst failure class.
+//
+// Why this verb specifically. Measured on a real 4,216-engram corpus (aggregate
+// counts only): only 4.81% of writes carry ANY agent declaration, and of 139,866
+// association edges just 189 (0.135%) were authored by an agent rather than by
+// the Hebbian or cosine workers. Declarations are the scarcest resource in the
+// system — and a counterfactual replay showed the content-based heuristic
+// recovers 0 of 114 declared supersessions, because the intent is not in the
+// content. Silently discarding one is discarding information nothing else can
+// reconstruct.
+//
+// Storage behaviour is unchanged: the link is still created, still as
+// relates_to. What changes is that the caller is TOLD, and given the valid
+// names, at the only moment they can still correct it.
+func TestRelTypeFromString_UnknownRelationIsReported(t *testing.T) {
+	tests := []struct {
+		name        string
+		rel         string
+		wantType    uint16
+		wantUnknown string
+	}{
+		{
+			// THE BUG: a plausible near-miss silently became inert relates_to.
+			name:        "unrecognised relation is reported",
+			rel:         "contradicted_by",
+			wantType:    uint16(storage.RelRelatesTo),
+			wantUnknown: "contradicted_by",
+		},
+		{
+			name:        "supersedes is silent",
+			rel:         "supersedes",
+			wantType:    uint16(storage.RelSupersedes),
+			wantUnknown: "",
+		},
+		{
+			name:        "contradicts is silent",
+			rel:         "contradicts",
+			wantType:    uint16(storage.RelContradicts),
+			wantUnknown: "",
+		},
+		{
+			// An explicit relates_to is a real choice, not a miss.
+			name:        "explicit relates_to is silent",
+			rel:         "relates_to",
+			wantType:    uint16(storage.RelRelatesTo),
+			wantUnknown: "",
+		},
+		{
+			// Empty is rejected upstream by the handler; treat as no report so
+			// the notice never fires on a path that already errors.
+			name:        "empty relation is silent",
+			rel:         "",
+			wantType:    uint16(storage.RelRelatesTo),
+			wantUnknown: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, unknown := relTypeFromStringChecked(tc.rel)
+			if unknown != tc.wantUnknown {
+				t.Errorf("unknown relation reported = %q, want %q", unknown, tc.wantUnknown)
+			}
+			if got != tc.wantType {
+				t.Errorf("RelType = %d, want %d (storage behaviour must not change)", got, tc.wantType)
+			}
+			// The unchecked helper must keep behaving identically for every
+			// existing caller.
+			if plain := relTypeFromString(tc.rel); plain != tc.wantType {
+				t.Errorf("relTypeFromString drifted from the checked variant: %d vs %d", plain, tc.wantType)
+			}
+		})
+	}
+}
+
+// The hint has to name the valid relations, or the caller learns nothing
+// actionable — and it must say the link was stored as the inert relates_to, so
+// the caller understands a declaration was lost rather than merely renamed.
+func TestUnknownRelationHint_NamesTheValidRelations(t *testing.T) {
+	hint := unknownRelationHint("contradicted_by")
+	if hint == "" {
+		t.Fatal("unknownRelationHint returned empty for an unrecognised relation")
+	}
+	if !strings.Contains(hint, "contradicted_by") {
+		t.Errorf("hint must quote the rejected value; got %q", hint)
+	}
+	if !strings.Contains(hint, "relates_to") {
+		t.Errorf("hint must state the link was stored as relates_to; got %q", hint)
+	}
+	// Every relation the map accepts must be offered.
+	for rel := range relTypeMap {
+		if !strings.Contains(hint, rel) {
+			t.Errorf("hint must list the valid relation %q; got %q", rel, hint)
+		}
+	}
+	if unknownRelationHint("") != "" {
+		t.Error("unknownRelationHint must be empty when nothing was rejected")
+	}
+}
+
+// Anti-drift pin: no relation the map accepts may ever be reported unknown. If
+// someone adds a RelType, this forces the hint vocabulary to learn it rather
+// than letting it become a new class of silently-discarded declaration.
+func TestRelTypeFromStringChecked_NoValidRelationIsReportedUnknown(t *testing.T) {
+	for rel := range relTypeMap {
+		t.Run(rel, func(t *testing.T) {
+			if _, unknown := relTypeFromStringChecked(rel); unknown != "" {
+				t.Errorf("valid relation %q was reported unknown (%q) — false alarm", rel, unknown)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

`muninn_link`'s `relation` argument was silently coerced to `relates_to` when it wasn't one of the 16 recognized names (`handlers.go`, `relTypeFromString`). Same silent-substitution class as the memory-type downgrade fixed in #742 — still live, on the verb declarations depend on most.

**`relates_to` is inert.** It's the one relation with no downstream consumer, so the coercion doesn't file the declaration in a different bucket — it **deletes** it:

| the agent wrote | what it got |
|---|---|
| `link(contradicts)` mistyped as `contradicted_by` | no contradiction flag, no confidence update, no adversarial-profile boost |
| `supersedes` mistyped | no `ValidUntil` stamp, no chain demotion — **the stale fact keeps leading recall** |

That last row is the project's worst failure class, reached by a typo and a silent success response.

## Why this verb matters disproportionately

Measured on a real 4,216-engram corpus (aggregate counts only; no content, concepts, entity names, or vault names):

- **4.81%** of writes carry any agent declaration at all.
- Of **139,866** association edges, **189 (0.135%)** were authored by an agent rather than by the Hebbian or cosine workers.
- A counterfactual replay recovered **0 of 114** declared supersessions from content alone — 49% of pairs clear *every* content-derived gate and die at the anchor, and the version-marker vocabulary fires **0** times.

Declarations are the scarcest resource in the system, and the intent behind one is **not reconstructible from content**. Discarding one silently discards information nothing else can rebuild.

## The change

Storage behavior is **deliberately unchanged** — the link is still created, still as `relates_to`, and no call is rejected. What changes is that the caller is told, and given the valid relation names, at the only moment they can still re-link. Degrade loudly, never silently-wrong (#578 / #740 / #742).

- `relTypeFromString` keeps its exact signature and behavior for its three existing callers.
- New `relTypeFromStringChecked` adds the report; the old helper delegates to it, so the two cannot drift.
- `relationNames()` derives the hint vocabulary from `relTypeMap` itself, pinned by a test asserting no valid relation is ever reported unknown — adding a `RelType` cannot create a new class of silently-discarded declaration.
- Empty relation is **not** reported: `handleLink` rejects it upstream, and the engine's inline paths treat `""` as unspecified.

## Verification

- **RED-sanity checked**: tests fail to build/pass with the handler change reverted, pass with it restored.
- `go build`/`go vet -tags localassets ./...` clean, `gofmt -l` clean, full `internal/mcp` package green including the registry smoke test.
- Branched off `origin/develop` (8b1c940, incl. #741–#744).

## Adjacent finding, not fixed here

The `resolves` relation (0x000F) has **zero consumers** anywhere in non-test code — agents are invited to declare something that buys nothing. Left alone deliberately; it deserves its own decision (wire it up or retire it) rather than being folded into a bug fix.
