### PR TITLE
fix(engine): declaring a contradiction no longer destroys both memories

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2891,7 +2891,7 @@ func (e *Engine) Link(ctx context.Context, req *mbp.LinkRequest) (*mbp.LinkRespo
 	// When a "contradicts" link is explicitly created via Link(), notify the
 	// ContradictWorker so it can flag the pair and drive confidence updates.
 	if storage.RelType(req.RelType) == storage.RelContradicts {
-		_, linkContra, linkConf := e.cogWorkers()
+		_, linkContra, _ := e.cogWorkers()
 		if linkContra != nil {
 			linkContra.Submit(cognitive.ContradictItem{
 				WS:          wsPrefix,
@@ -2933,22 +2933,21 @@ func (e *Engine) Link(ctx context.Context, req *mbp.LinkRequest) (*mbp.LinkRespo
 				},
 			})
 		}
-		// Also directly flag the pair and update confidence without waiting for
-		// ContradictWorker's batch processing — direct link is an explicit assertion.
-		if linkConf != nil {
-			linkConf.Submit(cognitive.ConfidenceUpdate{
-				WS:       wsPrefix,
-				EngramID: [16]byte(sourceID),
-				Evidence: cognitive.EvidenceContradiction,
-				Source:   "contradiction_detected",
-			})
-			linkConf.Submit(cognitive.ConfidenceUpdate{
-				WS:       wsPrefix,
-				EngramID: [16]byte(targetID),
-				Evidence: cognitive.EvidenceContradiction,
-				Source:   "contradiction_detected",
-			})
-		}
+		// The confidence penalty is applied ONLY by the ContradictWorker's OnFound
+		// callback above, which fires exactly once per pair (the 0x0A marker makes
+		// it idempotent). A second, unconditional submit used to live here to
+		// avoid waiting for the batch worker — but it bypassed that idempotency
+		// and applied the SAME evidence a second time. BayesianUpdate compounds
+		// repeat applications, so an explicit link cost two updates instead of
+		// one, and linking both directions (the natural thing for an agent to do)
+		// drove BOTH engrams 1.0 -> 0.975 -> 0.797 -> 0.313 -> 0.0709. Confidence
+		// multiplies into the recall score, so both memories — including the TRUE
+		// one, penalised exactly as hard as the false one — silently vanished from
+		// recall. Declaring a contradiction was a data-loss operation.
+		//
+		// The penalty is now delayed by up to one worker interval. That is the
+		// correct trade: a slightly late annotation beats a promptly destroyed
+		// memory.
 	}
 
 	return &mbp.LinkResponse{OK: true}, nil


### PR DESCRIPTION
## The bug

`muninn_link(relation="contradicts")` applied the confidence penalty **twice**:

1. inside the `ContradictWorker`'s `OnFound` callback — idempotent per pair since #746, and
2. **directly and unconditionally** in `Link` itself.

The direct submit was a shortcut for immediacy (*"without waiting for ContradictWorker's batch processing — direct link is an explicit assertion"*), and it bypassed that idempotency entirely.

`BayesianUpdate` compounds repeat applications of the **same** evidence, so one link cost two updates and linking both directions — the natural thing for an agent to do — cost four:

```
1.0 → 0.975 → 0.797 → 0.313 → 0.0709   (floor)
```

Confidence multiplies into the recall score, so **both memories fell below any usable threshold and disappeared** — the *true* memory penalised exactly as hard as the false one, with no annotation, no notice, and `muninn_contradictions` returning `[]` for the first 30 seconds.

**Recording a contradiction was a data-loss operation, reached by doing the right thing.** Declarations are the scarcest resource in this system — 0.135% of association edges are agent-authored — so a declaration that destroys data is worse than no declaration at all.

## Measured end-to-end

Two opposing memories, linked `contradicts` in **both** directions — the exact sequence that destroyed them:

| | before | after |
|---|---|---|
| confidence (both memories) | **0.0709** | **0.975**, stable |
| `recall` returns | **0** | **2** |
| contradiction flagged | yes | yes |

Both survive, both stay retrievable, the contradiction is still recorded, and repeat links now cost nothing.

## Diagnosis was instrumented, not guessed

Tagging both `OnFound` sites and logging every confidence application showed **one** detection, **one** `OnFound`, **one** newly-flagged pair — but **four** confidence applications. That discrepancy is what located the unconditional second submitter; a search for "the second detector" would not have found it, because there isn't one.

## The trade

The penalty now arrives up to one worker interval later. That is the correct trade: a slightly late annotation beats a promptly destroyed memory.

## What this does NOT fix

Two deeper problems are recorded in `docs/internals/agent-experience-findings.md` and deliberately left alone:

- **Penalising both sides is incoherent.** When A and B contradict, at most one is wrong. Halving confidence in both is not Bayesian evidence, it is a tax on honesty — a contradiction should mark a *conflict*, not degrade *truth*.
- **Confidence should not silently gate visibility.** Multiplying a "there is a dispute here" signal into the recall score turns an annotation into a deletion. This PR stops the deletion; it does not remove the mechanism that made deletion possible.

## Verification

- Live end-to-end against a sandbox daemon on non-default ports (numbers above); `~/.muninn` never touched.
- `go build` / `go vet -tags localassets ./...` clean, `gofmt -l` empty, full `go test -tags localassets ./internal/... ./cmd/...` green.
- **Test-coverage caveat, stated rather than overclaimed:** worker timing makes a hermetic unit test for this unreliable, so the proof is the live run plus the existing per-pair idempotency tests from #746. A timing-dependent test that passed both ways would prove nothing.
