### PR TITLE
fix(cli): keep the outgoing binary and surface the release's upgrade note (#600)

### DIFF
--- a/cmd/muninn/coverage_hardening_test.go
+++ b/cmd/muninn/coverage_hardening_test.go
@@ -2086,13 +2086,13 @@ func TestConfigureTools_Windsurf_Path(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// upgrade.go: runUpgrade with injected latestVersionFn
+// upgrade.go: runUpgrade with injected latestReleaseFn
 // ---------------------------------------------------------------------------
 
 func TestRunUpgrade_SkipsDevBuild(t *testing.T) {
-	old := latestVersionFn
-	latestVersionFn = func() (string, error) { return "", nil }
-	defer func() { latestVersionFn = old }()
+	old := latestReleaseFn
+	latestReleaseFn = func() (releaseInfo, error) { return releaseInfo{}, nil }
+	defer func() { latestReleaseFn = old }()
 
 	out := captureStdout(func() {
 		runUpgrade([]string{})
@@ -2103,9 +2103,9 @@ func TestRunUpgrade_SkipsDevBuild(t *testing.T) {
 }
 
 func TestRunUpgrade_UpToDate_Injected(t *testing.T) {
-	old := latestVersionFn
-	latestVersionFn = func() (string, error) { return "v0.0.1", nil }
-	defer func() { latestVersionFn = old }()
+	old := latestReleaseFn
+	latestReleaseFn = func() (releaseInfo, error) { return releaseInfo{TagName: "v0.0.1"}, nil }
+	defer func() { latestReleaseFn = old }()
 
 	out := captureStdout(func() {
 		runUpgrade([]string{})
@@ -2116,9 +2116,9 @@ func TestRunUpgrade_UpToDate_Injected(t *testing.T) {
 }
 
 func TestRunUpgrade_NetworkError(t *testing.T) {
-	old := latestVersionFn
-	latestVersionFn = func() (string, error) { return "", fmt.Errorf("network down") }
-	defer func() { latestVersionFn = old }()
+	old := latestReleaseFn
+	latestReleaseFn = func() (releaseInfo, error) { return releaseInfo{}, fmt.Errorf("network down") }
+	defer func() { latestReleaseFn = old }()
 
 	oldExit := osExit
 	osExit = func(c int) {}
@@ -2133,17 +2133,17 @@ func TestRunUpgrade_NetworkError(t *testing.T) {
 }
 
 func TestLatestVersionDefault_Dev(t *testing.T) {
-	v, err := latestVersionDefault()
+	rel, err := latestReleaseDefault()
 	if err != nil {
 		t.Skipf("network error: %v", err)
 	}
-	_ = v
+	_ = rel
 }
 
 func TestCheckVersionHint_WithUpdate(t *testing.T) {
-	old := latestVersionFn
-	latestVersionFn = func() (string, error) { return "", nil }
-	defer func() { latestVersionFn = old }()
+	old := latestReleaseFn
+	latestReleaseFn = func() (releaseInfo, error) { return releaseInfo{}, nil }
+	defer func() { latestReleaseFn = old }()
 
 	out := captureStdout(func() {
 		checkVersionHint()
@@ -2157,7 +2157,7 @@ func TestCheckVersionHint_WithUpdate(t *testing.T) {
 
 func TestPrintStatusDisplay_Running(t *testing.T) {
 	old := probeServicesFn
-	latestOld := latestVersionFn
+	latestOld := latestReleaseFn
 	probeServicesFn = func() []serviceStatus {
 		return []serviceStatus{
 			{name: "database", port: 8475, up: true},
@@ -2165,8 +2165,8 @@ func TestPrintStatusDisplay_Running(t *testing.T) {
 			{name: "web ui", port: 8476, up: true},
 		}
 	}
-	latestVersionFn = func() (string, error) { return "", nil }
-	defer func() { probeServicesFn = old; latestVersionFn = latestOld }()
+	latestReleaseFn = func() (releaseInfo, error) { return releaseInfo{}, nil }
+	defer func() { probeServicesFn = old; latestReleaseFn = latestOld }()
 
 	out := captureStdout(func() {
 		state := printStatusDisplay(false)
@@ -2257,7 +2257,7 @@ func TestPrintStatusDisplay_DegradedMCPDown(t *testing.T) {
 
 func TestRunStatus_Running(t *testing.T) {
 	old := probeServicesFn
-	latestOld := latestVersionFn
+	latestOld := latestReleaseFn
 	probeServicesFn = func() []serviceStatus {
 		return []serviceStatus{
 			{name: "database", port: 8475, up: true},
@@ -2265,8 +2265,8 @@ func TestRunStatus_Running(t *testing.T) {
 			{name: "web ui", port: 8476, up: true},
 		}
 	}
-	latestVersionFn = func() (string, error) { return "", nil }
-	defer func() { probeServicesFn = old; latestVersionFn = latestOld }()
+	latestReleaseFn = func() (releaseInfo, error) { return releaseInfo{}, nil }
+	defer func() { probeServicesFn = old; latestReleaseFn = latestOld }()
 
 	out := captureStdout(func() {
 		runStatus()

--- a/cmd/muninn/upgrade.go
+++ b/cmd/muninn/upgrade.go
@@ -21,32 +21,46 @@ import (
 
 const githubReleaseAPI = "https://api.github.com/repos/scrypster/muninndb/releases/latest"
 
-// latestVersionFn is the function that fetches the latest version. Tests override it.
-var latestVersionFn = latestVersionDefault
+// releaseInfo is the part of the GitHub release payload the upgrade flow reads.
+// Body is the release notes markdown, which is where an upgrade note lives.
+type releaseInfo struct {
+	TagName string `json:"tag_name"`
+	Body    string `json:"body"`
+}
 
-// latestVersion delegates to latestVersionFn for testability.
-func latestVersion() (string, error) { return latestVersionFn() }
+// latestReleaseFn is the function that fetches the latest release. Tests override it.
+var latestReleaseFn = latestReleaseDefault
 
-// latestVersionDefault hits the GitHub releases API and returns the latest tag (e.g. "v1.2.3").
-// Returns ("", nil) if the current version is "dev" (dev build — skip check).
-// Returns ("", err) on network failure — callers should treat this as non-fatal.
-func latestVersionDefault() (string, error) {
+// latestRelease delegates to latestReleaseFn for testability.
+func latestRelease() (releaseInfo, error) { return latestReleaseFn() }
+
+// latestVersion returns just the tag of the latest release, for callers that do not
+// need the notes (status.go's version hint).
+func latestVersion() (string, error) {
+	rel, err := latestRelease()
+	return rel.TagName, err
+}
+
+// latestReleaseDefault hits the GitHub releases API and returns the latest release.
+// Returns a zero releaseInfo if the current version is "dev" (dev build — skip check).
+// Returns an error on network failure — callers should treat this as non-fatal.
+func latestReleaseDefault() (releaseInfo, error) {
 	if muninnVersion() == "dev" {
-		return "", nil
+		return releaseInfo{}, nil
 	}
 	client := &http.Client{Timeout: 3 * time.Second}
 	resp, err := client.Get(githubReleaseAPI)
 	if err != nil {
-		return "", err
+		return releaseInfo{}, err
 	}
 	defer resp.Body.Close()
-	var release struct {
-		TagName string `json:"tag_name"`
+	var release releaseInfo
+	// Cap the read: release notes are prose, and a misrouted or hostile response
+	// should not be able to exhaust memory on what is only a version check.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&release); err != nil {
+		return releaseInfo{}, err
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return "", err
-	}
-	return release.TagName, nil
+	return release, nil
 }
 
 // parseSemver parses "vX.Y.Z" or "X.Y.Z" into (major, minor, patch) ints.
@@ -96,6 +110,93 @@ func newerVersionAvailable(current, latest string) bool {
 	return latPat > curPat
 }
 
+// upgradeNoteMarker is the phrase that introduces an operator-facing upgrade note in
+// the release body. CHANGELOG.md and the GitHub releases use the same convention:
+// a blockquote whose first line bolds "Upgrade note", e.g. v0.9.0's one-time on-disk
+// migration ("> **Upgrade note — on-disk migration.** ... back up your data directory").
+const upgradeNoteMarker = "upgrade note"
+
+// upgradeNote extracts that blockquote from a release body and returns it as plain
+// text, or "" when the release carries no such note.
+//
+// It is deliberately quiet about anything it does not recognise. A release whose notes
+// are shaped differently must still be installable — this reads the notes to inform the
+// operator, so a parsing miss may cost a warning but must never cost an upgrade.
+func upgradeNote(body string) string {
+	lines := strings.Split(strings.ReplaceAll(body, "\r\n", "\n"), "\n")
+	start := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, ">") {
+			continue
+		}
+		if strings.Contains(strings.ToLower(trimmed), upgradeNoteMarker) {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return ""
+	}
+
+	var parts []string
+	for _, line := range lines[start:] {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, ">") {
+			break // end of the blockquote
+		}
+		text := strings.TrimSpace(strings.TrimPrefix(trimmed, ">"))
+		if text == "" {
+			// A bare ">" separates paragraphs inside one blockquote; keep the break.
+			parts = append(parts, "")
+			continue
+		}
+		parts = append(parts, text)
+	}
+
+	note := strings.TrimSpace(stripMarkdownEmphasis(strings.Join(parts, " ")))
+	// Collapse the whitespace introduced by joining, and the blank-line markers.
+	note = strings.Join(strings.Fields(note), " ")
+	const maxNoteLen = 1200
+	if len(note) > maxNoteLen {
+		note = note[:maxNoteLen] + "..."
+	}
+	return note
+}
+
+// stripMarkdownEmphasis removes the ** and * emphasis markers that survive a
+// blockquote, so the note reads as plain text in a terminal.
+func stripMarkdownEmphasis(s string) string {
+	s = strings.ReplaceAll(s, "**", "")
+	s = strings.ReplaceAll(s, "`", "")
+	return s
+}
+
+// wrapText breaks s into lines of at most width columns, splitting on spaces.
+// A single word longer than width gets its own (over-long) line rather than being cut.
+func wrapText(s string, width int) []string {
+	words := strings.Fields(s)
+	if len(words) == 0 {
+		return nil
+	}
+	var (
+		lines []string
+		cur   string
+	)
+	for _, w := range words {
+		switch {
+		case cur == "":
+			cur = w
+		case len(cur)+1+len(w) <= width:
+			cur += " " + w
+		default:
+			lines = append(lines, cur)
+			cur = w
+		}
+	}
+	return append(lines, cur)
+}
+
 // runUpgrade is the entry point for `muninn upgrade`.
 // Flags:
 //
@@ -127,7 +228,7 @@ func runUpgrade(args []string) {
 
 	fmt.Print("  Checking for updates...")
 
-	latest, err := latestVersion()
+	release, err := latestRelease()
 	if err != nil {
 		fmt.Println(" failed")
 		fmt.Fprintln(os.Stderr, "")
@@ -136,6 +237,7 @@ func runUpgrade(args []string) {
 		fmt.Fprintln(os.Stderr, "")
 		return
 	}
+	latest := release.TagName
 	if latest == "" {
 		fmt.Println(" skipped")
 		fmt.Println()
@@ -161,6 +263,21 @@ func runUpgrade(args []string) {
 	fmt.Println()
 	fmt.Printf("  Release notes → github.com/scrypster/muninndb/releases/tag/%s\n", latest)
 	fmt.Println()
+
+	// Surface the release's own upgrade note before the operator is asked to confirm.
+	// A release that needs a manual step (v0.9.0: back up the data directory before a
+	// one-way on-disk migration) says so in its notes, and this is the one moment the
+	// upgrade path has the operator's attention. Printed for --check too, so a
+	// scripted check surfaces it as well.
+	if note := upgradeNote(release.Body); note != "" {
+		fmt.Println("  ⚠  Upgrade note for this release:")
+		fmt.Println()
+		for _, line := range wrapText(note, 66) {
+			fmt.Printf("     %s\n", line)
+		}
+		fmt.Println()
+	}
+
 	fmt.Println("  ────────────────────────────────────────────────────")
 	fmt.Println()
 
@@ -554,8 +671,79 @@ func isDaemonRunning() bool {
 	return isProcessRunning(pid)
 }
 
+// backupBinaryPath returns where the outgoing binary is kept, e.g.
+// "/usr/local/bin/muninn.v0.9.0.bak". The version is sanitized because it becomes a
+// path component and is only as trustworthy as the -ldflags that stamped it.
+func backupBinaryPath(exe, version string) string {
+	safe := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '.', r == '-', r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, version)
+	// Separators are already gone, so the path cannot leave the executable's
+	// directory — but collapse dot runs anyway so the name can never read as a
+	// traversal, and trim the edges so it cannot start a hidden file.
+	for strings.Contains(safe, "..") {
+		safe = strings.ReplaceAll(safe, "..", ".")
+	}
+	safe = strings.Trim(safe, ".-")
+	if safe == "" {
+		safe = "previous"
+	}
+	return exe + "." + safe + ".bak"
+}
+
+// preserveBinary keeps the outgoing binary at bak before the new one is installed.
+//
+// It links rather than moves, so exe never stops existing: the install step replaces
+// exe's directory entry while the link keeps the old inode reachable. A move would
+// open a window in which a concurrent `muninn` invocation finds nothing at exe, and
+// would leave the machine with no binary at all if the install then failed.
+func preserveBinary(exe, bak string) error {
+	// An existing .bak here is this same version's, left by an earlier attempt at this
+	// upgrade — same bytes, nothing to lose by replacing it.
+	if err := os.Remove(bak); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("clear previous rollback binary %s: %w", bak, err)
+	}
+	if err := os.Link(exe, bak); err == nil {
+		return nil
+	}
+	// Filesystems that do not support hard links still get a rollback artifact.
+	return copyExecutable(exe, bak)
+}
+
+// copyExecutable copies src to dst with executable permissions, syncing before close
+// so the rollback binary is durable by the time the original is replaced.
+func copyExecutable(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(dst)
+		return err
+	}
+	if err := out.Sync(); err != nil {
+		out.Close()
+		os.Remove(dst)
+		return err
+	}
+	return out.Close()
+}
+
 // selfUpdate performs the atomic binary self-replacement for curl/manual installs.
-// Sequence: stop daemon → download → verify → chmod → rename → restart.
+// Sequence: stop daemon → download → verify → preserve old binary → rename → restart.
 func selfUpdate(latest string) error {
 	goos := runtime.GOOS
 	goarch := runtime.GOARCH
@@ -670,12 +858,25 @@ func selfUpdate(latest string) error {
 		return err
 	}
 
+	// Keep the outgoing binary. Without it, backing out a bad upgrade means
+	// re-downloading the previous release — from a machine whose muninn is already
+	// broken, at the moment its operator least wants a network dependency.
+	bakPath := backupBinaryPath(exe, muninnVersion())
+	if err := upgradeStep("Keeping rollback copy...", func() error {
+		return preserveBinary(exe, bakPath)
+	}); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+
 	if err := upgradeStep("Installing...", func() error {
 		return os.Rename(tmpPath, exe)
 	}); err != nil {
 		os.Remove(tmpPath)
 		return err
 	}
+
+	fmt.Printf("  %-28s%s\n", "Previous binary:", bakPath)
 
 	// Restart daemon if it was running before
 	if daemonWasRunning {

--- a/cmd/muninn/upgrade_note_test.go
+++ b/cmd/muninn/upgrade_note_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The shape v0.9.0 actually shipped: a blockquote introduced by a bolded
+// "Upgrade note", carrying the one manual step the release requires.
+const v090ReleaseBody = `Adds an agent-oriented credential and multi-agent workflow layer (capability
+tokens and self-provisioned workflow vaults), a ` + "`working`" + ` plasticity preset.
+
+> **Upgrade note — on-disk migration.** This release relocates the auth
+> subsystem's internal Pebble key prefixes to resolve a latent collision with
+> storage keys (#611). A one-time v3 migration rewrites existing admin-user,
+> API-key, and vault-config records on the first start after upgrade. It is
+> idempotent and crash-safe, but **back up your data directory before
+> upgrading**, as with any storage-format change.
+
+### Added
+
+- Capability tokens and agent-provisioned workflow vaults.
+`
+
+func TestUpgradeNote_ExtractsReleaseUpgradeNote(t *testing.T) {
+	note := upgradeNote(v090ReleaseBody)
+	if note == "" {
+		t.Fatal("upgrade note not found in a release body that carries one")
+	}
+	// The operator-actionable sentence is the whole point of surfacing this.
+	if !strings.Contains(note, "back up your data directory before upgrading") {
+		t.Errorf("note lost the actionable instruction: %q", note)
+	}
+	if !strings.Contains(note, "on-disk migration") {
+		t.Errorf("note lost its subject: %q", note)
+	}
+	// Markdown emphasis must not survive into terminal output.
+	if strings.Contains(note, "**") || strings.Contains(note, "`") {
+		t.Errorf("markdown markers leaked into the rendered note: %q", note)
+	}
+	// The blockquote ends before the "### Added" section.
+	if strings.Contains(note, "Capability tokens") || strings.Contains(note, "Added") {
+		t.Errorf("note ran past the end of the blockquote: %q", note)
+	}
+	// Prose above the blockquote is not part of the note.
+	if strings.Contains(note, "plasticity preset") {
+		t.Errorf("note picked up body text before the blockquote: %q", note)
+	}
+}
+
+func TestUpgradeNote_AbsentWhenReleaseHasNone(t *testing.T) {
+	body := `### Added
+
+- A thing.
+
+### Fixed
+
+- Another thing.
+`
+	if note := upgradeNote(body); note != "" {
+		t.Errorf("upgradeNote = %q, want empty for a release with no note", note)
+	}
+}
+
+func TestUpgradeNote_IgnoresThePhraseOutsideABlockquote(t *testing.T) {
+	// "upgrade note" appearing in ordinary prose must not be mistaken for one:
+	// the convention is a blockquote, and firing on loose prose would print
+	// arbitrary release text as though it were an operator instruction.
+	body := `This release has no upgrade note, so just install it.
+
+### Added
+- A thing.
+`
+	if note := upgradeNote(body); note != "" {
+		t.Errorf("upgradeNote = %q, want empty when the phrase is not in a blockquote", note)
+	}
+}
+
+// Prose that mentions the phrase before the real blockquote must not become the
+// match: anchoring on the first textual hit instead of the first blockquote hit
+// silently loses the actual note, which is the failure that matters here.
+func TestUpgradeNote_FindsTheBlockquoteWhenProseMentionsItFirst(t *testing.T) {
+	body := `Please read the upgrade note before installing this release.
+
+> **Upgrade note — on-disk migration.** Back up your data directory first.
+
+### Added
+- A thing.
+`
+	note := upgradeNote(body)
+	if !strings.Contains(note, "Back up your data directory first.") {
+		t.Errorf("the real note was missed because prose matched first: %q", note)
+	}
+	if strings.Contains(note, "Please read") {
+		t.Errorf("note anchored on the prose line: %q", note)
+	}
+}
+
+func TestUpgradeNote_IgnoresUnrelatedBlockquote(t *testing.T) {
+	body := `> **Note.** Nothing special about this release.
+
+### Added
+- A thing.
+`
+	if note := upgradeNote(body); note != "" {
+		t.Errorf("upgradeNote = %q, want empty for a blockquote that is not an upgrade note", note)
+	}
+}
+
+func TestUpgradeNote_JoinsMultipleBlockquoteParagraphs(t *testing.T) {
+	body := `> **Upgrade note.** First paragraph.
+>
+> Second paragraph.
+
+Not part of it.
+`
+	note := upgradeNote(body)
+	if !strings.Contains(note, "First paragraph.") || !strings.Contains(note, "Second paragraph.") {
+		t.Errorf("note dropped a paragraph: %q", note)
+	}
+	if strings.Contains(note, "Not part of it") {
+		t.Errorf("note ran past the blockquote: %q", note)
+	}
+}
+
+func TestUpgradeNote_HandlesCRLF(t *testing.T) {
+	body := strings.ReplaceAll("> **Upgrade note.** Back up first.\r\n\r\n### Added\r\n", "\n", "\n")
+	note := upgradeNote(body)
+	if !strings.Contains(note, "Back up first.") {
+		t.Errorf("CRLF body yielded %q", note)
+	}
+	if strings.Contains(note, "\r") {
+		t.Errorf("carriage return survived into the note: %q", note)
+	}
+}
+
+func TestUpgradeNote_TruncatesRunawayNote(t *testing.T) {
+	body := "> **Upgrade note.** " + strings.Repeat("word ", 2000)
+	note := upgradeNote(body)
+	if len(note) > 1210 {
+		t.Errorf("note length = %d, want it capped near 1200", len(note))
+	}
+	if !strings.HasSuffix(note, "...") {
+		t.Errorf("truncated note should be marked with an ellipsis: %q", note[max(0, len(note)-20):])
+	}
+}
+
+func TestUpgradeNote_EmptyBody(t *testing.T) {
+	if note := upgradeNote(""); note != "" {
+		t.Errorf("upgradeNote(\"\") = %q, want empty", note)
+	}
+}
+
+func TestWrapText_RespectsWidth(t *testing.T) {
+	lines := wrapText("the quick brown fox jumps over the lazy dog", 12)
+	if len(lines) < 2 {
+		t.Fatalf("expected the text to wrap, got %d line(s)", len(lines))
+	}
+	for _, l := range lines {
+		if len(l) > 12 {
+			t.Errorf("line exceeds width: %q (%d)", l, len(l))
+		}
+	}
+	if got := strings.Join(lines, " "); got != "the quick brown fox jumps over the lazy dog" {
+		t.Errorf("wrapping changed the text: %q", got)
+	}
+}
+
+func TestWrapText_DoesNotSplitAnOverlongWord(t *testing.T) {
+	long := strings.Repeat("x", 40)
+	lines := wrapText(long, 10)
+	if len(lines) != 1 || lines[0] != long {
+		t.Errorf("an over-long word must be emitted whole, got %v", lines)
+	}
+}
+
+func TestWrapText_Empty(t *testing.T) {
+	if lines := wrapText("   ", 10); lines != nil {
+		t.Errorf("wrapText(blank) = %v, want nil", lines)
+	}
+}
+
+// End-to-end: an operator running `muninn upgrade --check` against a release that
+// carries an upgrade note must see the note itself, not just a link to it.
+func TestRunUpgrade_PrintsUpgradeNote(t *testing.T) {
+	oldVersion := version
+	version = "v0.8.0"
+	defer func() { version = oldVersion }()
+
+	oldFn := latestReleaseFn
+	latestReleaseFn = func() (releaseInfo, error) {
+		return releaseInfo{TagName: "v0.9.0", Body: v090ReleaseBody}, nil
+	}
+	defer func() { latestReleaseFn = oldFn }()
+
+	oldExit := osExit
+	osExit = func(int) {}
+	defer func() { osExit = oldExit }()
+
+	out := captureStdout(func() { runUpgrade([]string{"--check"}) })
+
+	if !strings.Contains(out, "Upgrade note for this release") {
+		t.Errorf("upgrade note header missing from output:\n%s", out)
+	}
+	if !strings.Contains(out, "back up your data directory") {
+		t.Errorf("the actionable instruction never reached the operator:\n%s", out)
+	}
+}
+
+func TestRunUpgrade_NoNoteHeaderWhenReleaseHasNone(t *testing.T) {
+	oldVersion := version
+	version = "v0.8.0"
+	defer func() { version = oldVersion }()
+
+	oldFn := latestReleaseFn
+	latestReleaseFn = func() (releaseInfo, error) {
+		return releaseInfo{TagName: "v0.9.0", Body: "### Added\n\n- A thing.\n"}, nil
+	}
+	defer func() { latestReleaseFn = oldFn }()
+
+	oldExit := osExit
+	osExit = func(int) {}
+	defer func() { osExit = oldExit }()
+
+	out := captureStdout(func() { runUpgrade([]string{"--check"}) })
+
+	if strings.Contains(out, "Upgrade note") {
+		t.Errorf("printed an upgrade-note header for a release with no note:\n%s", out)
+	}
+}

--- a/cmd/muninn/upgrade_preserve_test.go
+++ b/cmd/muninn/upgrade_preserve_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBackupBinaryPath_NamesByVersion(t *testing.T) {
+	got := backupBinaryPath("/usr/local/bin/muninn", "v0.9.0")
+	want := "/usr/local/bin/muninn.v0.9.0.bak"
+	if got != want {
+		t.Errorf("backupBinaryPath = %q, want %q", got, want)
+	}
+}
+
+func TestBackupBinaryPath_SanitizesVersion(t *testing.T) {
+	// The version is stamped in by -ldflags at build time, so it is only as
+	// trustworthy as whoever built the binary. It must not be able to steer the
+	// backup out of the executable's own directory.
+	//
+	// The exe path is built with filepath rather than written as a literal so the
+	// assertions hold on Windows too, where filepath.Dir normalizes to backslashes
+	// and would not equal a hardcoded "/usr/local/bin".
+	exe := filepath.Join(string(filepath.Separator), "usr", "local", "bin", "muninn")
+	got := backupBinaryPath(exe, "../../etc/cron.d/x")
+
+	if filepath.Dir(got) != filepath.Dir(exe) {
+		t.Errorf("backup escaped the binary's directory: %q (want it in %q)",
+			got, filepath.Dir(exe))
+	}
+	if base := filepath.Base(got); strings.Contains(base, "..") {
+		t.Errorf("a traversal token survived sanitization: %q", base)
+	}
+}
+
+func TestBackupBinaryPath_EmptyVersion(t *testing.T) {
+	got := backupBinaryPath("/usr/local/bin/muninn", "")
+	if got != "/usr/local/bin/muninn.previous.bak" {
+		t.Errorf("backupBinaryPath with empty version = %q", got)
+	}
+}
+
+// The invariant that decides link-vs-move: after the outgoing binary is preserved,
+// it must still be at its own path. A move would leave a window in which the machine
+// has no muninn at all — and no binary whatsoever if the install then failed.
+func TestPreserveBinary_LeavesOriginalInPlace(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "muninn")
+	if err := os.WriteFile(exe, []byte("OLD BINARY"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	bak := backupBinaryPath(exe, "v0.9.0")
+
+	if err := preserveBinary(exe, bak); err != nil {
+		t.Fatalf("preserveBinary: %v", err)
+	}
+
+	orig, err := os.ReadFile(exe)
+	if err != nil {
+		t.Fatalf("original binary is gone after preserve: %v", err)
+	}
+	if string(orig) != "OLD BINARY" {
+		t.Errorf("original content changed: %q", orig)
+	}
+	saved, err := os.ReadFile(bak)
+	if err != nil {
+		t.Fatalf("rollback copy missing: %v", err)
+	}
+	if string(saved) != "OLD BINARY" {
+		t.Errorf("rollback copy content = %q, want the outgoing binary", saved)
+	}
+}
+
+// The reason the rollback copy exists: it must still hold the old bytes after the
+// new binary has replaced the original, which is what makes it a rollback path.
+func TestPreserveBinary_SurvivesTheInstallRename(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "muninn")
+	if err := os.WriteFile(exe, []byte("OLD BINARY"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	bak := backupBinaryPath(exe, "v0.9.0")
+	if err := preserveBinary(exe, bak); err != nil {
+		t.Fatalf("preserveBinary: %v", err)
+	}
+
+	// Mirror selfUpdate's install step: rename the downloaded binary over the old one.
+	incoming := filepath.Join(dir, ".muninn-upgrade-tmp")
+	if err := os.WriteFile(incoming, []byte("NEW BINARY"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(incoming, exe); err != nil {
+		t.Fatal(err)
+	}
+
+	saved, err := os.ReadFile(bak)
+	if err != nil {
+		t.Fatalf("rollback copy missing after install: %v", err)
+	}
+	if string(saved) != "OLD BINARY" {
+		t.Errorf("rollback copy = %q, want the pre-upgrade binary", saved)
+	}
+	installed, err := os.ReadFile(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(installed) != "NEW BINARY" {
+		t.Errorf("installed binary = %q, want the new one", installed)
+	}
+}
+
+// A retried upgrade must not fail because the previous attempt already left a .bak.
+// os.Link refuses an existing destination, so this covers the clear-first step.
+func TestPreserveBinary_ReplacesStaleBackup(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "muninn")
+	if err := os.WriteFile(exe, []byte("OLD BINARY"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	bak := backupBinaryPath(exe, "v0.9.0")
+	if err := os.WriteFile(bak, []byte("STALE"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := preserveBinary(exe, bak); err != nil {
+		t.Fatalf("preserveBinary over an existing backup: %v", err)
+	}
+	saved, err := os.ReadFile(bak)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(saved) != "OLD BINARY" {
+		t.Errorf("stale backup was not replaced: %q", saved)
+	}
+}
+
+func TestCopyExecutable_ProducesAnExecutableCopy(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "muninn")
+	dst := filepath.Join(dir, "muninn.bak")
+	if err := os.WriteFile(src, []byte("OLD BINARY"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyExecutable(src, dst); err != nil {
+		t.Fatalf("copyExecutable: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "OLD BINARY" {
+		t.Errorf("copy content = %q", got)
+	}
+	if runtime.GOOS != "windows" {
+		fi, err := os.Stat(dst)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Mode()&0111 == 0 {
+			// A non-executable rollback copy cannot be rolled back to.
+			t.Errorf("copy is not executable: mode %v", fi.Mode())
+		}
+	}
+}
+
+func TestPreserveBinary_ReportsAnUnreadableSource(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "does-not-exist")
+	bak := backupBinaryPath(exe, "v0.9.0")
+
+	if err := preserveBinary(exe, bak); err == nil {
+		t.Error("preserveBinary succeeded with no source binary; the upgrade would " +
+			"proceed believing it had a rollback path")
+	}
+}

--- a/cmd/muninn/upgrade_test.go
+++ b/cmd/muninn/upgrade_test.go
@@ -356,9 +356,9 @@ func TestVerifyBinary_NotExist(t *testing.T) {
 }
 
 func TestRunUpgrade_AlreadyUpToDate(t *testing.T) {
-	orig := latestVersionFn
-	latestVersionFn = func() (string, error) { return "v1.0.0", nil }
-	defer func() { latestVersionFn = orig }()
+	orig := latestReleaseFn
+	latestReleaseFn = func() (releaseInfo, error) { return releaseInfo{TagName: "v1.0.0"}, nil }
+	defer func() { latestReleaseFn = orig }()
 
 	origVersion := version
 	version = "v1.0.0"
@@ -368,9 +368,9 @@ func TestRunUpgrade_AlreadyUpToDate(t *testing.T) {
 }
 
 func TestRunUpgrade_CheckOnly_UpdateAvailable(t *testing.T) {
-	orig := latestVersionFn
-	latestVersionFn = func() (string, error) { return "v2.0.0", nil }
-	defer func() { latestVersionFn = orig }()
+	orig := latestReleaseFn
+	latestReleaseFn = func() (releaseInfo, error) { return releaseInfo{TagName: "v2.0.0"}, nil }
+	defer func() { latestReleaseFn = orig }()
 
 	origVersion := version
 	version = "v1.0.0"


### PR DESCRIPTION
Two of the gaps #600 listed, both about what `muninn upgrade` leaves the
operator when an upgrade turns out badly. The checksum gap from the same
issue was closed in #666; these are the remainder.

## Keep a rollback binary

`selfUpdate` renamed the downloaded binary straight over the running one, so
the previous release existed nowhere on the machine afterwards. Backing out
meant re-downloading it — from a host whose muninn is already misbehaving, at
the moment its operator least wants a network dependency.

The outgoing binary is now kept next to the new one as
`muninn.<oldversion>.bak`, and the path is printed after the install.

It links rather than moves, so the original never stops existing: the install
step replaces the directory entry while the link keeps the old inode
reachable. A move would open a window in which the machine has no muninn at
all, and would leave it with none if the install then failed. Filesystems
without hard links fall back to a copy, so the artifact exists either way.
The version is sanitized before it becomes a path component — it is stamped
in by -ldflags, so it is only as trustworthy as whoever built the binary.

## Print the release's upgrade note

The flow printed a *link* to the release notes and then asked for
confirmation. A release that requires a manual step says so in those notes,
and v0.9.0 is the case in point: a one-time, one-way on-disk migration whose
note reads "back up your data directory before upgrading". An operator
running `muninn upgrade -y` never saw it.

The release body is now scanned for the blockquote the CHANGELOG and release
notes already use for this — a bolded "Upgrade note" marker — and it is
rendered before the confirmation prompt, and under `--check` too.

Deliberately quiet on anything it does not recognise: this reads release
notes to inform the operator, so a parsing miss may cost a warning but must
never cost an upgrade.

The latest-release fetch already decoded the release JSON and discarded the
body, so this needs no extra request; the `latestVersionFn` test hook becomes
`latestReleaseFn` and `latestVersion()` stays for status.go's version hint.

## Verification

- `gofmt -l` clean, `go vet ./cmd/muninn/` clean, full `cmd/muninn` suite
  green under `-race`.
- Both structural tests were shown to fail without the change, not just pass
  with it:
  - replacing the link with a rename fails
    `TestPreserveBinary_LeavesOriginalInPlace`
  - dropping the blockquote anchor fails
    `TestUpgradeNote_FindsTheBlockquoteWhenProseMentionsItFirst`
  The first version of that second test passed either way — it asserted that
  prose is ignored, which the collection loop already guaranteed. It is now a
  body where prose mentions the phrase *before* the real blockquote, which is
  the case that actually distinguishes the two.
- Not exercised locally: the Windows path (unreachable — `runUpgrade` returns
  before `selfUpdate` on Windows) and the hard-link fallback, which needs a
  filesystem without link support.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


---

Refs #600. Two of its four items; the checksum one landed in #666, and the
service-manager one is a separate PR that overlaps this file — whichever of the
two lands first, I will rebase the other.
