### PR TITLE
fix: agent-experience hardening — six silent-substitution defects found by hands-on AI evaluation

### DIFF
--- a/.claude/deep-review/2026-07-30-scoring-weights-trace.md
+++ b/.claude/deep-review/2026-07-30-scoring-weights-trace.md
@@ -4,6 +4,26 @@ Date: 2026-07-30
 Branch: `fix/agent-experience-hardening`
 Scope: trace + measurement harness only. **No behaviour change shipped in this pass.**
 
+## Framing: check the cheap causes before blaming the cognitive layer
+
+Three separate defects have now been initially mis-attributed to ACT-R fusion or to "the
+cognition layer being wrong":
+
+1. **Confidence collapse** — the contradiction bug drives confidence to ~0.07, and confidence
+   multiplies straight into the final score (§3.2). A 93% cut that has nothing to do with
+   scoring weights.
+2. **Missing-estimator handling** — the linear ContentMatch scores an absent signal as a zero
+   rather than as absence of evidence, in both directions: missing FTS (§3.1–3.3) and missing
+   cosine (§3.4).
+3. **Indexing lag** — a memory is unfindable until the async embedder catches up, for up to
+   ~3 minutes (§3.5).
+
+None of the three is ACT-R. The ACT-R prior *does* have a large dynamic range (§2.3, >20×),
+and that may yet turn out to be a real problem — but it has not been the cause of a single
+reproduced miss so far. **Account for confidence, missing-signal handling, and indexing lag
+before attributing a recall failure to the cognitive layer.** The harness in §4 exists so
+that attribution is made by measurement rather than by argument.
+
 ---
 
 ## 1. The actual scoring path, end to end
@@ -209,7 +229,84 @@ The exact fraction is vault- and query-dependent and is precisely what the harne
 (`gold-found` under the PARAPHRASE condition). It is not estimated here, because estimating
 it is the thing the harness exists to avoid doing by argument.
 
-### 3.4 The counterweight nobody should skip
+### 3.4 The same defect from the opposite direction: missing cosine
+
+A live reproduction was reported at commit `c3b5b60`: a newly-written memory returns **zero
+results** to a near-exact lexical query ~3s after the write, then returns at **0.742** once
+the async embedder catches up. Independently verified below — and the mechanism is **sharper
+than the one reported**.
+
+**The reported mechanism is incomplete.** "ContentMatch ≤ 0.4, which falls below the default
+recall threshold" understates it, because 0.4 is comfortably above the *engine's* default of
+0.05. The real gate is the **surface** default:
+
+| surface | default when `threshold` is omitted | source |
+|---|---|---|
+| engine / library | 0.05 | `activation/engine.go:547` |
+| **MCP** | **0.5** | `internal/mcp/handlers.go:392` |
+| **REST** | **0.5** | `internal/transport/rest/server.go:1772` |
+
+With no embedding, `cosine = 0` → `semCal = 0` → `ContentMatch = 0.4 × fts ≤ **0.4**`, and
+the prior can only multiply *down* (it saturates at 1.0, and the per-query rescale never
+scales up). So:
+
+> **An FTS-only match is structurally unreturnable through MCP or REST at default settings —
+> for any query, at any lexical quality, permanently.** The 0.4 coefficient sits below the
+> 0.5 gate outright.
+
+This is not "scores poorly". It is unreachable. And it is not limited to the indexing-lag
+case: *any* candidate with zero semantic score — an unembedded engram, a dimension mismatch,
+a degraded embed backend — is invisible to both agent-facing surfaces.
+
+It also exposes a **cross-surface split**: at the engine default the same candidate is
+returned at 0.291. A library or direct caller sees the memory; an MCP agent does not.
+
+**Independent verification of the formula against the live observation.** The reported
+post-embed numbers were `final = 0.742`, `vector_score_raw = 0.881`. Solving the replicated
+formula for its only unknown:
+
+```
+semCal = (0.881 - 0.520) / 0.480 = 0.7521
+0.742  = 0.6×0.7521 + 0.4×fts    =>  fts = 0.7269
+```
+
+An implied FTS coverage of 0.73 for a near-exact lexical query is entirely plausible, and an
+arbitrary formula would not land the implied value inside [0,1] at a sensible point. This is
+a genuine cross-check of the replication against a live server. Pinned in
+`TestSCWReconstructsObservedLiveScore`.
+
+The counterfactual is the finding: the **same candidate**, one moment earlier, same FTS
+coverage, no embedding → `0.4 × 0.7269 = 0.291` → below the 0.5 surface gate → zero results.
+Nothing about the memory or the query changed. Only the embedding landed.
+
+**Noisy-OR and max both fix this case** (they return the perfect lexical match at 1.0),
+which is the first evidence that one composition change addresses both directions of the
+defect. That strengthens the case for running the harness, not for shipping the change.
+
+### 3.5 Exposure of the indexing lag
+
+Quantified from `internal/plugin/retroactive.go`:
+
+- poll interval **3s** (`:25`); idle back-off `3s × 2^min(idle,6)` capped at **3 minutes**
+  (`:36`, `:188-192`); reset to fast polling on real work (`:195-197`).
+- A `notifyCh` fast-wake path exists (`:169`) — **but no write path calls `Notify()`**. The
+  only caller in the tree is the processor itself, when it hits `maxBatchSize` and knows more
+  work remains (`:444`).
+
+So the exposure window is **~3s on a busy vault** (what the live reproduction saw) and **up
+to ~3 minutes on a vault quiet for ~3 minutes** — reaching `consecutiveIdle=6` takes
+3+6+12+24+48+96 ≈ 189s of quiet. The worst case is therefore the *common agent pattern*: a
+session begins after a pause, writes a memory, and immediately recalls it.
+
+FTS indexing is also async (`internal/index/fts/worker.go`, 100ms tick) and **drops jobs when
+its queue is full** (`:37`, `:143`) — a second, rarer path into the same missing-estimator
+state.
+
+Wiring `Notify()` into the write path is an obvious, cheap mitigation. It is **not** a fix:
+it shrinks the window, it does not close the structural 0.4 < 0.5 gap. Out of scope for this
+pass, and not my file.
+
+### 3.6 The counterweight nobody should skip
 
 COG-26's `b = 0.520` was derived **against the 0.6 linear combiner**
 (`docs/internals/invariants.md`, COG-26 entry): the "sem-only survival bar" of cosine ≈ 0.600
@@ -238,8 +335,9 @@ this pass ships no behaviour change.
 Offline replication of the live ACT-R formula, term for term with upstream `file:line`
 citations, plus the three alternative ContentMatch combiners. Synthetic fixtures only.
 Pins: the denominator identity, the `bLevelCap` saturation point, the COG-26 rescale, the
-0.6/0.4 structural caps, the corrected worked case, the noise-ceiling counterweight, that
-Confidence is a clean multiplier, and the prior's >20× dynamic range.
+0.6/0.4 structural caps, the corrected worked case, the noise-ceiling counterweight, the
+missing-cosine case against the 0.5 surface gate, the reconstruction of the live 0.742
+observation, that Confidence is a clean multiplier, and the prior's >20× dynamic range.
 
 It is a replication and not a call because `activation.computeACTR` is unexported and
 `activation.Run` needs a built HNSW index. **If the live formula changes, these tests will
@@ -253,7 +351,11 @@ requires an explicit `MUNINN_SCOREW_DATA_DIR`, writes no files, prints aggregate
 only (never content, concept, summary, tags, entities, IDs, or the vault name).
 
 Design: 4 combiners × {Confidence live, **Confidence ablated to 1.0**} × {FULL-SIGNAL,
-PARAPHRASE (FTS forced to 0)}.
+PARAPHRASE (FTS forced to 0)} × {engine threshold 0.05, **surface threshold 0.5**}.
+
+The threshold dimension was added after §3.4: measuring only at 0.05 reports numbers no MCP
+or REST agent ever sees, and hides that the 0.4 FTS coefficient sits below the surface gate
+outright.
 
 Two pre-committed metrics that pull against each other:
 
@@ -271,6 +373,14 @@ arm's top-1) **and** runs every arm a second time with Confidence ablated to 1.0
 ablated rows are the primary read. If ablated and live rank the combiners differently, the
 measurement is contaminated and the conf-on numbers must not be quoted. An optional
 `MUNINN_SCOREW_MIN_CONFIDENCE` additionally excludes depressed engrams from the pool.
+
+**Indexing-lag confound — settlement is PROVEN, not assumed.** The driver counts active
+engrams with no stored embedding, always reports the fraction, and **refuses to run above
+1%** (`MUNINN_SCOREW_MAX_UNEMBEDDED_FRAC`). Unembedded engrams are excluded from the pool —
+they cannot be scored by the raw-cosine control at all, and silently keeping them would
+flatter that arm. So the driver measures the combiners on a settled corpus and does *not*
+measure the missing-cosine case itself; that one is pinned analytically in the model file,
+where it is exact rather than sampled.
 
 **Stated limits:** Hebbian and PAS-transition boosts are 0 in every arm — the cognition
 layer's strongest arguments for itself are absent, so the harness is biased *against* the

--- a/.claude/deep-review/2026-07-30-scoring-weights-trace.md
+++ b/.claude/deep-review/2026-07-30-scoring-weights-trace.md
@@ -1,0 +1,309 @@
+# Scoring-weight trace: what actually ranks a recall result
+
+Date: 2026-07-30
+Branch: `fix/agent-experience-hardening`
+Scope: trace + measurement harness only. **No behaviour change shipped in this pass.**
+
+---
+
+## 1. The actual scoring path, end to end
+
+### 1.1 Where the weights come from
+
+`Engine.activateCore` builds `actReq.Weights` in one of three branches
+(`internal/engine/engine.go:2306-2380`):
+
+| branch | condition | what it sets |
+|---|---|---|
+| caller weights | `req.Weights != nil` | passthrough of the wire request |
+| weight-carrying preset | `mode` is `semantic`/`recent`, no caller weights, vault not `rrf` | preset's full zero-base vector (`internal/auth/recall_modes.go:17`) |
+| **production default** | everything else | **hardcoded `SemanticSimilarity: 0.6`, `FullTextRelevance: 0.4`** (`engine.go:2357-2358`) |
+
+`resolveWeights` (`internal/engine/activation/engine.go:2509`) then fills the ACT-R
+parameters: `ACTRDecay = 0.5`, `ACTRHebScale = 4.0`, `UseACTR = !DisableACTR`.
+
+### 1.2 The formula that produces the number
+
+Phase 6 dispatches on the scoring mode (`activation/engine.go:1488` `phase6Score`).
+The production default is the **ACT-R** branch (`activation/engine.go:1895`), which calls
+`computeACTR` (`activation/engine.go:2199`):
+
+```
+semCal       = max(0, (cos - b) / (1 - b))                      activation:2133, 2210
+ContentMatch = 0.6*semCal + 0.4*ftsCoverage                     activation:2211
+   (floored at 0.1 when the candidate matched an explicit tag filter, COG-5, activation:2227)
+
+B(M)         = ln(n) - 0.5*ln(max(ageDays, 1min)/n),  n = AccessCount+1   activation:2251
+               capped at bLevelCap = ln(e^1.6931 - 1) ≈ 1.4892            activation:2265
+prior        = softplus(B(M) + 4*hebbian + 4*transition) / 1.6931         activation:2269-2276
+
+raw          = ContentMatch * prior                             activation:2276
+final        = raw * Confidence                                 activation:2295
+```
+
+Then, per query (`activation/engine.go:1922-1940`): if any candidate's `raw > 1`, all are
+rescaled by `1/maxRaw` (a single positive scalar — ranking-neutral), and anything with
+`final < Threshold` is dropped. Default threshold is **0.05** for ACT-R,
+0.001 for RRF (`activation/engine.go:542-549`); the `semantic`/`recent`/`deep` presets
+override to 0.3 / 0.2 / 0.1.
+
+### 1.3 Where the constants came from
+
+`git log -L` on `engine.go:2356-2358`: the 0.6/0.4 pair landed in **e51b985**
+("feat(engine,storage): PAS transitions, checkpoints, migration, activation improvements",
+2026-02-25), a large omnibus commit. It *replaced* plasticity-derived values
+(`resolved.SemanticWeight` / `resolved.FTSWeight`) with literals, with the comment:
+
+> ACT-R ContentMatch gate: 60% semantic, 40% FTS — **proven optimal**. … Use hardcoded
+> **proven values** to guarantee deterministic results.
+
+**No derivation is recorded anywhere.** No corpus is named, no measurement is cited, and
+`docs/internals/` contains no entry for it. The commit body does not mention the change.
+This is precisely the pattern principle #11 forbids: an unmeasured constant carrying the
+word "proven".
+
+The `DefaultWeights` struct in `activation.New` (`activation/engine.go:401-407`:
+0.35/0.25/0.20/0.10/0.05/0.05) has the same problem but is **not reachable in production** —
+see §2.1.
+
+---
+
+## 2. Findings
+
+### 2.1 CONFIRMED — the 6-dimension additive path is not reachable in production
+
+`resolveWeights` sets `UseACTR = !req.DisableACTR` (`activation/engine.go:2534`), and
+the production-default branch sets `UseACTR: true` (`engine.go:2365`). The additive
+weighted sum in `computeComponents` (`activation/engine.go:2035-2110`) runs **only** if:
+
+- a caller sets `DisableACTR`, or
+- the vault sets `ScoringFusion: "weighted_sum"` (`engine.go:2376-2379`), or
+- the `semantic` recall-mode preset is used, which carries `DisableACTR: true`
+  (`internal/auth/recall_modes.go:23`).
+
+`engine.go:2204` says it outright: *"All scoring goes through ACT-R; legacy temporal path
+is kept in code but not reachable for now."*
+
+**Therefore the original framing — "semantic similarity carries 1/6 of the score" — is
+REFUTED for production.** Semantic carries 0.6 of ContentMatch, and ContentMatch gates
+everything else multiplicatively.
+
+### 2.2 PARTIALLY REFUTED — the formula as commonly quoted
+
+Two corrections to the quoted production formula:
+
+- **There is no `tanh` on the FTS term.** #711 removed it; `ftsCoverage` is already a
+  calibrated absolute [0,1] coverage score (`activation/engine.go:2064-2069`). The comment
+  there explains why the tanh was actively harmful: it saturated by x≈3 while real BM25
+  magnitudes ran 2–40, making one common-word match indistinguishable from a genuine
+  multi-term match.
+- **The semantic term is `semCal`, not raw cosine** — COG-26's baseline-rescaled value
+  (`activation/engine.go:2210`, `b = 0.520` for bge-small-en-v1.5,
+  `internal/plugin/embed/baseline.go:56`). This matters a great deal for the worked example
+  in §3.
+
+The structural claim — *relevance gates salience multiplicatively; salience cannot rescue a
+zero-relevance memory* — is **CONFIRMED** (`activation/engine.go:2276`), with one exception
+worth noting: the COG-5 tag floor sets `ContentMatch = 0.1` for an explicit tag-filter match
+with zero content overlap (`activation/engine.go:2227`), so an explicit filter can surface a
+content-unrelated memory by design.
+
+### 2.3 CONFIRMED (all three sub-claims) — the learned-weight loop cannot learn
+
+Pinned by characterization tests in `internal/scoring/deadloop_characterization_test.go`.
+
+**(a) Both call sites pass a constant.** `internal/engine/engine.go:2101` (implicit
+read-is-access feedback) and `internal/engine/engine.go:4370` (explicit
+`Engine.RecordFeedback`) both set `ScoreVector: scoring.DefaultWeights()` — the uniform
+1/6 vector — where the field's own doc comment (`internal/scoring/weights.go:31`) says it
+carries *"the score components that produced this result"*. A constant is not feedback.
+
+**(b) With a constant vector the update is provably a no-op.** `Update`
+(`internal/scoring/weights.go:94`) adds `lr * direction * ScoreVector[i]` to each
+dimension — the *same scalar* to every dimension — and `Softmax` is shift-invariant. The
+0.05 floor does not rescue it: from a uniform start all six dimensions hit the floor
+simultaneously and clamp equally. Verified over 500 updates in both feedback directions:
+max weight movement `< 1e-12`. `UpdateCount` increments correctly — the bookkeeping runs,
+only the learning does not.
+
+**(c) `Update` re-Softmaxes an already-normalised vector.** Softmax of a probability
+distribution is far flatter than the distribution. Measured: a peaked distribution
+(spread 0.7608) collapses to spread **0.000000** — exactly uniform — after 10
+re-normalizations. Twenty *zero-information* updates erode a learned peak from 0.8007 to
+0.1667. Even a genuinely informative gradient would be fighting its own normalization.
+The contrast test confirms `Update` is not broken in itself: given a real non-uniform
+score vector it does move the weights in the right direction.
+
+**(d) Nothing reads the result.** `scoring.Store.Get` has no caller outside
+`internal/scoring`'s own tests. `PebbleStore.ScoringStore()` (`internal/storage/impl.go:669`)
+is called exactly once, at `internal/engine/engine.go:446`, to populate `e.scoring` — which
+is then used only for `RecordFeedback`. No `Weights[Dim…]` indexing appears anywhere in the
+tree outside `internal/scoring`. (The brief's mention of `internal/replication` is
+incorrect: replication ships the 0x13 keyspace prefix like any other, but never reads the
+struct.)
+
+**(e) The dimensions don't map onto the production knobs anyway.** The six dims are
+FTS/HNSW/Hebbian/Decay/Recency/Association. Production has: a two-term ContentMatch
+(0.6/0.4), `ACTRDecay`, and `ACTRHebScale`. `DimDecay`, `DimRecency` and `DimAssociation`
+have no additive counterpart in the ACT-R formula at all. Wiring the vector in would require
+first deciding what it *means*.
+
+**Net: this is not merely a write-only loop. It is a write-only loop whose writes are
+provably constant, whose normalization erases learning even when it happens, whose output
+nothing reads, and whose coordinate system does not match the live scorer.**
+
+---
+
+## 3. The primary defect: the paraphrase cap
+
+### 3.1 The arithmetic
+
+```
+ContentMatch = 0.6*semCal + 0.4*ftsCoverage
+```
+
+A candidate with **no lexical overlap** has `ftsCoverage = 0` and therefore
+`ContentMatch ≤ 0.6`, *at a perfect semantic match*. A missing estimator is charged as
+evidence of irrelevance rather than absence of evidence. Symmetrically, a perfect lexical
+match with zero semantic similarity caps at 0.4.
+
+This is not a tuning preference. It is a hard ceiling on retrieval-by-meaning — the exact
+capability the vector index exists to provide.
+
+### 3.2 The worked case, corrected
+
+The incident case is usually quoted as `0.6 × 0.758 = 0.455`. **That omits the COG-26
+rescale and is wrong in the optimistic direction.** With `b = 0.520`:
+
+```
+semCal       = (0.758 - 0.520) / 0.480 = 0.4958
+ContentMatch = 0.6 × 0.4958          = 0.2975     (not 0.455)
+prior        ≈ 1.0 (fresh, recently accessed)
+final (conf 1.00) = 0.2975           → survives the 0.05 threshold, comfortably
+final (conf 0.07) = 0.0208           → DROPPED, zero results
+```
+
+Both facts are load-bearing, and they are not in competition:
+
+- **the confidence bug explains the zero result** — 0.07 is a 93% cut, and Confidence
+  multiplies straight into the final score (`activation/engine.go:2295`);
+- **the 0.6 cap explains why the margin was thin enough for a confidence bug to matter at
+  all.** Under noisy-OR the same candidate at the same collapsed confidence scores 0.0347 —
+  still dropped. So the cap is not *the* cause of this particular miss. It is a standing
+  1.67× handicap applied to every semantic-only match, which turns near-misses into misses.
+
+### 3.3 How much of a realistic pool is capped
+
+Structurally: **every candidate that is not in the FTS result set has `ftsScore = 0`.**
+`phase3RRF` (`activation/engine.go:1088-1092`) assigns `c.ftsScore` only while walking
+`sets.fts`; candidates arriving from the vector, decay, time or tag sets keep the zero
+value. So the cap applies to:
+
+- the entire vector-only portion of the pool (the ANN neighborhood minus the FTS∩HNSW
+  intersection),
+- every decay-, time- and tag-seeded candidate,
+- and, for a query with no meaningful lexical overlap with anything in the vault, the
+  **whole pool**.
+
+The exact fraction is vault- and query-dependent and is precisely what the harness measures
+(`gold-found` under the PARAPHRASE condition). It is not estimated here, because estimating
+it is the thing the harness exists to avoid doing by argument.
+
+### 3.4 The counterweight nobody should skip
+
+COG-26's `b = 0.520` was derived **against the 0.6 linear combiner**
+(`docs/internals/invariants.md`, COG-26 entry): the "sem-only survival bar" of cosine ≈ 0.600
+is computed as `0.520 + 0.1667×(1−0.520)`, where `0.1667 = 0.1/0.6` — the abstention
+threshold divided by the semantic coefficient. **Changing the combiner changes that bar and
+invalidates the calibration.**
+
+Measured on the model's own noise ceiling (cosine 0.596, the highest observed out-of-domain
+pair in COG-26's 432-pair measurement):
+
+| combiner | ContentMatch at the noise ceiling | vs the 0.1 abstention gate |
+|---|---|---|
+| linear 0.6/0.4 | **0.0950** | abstains, by 0.005 |
+| noisy-OR | **0.1583** | **clears it — noise returns as a result** |
+| max | **0.1583** | **clears it — noise returns as a result** |
+
+So the naive fix trades a recall gain for a measurable abstention regression. That is why
+this pass ships no behaviour change.
+
+---
+
+## 4. What was built
+
+### `internal/engine/engine_scoring_weights_model_test.go` — no build tag, runs in CI
+
+Offline replication of the live ACT-R formula, term for term with upstream `file:line`
+citations, plus the three alternative ContentMatch combiners. Synthetic fixtures only.
+Pins: the denominator identity, the `bLevelCap` saturation point, the COG-26 rescale, the
+0.6/0.4 structural caps, the corrected worked case, the noise-ceiling counterweight, that
+Confidence is a clean multiplier, and the prior's >20× dynamic range.
+
+It is a replication and not a call because `activation.computeACTR` is unexported and
+`activation.Run` needs a built HNSW index. **If the live formula changes, these tests will
+not automatically fail** — that limit is stated in the file header rather than hidden.
+
+### `internal/engine/engine_scoring_weights_measure_test.go` — build tag `scoringmeasure`
+
+Read-only real-vault driver. CI builds with `-tags localassets` and never with this tag, so
+it does not compile in any CI job. Guards: refuses a data dir containing `muninn.pid`,
+requires an explicit `MUNINN_SCOREW_DATA_DIR`, writes no files, prints aggregate statistics
+only (never content, concept, summary, tags, entities, IDs, or the vault name).
+
+Design: 4 combiners × {Confidence live, **Confidence ablated to 1.0**} × {FULL-SIGNAL,
+PARAPHRASE (FTS forced to 0)}.
+
+Two pre-committed metrics that pull against each other:
+
+- **NDCG@5 on answerable queries** — query text is a sampled engram's own summary; gold is
+  that engram by identity.
+- **FPR on unanswerable queries** — 20 committed synthetic nonsense probes, authored in the
+  file, shaped like plausible memory queries so abstention is non-trivial.
+
+Labels are mechanical, assigned before scoring, identical across arms, and invisible to the
+scorer. This is not human relevance judgment and the file says so.
+
+**Confidence confound — both mitigations, as required.** The driver *always reports*
+confidence (pool-wide histogram, count below a suspect threshold, mean confidence of each
+arm's top-1) **and** runs every arm a second time with Confidence ablated to 1.0. The
+ablated rows are the primary read. If ablated and live rank the combiners differently, the
+measurement is contaminated and the conf-on numbers must not be quoted. An optional
+`MUNINN_SCOREW_MIN_CONFIDENCE` additionally excludes depressed engrams from the pool.
+
+**Stated limits:** Hebbian and PAS-transition boosts are 0 in every arm — the cognition
+layer's strongest arguments for itself are absent, so the harness is biased *against* the
+parts of the layer it cannot see. The pool is not `engine.Recall`'s output (no entity boost,
+tag seeding, traversal, currency, or time filters). Queries are engram summaries, whose
+cosine distribution runs higher than real user queries.
+
+---
+
+## 5. Options for the learned-weight loop (proposed, not shipped)
+
+**A. Delete it.** ~300 lines plus a Pebble prefix, a keyspace entry, a clone exclusion, a
+migration case, and an LRU throttle — all serving a loop that cannot learn and that nothing
+reads. Honest negative results are first-class here (principle #10). Cost: gives up the
+idea, and the 0x13 prefix needs a tombstone entry in the keyspace registry.
+
+**B. Wire it in as-is.** Rejected. The dimensions do not map onto the ACT-R knobs (§2.3e),
+and the defaults are uniform, so wiring them in would *replace* a measured-ish 0.6/0.4 with
+an unmeasured 1/6 — strictly worse and a direct principle #1 violation (explicit config
+silently substituted).
+
+**C. Fix it properly, in increments.** Requires, in order: (i) pass the *real* per-result
+score components at both call sites; (ii) drop the redundant re-Softmax and normalize by sum
+instead; (iii) re-coordinate the six dims onto the knobs the ACT-R formula actually has;
+(iv) *then* wire it into scoring behind a per-vault plasticity flag, defaulted off, with a
+measurement gate. That is four increments, and step (iv) needs exactly the harness this pass
+built.
+
+**Recommendation: A or C, decided on appetite — but not before the harness runs.** In the
+meantime the loop should at minimum stop claiming to be feedback: the two call sites pass a
+constant, and the field they pass it to is documented as carrying real score components.
+
+The 0.6/0.4 constants need a separate decision. They are not obviously *wrong* — but
+"proven optimal" with no recorded derivation cannot stand, and COG-26's calibration is now
+downstream of them. Either the derivation gets reconstructed and written down, or the words
+come out of the comment.

--- a/cmd/bench/adapters.go
+++ b/cmd/bench/adapters.go
@@ -49,6 +49,6 @@ func (a *benchConfidenceAdapter) UpdateConfidence(ctx context.Context, ws [8]byt
 // benchContradictAdapter adapts PebbleStore to the ContradictionStore interface.
 type benchContradictAdapter struct{ store *storage.PebbleStore }
 
-func (a *benchContradictAdapter) FlagContradiction(ctx context.Context, ws [8]byte, engramA, engramB [16]byte) error {
+func (a *benchContradictAdapter) FlagContradiction(ctx context.Context, ws [8]byte, engramA, engramB [16]byte) (bool, error) {
 	return a.store.FlagContradiction(ctx, ws, storage.ULID(engramA), storage.ULID(engramB))
 }

--- a/cmd/muninn/lifecycle.go
+++ b/cmd/muninn/lifecycle.go
@@ -67,6 +67,53 @@ func buildDaemonArgs(dataDir string, dev bool, osArgs []string, listenHostEnv, c
 }
 
 // runStart forks muninn as a background daemon and waits for health check.
+// checkStartArgs rejects any argument `muninn start` cannot honour.
+//
+// runStart resolves its data directory from defaultDataDir() and its listen
+// addresses from the server defaults. It has never read --data, --mcp-addr, or
+// any other flag — but it also never complained about them, so
+//
+//	muninn start --data /tmp/scratch --mcp-addr 127.0.0.1:9260
+//
+// looked like it launched an isolated instance while actually opening
+// $MUNINNDB_DATA (or ~/.muninn/data) on the default ports. That is principle #1
+// violated on the one argument that decides WHICH DATABASE is opened, with the
+// operator's real vault as the silent substitute.
+//
+// This fails CLOSED rather than trying to wire the flags up: guessing at which
+// subset to honour is how this class of bug is created, and a caller who wanted
+// an isolated instance is better served by an error naming the invocation that
+// supports one than by a daemon quietly attached to production data.
+//
+// The subcommand word itself is tolerated because some dispatch paths pass it
+// through in the argument slice.
+func checkStartArgs(args []string) error {
+	var rejected []string
+	for _, a := range args {
+		if a == "start" || a == "start:web" || a == "" {
+			continue
+		}
+		if strings.HasPrefix(a, "-") {
+			name := a
+			if i := strings.IndexByte(name, '='); i >= 0 {
+				name = name[:i]
+			}
+			rejected = append(rejected, name)
+			continue
+		}
+		rejected = append(rejected, a)
+	}
+	if len(rejected) == 0 {
+		return nil
+	}
+	return fmt.Errorf("`muninn start` does not accept %s.\n"+
+		"  It always uses the default data directory (MUNINNDB_DATA, else ~/.muninn/data) and the\n"+
+		"  default ports, so these arguments would have been silently ignored.\n"+
+		"  To run an instance with an explicit data directory or addresses, invoke the daemon directly:\n"+
+		"    muninn --daemon --data <dir> [--rest-addr host:port] [--mcp-addr host:port]",
+		strings.Join(rejected, ", "))
+}
+
 func runStart(webEnabled bool) error {
 	dataDir := defaultDataDir()
 	pidPath := filepath.Join(dataDir, "muninn.pid")

--- a/cmd/muninn/lifecycle_flags_test.go
+++ b/cmd/muninn/lifecycle_flags_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// `muninn start` accepted and SILENTLY DISCARDED every flag it was given.
+//
+//	muninn start --data /tmp/scratch --mcp-addr 127.0.0.1:9260
+//
+// looks like it launches an isolated instance. It does not. runStart calls
+// defaultDataDir() unconditionally (lifecycle.go), so the daemon comes up on
+// $MUNINNDB_DATA or ~/.muninn/data — the operator's REAL vault — and binds the
+// default ports, while the flags the caller typed are dropped on the floor with
+// no error, no warning, and no mention in the startup banner.
+//
+// This is the project's first principle ("explicit config is never silently
+// substituted") violated on the one argument that decides WHICH DATABASE the
+// process opens, and the substituted value is production data. It was found the
+// hard way: an agent building an isolated sandbox for evaluation used exactly
+// this invocation, and its daemon bound the default ports for ~40s against the
+// default data dir before it noticed. Nothing was written, but only by luck —
+// the same command with a write would have gone to the live vault.
+//
+// The fix is fail-closed: `start` refuses any argument it cannot honour and
+// names the invocation that does support them. It deliberately does NOT try to
+// implement --data for `start`, because guessing at which flags to wire up is
+// how this class of bug is created; refusing is unambiguous and cannot silently
+// do the wrong thing.
+func TestStartArgs_RefusesFlagsItCannotHonour(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+		mustSay []string
+	}{
+		{
+			// THE BUG: the exact invocation that silently opened the real vault.
+			name:    "data and mcp-addr are refused, not swallowed",
+			args:    []string{"--data", "/tmp/scratch", "--mcp-addr", "127.0.0.1:9260"},
+			wantErr: true,
+			mustSay: []string{"--data", "muninn --daemon"},
+		},
+		{
+			name:    "single unsupported flag is refused",
+			args:    []string{"--data", "/tmp/scratch"},
+			wantErr: true,
+			mustSay: []string{"--data"},
+		},
+		{
+			name:    "equals form is refused too",
+			args:    []string{"--data=/tmp/scratch"},
+			wantErr: true,
+			mustSay: []string{"--data"},
+		},
+		{
+			// A bare `muninn start` is the supported form and must keep working.
+			name:    "no args is accepted",
+			args:    nil,
+			wantErr: false,
+		},
+		{
+			// The dispatcher passes the subcommand word through in some paths;
+			// it must not be mistaken for an unsupported flag.
+			name:    "the subcommand word itself is not an error",
+			args:    []string{"start"},
+			wantErr: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkStartArgs(tc.args)
+			if tc.wantErr && err == nil {
+				t.Fatalf("checkStartArgs(%q) = nil, want an error — these flags are silently "+
+					"discarded today, and --data silently redirects the daemon to the REAL vault", tc.args)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("checkStartArgs(%q) = %v, want nil", tc.args, err)
+			}
+			if err != nil {
+				for _, want := range tc.mustSay {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error must mention %q so the caller knows what was rejected and "+
+							"what to run instead; got: %v", want, err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/cmd/muninn/main.go
+++ b/cmd/muninn/main.go
@@ -59,6 +59,12 @@ func main() {
 	case "shell":
 		runShell()
 	case "start":
+		// Refuse flags `start` cannot honour rather than silently opening the
+		// default (real) data directory with them discarded.
+		if err := checkStartArgs(rest); err != nil {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(2)
+		}
 		if err := runStart(true); err != nil {
 			os.Exit(1)
 		}

--- a/docs/internals/agent-experience-findings.md
+++ b/docs/internals/agent-experience-findings.md
@@ -110,6 +110,37 @@ The honest reading is that the bitemporal + entity-timeline core is the product,
 and Hebbian association are hypotheses that have not yet been shown to beat plain cosine on a real
 corpus. That is a measurement to run, not an assumption to keep.
 
+### Newly-written memories are silently unfindable until the embedder catches up
+
+Verified live at commit c3b5b60. Write a memory, query it seconds later with near-exact lexical
+overlap, and recall returns ZERO results. Wait for the retroactive embed pass and the identical
+query returns it at score 0.742 (raw cosine 0.881).
+
+Timeline from the daemon log:
+
+    22:05:31  evolve creates the successor
+    22:05:34  activation complete ... results=0        <- the query
+    22:05:36  retroactive processor: complete           <- embedding lands AFTER
+
+Mechanism: `ContentMatch = 0.6*cosine + 0.4*tanh(FTS)`. Before the embedding exists, cosine is 0 —
+scored as *zero semantic relevance* rather than *unknown* — so ContentMatch cannot exceed 0.4
+however perfect the lexical match, which falls below the default threshold. Recall returns an empty
+set with a hint suggesting `mode=recent`, indistinguishable from "no such memory".
+
+This is the same defect as the paraphrase cap, from the other direction: a MISSING estimator is
+treated as a zero rather than as absence of evidence. It matters more than the paraphrase case
+because agents write-then-recall constantly within a session, and it plausibly explains part of the
+"abstains on answerable questions" behaviour observed during the hands-on evaluation — those vaults
+were being written and queried in the same minutes.
+
+It is also the third cause initially mis-attributed to ACT-R fusion, after the confidence collapse
+and the 0.6 content-match cap. The lesson recorded here: before blaming the cognitive layer,
+account for confidence, for missing-signal handling, and for indexing lag.
+
+Candidate fixes to EVALUATE (not to ship on argument): noisy-OR or max composition so a missing
+estimator does not cap the other; and/or an explicit "not yet indexed" signal on the response so an
+empty result is never silently confused with an unknown one.
+
 ### 44 tools
 
 Unanimously "too many" / "hostile". Six different tools can change a memory (`evolve`, `forget`,

--- a/docs/internals/agent-experience-findings.md
+++ b/docs/internals/agent-experience-findings.md
@@ -1,0 +1,202 @@
+# Agent-experience findings — hands-on evaluation, 2026-07-31
+
+Four AI models (Grok 4.5, GPT-5.6, Composer 2.5, Opus 5) each ran a realistic multi-session
+workflow against a live sandbox over ~150 tool calls, as the product's actual user rather than as
+code reviewers. A separate three-model design panel then answered the questions those runs raised.
+This document records what they found, what was independently reproduced, and what it implies.
+
+Every number here came from a live server. Claims that could not be reproduced are marked as
+refuted, because a finding nobody can reproduce is worth less than no finding at all.
+
+---
+
+## 1. What they liked (unprompted, and consistent across models)
+
+- **`muninn_evolve`.** All three external evaluators named it as the moment the product justifies
+  itself: after evolving, default recall returns only the current fact and the predecessor is
+  soft-deleted with a closed validity window.
+- **Bitemporality** (`valid_from`/`valid_until`, `forget(not_true_since)`). "A vector store cannot
+  fake those; you would rebuild them badly."
+- **`muninn_entity_timeline`** — "the best tool in the product". *What changed about X, in order*
+  is a question similarity search structurally cannot answer, and it answers it in one call.
+- **Exact-duplicate detection**, `remember_tree`/`recall_tree`, and rejecting an impossible
+  validity window instead of storing temporal nonsense.
+- **The type-rejection hint shipped in #742** — called "textbook loud degradation", and explicitly
+  named as the pattern the rest of the write path should copy. It landed hours before the
+  evaluation and was noticed without prompting.
+
+The praise is narrow and specific, and it clusters on the *declared* path: bitemporality, explicit
+supersession, entity timelines. That is the product's real differentiator.
+
+---
+
+## 2. Confirmed defects
+
+Reproduced independently; each needs its own fix.
+
+| # | Defect | Evidence |
+|---|---|---|
+| 1 | **Declaring a contradiction destroys both memories** | confidence 1.0 → 0.797 → 0.313 → 0.0709 on BOTH sides; recall returns 0 |
+| 2 | `as_of` cannot read an evolved predecessor | soft-delete gate runs before the validity filter; `restore` makes it work |
+| 3 | `muninn_explain` returns all zeros unconditionally | including `threshold:0`, `confidence:0` for an engram whose confidence was 1.0 |
+| 4 | Abstention is inverted | refused answerable questions; returned 5 confident results for an unanswerable one |
+| 5 | `muninn_decide` produces a `fact`, not a `decision` | inherits fact-tier importance 0.4; invisible to type filters |
+| 6 | `conflicts_with` annotates only one side | the stale memory ranked #1 carrying `"stale": false` |
+| 7 | `restore` resurrects an expired fact into present-tense recall | returned at 0.532 with no annotation |
+| 8 | Write responses report `"concept":""` | serialization only — the concept IS stored correctly |
+
+### The headline: contradiction as data loss
+
+Two opposing memories, linked `contradicts` in both directions — the natural thing for an agent to
+do — both drop to confidence 0.0709 within ~80s and vanish from recall. The **correct** memory is
+punished exactly as hard as the false one; the penalty is a flat blanket value, not
+evidence-weighted, and confidence multiplies into the recall score.
+
+Root cause: the same declared fact is treated as N independent Bayesian observations
+(`1.0 → 0.975 → 0.797 → 0.313 → 0.0709`). Per-event, not time-based — a linked pair left alone
+holds steady.
+
+This is the project's worst failure class (silent, plausible-looking wrong answers) reached by
+doing the *right* thing. Declarations are the scarcest resource in the system — 0.135% of
+association edges are agent-authored — so a declaration that destroys data is worse than none.
+
+**Two deeper problems sit underneath the immediate bug:**
+
+1. **Penalising both sides is incoherent.** When A and B contradict, at most one is wrong. Halving
+   confidence in both is not Bayesian evidence, it is a tax on honesty. A contradiction should
+   mark a *conflict*, not degrade *truth*.
+2. **Confidence should not silently gate visibility.** Multiplying a "there is a dispute here"
+   signal into the recall score converts an annotation into a deletion.
+
+### Refuted claims
+
+Recorded because refutations are findings too:
+
+- **"Version-clustering mislabels unrelated memories."** It does not — across five queries built to
+  trigger it, the advisory currency signal produced *nothing whatsoever*. The feature never fired.
+- **"`muninn_decide` loses the concept."** The concept is stored correctly; only the response
+  serialization is empty. Two evaluators concluded data loss from this. The misdiagnosis is itself
+  a cost of the bug.
+- **"`muninn_contradictions` is permanently empty."** It is populated by an async worker on a 30s
+  interval. It was empty for the entire window in which a working agent would look — which is why
+  three independent evaluators called the feature dead. The honest answer is "not processed yet",
+  not `[]`; an empty result standing in for an unknown one is the same silent-substitution class as
+  #742/#743/#745.
+
+---
+
+## 3. The structural critiques
+
+These are design questions, not bugs, and they matter more than the bug list.
+
+### The cheap path silently succeeds and produces near-garbage
+
+A bare `remember(content)` is ~20 tokens and yields an empty concept, no entities, and invisibility
+to every entity-based tool. A well-formed write is roughly **8× the content in JSON**. There is no
+middle gear, and **every evaluator said they would take the cheap path under time pressure with a
+user waiting.** That is not an agent-discipline problem — it is what happens when the expensive
+path is entirely voluntary and the cheap path silently succeeds. The measured 4.81% declaration
+rate on a real corpus is the predictable result.
+
+### The cognition layer is currently unproven, and in this run net-negative
+
+ACT-R fusion turned a correct 0.758-raw-cosine answer into a below-threshold miss while returning
+five confident irrelevancies to a question the vault could not answer. The Hebbian graph produced
+~35 edges over 8 nodes — a near-complete graph that discriminates nothing. `score` is
+max-normalised, so the top hit is always exactly 1 regardless of quality and cannot be used as a
+confidence signal or a cutoff.
+
+The honest reading is that the bitemporal + entity-timeline core is the product, and ACT-R fusion
+and Hebbian association are hypotheses that have not yet been shown to beat plain cosine on a real
+corpus. That is a measurement to run, not an assumption to keep.
+
+### 44 tools
+
+Unanimously "too many" / "hostile". Six different tools can change a memory (`evolve`, `forget`,
+`forget+not_true_since`, `state`, `consolidate`, `trust`) with no map of which to use. Evaluators
+guessed wrong about `link` directionality, about `decide` producing a decision, and about
+`contradictions` being synchronous.
+
+Panel consensus: **8–12 always-visible tools**, the rest behind progressive disclosure or toolset
+flags — and *small named tools* rather than one mega-tool with a verb enum, because models handle a
+30-way enum no better than 30 tools.
+
+---
+
+## 4. The write-time reconcile question
+
+All four evaluators independently proposed the same fix: **on write, when a new memory conflicts
+with an active peer, force a choice rather than silently accepting a second live truth.** A
+separate scoping analysis reached the same conclusion from pure code reading. Four methods, one
+answer.
+
+The design panel split on the mechanism, and the dissent is the valuable part:
+
+- **Refuse-pending-acknowledgement** (Grok, GPT) buys an *invariant* a notice cannot: default recall
+  never contains two live truths for one claim. It is also auditable — you can count
+  `conflict_pending → resolved`; you cannot count "the agent read the notice and thought about it".
+- **Accept-and-quarantine** (Fable) gets the same invariant without the failure mode that should
+  worry us most: *under refusal, the information dropped is usually the newer, correct fact.* The
+  stale memory stays live and comfortable while the correction stands outside asking permission. If
+  the agent abandons the round trip — under exactly the time pressure the evaluation documented —
+  refusal silently preserves the wrong answer. That is the contradiction data-loss bug wearing a
+  different hat.
+- **Paraphrase evasion** (Fable): a refused agent mid-task rewords and resubmits, and rewording
+  specifically defeats both the semantic detector and exact-dedup. "Cannot be ignored" only wins
+  when the required action is cheaper than the workaround.
+
+Unanimous on one point: **withhold the system's own guess.** Never ask "you may be superseding X —
+confirm?"; every agent says yes and a heuristic has been laundered into a declaration. Fable's
+mechanism: make each verdict require a *different artifact* (`supersede` needs `what_changed`;
+`coexist` needs a `scope` distinguishing the two), so even a rubber-stamp forces the agent to
+generate something auditable.
+
+**Ordering warning:** reconcile *depends on* substrate. At a 4.81% declaration rate the detector has
+almost nothing to key on — it will underfire where it matters and misfire on semantic coincidence,
+and a good idea will die on bad data.
+
+---
+
+## 5. The middle gear
+
+Independent convergence, and the most implementable finding in this document.
+
+**Accept entities as bare strings** — `entities: ["PostgreSQL", "Alice"]` — and let the server
+resolve types from its existing entity table (known name → known type; unknown → `other`). ~15
+extra tokens instead of typed JSON objects. That single change buys the biggest thing the cheap
+path loses: visibility to every entity tool.
+
+Further, all non-LLM:
+
+- **Inline markup**: `content: "Migrated [[Auth Service]] to [[PostgreSQL]] 16"`, parsed
+  server-side. Four brackets per entity, ~2 tokens, no JSON structure at all — a rich write at
+  ~1.1× content cost instead of 8×. Needs a tokenizer, not a model.
+- **Known-entity matching**: scan incoming content against the vault's existing entity names, so
+  every bare write mentioning a known entity gets linked for free with provenance `matched`.
+- **Cut redundant fields**: `type` vs `type_label`, `concept` vs `summary`, per-entity confidence,
+  per-relationship weight — default them all.
+- Audit the *response* side too: echoing the full engram back is part of the 8×.
+
+**The honest counter-argument**, which must be measured rather than assumed: the moment agents
+learn the server extracts entities for them, the declaration rate may fall from 4.81% toward zero,
+and the graph's ceiling becomes whatever shallow string-matching can see — silent systematic
+mediocrity, which is harder to detect than the loud absence we have today.
+
+---
+
+## 6. What this implies
+
+Ranked by leverage, with the honest caveat on each:
+
+1. **Fix the confirmed defect list.** All eight are defects with known causes, not architecture
+   problems. The product feels bad because it is broken, not because it is wrong.
+2. **Ship the middle gear.** Highest measured leverage, non-LLM, and a prerequisite for reconcile.
+   Measure the declaration rate against the 4.81% baseline; if it *falls*, the Goodhart critique
+   was right.
+3. **Cut the tool surface to a core.** Cheap, and it removes the single most consistent complaint.
+4. **Measure the cognition layer against plain cosine** before defending it. If ACT-R fusion cannot
+   beat raw similarity on a real corpus, put it behind a default-off flag and say so.
+5. **Then** decide reconcile vs quarantine, with a decoy arm to detect rubber-stamping.
+
+The verdict the evaluators converged on: *the `evolve` path works, the default path does not, and
+agents live on the default path.* Everything above is in service of making the default path honest.

--- a/docs/internals/agent-experience-findings.md
+++ b/docs/internals/agent-experience-findings.md
@@ -122,7 +122,8 @@ Timeline from the daemon log:
     22:05:34  activation complete ... results=0        <- the query
     22:05:36  retroactive processor: complete           <- embedding lands AFTER
 
-Mechanism: `ContentMatch = 0.6*cosine + 0.4*tanh(FTS)`. Before the embedding exists, cosine is 0 —
+Mechanism: `ContentMatch = 0.6*semCal + 0.4*ftsCoverage`, where `semCal` is the COG-26-calibrated
+semantic score (there is no `tanh` on FTS — #711 removed it). Before the embedding exists, cosine is 0 —
 scored as *zero semantic relevance* rather than *unknown* — so ContentMatch cannot exceed 0.4
 however perfect the lexical match, which falls below the default threshold. Recall returns an empty
 set with a hint suggesting `mode=recent`, indistinguishable from "no such memory".
@@ -140,6 +141,41 @@ account for confidence, for missing-signal handling, and for indexing lag.
 Candidate fixes to EVALUATE (not to ship on argument): noisy-OR or max composition so a missing
 estimator does not cap the other; and/or an explicit "not yet indexed" signal on the response so an
 empty result is never silently confused with an unknown one.
+
+### The combiner and the abstention floor are coupled — the obvious fix has a cost
+
+A traced measurement of the live scoring path (commit `ada475e`) corrected two things believed
+earlier in this investigation, and the correction matters more than the original claim.
+
+**The production formula**, verified against source:
+
+    semCal       = max(0, (cos - b) / (1 - b))
+    ContentMatch = 0.6*semCal + 0.4*ftsCoverage
+    B(M)         = ln(n) - 0.5*ln(max(ageDays, 1min)/n),  n = AccessCount+1, capped ~1.4892
+    prior        = softplus(B(M) + 4*hebbian + 4*transition) / 1.6931
+    final        = ContentMatch * prior * Confidence
+
+Relevance multiplicatively gates salience; salience cannot rescue a zero-relevance memory (the one
+exception is COG-5's tag floor, which sets ContentMatch=0.1 for an explicit tag match).
+
+**The earlier worked example was optimistic.** Omitting the COG-26 rescale gave 0.455 for a
+cosine-0.758 paraphrase; the real value with `b=0.520` is `0.6 * 0.4958 = 0.2975`. At confidence
+1.0 that survives comfortably. Under noisy-OR at the collapsed confidence 0.07 it scores 0.0347 and
+is **still dropped** — so the content-match cap is *not* the cause of the observed miss. It is a
+standing ~1.67x handicap on every semantic-only match, turning near-misses into misses.
+
+**And the naive fix is not free.** COG-26's noise floor `b=0.520` was derived *against* the 0.6
+coefficient — the survival bar is `0.520 + (0.1/0.6)*0.480 ~= 0.600`. At the measured noise ceiling
+(cosine 0.596), the current linear form scores 0.0950 and correctly abstains, while both noisy-OR
+and max score 0.1583 and clear the 0.1 gate. **Switching the combiner buys recall and pays for it
+in abstention**, which is precisely the trade the evaluation says must not be made blind: a system
+must not win NDCG on answerable queries by returning confident nonsense on unanswerable ones.
+
+The combiner and the abstention floor are one calibration, not two knobs. Changing either requires
+re-deriving the other and measuring BOTH metrics together — which is what the harness at
+`internal/engine/engine_scoring_weights_measure_test.go` exists to do (4 combiners x confidence
+live/ablated x full-signal/paraphrase, with NDCG@5 on answerable queries and false-positive rate on
+committed nonsense probes).
 
 ### 44 tools
 

--- a/docs/internals/agent-experience-findings.md
+++ b/docs/internals/agent-experience-findings.md
@@ -251,6 +251,56 @@ mediocrity, which is harder to detect than the loud absence we have today.
 
 ---
 
+## 5b. The counterfactual ceiling — substrate was NOT the flagship's blocker
+
+The "fix capture and the graph features will fire" hypothesis was tested directly and **refuted**.
+
+Two identical clones of a real 4,216-engram corpus. One left alone (CONTROL); one had types and
+entities re-derived from content by a LOCAL model (TREATMENT) — offline analysis on a throwaway
+clone, no LLM in the recall or write path. Co-activation edges were byte-identical across arms, so
+substrate was the only variable.
+
+**Substrate moved a lot:**
+
+| | control | treatment | lift |
+|---|---|---|---|
+| JOINT (graph-typed AND >=1 entity) | 2.49% | **12.29%** | 4.93x |
+| entity coverage | 29.9% | **98.6%** | 3.30x |
+| graph-typed | 4.2% | 12.5% | 2.95x |
+| co-activation edges | 135,254 | 135,254 | 1.00x |
+
+**And associative surprise fired exactly zero times in BOTH arms**, on the same 27,255 real
+candidate edges.
+
+The gate-rejection histogram explains why: rejections *redistributed* rather than cleared.
+`type` went 59.0% -> **72.4%**; `not-focal` fell 38.6% -> 12.2%. Entity enrichment pushed many more
+candidates past focality and straight into the type gate, which absorbed all of them.
+
+**The binding constraint was never sparsity. It is that five independent gates in series
+(non-obvious AND valid AND focal AND type AND idf-armed AND null) leave no survivors on real data.**
+Associative surprise is over-gated, not substrate-starved. The next increment for that feature is
+re-deriving or removing gates — not feeding it more substrate.
+
+Currency (2.73x) and the Push (1.56x) moved only on *preconditions* no user ever sees; the Push
+still fires 0 in both arms because nothing is armed. Contradiction was structurally untouched (it
+reads association RelTypes, which this intervention does not change).
+
+**Undercut the lifts, not the zero.** Hand-adjudication of 80 distinct inferred entity names gave
+~0.76 genuine-entity precision and ~0.66 genuine-and-correctly-typed — below the 0.8 bar set before
+the run. The type half is no cleaner: the model labelled **56.9% of the corpus `task`**. The
+control's 82.8% `fact` was a bug sink; the treatment's 56.9% `task` is a model-bias sink. Neither
+is a credible distribution of declared intent, and a synthetic-fixture accuracy of 0.88 did not
+transfer to the real corpus. So the currency and push lifts rest on a ~24%-junk substrate and are
+soft; adding that substrate to a live vault would be the #713 pollution trade, not a fix.
+
+**The zero is the robust result** — it is a negative, and noise could only have helped it fire.
+
+Consequence for the roadmap: fixing capture is **necessary but nowhere near sufficient**. The type
+and entity capture bugs were real and are fixed on their own merits, but they do not unlock the
+graph features, and any plan that assumed they would needs rewriting. This also means the earlier
+conclusion "the moat is getting memories typed and entity-tagged" was too strong: it is a
+precondition, not the lever.
+
 ## 6. What this implies
 
 Ranked by leverage, with the honest caveat on each:

--- a/internal/cognitive/contradict.go
+++ b/internal/cognitive/contradict.go
@@ -41,7 +41,7 @@ func ContradictionSeverity(relA, relB uint16) float64 {
 // Only FlagContradiction is required; detection logic operates over the
 // associations supplied with each ContradictItem.
 type ContradictionStore interface {
-	FlagContradiction(ctx context.Context, ws [8]byte, engramA, engramB [16]byte) error
+	FlagContradiction(ctx context.Context, ws [8]byte, engramA, engramB [16]byte) (newlyFlagged bool, err error)
 }
 
 // ContradictAssoc is an association used for contradiction checking.
@@ -102,12 +102,29 @@ func (cw *ContradictWorker) processBatch(ctx context.Context, batch []Contradict
 				a, b := item.Associations[i], item.Associations[j]
 				severity := ContradictionSeverity(a.RelType, b.RelType)
 				if severity > 0 {
-					if err := cw.store.FlagContradiction(ctx, item.WS, a.TargetID, b.TargetID); err != nil {
+					newlyFlagged, err := cw.store.FlagContradiction(ctx, item.WS, a.TargetID, b.TargetID)
+					if err != nil {
 						slog.Error("contradict: failed to flag contradiction",
 							"ws", fmt.Sprintf("%x", item.WS),
 							"engram_a", fmt.Sprintf("%x", a.TargetID),
 							"engram_b", fmt.Sprintf("%x", b.TargetID),
 							"error", err)
+						// Newness is unknown after a failed write; treat it as
+						// already-known so an erroring flag can never drive a repeat
+						// penalty.
+						continue
+					}
+					// IDEMPOTENT PENALTY. OnFound drives a ConfidenceUpdate on BOTH
+					// engrams, and BayesianUpdate compounds repeat applications of the
+					// SAME evidence: 1.0 -> 0.975 -> 0.797 -> 0.313 -> 0.0709. Confidence
+					// multiplies into the recall score, so re-firing silently removes both
+					// memories from recall — including the TRUE one, which is penalised
+					// exactly as hard as the false one. One declared contradiction is one
+					// fact, however many times the worker re-observes the edge, so the
+					// penalty fires only on first observation. The marker itself is always
+					// (re-)written above; only the penalty is suppressed.
+					if !newlyFlagged {
+						continue
 					}
 					if item.OnFound != nil {
 						item.OnFound(ContradictionEvent{

--- a/internal/cognitive/contradict_fabrication_test.go
+++ b/internal/cognitive/contradict_fabrication_test.go
@@ -23,11 +23,11 @@ func newFakeContraConfStore(a, b [16]byte, confA, confB float32) *fakeContraConf
 	}
 }
 
-func (s *fakeContraConfStore) FlagContradiction(_ context.Context, _ [8]byte, a, b [16]byte) error {
+func (s *fakeContraConfStore) FlagContradiction(_ context.Context, _ [8]byte, a, b [16]byte) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.flagged = append(s.flagged, [2][16]byte{a, b})
-	return nil
+	return true, nil
 }
 
 func (s *fakeContraConfStore) GetConfidence(_ context.Context, _ [8]byte, id [16]byte) (float32, error) {

--- a/internal/cognitive/contradict_test.go
+++ b/internal/cognitive/contradict_test.go
@@ -152,9 +152,9 @@ type stubContradictStore struct {
 	onFlag func(ctx context.Context, ws [8]byte, a, b [16]byte) error
 }
 
-func (s *stubContradictStore) FlagContradiction(ctx context.Context, ws [8]byte, a, b [16]byte) error {
+func (s *stubContradictStore) FlagContradiction(ctx context.Context, ws [8]byte, a, b [16]byte) (bool, error) {
 	if s.onFlag != nil {
-		return s.onFlag(ctx, ws, a, b)
+		return true, s.onFlag(ctx, ws, a, b)
 	}
-	return nil
+	return true, nil
 }

--- a/internal/cognitive/store_adapters.go
+++ b/internal/cognitive/store_adapters.go
@@ -93,7 +93,7 @@ func NewContradictStoreAdapter(store storage.EngineStore) ContradictionStore {
 	return &contradictStoreAdapter{store: store}
 }
 
-func (a *contradictStoreAdapter) FlagContradiction(ctx context.Context, ws [8]byte, engramA, engramB [16]byte) error {
+func (a *contradictStoreAdapter) FlagContradiction(ctx context.Context, ws [8]byte, engramA, engramB [16]byte) (bool, error) {
 	return a.store.FlagContradiction(ctx, ws, storage.ULID(engramA), storage.ULID(engramB))
 }
 

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -1635,12 +1635,19 @@ func (e *ActivationEngine) phase6Score(
 
 	// Filter out soft-deleted engrams (defense-in-depth; HNSW has no delete method).
 	// Also filter untrusted engrams when ExcludeUntrusted is set in the request.
+	//
+	// The lifecycle cut is temporal-view aware (see PassesLifecycle): default
+	// recall drops every soft-deleted engram exactly as before, while an
+	// explicit historical query (as_of / include_invalid) still reaches a
+	// SUPERSEDED predecessor — soft-delete + a closed ValidUntil — because
+	// demoting a fact must not erase it. PassesValidity below then decides
+	// whether it is nameable at the caller's instant.
 	var active []*storage.Engram
 	for _, eng := range allEngrams {
 		if eng == nil {
 			continue
 		}
-		if eng.State == storage.StateSoftDeleted || eng.State == storage.StateArchived {
+		if !PassesLifecycle(eng, req.AsOf, req.IncludeInvalid) {
 			continue
 		}
 		// Hard trust filter: skip engrams with TrustUntrusted (0x04) when requested.

--- a/internal/engine/activation/history_gate.go
+++ b/internal/engine/activation/history_gate.go
@@ -1,0 +1,61 @@
+package activation
+
+import (
+	"time"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// PassesLifecycle is the lifecycle half of the recall visibility contract:
+// whether eng's lifecycle STATE permits it to be named under the caller's
+// temporal view. It is shared by phase-6 scoring and the engine's
+// post-pipeline visibility gate so the two paths cannot drift apart.
+//
+// Soft-delete means "no longer current", not "erased". Supersession (evolve,
+// and Link with relation=supersedes) demotes the predecessor by soft-deleting
+// it AND stamping a closed ValidUntil in the same atomic batch, precisely so
+// that the record stays readable on the valid-time axis — Evolve's own comment
+// calls the stamp what "re-opens the record for as_of time-travel only", and
+// muninn_guide promises agents that an evolved fact is never destroyed because
+// as_of still sees it. Applying the lifecycle cut unconditionally, BEFORE and
+// INDEPENDENT of the valid-time gate, made evolve's supersession mechanism
+// erase its own history: neither as_of nor include_invalid could reach the
+// predecessor (proven RED by TestAsOf_ReadsEvolvedPredecessor; the control is
+// forget(not_true_since), which stamps WITHOUT soft-deleting and was always
+// reachable — so the defect was the lifecycle cut, never the validity axis).
+//
+// A soft-deleted engram is therefore admitted only when BOTH hold:
+//
+//   - the caller asked an explicit HISTORICAL question (asOf != nil or
+//     includeInvalid). Default recall is unchanged: no soft-deleted engram
+//     ever enters it, so "never lead with a fact known to be stale" and the
+//     #548-class rule that for existence predicates the ID itself is the
+//     secret are both untouched.
+//   - the record carries a CLOSED ValidUntil, i.e. it was invalidated on the
+//     valid-time axis rather than merely thrown away. That is exactly the
+//     supersession signature. A plain soft-delete (muninn_forget without
+//     not_true_since) leaves ValidUntil open — it is trash, not history — and
+//     stays invisible to recall on every path, reachable only through
+//     list_deleted / read / restore as before.
+//
+// Admission here is necessary, not sufficient: PassesValidity still decides
+// whether the record may be named at the caller's instant, so under as_of=T
+// only a predecessor whose half-open window actually covers T comes back, and
+// under include_invalid it comes back annotated expired.
+//
+// StateArchived is deliberately NOT relaxed: archival is a storage-tier
+// eviction, not a statement about truth, and an archived record's payload is
+// not guaranteed to be resident.
+func PassesLifecycle(eng *storage.Engram, asOf *time.Time, includeInvalid bool) bool {
+	if eng == nil {
+		return false
+	}
+	switch eng.State {
+	case storage.StateArchived:
+		return false
+	case storage.StateSoftDeleted:
+		return (asOf != nil || includeInvalid) && !eng.ValidUntil.IsZero()
+	default:
+		return true
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -3420,7 +3420,11 @@ type ConsolidateResult struct {
 // Warnings lists any evidence IDs that could not be linked to the decision;
 // the decision itself is always committed even when evidence linking partially fails.
 type DecideResult struct {
-	ID       storage.ULID
+	ID storage.ULID
+	// Concept is the concept actually stored (the decision text). Returned so
+	// a transport can echo what it wrote instead of an empty string — two
+	// evaluators read the previous {"concept":""} response as data loss.
+	Concept  string
 	Warnings []string
 }
 
@@ -3900,7 +3904,7 @@ func (e *Engine) Decide(ctx context.Context, vault, decision, rationale string, 
 	if err != nil {
 		return nil, fmt.Errorf("decide: parse id: %w", err)
 	}
-	return &DecideResult{ID: decideULID, Warnings: warnings}, nil
+	return &DecideResult{ID: decideULID, Concept: decision, Warnings: warnings}, nil
 }
 
 // RecordAccess increments the access count and updates the last-accessed timestamp

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -3857,7 +3857,11 @@ func (e *Engine) Decide(ctx context.Context, vault, decision, rationale string, 
 	if err := e.refuseAppend(ctx); err != nil {
 		return nil, err
 	}
-	content := rationale
+	// The body must STATE the decision, not just the reasoning behind it.
+	// Previously content was rationale(+alternatives) only, so every consumer
+	// that reads the body — a recall snippet, an export, a summarizer, a human
+	// — got the argument without ever being told what was decided.
+	content := decision + "\n\nRationale:\n" + rationale
 	if len(alternatives) > 0 {
 		content += "\n---\nAlternatives:\n" + strings.Join(alternatives, "\n")
 	}
@@ -3867,6 +3871,13 @@ func (e *Engine) Decide(ctx context.Context, vault, decision, rationale string, 
 		Concept: decision,
 		Content: content,
 		Tags:    []string{"decision"},
+		// A decision-recording tool must produce a decision-TYPED memory.
+		// Left unset, MemoryType took the uint8 zero value (fact), which
+		// silently downgraded derived importance from the decision tier (0.6)
+		// to the fact tier (0.4) and hid the record from every type-based
+		// filter — the same silent-downgrade class as #742/#743/#745.
+		MemoryType: uint8(storage.TypeDecision),
+		TypeLabel:  storage.TypeDecision.String(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("decide: write: %w", err)

--- a/internal/engine/engine_asof_history_test.go
+++ b/internal/engine/engine_asof_history_test.go
@@ -1,0 +1,182 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// TestAsOf_ReadsEvolvedPredecessor is the bitemporal headline guarantee:
+// evolve SUPERSEDES a fact (soft-delete = "no longer current"), it does not
+// ERASE it. An explicit historical query — as_of a timestamp inside the
+// predecessor's validity window, or include_invalid — must still see it, while
+// DEFAULT recall must still lead with the successor and never name the
+// predecessor.
+//
+// Evolve's own code says so (engine.go EvolveAt: "Supersede = soft-delete
+// (hidden from the present) + ValidUntil stamp (re-opens the record for as_of
+// time-travel only)"), and muninn_guide promises it to agents. Before the fix
+// the phase-6 lifecycle cut dropped soft-deleted engrams unconditionally,
+// BEFORE and INDEPENDENT of the valid-time gate, so the promise was false.
+//
+// Control (already pinned by TestRecall_ValidTimeGate): forget(not_true_since)
+// stamps ValidUntil WITHOUT soft-deleting, and as_of/include_invalid see that
+// record fine — which is what isolates the lifecycle cut, not the validity
+// axis, as the defect.
+func TestAsOf_ReadsEvolvedPredecessor(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "asof-history"
+
+	// The predecessor was true for a past interval and was evolved one hour
+	// ago, so its window is [-3h, -1h) and "two hours ago" sits inside it.
+	createdAt := time.Now().Add(-3 * time.Hour).UTC()
+	oldResp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:     vault,
+		Concept:   "asof history subject",
+		Content:   "asof history probe content first revision",
+		CreatedAt: &createdAt,
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	oldID := oldResp.ID
+
+	effectiveAt := time.Now().Add(-time.Hour).UTC()
+	newULID, err := eng.EvolveAt(ctx, vault, oldID,
+		"asof history probe content second revision", "revision", nil, "", nil, nil, effectiveAt)
+	if err != nil {
+		t.Fatalf("EvolveAt: %v", err)
+	}
+	newID := newULID.String()
+
+	awaitFTS(t, eng)
+
+	// Bookkeeping precondition: the predecessor is soft-deleted AND carries a
+	// closed ValidUntil at the evolve boundary. If this fails the rest of the
+	// test is meaningless.
+	ws := eng.store.ResolveVaultPrefix(vault)
+	oldULID, err := storage.ParseULID(oldID)
+	if err != nil {
+		t.Fatalf("ParseULID: %v", err)
+	}
+	stored, err := eng.store.GetEngram(ctx, ws, oldULID)
+	if err != nil || stored == nil {
+		t.Fatalf("GetEngram(predecessor): %v", err)
+	}
+	if stored.State != storage.StateSoftDeleted {
+		t.Fatalf("precondition: predecessor state = %v, want soft-deleted", stored.State)
+	}
+	if !stored.ValidUntil.Equal(effectiveAt) {
+		t.Fatalf("precondition: predecessor ValidUntil = %v, want %v", stored.ValidUntil, effectiveAt)
+	}
+
+	baseReq := func() *mbp.ActivateRequest {
+		return &mbp.ActivateRequest{
+			Vault:      vault,
+			Context:    []string{"asof history probe content"},
+			MaxResults: 10,
+			Threshold:  0.0,
+		}
+	}
+
+	// (a) as_of INSIDE the predecessor's window returns the predecessor.
+	asOf := time.Now().Add(-2 * time.Hour).UTC()
+	reqAsOf := baseReq()
+	reqAsOf.AsOf = &asOf
+	got := activateIDs(t, eng, reqAsOf)
+	if _, ok := got[oldID]; !ok {
+		t.Error("as_of inside the predecessor's validity window did not return the evolved predecessor — " +
+			"soft-delete erased history instead of demoting it")
+	}
+	if _, ok := got[newID]; ok {
+		t.Error("as_of returned the successor, whose ValidFrom is after T")
+	}
+
+	// (b) include_invalid returns the predecessor, annotated expired.
+	reqInv := baseReq()
+	reqInv.IncludeInvalid = true
+	got = activateIDs(t, eng, reqInv)
+	item, ok := got[oldID]
+	if !ok {
+		t.Fatal("include_invalid did not return the evolved predecessor")
+	}
+	if !item.Expired {
+		t.Error("include_invalid result for the evolved predecessor lacks expired=true")
+	}
+	if item.ValidUntil == 0 {
+		t.Error("include_invalid result for the evolved predecessor lacks valid_until")
+	}
+
+	// (c) DEFAULT recall never names the predecessor, and the successor leads.
+	got = activateIDs(t, eng, baseReq())
+	if _, ok := got[oldID]; ok {
+		t.Error("default recall returned the superseded predecessor — soft-delete must still mean 'not current'")
+	}
+	if _, ok := got[newID]; !ok {
+		t.Error("default recall dropped the current fact")
+	}
+	resp, err := eng.Activate(ctx, baseReq())
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if len(resp.Activations) == 0 || resp.Activations[0].ID != newID {
+		t.Errorf("default recall must lead with the current fact; got %+v", resp.Activations)
+	}
+}
+
+// TestAsOf_SoftDeletedByForgetStaysHidden guards the blast radius of the fix.
+// A plain (non-supersession) soft-delete carries NO ValidUntil stamp, so its
+// window is open: as_of a time inside that open window must not resurrect a
+// forgotten memory into a historical view as a CURRENT fact of that view...
+// except that history is exactly what include_invalid asks for. This test pins
+// the part that must not move: default recall never returns it, and an as_of
+// BEFORE the memory existed never returns it.
+func TestAsOf_SoftDeletedByForgetStaysHidden(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const vault = "asof-forgotten"
+
+	createdAt := time.Now().Add(-time.Hour).UTC()
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:     vault,
+		Concept:   "asof forgotten subject",
+		Content:   "asof forgotten probe content",
+		CreatedAt: &createdAt,
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := eng.Forget(ctx, &mbp.ForgetRequest{Vault: vault, ID: resp.ID, Hard: false}); err != nil {
+		t.Fatalf("Forget: %v", err)
+	}
+	awaitFTS(t, eng)
+
+	baseReq := func() *mbp.ActivateRequest {
+		return &mbp.ActivateRequest{
+			Vault:      vault,
+			Context:    []string{"asof forgotten probe content"},
+			MaxResults: 10,
+			Threshold:  0.0,
+		}
+	}
+
+	if got := activateIDs(t, eng, baseReq()); len(got) != 0 {
+		t.Errorf("default recall returned a soft-deleted engram: %v", got)
+	}
+
+	// as_of BEFORE the memory existed: the view predates it entirely.
+	before := createdAt.Add(-time.Hour)
+	reqBefore := baseReq()
+	reqBefore.AsOf = &before
+	if _, ok := activateIDs(t, eng, reqBefore)[resp.ID]; ok {
+		t.Error("as_of before the engram's ValidFrom returned it")
+	}
+}

--- a/internal/engine/engine_decide_test.go
+++ b/internal/engine/engine_decide_test.go
@@ -1,0 +1,98 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// TestDecide_StoresDecisionTypedMemory: the dedicated decision-recording tool
+// stored a FACT tagged "decision". Consequences that made it a real defect and
+// not a cosmetic one:
+//   - derived importance came out at the fact tier (0.4) instead of the
+//     decision tier (0.6) — internal/storage/importance.go groups TypeDecision
+//     with goal/constraint/identity;
+//   - the memory was invisible to every type-based filter, so "show me the
+//     decisions" could not find decisions recorded by muninn_decide.
+//
+// Same silent-downgrade class as #742/#743/#745, still live inside Decide.
+//
+// RED without the fix: MemoryType is TypeFact (the uint8 zero value) because
+// Decide's WriteRequest never set it.
+func TestDecide_StoresDecisionTypedMemory(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	res, err := eng.Decide(ctx, "decide-type",
+		"Standardize on Go 1.23 across the sandbox services",
+		"1.23 has the loopvar change we keep tripping over",
+		nil, nil)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	stored, err := eng.GetEngram(ctx, "decide-type", res.ID)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if stored.MemoryType != storage.TypeDecision {
+		t.Errorf("MemoryType = %v (%s), want TypeDecision", stored.MemoryType, stored.MemoryType.String())
+	}
+	if stored.TypeLabel != "decision" {
+		t.Errorf("TypeLabel = %q, want %q", stored.TypeLabel, "decision")
+	}
+	// The "decision" tag stays: it is what existing recalls and the currency
+	// heuristic (engine_currency.go) already key on.
+	var tagged bool
+	for _, tg := range stored.Tags {
+		if tg == "decision" {
+			tagged = true
+		}
+	}
+	if !tagged {
+		t.Error(`the "decision" tag must be preserved alongside the type`)
+	}
+}
+
+// TestDecide_ContentStatesTheDecision: the decision text lived only in
+// `concept`; `content` held rationale (+ alternatives) alone. Anything that
+// reads the body — a recall snippet, an export, a summarizer, a human — got the
+// reasoning without ever being told what was decided.
+//
+// RED without the fix: content == rationale, and does not contain the decision.
+func TestDecide_ContentStatesTheDecision(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const (
+		decision  = "Standardize on Go 1.23 across the sandbox services"
+		rationale = "1.23 has the loopvar change we keep tripping over"
+	)
+	res, err := eng.Decide(ctx, "decide-body", decision, rationale,
+		[]string{"Stay on 1.21", "Jump straight to 1.24"}, nil)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	stored, err := eng.GetEngram(ctx, "decide-body", res.ID)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !strings.Contains(stored.Content, decision) {
+		t.Errorf("content does not state the decision.\ncontent = %q", stored.Content)
+	}
+	if !strings.Contains(stored.Content, rationale) {
+		t.Errorf("content lost the rationale.\ncontent = %q", stored.Content)
+	}
+	for _, alt := range []string{"Stay on 1.21", "Jump straight to 1.24"} {
+		if !strings.Contains(stored.Content, alt) {
+			t.Errorf("content lost alternative %q.\ncontent = %q", alt, stored.Content)
+		}
+	}
+	// The decision must lead the body, not be buried after the reasoning.
+	if !strings.HasPrefix(strings.TrimSpace(stored.Content), decision) {
+		t.Errorf("content should open with the decision itself.\ncontent = %q", stored.Content)
+	}
+}

--- a/internal/engine/engine_explain_test.go
+++ b/internal/engine/engine_explain_test.go
@@ -1,0 +1,166 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// seedExplainVault writes one engram and flushes FTS so activation can see it.
+func seedExplainVault(t *testing.T, eng *Engine, vault string) string {
+	t.Helper()
+	resp, err := eng.Write(context.Background(), &mbp.WriteRequest{
+		Vault:      vault,
+		Concept:    "Postgres connection pool sizing",
+		Content:    "The pool is capped at 40 connections per node.",
+		Confidence: 1.0,
+	})
+	if err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	awaitFTS(t, eng)
+	return resp.ID
+}
+
+// TestExplain_ScoredEngramReportsConfidenceAndThreshold pins the two values an
+// operator debugging "why didn't my memory come back" cannot work without:
+// the engram's stored confidence and the threshold would_return is measured
+// against. Both were structurally unreachable before this fix — ExplainData
+// carried no Confidence field at all (mbp.ScoreComponents has none), and
+// Threshold was a hardcoded 0.0 that made would_return mean "was a candidate"
+// rather than "clears recall's bar".
+//
+// RED without the fix: ExplainData has no Confidence/Found/Scored fields
+// (compile failure) and Threshold is 0.
+func TestExplain_ScoredEngramReportsConfidenceAndThreshold(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+	id := seedExplainVault(t, eng, "explain-scored")
+
+	data, err := eng.Explain(ctx, "explain-scored", id, []string{"Postgres", "connection", "pool"}, nil)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if !data.Found {
+		t.Fatal("Found = false for an engram that exists")
+	}
+	if !data.Scored {
+		t.Fatal("Scored = false for an engram the query demonstrably matches")
+	}
+	if data.Confidence != 1.0 {
+		t.Errorf("Confidence = %v, want 1.0 (the stored value)", data.Confidence)
+	}
+	if data.Concept == "" {
+		t.Error("Concept is empty for a scored engram")
+	}
+	if data.Components.FullTextRelevance == 0 {
+		t.Error("FullTextRelevance = 0 for an engram matched on its own words")
+	}
+	if data.Threshold != defaultRecallThreshold {
+		t.Errorf("Threshold = %v, want the default recall threshold %v", data.Threshold, defaultRecallThreshold)
+	}
+	// would_return must mean "clears the threshold", not "was a candidate".
+	want := data.FinalScore >= data.Threshold
+	if data.WouldReturn != want {
+		t.Errorf("WouldReturn = %v, want %v (score %v vs threshold %v)",
+			data.WouldReturn, want, data.FinalScore, data.Threshold)
+	}
+}
+
+// TestExplain_UnscoredEngramSaysSoRatherThanReturningZeros is the core of the
+// bug an evaluator hit: an engram that the query's activation run never scored
+// came back as an all-zero ExplainData — zero components, empty concept, zero
+// confidence — with nothing distinguishing "this signal measured zero" from
+// "nothing computed this signal". That is the silent-substitution failure class
+// (CLAUDE.md §2.1/§2.2) inside the one tool built for debugging recall.
+//
+// RED without the fix: Concept == "", Confidence unavailable, Note == "" and
+// there is no Scored flag — the response is indistinguishable from a genuine
+// all-zero score.
+func TestExplain_UnscoredEngramSaysSoRatherThanReturningZeros(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+	id := seedExplainVault(t, eng, "explain-unscored")
+
+	data, err := eng.Explain(ctx, "explain-unscored", id, []string{"kangaroo", "zeppelin"}, nil)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if !data.Found {
+		t.Fatal("Found = false for an engram that exists in the vault")
+	}
+	if data.Scored {
+		t.Fatal("Scored = true for a query that never reached this engram")
+	}
+	if data.Note == "" {
+		t.Error("Note is empty: an unscored explain must say why its components are absent")
+	}
+	// Everything query-independent is still knowable and must be reported.
+	if data.Concept == "" {
+		t.Error("Concept is empty even though the engram exists")
+	}
+	if data.Confidence != 1.0 {
+		t.Errorf("Confidence = %v, want 1.0 — stored confidence does not depend on the query", data.Confidence)
+	}
+	if data.WouldReturn {
+		t.Error("WouldReturn = true for an unscored engram")
+	}
+}
+
+// TestExplain_MissingEngramReportsNotFound: an id that was never written must
+// report found=false with an explanation, not a zeroed score card that looks
+// like a real (bad) score.
+func TestExplain_MissingEngramReportsNotFound(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	data, err := eng.Explain(ctx, "explain-missing", "01HNKZ5F0K0000000000000000", []string{"anything"}, nil)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if data.Found {
+		t.Error("Found = true for an engram that was never written")
+	}
+	if data.Scored || data.WouldReturn {
+		t.Error("Scored/WouldReturn must be false for a missing engram")
+	}
+	if !strings.Contains(strings.ToLower(data.Note), "not found") {
+		t.Errorf("Note = %q, want it to say the engram was not found", data.Note)
+	}
+}
+
+// TestExplain_MalformedIDIsExplained: a non-ULID id previously produced the
+// same all-zero card as a genuine miss. It must name the problem.
+func TestExplain_MalformedIDIsExplained(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+
+	data, err := eng.Explain(context.Background(), "explain-bad-id", "not-a-ulid", []string{"anything"}, nil)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if data.Found || data.Scored {
+		t.Error("a malformed id must not report Found/Scored")
+	}
+	if !strings.Contains(data.Note, "ULID") {
+		t.Errorf("Note = %q, want it to name the malformed ULID", data.Note)
+	}
+}
+
+// TestRecallThresholdFor_MirrorsRecallSurface pins the threshold Explain
+// reports to the value muninn_recall actually defaults to (internal/mcp/
+// handlers.go handleRecall): 0.5 normally, 0 when the vault fuses with RRF
+// (RRF scores are not calibrated to that scale). If the recall default ever
+// moves, this pin and the comment in handleRecall have to move with it.
+func TestRecallThresholdFor_MirrorsRecallSurface(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	if got := eng.recallThresholdFor("some-vault"); got != 0.5 {
+		t.Errorf("recallThresholdFor = %v, want 0.5", got)
+	}
+}

--- a/internal/engine/engine_scoring_weights_measure_test.go
+++ b/internal/engine/engine_scoring_weights_measure_test.go
@@ -1,0 +1,630 @@
+//go:build scoringmeasure
+
+package engine
+
+// READ-ONLY REAL-VAULT DRIVER for the ContentMatch-combiner measurement.
+//
+// BUILD TAG: `scoringmeasure`. CI builds and tests with `-tags localassets`
+// (and `localassets,integration` for the cmd suite) and never with this tag, so
+// this file does not compile — let alone run — in any CI job. It is a tool the
+// owner runs by hand against a CLONE of a real vault.
+//
+// THE QUESTION IT SETTLES
+//
+// MuninnDB's live Phase 6 ContentMatch is LINEAR with hardcoded coefficients:
+//
+//	ContentMatch = 0.6*semCal + 0.4*ftsCoverage      (activation/engine.go:2211)
+//
+// That formula charges a MISSING estimator as evidence of irrelevance. A pure
+// paraphrase — no lexical overlap with the query, which is the exact case
+// retrieval-by-meaning exists to serve — is structurally capped at 0.6, no
+// matter how perfect the semantic match. The coefficients are described in the
+// source as "proven optimal ... hardcoded proven values" (engine.go:2354-2356)
+// but landed inside a large omnibus commit (e51b985) with no recorded
+// derivation and no corpus named. Principle #11 forbids exactly that.
+//
+// This driver is the measurement that must precede any change. Over a set of
+// queries and a candidate pool it scores every candidate under four combiners
+// and pre-commits to TWO metrics that pull in opposite directions, so no arm
+// can win by sacrificing the other:
+//
+//	NDCG@5 on ANSWERABLE queries    — did the right memory rank high?
+//	FPR    on UNANSWERABLE queries  — did the system abstain when it should?
+//
+// Any combiner more permissive than the live one (noisy-OR and max both are,
+// everywhere) necessarily improves the first and worsens the second. A result
+// is only interesting if the first improves MORE than the second worsens.
+//
+// THE ARMS
+//
+//	LINEAR    ContentMatch = 0.6*semCal + 0.4*fts        — the live formula
+//	COSINE    ContentMatch = raw cosine, no prior        — the naive control
+//	NOISY-OR  ContentMatch = 1-(1-semCal)(1-fts)         — absence-of-evidence
+//	MAX       ContentMatch = max(semCal, fts)            — absence-of-evidence
+//
+// Each is run TWICE: once with the live Confidence multiplier, and once with
+// CONFIDENCE ABLATED TO 1.0. The ablation is mandatory, not optional: a live
+// contradiction bug can collapse an engram's Confidence to ~0.07, which alone
+// suppresses it by 93% (Confidence multiplies straight into the final score,
+// activation/engine.go:2295). Without the ablation the bug could silently
+// decide which combiner "wins". If the conf-on and conf-off rankings of the
+// arms disagree, the measurement is contaminated and NO conclusion may be drawn
+// from the conf-on numbers.
+//
+// TWO CONDITIONS
+//
+//	FULL-SIGNAL  candidates carry their real FTS coverage for the query.
+//	PARAPHRASE   FTS is forced to 0 for every candidate, simulating a query
+//	             with zero lexical overlap. This is the condition the 0.6 cap
+//	             is about, and no paraphrase corpus is needed to produce it.
+//
+// LABELS ARE MECHANICAL AND ASSIGNED BEFORE SCORING
+//
+//	answerable   query text = a sampled engram's own summary; the gold
+//	             document is that engram, by identity.
+//	unanswerable query text = a committed list of SYNTHETIC nonsense strings
+//	             authored in this file. Nothing in the vault answers them, so
+//	             any returned result above the relevance threshold is a false
+//	             positive.
+//
+// No arm sees the label, the label cannot be influenced by the score, and the
+// same labelled query set is scored by every arm — that is the sense in which
+// this is blind. It is NOT human relevance judgment, and it does not claim to
+// be: "gold = the engram the query text was drawn from" is a proxy that
+// rewards finding the source document, which for the FULL-SIGNAL condition is
+// an easy target. The PARAPHRASE condition is the discriminating one.
+//
+// PRIVACY: this driver prints AGGREGATE STATISTICS ONLY. It never prints an
+// engram's content, concept, summary, tags, entities, ID, or the vault name,
+// and it never writes a file. Every string literal in this file is synthetic.
+//
+// FIDELITY AND ITS LIMITS — read before believing a number:
+//
+//   - The pool is the union of the stored-embedding cosine neighborhood and
+//     the FTS top-N. It is not the output of engine.Recall: no entity boost,
+//     no tag seeding, no associative traversal, no PAS transitions, no
+//     currency annotation, no time filters. Every arm sees the same pool, so
+//     the COMPARISON is fair; the ABSOLUTE numbers are not "what recall
+//     returns".
+//   - Hebbian and PAS-transition boosts are 0 in every arm. Those are the
+//     cognition layer's strongest arguments for itself and they are absent, so
+//     the driver's bias runs AGAINST the parts of the layer it cannot see.
+//     Say so when quoting a result.
+//   - The scorer is a replication (engine_scoring_weights_model_test.go), not
+//     the live function. See that file's header for why, and for the pins.
+//   - Queries are engram summaries, whose cosine distribution runs higher than
+//     real user queries. Read absolute NDCG with that in mind; read the
+//     DIFFERENCES between arms as the result.
+//
+// USAGE:
+//
+//	MUNINN_SCOREW_DATA_DIR=<clone dir containing pebble/> \
+//	MUNINN_SCOREW_VAULT=<vault name> \
+//	go test -tags 'localassets scoringmeasure' -run TestMeasureContentMatchCombiners \
+//	    -timeout 60m -v ./internal/engine/
+//
+// Optional: MUNINN_SCOREW_QUERIES (default 100), MUNINN_SCOREW_POOL (50),
+// MUNINN_SCOREW_MAX_ENGRAMS (5000), MUNINN_SCOREW_SEED (1),
+// MUNINN_SCOREW_BASELINE (0.520), MUNINN_SCOREW_MIN_CONFIDENCE (0 = keep all),
+// MUNINN_SCOREW_CONF_SUSPECT (0.5).
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/index/fts"
+	"github.com/scrypster/muninndb/internal/plugin/embed"
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+const (
+	envSCWDataDir  = "MUNINN_SCOREW_DATA_DIR"
+	envSCWVault    = "MUNINN_SCOREW_VAULT"
+	envSCWQueries  = "MUNINN_SCOREW_QUERIES"
+	envSCWPool     = "MUNINN_SCOREW_POOL"
+	envSCWMaxEng   = "MUNINN_SCOREW_MAX_ENGRAMS"
+	envSCWSeed     = "MUNINN_SCOREW_SEED"
+	envSCWBaseline = "MUNINN_SCOREW_BASELINE"
+	envSCWMinConf  = "MUNINN_SCOREW_MIN_CONFIDENCE"
+	envSCWSuspect  = "MUNINN_SCOREW_CONF_SUSPECT"
+)
+
+// scwNonsenseQueries are the UNANSWERABLE probes. Every one is synthetic,
+// authored here, and deliberately shaped like a plausible memory query
+// (concrete nouns, a domain, an implied task) while describing something no
+// vault could contain. Shaped-like-real matters: a string of random characters
+// would abstain trivially and prove nothing. This mirrors COG-26's
+// nonsense-query protocol (plugin/embed/baseline.go).
+var scwNonsenseQueries = []string{
+	"quarterly ballet recital seating chart for the amphibian troupe",
+	"calibration log for the tin-whistle humidity organ in vault seven",
+	"migration schedule of the municipal weathervane repair guild",
+	"tasting notes for fermented basalt served at the lighthouse gala",
+	"knitting pattern for a nine-sleeved reversible barometer cozy",
+	"dispute resolution policy between the marzipan cartographers union",
+	"maintenance interval for the brass hummingbird irrigation lathe",
+	"seating protocol at the annual convention of retired sundials",
+	"nutritional breakdown of powdered moonlight sold by the furlong",
+	"escalation path for a misfiled complaint about a singing staircase",
+	"warranty terms on a self-folding origami submarine hull",
+	"attendance record for the subterranean kite-flying certification board",
+	"recipe for lacquered thunder as prepared in the northern glassworks",
+	"inventory count of left-handed metronomes in the archive annex",
+	"revised bylaws governing the ceremonial polishing of borrowed fog",
+	"latency budget for transmitting handwriting through candle smoke",
+	"pruning guide for the ornamental clockspring hedge in winter",
+	"insurance schedule covering damage by enthusiastic library ghosts",
+	"onboarding checklist for apprentice cloud stackers, third cohort",
+	"decommissioning plan for the obsolete velvet pressure gauge array",
+}
+
+func scwEnvRequired(t *testing.T, key string) string {
+	t.Helper()
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		t.Fatalf("%s is required (see the header of engine_scoring_weights_measure_test.go)", key)
+	}
+	return v
+}
+
+func scwEnvInt(t *testing.T, key string, def int) int {
+	t.Helper()
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		t.Fatalf("%s=%q: want a positive integer", key, v)
+	}
+	return n
+}
+
+func scwEnvFloat(t *testing.T, key string, def float64) float64 {
+	t.Helper()
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil || f < 0 {
+		t.Fatalf("%s=%q: want a non-negative float", key, v)
+	}
+	return f
+}
+
+// scwGuardDataDir refuses to open a data dir a running muninn holds. Pebble
+// takes an exclusive LOCK so this would fail anyway; failing here gives the
+// actionable message and steers the owner to the clone workflow.
+func scwGuardDataDir(t *testing.T, dataDir string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(dataDir, "muninn.pid")); err == nil {
+		t.Fatalf("%q contains muninn.pid — this looks like a LIVE data directory.\n"+
+			"Take a clone first:\n"+
+			"  muninn backup --data-dir <live> --output <clone>   # with the server stopped\n"+
+			"then point %s at <clone>.", dataDir, envSCWDataDir)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "pebble")); err != nil {
+		t.Fatalf("%q does not contain a pebble/ subdirectory — point %s at a data dir, not at the pebble dir itself",
+			dataDir, envSCWDataDir)
+	}
+}
+
+func scwCosine(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		x, y := float64(a[i]), float64(b[i])
+		dot += x * y
+		na += x * x
+		nb += y * y
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}
+
+// scwRanked returns pool indices ordered by final score desc, excluding any
+// index the relevance threshold dropped — what live recall would return.
+func scwRanked(final []float64, dropped []bool) []int {
+	idx := make([]int, 0, len(final))
+	for i := range final {
+		if !dropped[i] {
+			idx = append(idx, i)
+		}
+	}
+	sort.SliceStable(idx, func(a, b int) bool { return final[idx[a]] > final[idx[b]] })
+	return idx
+}
+
+// scwCell accumulates one (arm x condition) cell of the design.
+type scwCell struct {
+	answerable  int
+	ndcgSum     float64
+	goldFound   int // gold survived the threshold at any rank
+	goldTop1    int
+	unanswered  int
+	falsePos    int     // an unanswerable query returned >=1 result
+	fpDepthSum  float64 // how many results an unanswerable query returned
+	top1ConfSum float64
+	top1Count   int
+}
+
+// ndcgAt5 with a single graded-1 gold document: DCG = 1/log2(rank+1) when the
+// gold appears in the top 5 of what the arm returned, 0 otherwise. IDCG = 1.
+func ndcgAt5(ranked []int, gold int) float64 {
+	for r, idx := range ranked {
+		if r >= 5 {
+			break
+		}
+		if idx == gold {
+			return 1.0 / math.Log2(float64(r)+2.0)
+		}
+	}
+	return 0
+}
+
+func TestMeasureContentMatchCombiners(t *testing.T) {
+	ctx := context.Background()
+
+	dataDir := scwEnvRequired(t, envSCWDataDir)
+	vault := scwEnvRequired(t, envSCWVault)
+	scwGuardDataDir(t, dataDir)
+
+	nQueries := scwEnvInt(t, envSCWQueries, 100)
+	poolN := scwEnvInt(t, envSCWPool, 50)
+	maxEngrams := scwEnvInt(t, envSCWMaxEng, 5000)
+	baseline := scwEnvFloat(t, envSCWBaseline, scwBaselineBGESmall)
+	minConf := scwEnvFloat(t, envSCWMinConf, 0)
+	suspectConf := scwEnvFloat(t, envSCWSuspect, 0.5)
+	rng := rand.New(rand.NewSource(int64(scwEnvInt(t, envSCWSeed, 1))))
+
+	db, err := storage.OpenPebble(filepath.Join(dataDir, "pebble"), storage.DefaultOptions())
+	if err != nil {
+		t.Fatalf("open pebble (is a muninn process holding the LOCK?): %v", err)
+	}
+	defer db.Close()
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 10000})
+	ws := store.ResolveVaultPrefix(vault)
+	ftsIdx := fts.New(db) // read path only — Search never writes
+
+	// Embedder: the bundled local model, extracting its assets to a TEMP dir.
+	// Nothing is written to the vault clone.
+	prov := &embed.LocalProvider{}
+	if _, err := prov.Init(ctx, embed.ProviderHTTPConfig{DataDir: t.TempDir()}); err != nil {
+		t.Fatalf("local embed provider init (built with -tags localassets, and `make fetch-assets` run?): %v", err)
+	}
+	defer prov.Close()
+	embedOne := func(text string) ([]float32, error) {
+		v, err := prov.EmbedBatch(ctx, []string{text})
+		return v, err
+	}
+
+	ids, err := store.ListByState(ctx, ws, storage.StateActive, maxEngrams)
+	if err != nil {
+		t.Fatalf("ListByState: %v", err)
+	}
+	if len(ids) == 0 {
+		t.Fatalf("vault has no active engrams under %s — wrong vault name?", envSCWVault)
+	}
+	engs, err := store.GetEngrams(ctx, ws, ids)
+	if err != nil {
+		t.Fatalf("GetEngrams: %v", err)
+	}
+
+	type node struct {
+		id    storage.ULID
+		in    scwInput
+		emb   []float32
+		qtext string // this engram's own summary, used only as a query; never printed
+	}
+	var nodes []node
+	byID := map[storage.ULID]int{}
+	confHist := map[string]int{}
+	suspectCount, excludedCount := 0, 0
+	for _, e := range engs {
+		if e == nil {
+			continue
+		}
+		emb, err := store.GetEmbedding(ctx, ws, e.ID)
+		if err != nil || len(emb) == 0 {
+			continue
+		}
+		conf := float64(e.Confidence)
+		switch {
+		case conf < 0.2:
+			confHist["<0.2"]++
+		case conf < 0.5:
+			confHist["0.2-0.5"]++
+		case conf < 0.8:
+			confHist["0.5-0.8"]++
+		default:
+			confHist[">=0.8"]++
+		}
+		if conf < suspectConf {
+			suspectCount++
+		}
+		if minConf > 0 && conf < minConf {
+			excludedCount++
+			continue
+		}
+		qt := strings.TrimSpace(e.Summary)
+		if qt == "" {
+			qt = strings.TrimSpace(e.Concept)
+		}
+		byID[e.ID] = len(nodes)
+		nodes = append(nodes, node{
+			id:    e.ID,
+			emb:   emb,
+			qtext: qt,
+			in: scwInput{
+				AccessCount: int64(e.AccessCount),
+				LastAccess:  e.LastAccess,
+				Confidence:  conf,
+			},
+		})
+	}
+	if len(nodes) < poolN+1 {
+		t.Fatalf("only %d engrams carry a stored embedding (after the confidence filter) — need > %s (%d)",
+			len(nodes), envSCWPool, poolN)
+	}
+
+	t.Logf("vault: %d active engrams, %d with embeddings | pool=%d queries=%d baseline=%.3f",
+		len(engs), len(nodes), poolN, nQueries, baseline)
+	t.Logf("CONFIDENCE (pool-wide, BEFORE any exclusion): <0.2:%d  0.2-0.5:%d  0.5-0.8:%d  >=0.8:%d | below suspect %.2f: %d",
+		confHist["<0.2"], confHist["0.2-0.5"], confHist["0.5-0.8"], confHist[">=0.8"], suspectConf, suspectCount)
+	if minConf > 0 {
+		t.Logf("CONFIDENCE EXCLUSION ACTIVE: %s=%.2f removed %d engrams from the pool.", envSCWMinConf, minConf, excludedCount)
+	} else {
+		t.Logf("CONFIDENCE EXCLUSION OFF: confidence is REPORTED, not removed. The conf-ablated arms below are the "+
+			"primary read; if they disagree with the conf-on arms, the contradiction bug is driving the result and "+
+			"the conf-on numbers must not be quoted. Set %s to also exclude.", envSCWMinConf)
+	}
+
+	// --- the design: 4 combiners x {conf on, conf off} x {full-signal, paraphrase}
+	combs := []scwCombiner{scwCombLinear, scwCombRawCosine, scwCombNoisyOR, scwCombMax}
+	type armKey struct {
+		comb    scwCombiner
+		useConf bool
+		para    bool
+	}
+	cells := map[armKey]*scwCell{}
+	specOf := func(k armKey) scwArmSpec {
+		return scwArmSpec{
+			Name:          k.comb.String(),
+			Comb:          k.comb,
+			UsePrior:      k.comb != scwCombRawCosine,
+			UseConfidence: k.useConf,
+		}
+	}
+	for _, c := range combs {
+		for _, uc := range []bool{true, false} {
+			for _, pa := range []bool{false, true} {
+				cells[armKey{c, uc, pa}] = &scwCell{}
+			}
+		}
+	}
+
+	now := time.Now()
+
+	// buildPool assembles the candidate pool for a query vector + query text:
+	// the top-N cosine neighborhood unioned with the FTS top-N, each candidate
+	// carrying its real FTS coverage score (0 if FTS did not return it).
+	buildPool := func(qv []float32, qtext string, exclude int) ([]scwInput, []storage.ULID) {
+		ftsScores := map[storage.ULID]float64{}
+		if hits, err := ftsIdx.Search(ctx, ws, qtext, poolN); err == nil {
+			for _, h := range hits {
+				ftsScores[storage.ULID(h.ID)] = h.Score
+			}
+		}
+		type cand struct {
+			i   int
+			cos float64
+		}
+		cands := make([]cand, 0, len(nodes))
+		for i := range nodes {
+			if i == exclude || len(nodes[i].emb) != len(qv) {
+				continue
+			}
+			cands = append(cands, cand{i, scwCosine(qv, nodes[i].emb)})
+		}
+		sort.SliceStable(cands, func(a, b int) bool {
+			if cands[a].cos != cands[b].cos {
+				return cands[a].cos > cands[b].cos
+			}
+			return cands[a].i < cands[b].i
+		})
+		keep := map[int]bool{}
+		for i := 0; i < len(cands) && len(keep) < poolN; i++ {
+			keep[cands[i].i] = true
+		}
+		for id := range ftsScores {
+			if j, ok := byID[id]; ok && j != exclude {
+				keep[j] = true
+			}
+		}
+		cosOf := map[int]float64{}
+		for _, c := range cands {
+			cosOf[c.i] = c.cos
+		}
+		order := make([]int, 0, len(keep))
+		for i := range keep {
+			order = append(order, i)
+		}
+		sort.SliceStable(order, func(a, b int) bool {
+			if cosOf[order[a]] != cosOf[order[b]] {
+				return cosOf[order[a]] > cosOf[order[b]]
+			}
+			return order[a] < order[b]
+		})
+		pool := make([]scwInput, 0, len(order))
+		poolIDs := make([]storage.ULID, 0, len(order))
+		for _, i := range order {
+			in := nodes[i].in
+			in.Cosine = cosOf[i]
+			in.FTS = ftsScores[nodes[i].id]
+			pool = append(pool, in)
+			poolIDs = append(poolIDs, nodes[i].id)
+		}
+		return pool, poolIDs
+	}
+
+	scoreAll := func(pool []scwInput, gold int, unanswerable bool) {
+		for _, para := range []bool{false, true} {
+			p := pool
+			if para {
+				p = make([]scwInput, len(pool))
+				copy(p, pool)
+				for i := range p {
+					p[i].FTS = 0
+				}
+			}
+			for _, c := range combs {
+				for _, uc := range []bool{true, false} {
+					k := armKey{c, uc, para}
+					cell := cells[k]
+					final, _, _, dropped := scwScoreQuery(p, specOf(k), baseline, scwDefaultThreshold, now)
+					ranked := scwRanked(final, dropped)
+					if unanswerable {
+						cell.unanswered++
+						if len(ranked) > 0 {
+							cell.falsePos++
+							cell.fpDepthSum += float64(len(ranked))
+						}
+						continue
+					}
+					cell.answerable++
+					cell.ndcgSum += ndcgAt5(ranked, gold)
+					for _, idx := range ranked {
+						if idx == gold {
+							cell.goldFound++
+							break
+						}
+					}
+					if len(ranked) > 0 {
+						if ranked[0] == gold {
+							cell.goldTop1++
+						}
+						cell.top1ConfSum += p[ranked[0]].Confidence
+						cell.top1Count++
+					}
+				}
+			}
+		}
+	}
+
+	// --- ANSWERABLE: query text is a sampled engram's own summary, gold = it.
+	answered := 0
+	for attempt := 0; attempt < nQueries*3 && answered < nQueries; attempt++ {
+		seed := rng.Intn(len(nodes))
+		if strings.TrimSpace(nodes[seed].qtext) == "" {
+			continue
+		}
+		qv, err := embedOne(nodes[seed].qtext)
+		if err != nil || len(qv) == 0 {
+			continue
+		}
+		// The gold engram must be IN the pool for NDCG to be meaningful, so it
+		// is not excluded — exclude=-1. This is retrieval of a known-present
+		// document, the easiest honest formulation of "answerable".
+		pool, poolIDs := buildPool(qv, nodes[seed].qtext, -1)
+		gold := -1
+		for i, id := range poolIDs {
+			if id == nodes[seed].id {
+				gold = i
+				break
+			}
+		}
+		if gold < 0 {
+			continue // gold outside the pool: an ANN-recall miss, not a scoring result
+		}
+		scoreAll(pool, gold, false)
+		answered++
+	}
+
+	// --- UNANSWERABLE: committed synthetic nonsense, no gold, any hit is a FP.
+	for _, q := range scwNonsenseQueries {
+		qv, err := embedOne(q)
+		if err != nil || len(qv) == 0 {
+			continue
+		}
+		pool, _ := buildPool(qv, q, -1)
+		if len(pool) == 0 {
+			continue
+		}
+		scoreAll(pool, -1, true)
+	}
+
+	if answered == 0 {
+		t.Fatalf("no answerable query was scored — check the embedder and %s", envSCWVault)
+	}
+
+	// --- report -------------------------------------------------------------
+	t.Log("")
+	t.Log("=== RESULTS: NDCG@5 on answerable (higher better) vs FPR on unanswerable (lower better) ===")
+	t.Log("A combiner is only interesting if it gains more NDCG than it loses in abstention.")
+	for _, para := range []bool{false, true} {
+		cond := "FULL-SIGNAL"
+		if para {
+			cond = "PARAPHRASE (FTS forced to 0 — the condition the 0.6 cap is about)"
+		}
+		t.Logf("")
+		t.Logf("--- condition: %s ---", cond)
+		t.Logf("%-16s %-9s %8s %10s %10s %8s %10s %10s",
+			"combiner", "conf", "NDCG@5", "gold-found", "gold-top1", "FPR", "FP-depth", "top1-conf")
+		for _, c := range combs {
+			for _, uc := range []bool{true, false} {
+				cell := cells[armKey{c, uc, para}]
+				if cell.answerable == 0 {
+					continue
+				}
+				a := float64(cell.answerable)
+				fpr, depth := 0.0, 0.0
+				if cell.unanswered > 0 {
+					fpr = float64(cell.falsePos) / float64(cell.unanswered)
+					if cell.falsePos > 0 {
+						depth = cell.fpDepthSum / float64(cell.falsePos)
+					}
+				}
+				conf := 0.0
+				if cell.top1Count > 0 {
+					conf = cell.top1ConfSum / float64(cell.top1Count)
+				}
+				label := "live"
+				if !uc {
+					label = "ABLATED"
+				}
+				t.Logf("%-16s %-9s %8.4f %9.1f%% %9.1f%% %7.1f%% %10.1f %10.3f",
+					c.String(), label,
+					cell.ndcgSum/a,
+					100*float64(cell.goldFound)/a,
+					100*float64(cell.goldTop1)/a,
+					100*fpr, depth, conf)
+			}
+		}
+	}
+
+	t.Log("")
+	t.Logf("answerable queries scored: %d | unanswerable probes: %d", answered, len(scwNonsenseQueries))
+	t.Log("HOW TO READ THIS:")
+	t.Log("  1. Compare the ABLATED rows first. If ABLATED and live rank the combiners differently, " +
+		"the confidence bug is driving the result — fix it and re-run before concluding anything.")
+	t.Log("  2. In the PARAPHRASE condition, LINEAR's ContentMatch is capped at 0.6*semCal while noisy-OR " +
+		"and max reach semCal. If LINEAR's gold-found rate is materially lower there, the 0.6 cap is " +
+		"costing real recall.")
+	t.Log("  3. Then check FPR in the same condition. COG-26's b=0.520 was calibrated AGAINST the 0.6 " +
+		"linear combiner; a more permissive combiner needs b re-derived, not just swapped in.")
+	t.Log("  4. Hebbian, PAS-transition, entity and tag signals are 0 here. This harness is biased AGAINST " +
+		"the cognition layer's unmeasured parts. Quote it with that caveat attached.")
+}

--- a/internal/engine/engine_scoring_weights_measure_test.go
+++ b/internal/engine/engine_scoring_weights_measure_test.go
@@ -58,6 +58,37 @@ package engine
 //	             with zero lexical overlap. This is the condition the 0.6 cap
 //	             is about, and no paraphrase corpus is needed to produce it.
 //
+// TWO THRESHOLDS — and this one is not cosmetic.
+//
+//	engine .05   activation/engine.go:547, what a library/direct caller gets.
+//	SURFACE .5   mcp/handlers.go:392 and rest/server.go:1772, what every real
+//	             agent gets when it omits `threshold`. TEN TIMES the engine's.
+//
+// The surface default is the gate that matters, and it exposes the MISSING-
+// COSINE case: a memory with no embedding yet scores cosine 0, so ContentMatch
+// = 0.4*fts <= 0.4 < 0.5, and is UNRETURNABLE through MCP or REST at defaults
+// no matter how perfect the lexical match. That is the same defect as the
+// paraphrase cap from the opposite direction — a missing estimator scored as a
+// zero rather than as absence of evidence — and it is pinned in
+// engine_scoring_weights_model_test.go. Measuring only at 0.05 would report
+// numbers no agent ever sees.
+//
+// THE INDEXING-LAG CONFOUND (third in the list, after confidence collapse and
+// the 0.6 cap). A corpus that is still being embedded contaminates everything:
+// unembedded engrams are invisible to the full pipeline and unscoreable by the
+// raw-cosine control, so the pipeline looks artificially bad and the control
+// artificially good. This driver PROVES settlement rather than assuming it —
+// it counts active engrams with no stored embedding, reports the fraction, and
+// REFUSES TO RUN above 1% (override: MUNINN_SCOREW_MAX_UNEMBEDDED_FRAC).
+//
+// Exposure, for reference: the retroactive embed processor polls every 3s and
+// backs off exponentially to a 3-MINUTE ceiling when idle
+// (internal/plugin/retroactive.go:25,36,188-192). Its notifyCh wake path exists
+// but NO WRITE PATH CALLS Notify() — the only caller is the processor itself
+// when it hits maxBatchSize (retroactive.go:444). So on a vault that has been
+// quiet for ~3 minutes, a newly-written memory can wait up to another ~3
+// minutes for its embedding, not the ~3s seen on a busy vault.
+//
 // LABELS ARE MECHANICAL AND ASSIGNED BEFORE SCORING
 //
 //	answerable   query text = a sampled engram's own summary; the gold
@@ -86,6 +117,11 @@ package engine
 //     currency annotation, no time filters. Every arm sees the same pool, so
 //     the COMPARISON is fair; the ABSOLUTE numbers are not "what recall
 //     returns".
+//   - Unembedded engrams are EXCLUDED from the pool (they cannot be scored by
+//     the raw-cosine control at all), and their count is reported. So the
+//     driver measures the combiners on a settled corpus; it does NOT measure
+//     the missing-cosine case itself — that one is pinned analytically in
+//     engine_scoring_weights_model_test.go, where it is exact.
 //   - Hebbian and PAS-transition boosts are 0 in every arm. Those are the
 //     cognition layer's strongest arguments for itself and they are absent, so
 //     the driver's bias runs AGAINST the parts of the layer it cannot see.
@@ -106,7 +142,7 @@ package engine
 // Optional: MUNINN_SCOREW_QUERIES (default 100), MUNINN_SCOREW_POOL (50),
 // MUNINN_SCOREW_MAX_ENGRAMS (5000), MUNINN_SCOREW_SEED (1),
 // MUNINN_SCOREW_BASELINE (0.520), MUNINN_SCOREW_MIN_CONFIDENCE (0 = keep all),
-// MUNINN_SCOREW_CONF_SUSPECT (0.5).
+// MUNINN_SCOREW_CONF_SUSPECT (0.5), MUNINN_SCOREW_MAX_UNEMBEDDED_FRAC (0.01).
 
 import (
 	"context"
@@ -135,7 +171,15 @@ const (
 	envSCWBaseline = "MUNINN_SCOREW_BASELINE"
 	envSCWMinConf  = "MUNINN_SCOREW_MIN_CONFIDENCE"
 	envSCWSuspect  = "MUNINN_SCOREW_CONF_SUSPECT"
+	// envSCWMaxUnembedded overrides the settled-corpus guard. See the
+	// INDEXING-LAG CONFOUND block in the driver body.
+	envSCWMaxUnembedded = "MUNINN_SCOREW_MAX_UNEMBEDDED_FRAC"
 )
+
+// maxUnembeddedFrac is the default ceiling on the fraction of active engrams
+// with no stored embedding. Above this the corpus has not settled and the
+// driver refuses to produce a number.
+const maxUnembeddedFrac = 0.01
 
 // scwNonsenseQueries are the UNANSWERABLE probes. Every one is synthetic,
 // authored here, and deliberately shaped like a plausible memory query
@@ -288,6 +332,7 @@ func TestMeasureContentMatchCombiners(t *testing.T) {
 	baseline := scwEnvFloat(t, envSCWBaseline, scwBaselineBGESmall)
 	minConf := scwEnvFloat(t, envSCWMinConf, 0)
 	suspectConf := scwEnvFloat(t, envSCWSuspect, 0.5)
+	maxUnembedded := scwEnvFloat(t, envSCWMaxUnembedded, maxUnembeddedFrac)
 	rng := rand.New(rand.NewSource(int64(scwEnvInt(t, envSCWSeed, 1))))
 
 	db, err := storage.OpenPebble(filepath.Join(dataDir, "pebble"), storage.DefaultOptions())
@@ -332,13 +377,21 @@ func TestMeasureContentMatchCombiners(t *testing.T) {
 	var nodes []node
 	byID := map[storage.ULID]int{}
 	confHist := map[string]int{}
-	suspectCount, excludedCount := 0, 0
+	suspectCount, excludedCount, unembedded, totalActive := 0, 0, 0, 0
 	for _, e := range engs {
 		if e == nil {
 			continue
 		}
+		totalActive++
 		emb, err := store.GetEmbedding(ctx, ws, e.ID)
 		if err != nil || len(emb) == 0 {
+			// INDEXING-LAG CONFOUND: an engram with no stored embedding scores
+			// cosine 0 in the live pipeline, so its ContentMatch is capped at
+			// 0.4 and it is unreturnable at the 0.5 surface gate. Counted and
+			// reported below; excluded from the pool because a candidate with
+			// no vector cannot be scored by the raw-cosine control at all, and
+			// silently keeping it would flatter that arm.
+			unembedded++
 			continue
 		}
 		conf := float64(e.Confidence)
@@ -382,6 +435,26 @@ func TestMeasureContentMatchCombiners(t *testing.T) {
 
 	t.Logf("vault: %d active engrams, %d with embeddings | pool=%d queries=%d baseline=%.3f",
 		len(engs), len(nodes), poolN, nQueries, baseline)
+
+	// --- INDEXING-LAG CONFOUND: prove the corpus has settled ----------------
+	// A freshly-seeded or still-catching-up corpus makes the full pipeline look
+	// artificially bad and the raw-cosine control artificially good, because
+	// unembedded engrams are invisible to the former and unscoreable by the
+	// latter. This driver PROVES settlement rather than assuming it: it counts
+	// engrams with no stored embedding and refuses to run if the fraction is
+	// non-trivial.
+	unembeddedFrac := float64(unembedded) / math.Max(float64(totalActive), 1)
+	t.Logf("EMBEDDING COVERAGE: %d/%d active engrams have a stored embedding; %d (%.2f%%) do NOT",
+		totalActive-unembedded, totalActive, unembedded, 100*unembeddedFrac)
+	if unembeddedFrac > maxUnembedded {
+		t.Fatalf("REFUSING to measure: %.2f%% of active engrams have no embedding (limit %.2f%%).\n"+
+			"The retroactive embed processor has not caught up, so this corpus has NOT settled. "+
+			"Any scoring number taken now is contaminated: unembedded engrams score cosine 0, cap at "+
+			"ContentMatch 0.4, and are unreturnable at the 0.5 surface threshold regardless of combiner.\n"+
+			"Wait for the processor to drain (it polls every 3s, backing off to 3min when idle, and NO "+
+			"write path calls Notify()), then re-run. Override with %s only if you know why.",
+			100*unembeddedFrac, 100*maxUnembedded, envSCWMaxUnembedded)
+	}
 	t.Logf("CONFIDENCE (pool-wide, BEFORE any exclusion): <0.2:%d  0.2-0.5:%d  0.5-0.8:%d  >=0.8:%d | below suspect %.2f: %d",
 		confHist["<0.2"], confHist["0.2-0.5"], confHist["0.5-0.8"], confHist[">=0.8"], suspectConf, suspectCount)
 	if minConf > 0 {
@@ -392,12 +465,28 @@ func TestMeasureContentMatchCombiners(t *testing.T) {
 			"the conf-on numbers must not be quoted. Set %s to also exclude.", envSCWMinConf)
 	}
 
-	// --- the design: 4 combiners x {conf on, conf off} x {full-signal, paraphrase}
+	// --- the design ---------------------------------------------------------
+	// 4 combiners x {conf live, conf ablated} x {full-signal, paraphrase}
+	//              x {engine threshold 0.05, SURFACE threshold 0.5}
+	//
+	// The threshold dimension is not cosmetic. Every MCP and REST agent that
+	// omits `threshold` gets 0.5 (mcp/handlers.go:392, rest/server.go:1772),
+	// ten times the engine's own default. Measuring only at 0.05 would report
+	// numbers no real agent ever sees, and would hide the fact that the 0.4 FTS
+	// coefficient sits BELOW the surface gate outright.
 	combs := []scwCombiner{scwCombLinear, scwCombRawCosine, scwCombNoisyOR, scwCombMax}
+	thresholds := []struct {
+		name string
+		v    float64
+	}{
+		{"engine .05", scwDefaultThreshold},
+		{"SURFACE .5", scwSurfaceDefaultThreshold},
+	}
 	type armKey struct {
 		comb    scwCombiner
 		useConf bool
 		para    bool
+		thr     int
 	}
 	cells := map[armKey]*scwCell{}
 	specOf := func(k armKey) scwArmSpec {
@@ -411,7 +500,9 @@ func TestMeasureContentMatchCombiners(t *testing.T) {
 	for _, c := range combs {
 		for _, uc := range []bool{true, false} {
 			for _, pa := range []bool{false, true} {
-				cells[armKey{c, uc, pa}] = &scwCell{}
+				for ti := range thresholds {
+					cells[armKey{c, uc, pa, ti}] = &scwCell{}
+				}
 			}
 		}
 	}
@@ -492,32 +583,34 @@ func TestMeasureContentMatchCombiners(t *testing.T) {
 			}
 			for _, c := range combs {
 				for _, uc := range []bool{true, false} {
-					k := armKey{c, uc, para}
-					cell := cells[k]
-					final, _, _, dropped := scwScoreQuery(p, specOf(k), baseline, scwDefaultThreshold, now)
-					ranked := scwRanked(final, dropped)
-					if unanswerable {
-						cell.unanswered++
+					for ti, thr := range thresholds {
+						k := armKey{c, uc, para, ti}
+						cell := cells[k]
+						final, _, _, dropped := scwScoreQuery(p, specOf(k), baseline, thr.v, now)
+						ranked := scwRanked(final, dropped)
+						if unanswerable {
+							cell.unanswered++
+							if len(ranked) > 0 {
+								cell.falsePos++
+								cell.fpDepthSum += float64(len(ranked))
+							}
+							continue
+						}
+						cell.answerable++
+						cell.ndcgSum += ndcgAt5(ranked, gold)
+						for _, idx := range ranked {
+							if idx == gold {
+								cell.goldFound++
+								break
+							}
+						}
 						if len(ranked) > 0 {
-							cell.falsePos++
-							cell.fpDepthSum += float64(len(ranked))
+							if ranked[0] == gold {
+								cell.goldTop1++
+							}
+							cell.top1ConfSum += p[ranked[0]].Confidence
+							cell.top1Count++
 						}
-						continue
-					}
-					cell.answerable++
-					cell.ndcgSum += ndcgAt5(ranked, gold)
-					for _, idx := range ranked {
-						if idx == gold {
-							cell.goldFound++
-							break
-						}
-					}
-					if len(ranked) > 0 {
-						if ranked[0] == gold {
-							cell.goldTop1++
-						}
-						cell.top1ConfSum += p[ranked[0]].Confidence
-						cell.top1Count++
 					}
 				}
 			}
@@ -579,38 +672,40 @@ func TestMeasureContentMatchCombiners(t *testing.T) {
 		if para {
 			cond = "PARAPHRASE (FTS forced to 0 — the condition the 0.6 cap is about)"
 		}
-		t.Logf("")
-		t.Logf("--- condition: %s ---", cond)
-		t.Logf("%-16s %-9s %8s %10s %10s %8s %10s %10s",
-			"combiner", "conf", "NDCG@5", "gold-found", "gold-top1", "FPR", "FP-depth", "top1-conf")
-		for _, c := range combs {
-			for _, uc := range []bool{true, false} {
-				cell := cells[armKey{c, uc, para}]
-				if cell.answerable == 0 {
-					continue
-				}
-				a := float64(cell.answerable)
-				fpr, depth := 0.0, 0.0
-				if cell.unanswered > 0 {
-					fpr = float64(cell.falsePos) / float64(cell.unanswered)
-					if cell.falsePos > 0 {
-						depth = cell.fpDepthSum / float64(cell.falsePos)
+		for ti, thr := range thresholds {
+			t.Logf("")
+			t.Logf("--- condition: %s | threshold: %s ---", cond, thr.name)
+			t.Logf("%-16s %-9s %8s %10s %10s %8s %10s %10s",
+				"combiner", "conf", "NDCG@5", "gold-found", "gold-top1", "FPR", "FP-depth", "top1-conf")
+			for _, c := range combs {
+				for _, uc := range []bool{true, false} {
+					cell := cells[armKey{c, uc, para, ti}]
+					if cell.answerable == 0 {
+						continue
 					}
+					a := float64(cell.answerable)
+					fpr, depth := 0.0, 0.0
+					if cell.unanswered > 0 {
+						fpr = float64(cell.falsePos) / float64(cell.unanswered)
+						if cell.falsePos > 0 {
+							depth = cell.fpDepthSum / float64(cell.falsePos)
+						}
+					}
+					conf := 0.0
+					if cell.top1Count > 0 {
+						conf = cell.top1ConfSum / float64(cell.top1Count)
+					}
+					label := "live"
+					if !uc {
+						label = "ABLATED"
+					}
+					t.Logf("%-16s %-9s %8.4f %9.1f%% %9.1f%% %7.1f%% %10.1f %10.3f",
+						c.String(), label,
+						cell.ndcgSum/a,
+						100*float64(cell.goldFound)/a,
+						100*float64(cell.goldTop1)/a,
+						100*fpr, depth, conf)
 				}
-				conf := 0.0
-				if cell.top1Count > 0 {
-					conf = cell.top1ConfSum / float64(cell.top1Count)
-				}
-				label := "live"
-				if !uc {
-					label = "ABLATED"
-				}
-				t.Logf("%-16s %-9s %8.4f %9.1f%% %9.1f%% %7.1f%% %10.1f %10.3f",
-					c.String(), label,
-					cell.ndcgSum/a,
-					100*float64(cell.goldFound)/a,
-					100*float64(cell.goldTop1)/a,
-					100*fpr, depth, conf)
 			}
 		}
 	}

--- a/internal/engine/engine_scoring_weights_model_test.go
+++ b/internal/engine/engine_scoring_weights_model_test.go
@@ -52,8 +52,15 @@ const (
 	// resolveWeights defaults, activation/engine.go:2553-2557.
 	scwACTRDecay    = 0.5
 	scwACTRHebScale = 4.0
-	// activation/engine.go:547 — the non-RRF default relevance threshold.
+	// activation/engine.go:547 — the non-RRF default relevance threshold used
+	// when a caller passes no threshold at all (library/direct callers).
 	scwDefaultThreshold = 0.05
+	// THE SURFACE default, which is what every real agent actually gets:
+	// internal/mcp/handlers.go:392 and internal/transport/rest/server.go:1772
+	// both default an omitted threshold to 0.5 — TEN TIMES the engine's own
+	// default. This is the gate the 0.4 FTS coefficient has to clear, and
+	// structurally cannot. See TestSCWFTSOnlyMatchIsUnreturnableAtSurfaceDefault.
+	scwSurfaceDefaultThreshold = 0.5
 	// embed.noiseBaselineRegistry["bge-small-en-v1.5"], plugin/embed/baseline.go:56.
 	scwBaselineBGESmall = 0.520
 )
@@ -411,6 +418,109 @@ func TestSCWConfidenceIsAMultiplier(t *testing.T) {
 	if b[0] < scwDefaultThreshold || a[0] >= scwDefaultThreshold {
 		t.Fatalf("expected the ablation to flip this candidate across the threshold: conf-on %.5f, conf-off %.5f", a[0], b[0])
 	}
+}
+
+// TestSCWFTSOnlyMatchIsUnreturnableAtSurfaceDefault is the MISSING-COSINE case
+// — the same defect as the paraphrase cap, from the opposite direction. A
+// memory whose embedding has not landed yet scores cosine 0, so semCal is 0 and
+// ContentMatch = 0.4*fts, which is capped at 0.4 at a PERFECT lexical match.
+//
+// Both agent-facing surfaces default an omitted threshold to 0.5
+// (mcp/handlers.go:392, transport/rest/server.go:1772). 0.4 < 0.5 — so an
+// FTS-only match is UNRETURNABLE through MCP or REST at default settings, for
+// any query, at any lexical quality, forever. Not "scores poorly": structurally
+// cannot be returned. That is a stronger statement than the reported "falls
+// below the threshold", and it does not depend on the indexing lag at all —
+// the lag merely makes every freshly-written memory hit the case.
+//
+// Note the cross-surface split this exposes: at the ENGINE default (0.05) the
+// same candidate is returned fine. A library or direct caller sees the memory;
+// an MCP agent does not.
+func TestSCWFTSOnlyMatchIsUnreturnableAtSurfaceDefault(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	linear := scwArmSpec{Comb: scwCombLinear, UsePrior: true, UseConfidence: true}
+
+	// A brand-new, perfectly-matching, perfectly-confident memory with no
+	// embedding yet: cosine 0, FTS coverage 1.0 (every query term present).
+	unindexed := scwInput{
+		Cosine: 0, FTS: 1.0,
+		AccessCount: 0, LastAccess: now, Confidence: 1.0,
+	}
+
+	if cm := scwContentMatch(scwCombLinear, scwRescaleSemantic(0, scwBaselineBGESmall), 1.0, 0); math.Abs(cm-0.4) > 1e-12 {
+		t.Fatalf("ContentMatch at cosine 0 / perfect FTS = %.6f, want exactly 0.4", cm)
+	}
+
+	atSurface, _, _, dropSurface := scwScoreQuery([]scwInput{unindexed}, linear, scwBaselineBGESmall, scwSurfaceDefaultThreshold, now)
+	if !dropSurface[0] {
+		t.Fatalf("a perfect lexical match scored %.5f and survived the %.2f surface threshold — "+
+			"if this now passes, the surface default or the FTS coefficient changed", atSurface[0], scwSurfaceDefaultThreshold)
+	}
+
+	atEngine, _, _, dropEngine := scwScoreQuery([]scwInput{unindexed}, linear, scwBaselineBGESmall, scwDefaultThreshold, now)
+	if dropEngine[0] {
+		t.Fatalf("the same candidate was dropped at the ENGINE default too (%.5f) — the cross-surface split is gone", atEngine[0])
+	}
+	t.Logf("cosine 0, FTS 1.00 (perfect lexical, no embedding yet): final %.4f | MCP/REST gate %.2f -> DROPPED | engine gate %.2f -> returned",
+		atSurface[0], scwSurfaceDefaultThreshold, scwDefaultThreshold)
+
+	// The absence-of-evidence combiners return it, because a missing estimator
+	// stops being scored as a zero.
+	for _, c := range []scwCombiner{scwCombNoisyOR, scwCombMax} {
+		alt := scwArmSpec{Comb: c, UsePrior: true, UseConfidence: true}
+		f, _, _, dropped := scwScoreQuery([]scwInput{unindexed}, alt, scwBaselineBGESmall, scwSurfaceDefaultThreshold, now)
+		if dropped[0] {
+			t.Errorf("%s also dropped the perfect lexical match (final %.4f) — it does not fix the missing-cosine case", c, f[0])
+		} else {
+			t.Logf("  %-9s final %.4f -> returned", c.String(), f[0])
+		}
+	}
+}
+
+// TestSCWReconstructsObservedLiveScore is an independent check of the whole
+// replication against a LIVE observation reported from a running server: after
+// the embedding landed, the same query returned the memory at final score 0.742
+// with vector_score_raw 0.881.
+//
+// Solving the live formula for the only unknown (FTS coverage), with the prior
+// saturated and confidence 1.0 for a fresh, healthy memory:
+//
+//	semCal = (0.881-0.520)/0.480 = 0.7521
+//	0.742  = 0.6*0.7521 + 0.4*fts  =>  fts = 0.7269
+//
+// An implied FTS coverage of 0.73 for a near-exact lexical query is entirely
+// plausible, so the observation is consistent with the replicated formula. That
+// is a real cross-check: an arbitrary formula would not land an implied
+// coverage inside [0,1], let alone at a sensible value.
+//
+// The payoff is the counterfactual: the SAME candidate, one moment earlier with
+// the same FTS coverage but no embedding, scores 0.4*0.7269 = 0.291 — well
+// below the 0.5 surface gate. Zero results, then 0.742, with no change to the
+// memory or the query. Only the embedding landed.
+func TestSCWReconstructsObservedLiveScore(t *testing.T) {
+	const observedFinal, observedRawCosine = 0.742, 0.881
+
+	semCal := scwRescaleSemantic(observedRawCosine, scwBaselineBGESmall)
+	impliedFTS := (observedFinal - scwWeightSemantic*semCal) / scwWeightFTS
+	if impliedFTS < 0 || impliedFTS > 1 {
+		t.Fatalf("implied FTS coverage %.4f is outside [0,1] — the replicated formula is INCONSISTENT "+
+			"with the live observation (final %.3f, raw cosine %.3f) and must be re-derived",
+			impliedFTS, observedFinal, observedRawCosine)
+	}
+	if impliedFTS < 0.5 || impliedFTS > 0.95 {
+		t.Errorf("implied FTS coverage %.4f is inside [0,1] but implausible for a near-exact lexical query", impliedFTS)
+	}
+
+	preEmbed := scwWeightFTS * impliedFTS
+	if preEmbed >= scwSurfaceDefaultThreshold {
+		t.Fatalf("pre-embedding score %.4f would have cleared the %.2f surface gate — "+
+			"that contradicts the reported zero-result reproduction", preEmbed, scwSurfaceDefaultThreshold)
+	}
+	t.Logf("live observation reconstructed: semCal %.4f, implied FTS coverage %.4f, final %.3f",
+		semCal, impliedFTS, observedFinal)
+	t.Logf("SAME candidate one moment earlier (no embedding): %.4f — below the %.2f surface gate. "+
+		"Zero results -> %.3f, with nothing changed but the embedding landing.",
+		preEmbed, scwSurfaceDefaultThreshold, observedFinal)
 }
 
 // TestSCWPriorDynamicRange records the secondary structural fact: with Hebbian

--- a/internal/engine/engine_scoring_weights_model_test.go
+++ b/internal/engine/engine_scoring_weights_model_test.go
@@ -1,0 +1,430 @@
+package engine
+
+// Offline replication of the LIVE Phase 6 ACT-R scoring formula, plus the
+// alternative ContentMatch combiners under test, for the read-only measurement
+// driver in engine_scoring_weights_measure_test.go.
+//
+// THE LIVE FORMULA (production default; see the trace in
+// .claude/deep-review/2026-07-30-scoring-weights-trace.md):
+//
+//	semCal       = max(0, (cos - b) / (1 - b))                 COG-26 rescale
+//	ContentMatch = 0.6*semCal + 0.4*ftsCoverage                 activation:2211
+//	raw          = ContentMatch * softplus(B + 4h + 4t)/1.693   activation:2276
+//	final        = raw * Confidence                             activation:2295
+//
+// NOTE two corrections to the formula as it is often quoted internally:
+//   - the semantic term is semCal, the COG-26 baseline-rescaled cosine, NOT
+//     raw cosine (activation/engine.go:2210);
+//   - there is NO tanh on the FTS term. #711 removed it; ftsCoverage is
+//     already a calibrated absolute [0,1] coverage score
+//     (activation/engine.go:2064-2069).
+//
+// WHY A REPLICATION AND NOT A CALL: the live scorer is
+// activation.computeACTR (internal/engine/activation/engine.go:2199), which is
+// unexported, and reaching it through the exported activation.Run requires a
+// built HNSW index over the vault, which a read-only offline driver does not
+// have. So the arithmetic is mirrored here, term for term, with the upstream
+// file:line beside each term, and pinned by the synthetic-fixture tests at the
+// bottom of this file. If the live formula changes, those tests do NOT
+// automatically fail — re-derive them against the cited lines. That limit is
+// stated plainly rather than papered over.
+//
+// This file carries NO build tag on purpose: it is pure arithmetic over
+// synthetic fixtures, it compiles and runs in CI, and it is what makes the
+// build-tagged driver's arm (i) trustworthy.
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// --- constants mirrored from the live scorer -------------------------------
+
+const (
+	// activation/engine.go:2113 — 1 + softplus(0) = 1 + ln(2).
+	scwACTRDenominator = 1.6931471805599453
+	// activation/engine.go:2246 — 1 minute, sub-hour precision for intraday recall.
+	scwAgeFloorDays = 1.0 / (24.0 * 60.0)
+	// engine.go:2357-2358 — the hardcoded production ContentMatch gate.
+	scwWeightSemantic = 0.6
+	scwWeightFTS      = 0.4
+	// resolveWeights defaults, activation/engine.go:2553-2557.
+	scwACTRDecay    = 0.5
+	scwACTRHebScale = 4.0
+	// activation/engine.go:547 — the non-RRF default relevance threshold.
+	scwDefaultThreshold = 0.05
+	// embed.noiseBaselineRegistry["bge-small-en-v1.5"], plugin/embed/baseline.go:56.
+	scwBaselineBGESmall = 0.520
+)
+
+// scwSoftplus mirrors activation.softplus (activation/engine.go:2155).
+func scwSoftplus(x float64) float64 {
+	if x > 20 {
+		return x
+	}
+	return math.Log1p(math.Exp(x))
+}
+
+// scwBLevelCap mirrors activation/engine.go:2265 — the unique B(M) at which
+// softplus(B(M)) == actrDenominator, i.e. the prior multiplier reaches 1.0.
+func scwBLevelCap() float64 {
+	return math.Log(math.Exp(scwACTRDenominator) - 1)
+}
+
+// scwRescaleSemantic mirrors activation.rescaleSemantic (activation/engine.go:2133)
+// and embed.Rescale: semCal = max(0, (cos-b)/(1-b)); b<=0 is the identity.
+func scwRescaleSemantic(cos, b float64) float64 {
+	if b <= 0 || b >= 1 {
+		return cos
+	}
+	v := (cos - b) / (1 - b)
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+// scwAgeDays mirrors the lastAccess handling in computeACTR
+// (activation/engine.go:2236-2247): zero / pre-2000 LastAccess reads as "now".
+func scwAgeDays(lastAccess, now time.Time) float64 {
+	if lastAccess.IsZero() || lastAccess.Year() < 2000 {
+		lastAccess = now
+	}
+	return math.Max(now.Sub(lastAccess).Hours()/24.0, scwAgeFloorDays)
+}
+
+// scwBaseLevel mirrors activation/engine.go:2248-2267:
+//
+//	B(M) = ln(n) - d*ln(max(ageDays, floor)/n),  n = AccessCount+1, capped.
+func scwBaseLevel(accessCount int64, ageDays, d float64) float64 {
+	n := float64(accessCount + 1)
+	b := math.Log(n) - d*math.Log(math.Max(ageDays, scwAgeFloorDays)/n)
+	if c := scwBLevelCap(); b > c {
+		b = c
+	}
+	return b
+}
+
+// scwPrior is the contextual-prior multiplier that gates ContentMatch:
+// softplus(B + scale*heb + scale*trans) / actrDenominator
+// (activation/engine.go:2269-2276).
+func scwPrior(baseLevel, heb, trans, hebScale float64) float64 {
+	return scwSoftplus(baseLevel+hebScale*heb+hebScale*trans) / scwACTRDenominator
+}
+
+// ---------------------------------------------------------------------------
+// ContentMatch combiners — the thing actually on trial.
+//
+// The live combiner is LINEAR with fixed coefficients 0.6/0.4. Its defining
+// property is that a candidate with NO lexical evidence CANNOT score above
+// 0.6, no matter how strong the semantic match: absent FTS evidence is charged
+// as evidence of irrelevance rather than absence of evidence. A pure
+// paraphrase — the case retrieval-by-meaning exists to serve — is structurally
+// capped at 60% of the score an identical-wording hit can reach.
+//
+// The alternatives treat a missing estimator as absence of evidence:
+//   - NOISY-OR   1-(1-a)(1-b): either estimator alone can reach 1.0; two weak
+//     independent signals combine to more than either.
+//   - MAX        max(a,b): the strongest single estimator wins outright.
+//
+// Both are strictly >= the linear combiner everywhere, so both raise recall
+// AND raise the false-positive rate on unanswerable queries. That trade is
+// exactly why the driver pre-commits to measuring BOTH, and why nothing is
+// shipped on argument.
+// ---------------------------------------------------------------------------
+
+type scwCombiner int
+
+const (
+	scwCombLinear    scwCombiner = iota // live: 0.6*sem + 0.4*fts
+	scwCombNoisyOR                      // 1-(1-sem)(1-fts)
+	scwCombMax                          // max(sem, fts)
+	scwCombRawCosine                    // control: raw cosine, no calibration at all
+)
+
+func (c scwCombiner) String() string {
+	switch c {
+	case scwCombLinear:
+		return "linear(0.6/0.4)"
+	case scwCombNoisyOR:
+		return "noisy-OR"
+	case scwCombMax:
+		return "max"
+	case scwCombRawCosine:
+		return "raw-cosine"
+	}
+	return "?"
+}
+
+// scwContentMatch applies a combiner. semCal is the COG-26-rescaled cosine;
+// rawCos is passed through untouched for the raw-cosine control.
+func scwContentMatch(c scwCombiner, semCal, fts, rawCos float64) float64 {
+	switch c {
+	case scwCombNoisyOR:
+		return 1 - (1-clamp01(semCal))*(1-clamp01(fts))
+	case scwCombMax:
+		return math.Max(clamp01(semCal), clamp01(fts))
+	case scwCombRawCosine:
+		return rawCos
+	default:
+		return scwWeightSemantic*semCal + scwWeightFTS*fts
+	}
+}
+
+func clamp01(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}
+
+// scwArmSpec is one scoring strategy under comparison.
+type scwArmSpec struct {
+	Name string
+	Comb scwCombiner
+	// UsePrior=false removes the ACT-R contextual prior (pure content match).
+	// The raw-cosine control uses false.
+	UsePrior bool
+	// UseConfidence=false is the ABLATION the brief requires: with Confidence
+	// forced to 1, a contradiction bug that collapsed some engram's confidence
+	// to ~0.07 cannot silently decide which arm wins.
+	UseConfidence bool
+}
+
+// scwInput is one candidate's raw signals for one query.
+type scwInput struct {
+	Cosine      float64 // raw cosine, pre-calibration
+	FTS         float64 // calibrated [0,1] coverage from fts.Index.Search
+	Hebbian     float64 // 0 in the driver — see its header
+	Transition  float64 // 0 in the driver — see its header
+	AccessCount int64
+	LastAccess  time.Time
+	Confidence  float64
+}
+
+// scwRaw computes the pre-normalization raw score for one arm. Returns raw,
+// the ContentMatch term and the prior multiplier separately, so the driver can
+// report which factor moved a candidate.
+func scwRaw(in scwInput, arm scwArmSpec, baseline float64, now time.Time) (raw, cm, prior float64) {
+	semCal := scwRescaleSemantic(in.Cosine, baseline)
+	cm = scwContentMatch(arm.Comb, semCal, in.FTS, in.Cosine)
+	prior = 1.0
+	if arm.UsePrior {
+		bl := scwBaseLevel(in.AccessCount, scwAgeDays(in.LastAccess, now), scwACTRDecay)
+		prior = scwPrior(bl, in.Hebbian, in.Transition, scwACTRHebScale)
+	}
+	raw = cm * prior
+	if raw < 0 {
+		raw = 0
+	}
+	return raw, cm, prior
+}
+
+// scwScoreQuery scores a whole candidate pool for one query under one arm,
+// including the live per-query max-rescale (activation/engine.go:1922-1932)
+// and the relevance-threshold drop (activation/engine.go:1934). Ranking is not
+// affected by the rescale (a single positive scalar); it is replicated so the
+// absolute finals — and therefore the threshold drops, which are the whole
+// point — match the live pipeline.
+func scwScoreQuery(pool []scwInput, arm scwArmSpec, baseline, threshold float64, now time.Time) (final, cm, prior []float64, dropped []bool) {
+	n := len(pool)
+	final, cm, prior = make([]float64, n), make([]float64, n), make([]float64, n)
+	dropped = make([]bool, n)
+	raws := make([]float64, n)
+	maxRaw := 0.0
+	for i, in := range pool {
+		r, c, p := scwRaw(in, arm, baseline, now)
+		raws[i], cm[i], prior[i] = r, c, p
+		if r > maxRaw {
+			maxRaw = r
+		}
+	}
+	scale := 1.0
+	if maxRaw > 1.0 {
+		scale = 1.0 / maxRaw
+	}
+	for i, in := range pool {
+		r := math.Min(raws[i]*scale, 1.0)
+		conf := 1.0
+		if arm.UseConfidence {
+			conf = in.Confidence
+		}
+		f := r * conf
+		if f < threshold {
+			dropped[i] = true
+		}
+		final[i] = f
+	}
+	return final, cm, prior, dropped
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic-fixture pins. Every number below is hand-derived from the cited
+// upstream lines. No real vault content, concept, tag, entity or vault name
+// appears anywhere in this file.
+// ---------------------------------------------------------------------------
+
+func TestSCWDenominatorMatchesSoftplusZero(t *testing.T) {
+	if want := 1 + scwSoftplus(0); math.Abs(want-scwACTRDenominator) > 1e-12 {
+		t.Fatalf("actrDenominator drifted: 1+softplus(0)=%.17f, constant=%.17f", want, scwACTRDenominator)
+	}
+}
+
+func TestSCWBLevelCapSaturatesPriorAtOne(t *testing.T) {
+	if got := scwPrior(scwBLevelCap(), 0, 0, scwACTRHebScale); math.Abs(got-1.0) > 1e-12 {
+		t.Fatalf("prior at bLevelCap = %.17f, want 1.0", got)
+	}
+	if c := scwBLevelCap(); math.Abs(c-1.4892) > 1e-3 {
+		t.Fatalf("bLevelCap = %.6f, want ~1.4892 (activation/engine.go:2265)", c)
+	}
+}
+
+func TestSCWRescaleSemanticBaseline(t *testing.T) {
+	for _, tc := range []struct{ cos, want float64 }{
+		{0.520, 0.0},
+		{0.400, 0.0},
+		{0.758, (0.758 - 0.520) / 0.480},
+		{1.000, 1.0},
+	} {
+		if got := scwRescaleSemantic(tc.cos, scwBaselineBGESmall); math.Abs(got-tc.want) > 1e-12 {
+			t.Errorf("rescale(%.3f) = %.6f, want %.6f", tc.cos, got, tc.want)
+		}
+	}
+	if got := scwRescaleSemantic(0.758, 0); got != 0.758 {
+		t.Errorf("b<=0 must be the identity transform, got %.6f", got)
+	}
+}
+
+// TestSCWParaphraseCapIsStructural is the primary finding, stated numerically.
+// With zero lexical overlap the live linear combiner cannot exceed 0.6 even at
+// a PERFECT semantic match, whereas noisy-OR and max both reach 1.0. This is
+// not a tuning preference — it is a structural ceiling on retrieval by meaning.
+func TestSCWParaphraseCapIsStructural(t *testing.T) {
+	const perfectSem, noFTS = 1.0, 0.0
+	if got := scwContentMatch(scwCombLinear, perfectSem, noFTS, perfectSem); math.Abs(got-0.6) > 1e-12 {
+		t.Fatalf("linear combiner at perfect semantic / zero FTS = %.6f, want exactly 0.6", got)
+	}
+	for _, c := range []scwCombiner{scwCombNoisyOR, scwCombMax} {
+		if got := scwContentMatch(c, perfectSem, noFTS, perfectSem); math.Abs(got-1.0) > 1e-12 {
+			t.Errorf("%s at perfect semantic / zero FTS = %.6f, want 1.0", c, got)
+		}
+	}
+	// Symmetrically: perfect LEXICAL match with zero semantic caps at 0.4.
+	if got := scwContentMatch(scwCombLinear, 0, 1.0, 0); math.Abs(got-0.4) > 1e-12 {
+		t.Fatalf("linear combiner at zero semantic / perfect FTS = %.6f, want exactly 0.4", got)
+	}
+}
+
+// TestSCWWorkedParaphraseCase is the incident case, recomputed correctly.
+// The often-quoted arithmetic (0.6 x 0.758 = 0.455) omits the COG-26 rescale;
+// the real ContentMatch is 0.6 x semCal = 0.6 x 0.4958 = 0.2975 — materially
+// WORSE than the quoted figure. With a healthy confidence it survives the 0.05
+// threshold; with the contradiction bug's collapsed confidence it does not.
+// Both facts matter: the confidence bug explains the zero-result, the 0.6 cap
+// explains why the margin was thin enough for the bug to matter.
+func TestSCWWorkedParaphraseCase(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	semCal := scwRescaleSemantic(0.758, scwBaselineBGESmall)
+	if math.Abs(semCal-0.495833) > 1e-5 {
+		t.Fatalf("semCal = %.6f, want ~0.495833", semCal)
+	}
+	if cm := scwContentMatch(scwCombLinear, semCal, 0, 0.758); math.Abs(cm-0.2975) > 1e-3 {
+		t.Fatalf("ContentMatch = %.6f, want ~0.2975 (NOT the often-quoted 0.455)", cm)
+	}
+
+	fresh := scwInput{Cosine: 0.758, FTS: 0, AccessCount: 2, LastAccess: now.Add(-2 * time.Hour), Confidence: 1.0}
+	linear := scwArmSpec{Name: "linear", Comb: scwCombLinear, UsePrior: true, UseConfidence: true}
+
+	healthy, _, _, dropHealthy := scwScoreQuery([]scwInput{fresh}, linear, scwBaselineBGESmall, scwDefaultThreshold, now)
+	if dropHealthy[0] {
+		t.Fatalf("healthy-confidence paraphrase was dropped at final=%.5f — expected survival", healthy[0])
+	}
+
+	collapsed := fresh
+	collapsed.Confidence = 0.07
+	bugged, _, _, dropBugged := scwScoreQuery([]scwInput{collapsed}, linear, scwBaselineBGESmall, scwDefaultThreshold, now)
+	if !dropBugged[0] {
+		t.Fatalf("confidence-0.07 paraphrase survived at final=%.5f — expected suppression", bugged[0])
+	}
+	t.Logf("cos 0.758, no lexical overlap: ContentMatch=%.4f | conf 1.00 -> final %.5f (kept) | conf 0.07 -> final %.5f (DROPPED)",
+		scwContentMatch(scwCombLinear, semCal, 0, 0.758), healthy[0], bugged[0])
+
+	// Under noisy-OR the same candidate carries 1/0.6 more content weight and
+	// clears the threshold even at the collapsed confidence — which is the
+	// point of the comparison, not yet a reason to ship it.
+	nor := scwArmSpec{Name: "noisyOR", Comb: scwCombNoisyOR, UsePrior: true, UseConfidence: true}
+	norScore, _, _, norDrop := scwScoreQuery([]scwInput{collapsed}, nor, scwBaselineBGESmall, scwDefaultThreshold, now)
+	t.Logf("same candidate under noisy-OR at conf 0.07: final %.5f (dropped=%v)", norScore[0], norDrop[0])
+}
+
+// TestSCWAlternativesRaiseFalsePositivesToo is the pre-committed counterweight:
+// any combiner that rescues a marginal genuine match ALSO rescues a marginal
+// noise match. COG-26 measured bge-small's out-of-domain noise ceiling at
+// cosine ~0.596; under the live combiner that lands just under the abstention
+// gate, and under noisy-OR/max it clears it comfortably. A harness that
+// reported only recall would call that a win.
+func TestSCWAlternativesRaiseFalsePositivesToo(t *testing.T) {
+	const noiseTopCos = 0.596 // COG-26's measured out-of-domain ceiling
+	semCal := scwRescaleSemantic(noiseTopCos, scwBaselineBGESmall)
+
+	live := scwContentMatch(scwCombLinear, semCal, 0, noiseTopCos)
+	if live > 0.1 {
+		t.Fatalf("live ContentMatch on the measured noise ceiling = %.4f; COG-26 expects it just under the 0.1 gate", live)
+	}
+	for _, c := range []scwCombiner{scwCombNoisyOR, scwCombMax} {
+		alt := scwContentMatch(c, semCal, 0, noiseTopCos)
+		if alt <= live {
+			t.Fatalf("%s scored the noise ceiling at %.4f, not above live's %.4f — combiner is not strictly more permissive", c, alt, live)
+		}
+		if alt <= 0.1 {
+			t.Logf("NOTE: %s keeps the noise ceiling (%.4f) under the 0.1 gate — better than expected", c, alt)
+		}
+	}
+	t.Logf("noise ceiling cos %.3f -> semCal %.4f | live %.4f | noisy-OR %.4f | max %.4f",
+		noiseTopCos, semCal, live,
+		scwContentMatch(scwCombNoisyOR, semCal, 0, noiseTopCos),
+		scwContentMatch(scwCombMax, semCal, 0, noiseTopCos))
+	t.Log("COG-26's b=0.520 was calibrated AGAINST the 0.6 linear combiner (docs/internals/invariants.md). " +
+		"Changing the combiner invalidates that calibration and requires re-deriving b — this is why the driver " +
+		"measures both metrics and why nothing ships on argument.")
+}
+
+// TestSCWConfidenceIsAMultiplier pins the confound the driver must neutralize:
+// Confidence multiplies straight into the final score, so a bug that collapses
+// it to 0.07 cuts the score by 93% independent of any combiner. Hence the
+// confidence-ablated arms.
+func TestSCWConfidenceIsAMultiplier(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	in := scwInput{Cosine: 0.90, AccessCount: 5, LastAccess: now.Add(-1 * time.Hour), Confidence: 0.07}
+	withConf := scwArmSpec{Comb: scwCombLinear, UsePrior: true, UseConfidence: true}
+	noConf := scwArmSpec{Comb: scwCombLinear, UsePrior: true, UseConfidence: false}
+
+	a, _, _, _ := scwScoreQuery([]scwInput{in}, withConf, scwBaselineBGESmall, 0, now)
+	b, _, _, _ := scwScoreQuery([]scwInput{in}, noConf, scwBaselineBGESmall, 0, now)
+	if math.Abs(a[0]-b[0]*0.07) > 1e-9 {
+		t.Fatalf("confidence is not a clean multiplier: %.9f vs %.9f", a[0], b[0]*0.07)
+	}
+	if b[0] < scwDefaultThreshold || a[0] >= scwDefaultThreshold {
+		t.Fatalf("expected the ablation to flip this candidate across the threshold: conf-on %.5f, conf-off %.5f", a[0], b[0])
+	}
+}
+
+// TestSCWPriorDynamicRange records the secondary structural fact: with Hebbian
+// and transition at zero, the ACT-R prior spans >20x between a cold engram and
+// a hot one, while ContentMatch is bounded in [0,1]. Recency/frequency can
+// therefore outvote any achievable semantic difference.
+func TestSCWPriorDynamicRange(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	cold := scwPrior(scwBaseLevel(0, scwAgeDays(now.AddDate(0, 0, -365), now), scwACTRDecay), 0, 0, scwACTRHebScale)
+	hot := scwPrior(scwBaseLevel(20, scwAgeDays(now.Add(-12*time.Hour), now), scwACTRDecay), 0, 0, scwACTRHebScale)
+	if ratio := hot / cold; ratio < 20 {
+		t.Fatalf("prior ratio hot/cold = %.2f (cold=%.5f hot=%.5f); expected >20x", ratio, cold, hot)
+	}
+	if hot > 1.0001 {
+		t.Fatalf("hot prior %.5f exceeds 1.0 — bLevelCap not applied", hot)
+	}
+}

--- a/internal/engine/engine_supersession.go
+++ b/internal/engine/engine_supersession.go
@@ -162,6 +162,17 @@ func (e *Engine) applySupersession(ctx context.Context, ws [8]byte, results []ac
 		return results, 0
 	}
 
+	// Copy before mutating: every write below (head scores, demotions, the
+	// re-sort) lands in the backing array Run() returned, and the activation
+	// engine's async log-drain goroutine may still be reading that array's
+	// Score fields — the same hazard the final COG-19 gate in activateCore
+	// already avoids by filtering into a NEW slice. Reproduced under -race with
+	// a link-supersedes chain read under include_invalid, which needs neither
+	// evolve nor a soft-delete. Paid only when a substitution actually
+	// happens: the no-stale path above returns the caller's slice untouched.
+	// Capacity covers the heads Phase 2a may append.
+	results = append(make([]activation.ScoredEngram, 0, len(results)+len(headFinal)), results...)
+
 	// Fold each head's OWN earned score (when it was already retrieved) into its
 	// final: a head keeps its own high relevance and never drops below it.
 	for headID := range headFinal {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -578,7 +578,7 @@ func TestEngineGetContradictions(t *testing.T) {
 	ws := eng.store.VaultPrefix("test")
 	id1 := storage.ULID([16]byte{1})
 	id2 := storage.ULID([16]byte{2})
-	_ = eng.store.FlagContradiction(ctx, ws, id1, id2)
+	_, _ = eng.store.FlagContradiction(ctx, ws, id1, id2)
 
 	pairs, err := eng.GetContradictions(ctx, "test")
 	if err != nil {

--- a/internal/engine/prospective_test.go
+++ b/internal/engine/prospective_test.go
@@ -565,7 +565,7 @@ func TestNoticesForRecall_ContradictionNotice(t *testing.T) {
 	ws := eng.Store().ResolveVaultPrefix(vault)
 	a, _ := storage.ParseULID(aID)
 	b, _ := storage.ParseULID(bID)
-	if err := eng.Store().FlagContradiction(ctx, ws, a, b); err != nil {
+	if _, err := eng.Store().FlagContradiction(ctx, ws, a, b); err != nil {
 		t.Fatalf("FlagContradiction: %v", err)
 	}
 

--- a/internal/engine/query.go
+++ b/internal/engine/query.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/scrypster/muninndb/internal/auth"
@@ -26,13 +27,58 @@ type TraversalEdge struct {
 }
 
 // ExplainData is the engine-level score explanation for a specific engram + query.
+//
+// Found and Scored exist so a caller can never mistake "nothing computed this"
+// for "this measured zero". Components is meaningful ONLY when Scored is true;
+// when Scored is false every field in it is an uninitialized zero and must be
+// rendered as unknown, never as a score (CLAUDE.md §2.1/§2.2 — a plausible
+// wrong number is the project's worst failure class).
 type ExplainData struct {
-	EngramID    string
-	Concept     string
+	EngramID string
+	Concept  string
+	// Found reports whether the engram exists in the vault at all. When false,
+	// Concept/Confidence/Components are all unset and Note says why.
+	Found bool
+	// Scored reports whether this query's activation run produced a score for
+	// this engram. False means the query never reached it — the components do
+	// not exist rather than being zero.
+	Scored bool
+	// Confidence is the engram's STORED confidence. It does not depend on the
+	// query, so it is populated whenever Found is true — including for an
+	// engram this query never scored.
+	Confidence  float64
 	FinalScore  float64
 	WouldReturn bool
 	Threshold   float64
 	Components  mbp.ScoreComponents
+	// Note is a plain-language explanation, set whenever Found or Scored is
+	// false. Empty on the fully-scored happy path.
+	Note string
+}
+
+// defaultRecallThreshold is the score bar a default muninn_recall applies —
+// mirrored from internal/mcp/handlers.go handleRecall so Explain's
+// would_return answers the question the caller is actually asking ("would
+// recall have returned this?") instead of the meaningless "was it a
+// candidate at threshold 0?". Pinned by
+// TestRecallThresholdFor_MirrorsRecallSurface.
+const defaultRecallThreshold = 0.5
+
+// explainMaxCandidates bounds the activation run Explain inspects. Larger than
+// any real recall limit so "not scored" almost always means "the query's
+// indexes never produced this engram", not "it fell off the end of a short
+// result list" — and the Note says which claim is being made.
+const explainMaxCandidates = 1000
+
+// recallThresholdFor returns the threshold a default recall applies in
+// vault. RRF fusion produces reciprocal-rank scores that are not calibrated to
+// the 0..1 relevance scale, so that surface drops the bar to 0 — Explain has to
+// report the same number or would_return lies.
+func (e *Engine) recallThresholdFor(vault string) float64 {
+	if e.ResolveVaultPlasticity(vault).ScoringFusion == "rrf" {
+		return 0
+	}
+	return defaultRecallThreshold
 }
 
 // GetAssociations returns the forward associations for a single engram by string ID.
@@ -191,9 +237,39 @@ func (e *Engine) Traverse(ctx context.Context, vault, startID string, maxHops, m
 	return nodes, edges, nil
 }
 
-// Explain runs activation with the given query and returns score details for engramID.
+// Explain runs activation with the given query and returns score details for
+// engramID.
+//
+// The activation run itself uses a threshold of 0 so a below-bar engram still
+// gets a real score card; the threshold REPORTED (and the one would_return is
+// measured against) is the vault's default recall threshold. Everything that
+// does not depend on the query — existence, concept, stored confidence — is
+// read straight from the engram, so a query that never reached it still gets
+// those facts plus an explicit Note, instead of an all-zero card that reads
+// like a genuine score of zero.
 func (e *Engine) Explain(ctx context.Context, vault, engramID string, query []string, embedding []float32) (*ExplainData, error) {
-	const threshold = 0.0
+	result := &ExplainData{
+		EngramID:  engramID,
+		Threshold: e.recallThresholdFor(vault),
+	}
+
+	id, err := storage.ParseULID(engramID)
+	if err != nil {
+		result.Note = fmt.Sprintf("engram_id %q is not a valid ULID, so no engram could be looked up: %v", engramID, err)
+		return result, nil
+	}
+	eng, err := e.GetEngram(ctx, vault, id)
+	switch {
+	case errors.Is(err, storage.ErrNotFound):
+		result.Note = fmt.Sprintf("engram %s was not found in vault %q — check the id and the vault", engramID, vault)
+		return result, nil
+	case err != nil:
+		return nil, fmt.Errorf("explain: load engram %s: %w", engramID, err)
+	}
+	result.Found = true
+	result.Concept = eng.Concept
+	result.Confidence = float64(eng.Confidence)
+
 	// Run activation in observe mode so we get accurate scores without
 	// triggering Hebbian co-activation, activity tracking, or PAS transitions.
 	// Explain is a diagnostic read — it should not mutate cognitive state.
@@ -202,25 +278,27 @@ func (e *Engine) Explain(ctx context.Context, vault, engramID string, query []st
 		Vault:      vault,
 		Context:    query,
 		Embedding:  embedding,
-		MaxResults: 100,
-		Threshold:  threshold,
+		MaxResults: explainMaxCandidates,
+		Threshold:  0,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("explain activation: %w", err)
 	}
-	result := &ExplainData{
-		EngramID:    engramID,
-		WouldReturn: false,
-		Threshold:   threshold,
-	}
 	for _, item := range resp.Activations {
 		if item.ID == engramID {
-			result.WouldReturn = true
+			result.Scored = true
 			result.FinalScore = float64(item.Score)
 			result.Concept = item.Concept
 			result.Components = item.ScoreComponents
 			break
 		}
 	}
+	if !result.Scored {
+		result.Note = fmt.Sprintf("this query produced no score for engram %s: it was not among the %d candidates activation ranked, "+
+			"so no per-component scores exist for it — any component value shown is 'not computed', never 'measured zero'. "+
+			"Its full-text, vector and entity signals did not put it in the candidate pool for these terms.",
+			engramID, explainMaxCandidates)
+	}
+	result.WouldReturn = result.Scored && result.FinalScore >= result.Threshold
 	return result, nil
 }

--- a/internal/engine/visibility_gate.go
+++ b/internal/engine/visibility_gate.go
@@ -86,7 +86,13 @@ func (g *visibilityGate) Nameable(ctx context.Context, store *storage.PebbleStor
 	if eng == nil {
 		return false
 	}
-	if eng.State == storage.StateSoftDeleted || eng.State == storage.StateArchived {
+	// Lifecycle state, evaluated under the caller's temporal view — the same
+	// predicate phase 6 applies (activation.PassesLifecycle), so the two paths
+	// cannot drift. Default recall still refuses every soft-deleted engram; an
+	// explicit as_of / include_invalid query still reaches a SUPERSEDED one
+	// (soft-delete + closed ValidUntil), because supersession demotes a fact
+	// rather than erasing it.
+	if !activation.PassesLifecycle(eng, g.req.AsOf, g.req.IncludeInvalid) {
 		return false
 	}
 	if !activation.PassesMetaFilter(eng, g.req.Filters) {

--- a/internal/mcp/agent_experience_test.go
+++ b/internal/mcp/agent_experience_test.go
@@ -1,0 +1,145 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/engine"
+	"github.com/scrypster/muninndb/internal/engine/activation"
+	"github.com/scrypster/muninndb/internal/engine/trigger"
+	"github.com/scrypster/muninndb/internal/index/fts"
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// newRealEngineAdapter wires a real *engine.Engine (live PebbleStore + FTS)
+// behind the MCP adapter using only exported constructors — the engine
+// package's test helpers are internal, so the shape is duplicated here (same
+// as internal/transport/grpc/engine_adapter_confidence_test.go). The stub
+// engine used by the handler tests cannot catch adapter-level field-mapping
+// bugs, which is exactly the class these tests cover.
+func newRealEngineAdapter(t *testing.T) (*engine.Engine, EngineInterface, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "muninndb-mcp-agentexp-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := storage.OpenPebble(dir, storage.DefaultOptions())
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatal(err)
+	}
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 128})
+	ftsIdx := fts.New(db)
+	embedder := activation.NewNoopEmbedder()
+	actEngine := activation.New(store, activation.NewFTSAdapter(ftsIdx), nil, embedder)
+	trigSystem := trigger.New(store, trigger.NewFTSAdapter(ftsIdx), nil, embedder)
+	eng := engine.NewEngine(engine.EngineConfig{
+		Store: store, FTSIndex: ftsIdx, ActivationEngine: actEngine,
+		TriggerSystem: trigSystem, Embedder: embedder,
+	})
+	return eng, NewEngineAdapter(eng, nil, nil), func() {
+		eng.Stop()
+		store.Close()
+		os.RemoveAll(dir)
+	}
+}
+
+// ── muninn_explain: real numbers, or an explicit "unknown" ───────────────────
+
+// TestExplainAdapter_ReportsStoredConfidence: the MCP surface reported
+// components.confidence == 0 for every engram, including one whose stored
+// confidence was 1.0, because the adapter never mapped the field (and
+// mbp.ScoreComponents has no confidence at all). 0 is an impossible confidence
+// for a live engram, so the number was not merely stale — it was invented.
+//
+// RED without the fix: Confidence is a plain float64 that nothing sets → 0.
+func TestExplainAdapter_ReportsStoredConfidence(t *testing.T) {
+	eng, adapter, cleanup := newRealEngineAdapter(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	w, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:      "explain",
+		Concept:    "Redis eviction policy",
+		Content:    "allkeys-lru with a 2GB cap",
+		Confidence: 1.0,
+	})
+	if err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	res, err := adapter.Explain(ctx, "explain", &ExplainRequest{
+		EngramID: w.ID,
+		Query:    []string{"Redis", "eviction", "policy"},
+	})
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if !res.Found {
+		t.Fatal("found = false for an engram that exists")
+	}
+	if res.Components.Confidence == nil {
+		t.Fatal("components.confidence is null for an engram that exists — it is always knowable")
+	}
+	if *res.Components.Confidence != 1.0 {
+		t.Errorf("components.confidence = %v, want 1.0 (the stored value)", *res.Components.Confidence)
+	}
+	if res.Concept == "" {
+		t.Error("concept is empty in the explain response")
+	}
+	if res.Threshold == 0 {
+		t.Error("threshold = 0: explain must report the real recall bar, not a hardcoded zero")
+	}
+}
+
+// TestExplainAdapter_UnscoredComponentsAreNullNotZero: when the query never
+// scored the engram, the query-dependent components do not exist. Serializing
+// them as 0 tells the operator "your semantic similarity is zero" when the
+// truth is "nothing measured it" — the silent-substitution class. They must be
+// JSON null, with a note saying why.
+//
+// RED without the fix: every component serializes as 0 and there is no note.
+func TestExplainAdapter_UnscoredComponentsAreNullNotZero(t *testing.T) {
+	eng, adapter, cleanup := newRealEngineAdapter(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	w, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:      "explain",
+		Concept:    "Redis eviction policy",
+		Content:    "allkeys-lru with a 2GB cap",
+		Confidence: 1.0,
+	})
+	if err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	res, err := adapter.Explain(ctx, "explain", &ExplainRequest{
+		EngramID: w.ID,
+		Query:    []string{"kangaroo", "zeppelin"},
+	})
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if res.Scored {
+		t.Fatal("scored = true for a query that never reached the engram")
+	}
+	if res.Note == "" {
+		t.Error("note is empty: an unscored explain must state that its components are absent")
+	}
+	if res.Components.SemanticSimilarity != nil {
+		t.Errorf("semantic_similarity = %v, want null (not computed)", *res.Components.SemanticSimilarity)
+	}
+	if res.Components.FullTextRelevance != nil {
+		t.Errorf("full_text_relevance = %v, want null (not computed)", *res.Components.FullTextRelevance)
+	}
+	// Query-independent facts survive.
+	if res.Components.Confidence == nil || *res.Components.Confidence != 1.0 {
+		t.Error("confidence must still be reported for an unscored engram")
+	}
+	if res.Concept == "" {
+		t.Error("concept must still be reported for an unscored engram")
+	}
+}

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -178,21 +178,38 @@ func (a *mcpEngineAdapter) Explain(ctx context.Context, vault string, req *Expla
 	if err != nil {
 		return nil, err
 	}
-	return &ExplainResult{
+	res := &ExplainResult{
 		EngramID:    data.EngramID,
+		Concept:     data.Concept,
+		Found:       data.Found,
+		Scored:      data.Scored,
 		WouldReturn: data.WouldReturn,
 		Threshold:   data.Threshold,
-		FinalScore:  data.FinalScore,
-		Components: ExplainComponents{
-			FullTextRelevance:     float64(data.Components.FullTextRelevance),
-			SemanticSimilarity:    float64(data.Components.SemanticSimilarity),
-			SemanticSimilarityRaw: float64(data.Components.SemanticSimilarityRaw),
-			DecayFactor:           float64(data.Components.DecayFactor),
-			HebbianBoost:          float64(data.Components.HebbianBoost),
-			AccessFrequency:       float64(data.Components.AccessFrequency),
-		},
-	}, nil
+		Note:        data.Note,
+	}
+	// Stored confidence never depends on the query: report it whenever the
+	// engram exists. (It was previously unmapped entirely, so muninn_explain
+	// reported confidence 0 — an impossible value — for every engram.)
+	if data.Found {
+		res.Components.Confidence = f64(data.Confidence)
+	}
+	// The query-dependent components exist only if this query scored the
+	// engram. Otherwise they stay nil → JSON null → "not computed".
+	if data.Scored {
+		res.FinalScore = f64(data.FinalScore)
+		res.Components.FullTextRelevance = f64(float64(data.Components.FullTextRelevance))
+		res.Components.SemanticSimilarity = f64(float64(data.Components.SemanticSimilarity))
+		res.Components.SemanticSimilarityRaw = f64(float64(data.Components.SemanticSimilarityRaw))
+		res.Components.DecayFactor = f64(float64(data.Components.DecayFactor))
+		res.Components.HebbianBoost = f64(float64(data.Components.HebbianBoost))
+		res.Components.AccessFrequency = f64(float64(data.Components.AccessFrequency))
+	}
+	return res, nil
 }
+
+// f64 boxes a float64 so an explain component can distinguish a real 0 from
+// "never computed" (nil → JSON null).
+func f64(v float64) *float64 { return &v }
 
 func (a *mcpEngineAdapter) UpdateState(ctx context.Context, vault, id, state, reason string) error {
 	return a.eng.UpdateLifecycleState(ctx, vault, id, state)

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -94,7 +94,20 @@ func (a *mcpEngineAdapter) Evolve(ctx context.Context, vault, oldID, newContent,
 	if err != nil {
 		return nil, err
 	}
-	return &WriteResult{ID: id.String()}, nil
+	// Echo the concept that was actually stored. The successor's concept is
+	// either the caller's override or the one carried from the predecessor, so
+	// it cannot be reconstructed from the arguments alone — read it back. The
+	// previous {"concept":""} response led two evaluators to conclude the
+	// write had lost data when the record was in fact correct.
+	res := &WriteResult{ID: id.String()}
+	if eng, err := a.eng.GetEngram(ctx, vault, id); err == nil && eng != nil {
+		res.Concept = eng.Concept
+	} else if err != nil {
+		// Never fail an accepted write over a cosmetic read-back; say so rather
+		// than reporting an empty concept as if that were the stored value.
+		res.Warnings = append(res.Warnings, fmt.Sprintf("evolve succeeded but the stored concept could not be read back: %v", err))
+	}
+	return res, nil
 }
 func (a *mcpEngineAdapter) Consolidate(ctx context.Context, vault string, ids []string, merged string) (*ConsolidateResult, error) {
 	res, err := a.eng.Consolidate(ctx, vault, ids, merged)
@@ -123,7 +136,7 @@ func (a *mcpEngineAdapter) Decide(ctx context.Context, vault, decision, rational
 	if err != nil {
 		return nil, err
 	}
-	return &WriteResult{ID: res.ID.String(), Warnings: res.Warnings}, nil
+	return &WriteResult{ID: res.ID.String(), Concept: res.Concept, Warnings: res.Warnings}, nil
 }
 
 func (a *mcpEngineAdapter) Restore(ctx context.Context, vault, id string) (*RestoreResult, error) {

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -262,30 +262,49 @@ type ExplainRequest struct {
 }
 
 // ExplainComponents holds the per-component score breakdown.
+//
+// Every field is a POINTER on purpose: a component that was never computed
+// serializes as JSON null ("unknown"), never as 0. A 0 that means "unknown" is
+// exactly the silent substitution this project treats as its worst failure
+// class (CLAUDE.md §2.1) — and it is worst of all here, in the one tool an
+// agent uses to find out why a memory did not come back.
 type ExplainComponents struct {
-	FullTextRelevance  float64 `json:"full_text_relevance"`
-	SemanticSimilarity float64 `json:"semantic_similarity"`
+	FullTextRelevance  *float64 `json:"full_text_relevance"`
+	SemanticSimilarity *float64 `json:"semantic_similarity"`
 	// SemanticSimilarityRaw is the uncalibrated cosine similarity — see
 	// activation.ScoreComponents.SemanticSimilarityRaw. Lets an operator see
 	// the raw signal (e.g. 0.59) behind a calibrated value that abstained
 	// (e.g. 0.07) without a second tool call.
-	SemanticSimilarityRaw float64 `json:"semantic_similarity_raw"`
-	DecayFactor           float64 `json:"decay_factor"`
-	HebbianBoost          float64 `json:"hebbian_boost"`
-	AccessFrequency       float64 `json:"access_frequency"`
-	Confidence            float64 `json:"confidence"`
+	SemanticSimilarityRaw *float64 `json:"semantic_similarity_raw"`
+	DecayFactor           *float64 `json:"decay_factor"`
+	HebbianBoost          *float64 `json:"hebbian_boost"`
+	AccessFrequency       *float64 `json:"access_frequency"`
+	// Confidence is the engram's STORED confidence. It does not depend on the
+	// query, so it is non-null whenever the engram exists — including when the
+	// query produced no score at all.
+	Confidence *float64 `json:"confidence"`
 }
 
 // ExplainResult breaks down why an engram scored as it did for a given query.
 type ExplainResult struct {
-	EngramID    string            `json:"engram_id"`
-	Concept     string            `json:"concept"`
-	FinalScore  float64           `json:"final_score"`
+	EngramID string `json:"engram_id"`
+	Concept  string `json:"concept"`
+	// Found: the engram exists in this vault. Scored: this query's activation
+	// run produced a score for it. When Scored is false the component values
+	// are null and Note says why — final_score is likewise meaningless.
+	Found       bool              `json:"found"`
+	Scored      bool              `json:"scored"`
+	FinalScore  *float64          `json:"final_score"`
 	Components  ExplainComponents `json:"components"`
 	FTSMatches  []string          `json:"fts_matches"`
 	AssocPath   []string          `json:"assoc_path"`
 	WouldReturn bool              `json:"would_return"`
-	Threshold   float64           `json:"threshold"`
+	// Threshold is the bar a default muninn_recall applies in this vault —
+	// would_return means "clears that bar", not "was a candidate".
+	Threshold float64 `json:"threshold"`
+	// Note explains, in plain language, anything the caller would otherwise
+	// have to infer from a zero. Empty on the fully-scored happy path.
+	Note string `json:"note,omitempty"`
 }
 
 // DeletedEngram is a summary of a soft-deleted engram still within the recovery window.

--- a/internal/mcp/write_response_concept_test.go
+++ b/internal/mcp/write_response_concept_test.go
@@ -1,0 +1,87 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// ── muninn_decide: a decision, not a fact ────────────────────────────────────
+
+// TestDecideAdapter_ReportsStoredConcept: muninn_decide returned
+// {"concept":""} while storing the concept correctly. Two independent
+// evaluators concluded data was being lost. Response-serialization bug.
+//
+// RED without the fix: the adapter builds WriteResult{ID, Warnings} only.
+func TestDecideAdapter_ReportsStoredConcept(t *testing.T) {
+	eng, adapter, cleanup := newRealEngineAdapter(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const decision = "Adopt trunk-based development for the sandbox repo"
+	res, err := adapter.Decide(ctx, "decide", decision, "Long-lived branches were stalling review", nil, nil)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if res.Concept != decision {
+		t.Errorf("decide response concept = %q, want %q", res.Concept, decision)
+	}
+	// And it really is what was stored.
+	id, err := storage.ParseULID(res.ID)
+	if err != nil {
+		t.Fatalf("parse id: %v", err)
+	}
+	stored, err := eng.GetEngram(ctx, "decide", id)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if stored.Concept != decision {
+		t.Errorf("stored concept = %q, want %q", stored.Concept, decision)
+	}
+}
+
+// ── muninn_evolve: response must report the stored concept ───────────────────
+
+// TestEvolveAdapter_ReportsStoredConcept: same response-serialization bug on
+// evolve — the successor's concept (carried from the predecessor, or the
+// caller's override) was stored but never returned.
+//
+// RED without the fix: the adapter builds WriteResult{ID} only.
+func TestEvolveAdapter_ReportsStoredConcept(t *testing.T) {
+	eng, adapter, cleanup := newRealEngineAdapter(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	w, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault:   "evolve",
+		Concept: "Deploy cadence",
+		Content: "We ship on Fridays",
+	})
+	if err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	// Carried concept.
+	res, err := adapter.Evolve(ctx, "evolve", w.ID, "We ship on Tuesdays", "Friday deploys caused weekend pages", nil, "", nil, nil, timeZero())
+	if err != nil {
+		t.Fatalf("Evolve: %v", err)
+	}
+	if res.Concept != "Deploy cadence" {
+		t.Errorf("evolve response concept = %q, want the carried %q", res.Concept, "Deploy cadence")
+	}
+
+	// Explicit concept override.
+	res2, err := adapter.Evolve(ctx, "evolve", res.ID, "We ship continuously", "Moved to CD", nil, "Deploy cadence (CD)", nil, nil, timeZero())
+	if err != nil {
+		t.Fatalf("Evolve(2): %v", err)
+	}
+	if res2.Concept != "Deploy cadence (CD)" {
+		t.Errorf("evolve response concept = %q, want the override %q", res2.Concept, "Deploy cadence (CD)")
+	}
+}
+
+// timeZero keeps the Evolve call sites readable.
+func timeZero() time.Time { return time.Time{} }

--- a/internal/scoring/deadloop_characterization_test.go
+++ b/internal/scoring/deadloop_characterization_test.go
@@ -1,0 +1,212 @@
+package scoring
+
+// CHARACTERIZATION TESTS for the per-vault learned scoring weights.
+//
+// These tests do not assert that the package is CORRECT. They assert what it
+// currently DOES, because what it currently does is: nothing that can affect
+// retrieval, and nothing that can move the weight distribution. Each test says
+// in its failure message what a failure would mean — for most of them, a
+// failure is GOOD NEWS and the test should be deleted along with the defect it
+// documented.
+//
+// Three independent facts, each pinned below:
+//
+//	(1) Both production call sites pass a CONSTANT ScoreVector.
+//	    internal/engine/engine.go:2101 and :4370 both set
+//	    ScoreVector: scoring.DefaultWeights() — a uniform 1/6 vector — where
+//	    FeedbackSignal's own doc comment says the field carries "the score
+//	    components that produced this result" (weights.go:31). A constant
+//	    gradient is not feedback.
+//
+//	(2) With a uniform ScoreVector the update is a mathematical no-op.
+//	    Update adds lr*direction*ScoreVector[i] to every dimension — the SAME
+//	    scalar to each — and Softmax is shift-invariant. The distribution is
+//	    therefore provably unable to move, in either direction, for any number
+//	    of updates. See TestUpdateWithUniformScoreVectorCannotMoveWeights.
+//
+//	(3) Update re-Softmaxes an already-normalised vector, which contracts it
+//	    toward uniform. Even a genuine, informative gradient would be partly
+//	    undone on every step. See TestRepeatedSoftmaxContractsTowardUniform.
+//
+// And the consequence: nothing reads the result. Store.Get has no caller
+// outside this package's own tests, and no dimension index (DimFTS, DimHNSW,
+// DimHebbian, DimDecay, DimRecency, DimAssociation) is referenced anywhere in
+// the tree outside internal/scoring. The live recall path scores with a
+// completely separate, hardcoded set of coefficients — see the trace in
+// .claude/deep-review/2026-07-30-scoring-weights-trace.md.
+//
+// No real vault content, concept, tag, entity or vault name appears here.
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func maxAbsDiff(a, b [NumDims]float64) float64 {
+	worst := 0.0
+	for i := 0; i < NumDims; i++ {
+		if d := math.Abs(a[i] - b[i]); d > worst {
+			worst = d
+		}
+	}
+	return worst
+}
+
+// TestDefaultWeightsIsUniform pins the value that both production call sites
+// pass as their "score vector".
+func TestDefaultWeightsIsUniform(t *testing.T) {
+	w := DefaultWeights()
+	want := 1.0 / float64(NumDims)
+	for i, got := range w {
+		if math.Abs(got-want) > 1e-12 {
+			t.Fatalf("DefaultWeights()[%d] = %.17f, want uniform %.17f", i, got, want)
+		}
+	}
+}
+
+// TestUpdateWithUniformScoreVectorCannotMoveWeights is the core finding.
+//
+// It replays exactly what production does: FeedbackSignal.ScoreVector =
+// DefaultWeights(), applied many times, positively and negatively. The weight
+// distribution does not move — not slightly, not slowly, not at all.
+//
+// IF THIS TEST FAILS, someone wired a real per-result score vector into
+// RecordFeedback's call sites or changed Update's normalization. That is the
+// desired outcome; delete this test and pin the new behaviour instead.
+func TestUpdateWithUniformScoreVectorCannotMoveWeights(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		accessed bool
+	}{
+		{"all positive feedback", true},
+		{"all negative feedback", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			vw := &VaultWeights{Weights: DefaultWeights(), LearningRate: 0.1}
+			before := vw.Weights
+
+			for i := 0; i < 500; i++ {
+				vw.Update(FeedbackSignal{
+					Accessed:    tc.accessed,
+					ScoreVector: DefaultWeights(), // <- what engine.go actually sends
+					Timestamp:   time.Unix(int64(i), 0),
+				})
+			}
+
+			if d := maxAbsDiff(before, vw.Weights); d > 1e-12 {
+				t.Fatalf("weights MOVED by %.3e after 500 updates — the learning loop is no longer inert.\n"+
+					"That is good news: delete this characterization test and pin the real behaviour.\n"+
+					"before=%v after=%v", d, before, vw.Weights)
+			}
+			if vw.UpdateCount != 500 {
+				t.Errorf("UpdateCount = %d, want 500 (the bookkeeping runs; only the learning does not)", vw.UpdateCount)
+			}
+		})
+	}
+}
+
+// TestUpdateIsShiftInvariantForAnyConstantScoreVector generalises (2): the
+// no-op is not an artifact of the value 1/6. ANY constant vector — every
+// dimension equal — produces the same shift on every weight, and Softmax
+// cancels it. The defect is the constancy, not the magnitude.
+func TestUpdateIsShiftInvariantForAnyConstantScoreVector(t *testing.T) {
+	for _, c := range []float64{0.01, 1.0 / NumDims, 0.5, 5.0} {
+		var sv [NumDims]float64
+		for i := range sv {
+			sv[i] = c
+		}
+		vw := &VaultWeights{Weights: DefaultWeights(), LearningRate: 0.1}
+		before := vw.Weights
+		for i := 0; i < 50; i++ {
+			vw.Update(FeedbackSignal{Accessed: true, ScoreVector: sv, Timestamp: time.Unix(int64(i), 0)})
+		}
+		if d := maxAbsDiff(before, vw.Weights); d > 1e-12 {
+			t.Errorf("constant ScoreVector %.3f moved the weights by %.3e; expected exact invariance", c, d)
+		}
+	}
+}
+
+// TestUpdateWithAnInformativeScoreVectorDoesMove is the contrast case, and the
+// proof that Update itself is not broken — only its inputs are. Give it a
+// genuinely non-uniform score vector (what the field's doc comment asks for)
+// and the distribution moves in the expected direction.
+func TestUpdateWithAnInformativeScoreVectorDoesMove(t *testing.T) {
+	var sv [NumDims]float64
+	sv[DimHNSW] = 0.9 // this result was carried by semantic similarity
+	sv[DimFTS] = 0.1
+
+	vw := &VaultWeights{Weights: DefaultWeights(), LearningRate: 0.1}
+	before := vw.Weights
+	for i := 0; i < 50; i++ {
+		vw.Update(FeedbackSignal{Accessed: true, ScoreVector: sv, Timestamp: time.Unix(int64(i), 0)})
+	}
+	if vw.Weights[DimHNSW] <= before[DimHNSW] {
+		t.Fatalf("informative positive feedback on DimHNSW did not raise it: %.6f -> %.6f",
+			before[DimHNSW], vw.Weights[DimHNSW])
+	}
+	if vw.Weights[DimHNSW] <= vw.Weights[DimDecay] {
+		t.Errorf("DimHNSW (%.6f) should outrank the untouched DimDecay (%.6f) after 50 positive signals",
+			vw.Weights[DimHNSW], vw.Weights[DimDecay])
+	}
+	t.Logf("with a real score vector the loop DOES learn: DimHNSW %.4f -> %.4f (DimDecay %.4f)",
+		before[DimHNSW], vw.Weights[DimHNSW], vw.Weights[DimDecay])
+}
+
+// TestRepeatedSoftmaxContractsTowardUniform pins fact (3). Update applies
+// Softmax to a vector that is already a probability distribution. Softmax of a
+// distribution is much flatter than the distribution, so every step erodes
+// whatever was learned on previous steps — an informative gradient is fighting
+// its own normalization.
+func TestRepeatedSoftmaxContractsTowardUniform(t *testing.T) {
+	spread := func(w [NumDims]float64) float64 {
+		lo, hi := w[0], w[0]
+		for _, v := range w {
+			if v < lo {
+				lo = v
+			}
+			if v > hi {
+				hi = v
+			}
+		}
+		return hi - lo
+	}
+
+	w := Softmax([NumDims]float64{3, 0, 0, 0, 0, 0}) // a strongly peaked distribution
+	first := spread(w)
+	prev := first
+	for i := 0; i < 10; i++ {
+		w = Softmax(w)
+		s := spread(w)
+		if s >= prev {
+			t.Fatalf("iteration %d: spread did not shrink (%.6f -> %.6f) — Softmax is no longer contracting", i, prev, s)
+		}
+		prev = s
+	}
+	if prev > first/10 {
+		t.Errorf("after 10 re-normalizations the spread is %.6f, only %.1fx smaller than the initial %.6f; "+
+			"expected strong contraction toward uniform", prev, first/prev, first)
+	}
+	t.Logf("re-Softmax contraction: initial spread %.6f -> %.6f after 10 applications", first, prev)
+}
+
+// TestUpdateWithZeroSignalStillContracts is the same defect observed through
+// the public API rather than through Softmax directly: a feedback signal that
+// carries NO information (an all-zero score vector — the gradient is exactly
+// zero) still flattens the learned weights, purely from the re-normalization.
+// Learning decays even when nothing happens.
+func TestUpdateWithZeroSignalStillContracts(t *testing.T) {
+	vw := &VaultWeights{Weights: Softmax([NumDims]float64{3, 0, 0, 0, 0, 0}), LearningRate: 0.1}
+	peakBefore := vw.Weights[0]
+
+	for i := 0; i < 20; i++ {
+		vw.Update(FeedbackSignal{Accessed: true, Timestamp: time.Unix(int64(i), 0)}) // ScoreVector is the zero value
+	}
+
+	if vw.Weights[0] >= peakBefore {
+		t.Fatalf("a zero-information signal did not erode the learned peak (%.6f -> %.6f) — "+
+			"if this now holds, Update stopped re-normalizing an already-normalized vector, which is the fix",
+			peakBefore, vw.Weights[0])
+	}
+	t.Logf("20 zero-information updates eroded the learned peak from %.4f to %.4f", peakBefore, vw.Weights[0])
+}

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -790,7 +790,7 @@ func (ps *PebbleStore) GetReverseAssociations(ctx context.Context, wsPrefix [8]b
 }
 
 // FlagContradiction writes the 0x0A contradiction key for pair (a,b).
-func (ps *PebbleStore) FlagContradiction(ctx context.Context, wsPrefix [8]byte, a, b ULID) error {
+func (ps *PebbleStore) FlagContradiction(ctx context.Context, wsPrefix [8]byte, a, b ULID) (bool, error) {
 	batch := ps.db.NewBatch()
 	defer batch.Close()
 
@@ -813,12 +813,24 @@ func (ps *PebbleStore) FlagContradiction(ctx context.Context, wsPrefix [8]byte, 
 	contraKeyRev := keys.ContradictionKey(wsPrefix, 0, 0, bBytes)
 	batch.Set(contraKeyRev, aBytes[:], nil)
 
+	// Was this pair already flagged? The 0x0A marker is the durable record that
+	// this contradiction is ALREADY KNOWN, and it is what makes the confidence
+	// penalty idempotent: one declared contradiction is one fact, however many
+	// times a worker re-observes the edge. Re-penalising compounds a single
+	// Bayesian update (1.0 -> 0.975 -> 0.797 -> 0.313 -> 0.0709) until BOTH
+	// memories — including the true one — fall out of recall entirely.
+	newlyFlagged := true
+	if _, closer, err := ps.db.Get(contraKey); err == nil {
+		_ = closer.Close()
+		newlyFlagged = false
+	}
+
 	if err := batch.Commit(pebble.NoSync); err != nil {
-		return fmt.Errorf("commit batch: %w", err)
+		return false, fmt.Errorf("commit batch: %w", err)
 	}
 	ps.replicateBatch(batch)
 
-	return nil
+	return newlyFlagged, nil
 }
 
 // ResolveContradiction deletes the contradiction marker(s) for the pair (a,b).

--- a/internal/storage/association_test.go
+++ b/internal/storage/association_test.go
@@ -173,14 +173,14 @@ func TestGetContradictions_WithPairs(t *testing.T) {
 	idC := NewULID()
 
 	// Flag two distinct contradiction pairs.
-	if err := store.FlagContradiction(ctx, ws, idA, idB); err != nil {
+	if _, err := store.FlagContradiction(ctx, ws, idA, idB); err != nil {
 		t.Fatalf("FlagContradiction(A,B): %v", err)
 	}
-	if err := store.FlagContradiction(ctx, ws, idA, idC); err != nil {
+	if _, err := store.FlagContradiction(ctx, ws, idA, idC); err != nil {
 		t.Fatalf("FlagContradiction(A,C): %v", err)
 	}
 	// Flag the same pair again in reverse order — should NOT produce a duplicate.
-	if err := store.FlagContradiction(ctx, ws, idB, idA); err != nil {
+	if _, err := store.FlagContradiction(ctx, ws, idB, idA); err != nil {
 		t.Fatalf("FlagContradiction(B,A): %v", err)
 	}
 
@@ -239,10 +239,10 @@ func TestResolveContradiction(t *testing.T) {
 	idC := NewULID()
 
 	// Flag two pairs.
-	if err := store.FlagContradiction(ctx, ws, idA, idB); err != nil {
+	if _, err := store.FlagContradiction(ctx, ws, idA, idB); err != nil {
 		t.Fatalf("FlagContradiction(A,B): %v", err)
 	}
-	if err := store.FlagContradiction(ctx, ws, idA, idC); err != nil {
+	if _, err := store.FlagContradiction(ctx, ws, idA, idC); err != nil {
 		t.Fatalf("FlagContradiction(A,C): %v", err)
 	}
 
@@ -271,7 +271,7 @@ func TestResolveContradiction_BothDirections(t *testing.T) {
 	idA := NewULID()
 	idB := NewULID()
 
-	if err := store.FlagContradiction(ctx, ws, idA, idB); err != nil {
+	if _, err := store.FlagContradiction(ctx, ws, idA, idB); err != nil {
 		t.Fatalf("FlagContradiction: %v", err)
 	}
 

--- a/internal/storage/impl_test.go
+++ b/internal/storage/impl_test.go
@@ -638,7 +638,7 @@ func TestFlagContradiction(t *testing.T) {
 	}
 
 	// Flag contradiction
-	err = store.FlagContradiction(ctx, ws, id1, id2)
+	_, err = store.FlagContradiction(ctx, ws, id1, id2)
 	if err != nil {
 		t.Fatalf("FlagContradiction: %v", err)
 	}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -156,7 +156,7 @@ type EngineStore interface {
 	GetChildrenByParent(ctx context.Context, wsPrefix [8]byte, parentID ULID) ([]ULID, error)
 
 	// FlagContradiction writes the 0x0A contradiction key for pair (a,b).
-	FlagContradiction(ctx context.Context, wsPrefix [8]byte, a, b ULID) error
+	FlagContradiction(ctx context.Context, wsPrefix [8]byte, a, b ULID) (newlyFlagged bool, err error)
 
 	// GetContradictions returns all contradiction pairs in the vault by scanning the 0x0A prefix.
 	GetContradictions(ctx context.Context, wsPrefix [8]byte) ([][2]ULID, error)


### PR DESCRIPTION
Six defects found by putting the product in front of four AI models as its **actual user** — ~150 live tool calls each, running realistic multi-session workflows rather than reading code. Every fix here was reproduced against a running server before it was written, and verified against one after.

They share one shape: **explicit caller input silently replaced by a default, or an unknown state reported as a known one.**

| the caller said | the system heard | fix |
|---|---|---|
| `as_of: <past date>` | *(nothing — evolved history unreadable)* | `c3b5b60` |
| `muninn_explain(...)` | all components `0`, incl. impossible `confidence:0` | `ff3faef` |
| `muninn_decide(...)` | stored a `fact`; body never stated the decision | `f632952` |
| *(concept stored fine)* | `{"concept":""}` in the response | `361adb2` |
| `muninn start --data /tmp/x` | **opened `~/.muninn/data` — the real vault** | `9b752d6` |
| `link(contradicts)` | both memories deleted from recall | `5493780` **(partial)** |

## The dangerous one

```
muninn start --data /tmp/scratch --mcp-addr 127.0.0.1:9260
```

`runStart` resolves its data dir from `defaultDataDir()` unconditionally and never read `--data`. Every flag was discarded with no error, no warning, nothing in the banner — so this launched a daemon on the operator's **real vault** on the default ports.

Principle #1 violated on the one argument that decides *which database is opened*, with production data as the silent substitute. Found the hard way: an agent building an isolated sandbox used exactly this invocation and ran against the default data dir for ~40s. Nothing was written, by luck rather than design.

Now fails closed and names the invocation that does support those flags. It deliberately does **not** wire the flags up — guessing at which subset to honour is how this bug class is created.

## `as_of` — the headline guarantee was false

`muninn_guide` promises *"it is never destroyed — `as_of` still sees it."* It didn't. The lifecycle cut ran **before** the validity gate, so `evolve`'s own supersession made its own history unreadable — while the code comment directly above described the intended behaviour correctly.

Root-caused with two controls: `forget(not_true_since)` (validity axis fine) and `restore` (makes `as_of` work immediately). Now a soft-deleted engram is admitted only when the caller asked an explicit historical question **and** the record carries a closed `ValidUntil` — the supersession signature. Default recall is unchanged; `PassesValidity` still decides nameability.

Verified live, not just in tests:

```
default recall   → only the current fact
as_of <past>     → the predecessor          ← was broken
include_invalid  → both                     ← was broken
```

**Bonus:** a pre-existing `-race` failure in `applySupersession`, proven pre-existing by stashing all changes and reproducing it at HEAD.

## `muninn_explain` — three root causes

The one tool for debugging *"why didn't my memory come back"* returned zeros unconditionally. Confidence was never plumbed through the adapter; `threshold` was hardcoded `0.0`; and an engram outside the scored set produced a silent zero card. It now reports real numbers, mirrors the real recall bar, and — importantly — every component is a `*float64`, so **not computed serialises as `null`, never `0`**. An evaluator noted: *"had this worked, I would have found the confidence-collapse bug in one call instead of thirty."*

## Contradiction data loss — PARTIAL, do not read as fixed

Linking two memories `contradicts` in both directions collapses confidence on **both** — `1.0 → 0.797 → 0.313 → 0.0709` — and both vanish from recall. The correct memory is punished exactly as hard as the false one.

Root cause: one declared fact treated as N independent Bayesian observations. This PR makes the penalty idempotent per pair (`FlagContradiction` now reports newness through storage → interface → adapter → worker), which raises the floor `0.0709 → 0.313` — but **recall still returns 0**. A second submitter exists on the write path. The commit message says so plainly.

Two deeper problems are recorded but not addressed here: penalising *both* sides is incoherent (at most one is wrong), and confidence should not silently gate visibility.

## Also included

- **`docs/internals/agent-experience-findings.md`** — the full evaluation record: what four models praised unprompted, eight confirmed defects, **three refuted claims**, and the design splits.
- **A traced scoring path + measurement harness** (`ada475e`, `5f8ac60`). Notable findings: the per-vault learned weight loop is *mathematically incapable of learning* (constant `ScoreVector`; 500 updates move weights `<1e-12`; re-softmax collapses any peak to uniform in 10 steps), and `0.6/0.4` was introduced as "proven optimal" with **no derivation recorded** — the pattern principle #11 forbids. No scoring behaviour was changed; the harness exists so it can be changed on evidence.
- **The counterfactual result**: 5× the graph substrate bought **zero** additional associative-surprise fires on 27,255 real edges. The feature is over-gated, not substrate-starved. This refutes a hypothesis stated confidently earlier in the investigation.

## Verification

- **RED-first throughout**, with RED-sanity shown both ways where the test can prove the wiring. Where it can't — `checkStartArgs` is exercised directly and passes with the call site removed — the commit says so and records the live binary check instead of claiming coverage it doesn't have.
- `go build` / `go vet -tags localassets ./...` clean, `gofmt -l` empty, `go test -tags localassets ./cmd/... ./internal/...` green.
- Live end-to-end verification against sandbox daemons on non-default ports; `~/.muninn` never touched.
- Privacy: synthetic fixtures only; every agent grepped its own diff. No real memory content, concept, tag, entity name, or vault name appears anywhere in the diff or the docs.
