### PR TITLE
fix(cli): refuse to self-update when a service manager owns the daemon (#600)

### DIFF
--- a/cmd/muninn/service_manager.go
+++ b/cmd/muninn/service_manager.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Detection of a service manager owning the running daemon.
+//
+// `muninn upgrade` stops the daemon by PID and restarts it itself. When a service
+// manager owns the daemon that is not a safe sequence: the service manager owns the
+// restart policy, so a systemd unit with Restart=always races the upgrade — it can
+// bring the daemon back up while the binary is mid-replacement, and afterwards the
+// unit's view of the process no longer matches reality.
+//
+// Only systemd is detected. Other managers (launchd, OpenRC, s6, Windows services)
+// report no ownership, so behaviour there is unchanged from today.
+
+// readProcCgroup returns the contents of /proc/<pid>/cgroup. A variable so tests can
+// supply cgroup layouts that cannot be produced on the machine running them.
+var readProcCgroup = func(pid int) (string, error) {
+	b, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	return string(b), err
+}
+
+// serviceUnitFromCgroup returns the systemd unit named by a /proc/<pid>/cgroup body.
+//
+// The leaf of the cgroup path is what decides ownership, not any ancestor. A daemon
+// started from an interactive shell inside a systemd user session sits under
+// ".../user@1000.service/app.slice/session-3.scope" — an ancestor is a .service, but
+// the process belongs to a .scope and no unit manages its lifecycle. Matching on any
+// ".service" in the path would report every interactively-started daemon as managed.
+func serviceUnitFromCgroup(content string) (string, bool) {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// cgroup v2: "0::/system.slice/muninndb.service"
+		// cgroup v1: "1:name=systemd:/system.slice/muninndb.service"
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		cgPath := parts[2]
+		if cgPath == "" || cgPath == "/" {
+			continue
+		}
+		// cgroup paths are always slash-separated, independent of the host's separator.
+		leaf := cgPath[strings.LastIndex(cgPath, "/")+1:]
+		if strings.HasSuffix(leaf, ".service") {
+			return leaf, true
+		}
+	}
+	return "", false
+}
+
+// serviceUnitForPID reports the systemd unit that owns pid, if any.
+func serviceUnitForPID(pid int) (string, bool) {
+	content, err := readProcCgroup(pid)
+	if err != nil {
+		// No /proc, no cgroup file, or no permission: we cannot show that a service
+		// manager is involved, so we do not claim one is.
+		return "", false
+	}
+	return serviceUnitFromCgroup(content)
+}
+
+// runningDaemonPIDs returns the PIDs of live processes running this same binary,
+// excluding this one.
+//
+// This exists because the PID file is not a reliable way to find a service-managed
+// daemon. `writePID` is reached only through runStart's fork path, so a unit that
+// execs the server directly — Type=simple with `ExecStart=... --daemon --data ...`,
+// the ordinary way to run a non-forking daemon under systemd — never writes one,
+// while systemd is unmistakably managing the process.
+//
+// So the guard cannot depend on an artifact that a correctly configured deployment
+// legitimately does not have; the process table is the fallback.
+var runningDaemonPIDs = func() []int {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return nil
+	}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	self := os.Getpid()
+	var pids []int
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil || pid == self {
+			continue
+		}
+		target, err := filepath.EvalSymlinks(fmt.Sprintf("/proc/%d/exe", pid))
+		if err != nil {
+			// Not ours to inspect, or gone since ReadDir. Either way, not evidence.
+			continue
+		}
+		if target == exe {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
+}
+
+// serviceManagerOwnsDaemon reports the unit managing the running daemon.
+//
+// It deliberately only fires while a daemon is actually running. With the daemon
+// stopped there is no lifecycle to fight over — replacing the binary is exactly what
+// the refusal message tells the operator to do, and the unit picks the new one up on
+// its next start.
+func serviceManagerOwnsDaemon() (string, bool) {
+	// The PID file is the precise answer when it exists: it names the daemon for
+	// *this* data directory.
+	if pid, err := readPID(filepath.Join(defaultDataDir(), "muninn.pid")); err == nil && isProcessRunning(pid) {
+		return serviceUnitForPID(pid)
+	}
+	// No usable PID file. Any live process running this binary under a unit is enough
+	// to make a self-update unsafe, so report the first one found.
+	for _, pid := range runningDaemonPIDs() {
+		if unit, ok := serviceUnitForPID(pid); ok {
+			return unit, true
+		}
+	}
+	return "", false
+}
+
+// serviceManagerRefusal is the message shown when the daemon is service-managed.
+// Returned rather than printed so the wording is testable.
+func serviceManagerRefusal(unit string) string {
+	name := strings.TrimSuffix(unit, ".service")
+	var b strings.Builder
+	fmt.Fprintf(&b, "  ⚠  The running daemon is managed by systemd (unit: %s).\n", unit)
+	b.WriteString("\n")
+	b.WriteString("     `muninn upgrade` stops the daemon by PID and restarts it itself.\n")
+	b.WriteString("     systemd owns that lifecycle here, so the two would race: the unit's\n")
+	b.WriteString("     restart policy can bring the daemon back while the binary is being\n")
+	b.WriteString("     replaced, and its view of the process would no longer match reality.\n")
+	b.WriteString("\n")
+	b.WriteString("     Upgrade through the service manager instead:\n")
+	b.WriteString("\n")
+	fmt.Fprintf(&b, "         sudo systemctl stop %s\n", name)
+	b.WriteString("         sudo muninn upgrade\n")
+	fmt.Fprintf(&b, "         sudo systemctl start %s\n", name)
+	b.WriteString("\n")
+	b.WriteString("     With the daemon stopped, `muninn upgrade` replaces the binary and\n")
+	b.WriteString("     leaves the restart to systemd.\n")
+	return b.String()
+}

--- a/cmd/muninn/service_manager_test.go
+++ b/cmd/muninn/service_manager_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestServiceUnitFromCgroup_V2SystemService(t *testing.T) {
+	unit, ok := serviceUnitFromCgroup("0::/system.slice/muninndb.service\n")
+	if !ok {
+		t.Fatal("a system.slice unit was not recognised as service-managed")
+	}
+	if unit != "muninndb.service" {
+		t.Errorf("unit = %q, want muninndb.service", unit)
+	}
+}
+
+func TestServiceUnitFromCgroup_V1SystemService(t *testing.T) {
+	// cgroup v1 lists one line per controller; only the name=systemd line carries
+	// the unit path, and the others must not confuse the parse.
+	content := `12:pids:/system.slice/muninndb.service
+5:memory:/system.slice/muninndb.service
+1:name=systemd:/system.slice/muninndb.service
+`
+	unit, ok := serviceUnitFromCgroup(content)
+	if !ok || unit != "muninndb.service" {
+		t.Errorf("serviceUnitFromCgroup = (%q, %v), want (muninndb.service, true)", unit, ok)
+	}
+}
+
+// The case that decides whether the leaf or any ancestor is consulted: a daemon
+// started by hand inside a systemd user session has ".service" in its cgroup path,
+// but belongs to a .scope and no unit manages its lifecycle. Matching an ancestor
+// would refuse to upgrade on every interactively-started daemon.
+func TestServiceUnitFromCgroup_InteractiveSessionIsNotManaged(t *testing.T) {
+	content := "0::/user.slice/user-1000.slice/user@1000.service/app.slice/session-3.scope\n"
+	if unit, ok := serviceUnitFromCgroup(content); ok {
+		t.Errorf("interactive session reported as managed by %q", unit)
+	}
+}
+
+func TestServiceUnitFromCgroup_UserManagerUnit(t *testing.T) {
+	// A per-user unit is still a unit, and systemd --user still owns its restarts.
+	content := "0::/user.slice/user-1000.slice/user@1000.service/app.slice/muninndb.service\n"
+	unit, ok := serviceUnitFromCgroup(content)
+	if !ok || unit != "muninndb.service" {
+		t.Errorf("serviceUnitFromCgroup = (%q, %v), want (muninndb.service, true)", unit, ok)
+	}
+}
+
+func TestServiceUnitFromCgroup_RootCgroupIsNotManaged(t *testing.T) {
+	// Containers and non-systemd inits commonly show a bare root cgroup.
+	for _, content := range []string{"0::/\n", "0::\n", "", "\n\n"} {
+		if unit, ok := serviceUnitFromCgroup(content); ok {
+			t.Errorf("content %q reported as managed by %q", content, unit)
+		}
+	}
+}
+
+func TestServiceUnitFromCgroup_MalformedLinesAreSkipped(t *testing.T) {
+	content := `not-a-cgroup-line
+0::/system.slice/muninndb.service
+`
+	unit, ok := serviceUnitFromCgroup(content)
+	if !ok || unit != "muninndb.service" {
+		t.Errorf("a malformed leading line broke the parse: (%q, %v)", unit, ok)
+	}
+}
+
+func TestServiceUnitFromCgroup_ScopeUnderSystemSliceIsNotManaged(t *testing.T) {
+	// `systemd-run --scope` produces a transient scope, not a service: systemd does
+	// not restart it, so the upgrade path is not racing anything.
+	content := "0::/system.slice/run-r123.scope\n"
+	if unit, ok := serviceUnitFromCgroup(content); ok {
+		t.Errorf("a transient scope reported as managed by %q", unit)
+	}
+}
+
+func TestServiceUnitForPID_UnreadableCgroupIsNotManaged(t *testing.T) {
+	old := readProcCgroup
+	readProcCgroup = func(int) (string, error) { return "", fmt.Errorf("no such file") }
+	defer func() { readProcCgroup = old }()
+
+	if unit, ok := serviceUnitForPID(1234); ok {
+		t.Errorf("unreadable cgroup reported as managed by %q — must not claim "+
+			"a service manager it cannot see", unit)
+	}
+}
+
+// A Type=simple unit that execs the server directly never reaches the code that
+// writes the PID file, while systemd is unmistakably managing the process. A guard
+// consulting only the PID file is inert on exactly that deployment, so the
+// process-table fallback has to carry it.
+func TestServiceManagerOwnsDaemon_FallsBackWhenNoPIDFile(t *testing.T) {
+	t.Setenv("MUNINNDB_DATA", t.TempDir()) // no muninn.pid in here
+
+	oldPIDs := runningDaemonPIDs
+	runningDaemonPIDs = func() []int { return []int{4242} }
+	defer func() { runningDaemonPIDs = oldPIDs }()
+
+	oldCgroup := readProcCgroup
+	readProcCgroup = func(pid int) (string, error) {
+		if pid != 4242 {
+			return "", fmt.Errorf("unexpected pid %d", pid)
+		}
+		return "0::/system.slice/muninndb.service\n", nil
+	}
+	defer func() { readProcCgroup = oldCgroup }()
+
+	unit, ok := serviceManagerOwnsDaemon()
+	if !ok {
+		t.Fatal("a service-managed daemon with no PID file was not detected")
+	}
+	if unit != "muninndb.service" {
+		t.Errorf("unit = %q, want muninndb.service", unit)
+	}
+}
+
+func TestServiceManagerOwnsDaemon_UnmanagedDaemonIsAllowed(t *testing.T) {
+	t.Setenv("MUNINNDB_DATA", t.TempDir())
+
+	oldPIDs := runningDaemonPIDs
+	runningDaemonPIDs = func() []int { return []int{4242} }
+	defer func() { runningDaemonPIDs = oldPIDs }()
+
+	oldCgroup := readProcCgroup
+	readProcCgroup = func(int) (string, error) {
+		return "0::/user.slice/user-1000.slice/session-3.scope\n", nil
+	}
+	defer func() { readProcCgroup = oldCgroup }()
+
+	if unit, ok := serviceManagerOwnsDaemon(); ok {
+		t.Errorf("refused an unmanaged daemon (reported %q) — a hand-started daemon "+
+			"must still be upgradable", unit)
+	}
+}
+
+func TestServiceManagerOwnsDaemon_NoDaemonRunning(t *testing.T) {
+	t.Setenv("MUNINNDB_DATA", t.TempDir())
+
+	oldPIDs := runningDaemonPIDs
+	runningDaemonPIDs = func() []int { return nil }
+	defer func() { runningDaemonPIDs = oldPIDs }()
+
+	if unit, ok := serviceManagerOwnsDaemon(); ok {
+		t.Errorf("refused with no daemon running (reported %q) — replacing the binary "+
+			"while stopped is the documented path", unit)
+	}
+}
+
+func TestServiceManagerRefusal_IsActionable(t *testing.T) {
+	msg := serviceManagerRefusal("muninndb.service")
+
+	if !strings.Contains(msg, "muninndb.service") {
+		t.Error("refusal does not name the unit it detected")
+	}
+	// The operator needs the exact commands, with the unit name resolved.
+	for _, want := range []string{
+		"systemctl stop muninndb",
+		"systemctl start muninndb",
+		"muninn upgrade",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("refusal is missing the step %q:\n%s", want, msg)
+		}
+	}
+	// ".service.service" would mean the suffix was not stripped for the CLI commands.
+	if strings.Contains(msg, "stop muninndb.service") {
+		t.Errorf("unit suffix leaked into the systemctl command:\n%s", msg)
+	}
+}

--- a/cmd/muninn/upgrade.go
+++ b/cmd/muninn/upgrade.go
@@ -169,6 +169,15 @@ func runUpgrade(args []string) {
 		return
 	}
 
+	// Refuse before touching anything if a service manager owns the running daemon.
+	// This sits after --check on purpose: reporting that an update exists is safe and
+	// useful on a service-managed host; performing one behind the manager's back is not.
+	if unit, managed := serviceManagerOwnsDaemon(); managed {
+		fmt.Fprint(os.Stderr, serviceManagerRefusal(unit))
+		osExit(1)
+		return
+	}
+
 	// Windows: no self-replace (OS locks running executables)
 	if runtime.GOOS == "windows" {
 		fmt.Printf("  Download %s from:\n", latest)


### PR DESCRIPTION
The third item in #600. `muninn upgrade` does not bypass the service manager
passively — it actively competes with it.

## What happens today

`selfUpdate` stops the daemon by PID, replaces the binary, and restarts it by
calling `runStart`. Under systemd the unit owns that lifecycle: a
`Restart=always` unit sees its main process die and starts its own replacement
while the binary is being swapped, and whichever process wins, the unit's
notion of the daemon no longer matches the one that is running. Nothing in the
flow notices.

The same is true in the other direction: after a successful self-update the
daemon running is one systemd did not start and does not track.

## The change

Before any of that, `runUpgrade` now asks whether a service manager owns the
running daemon, and refuses with the commands to do it properly:

    sudo systemctl stop muninndb
    sudo muninn upgrade
    sudo systemctl start muninndb

That sequence works because the guard only fires while a daemon is actually
running — stopped, there is no lifecycle to contend for, and the unit picks up
the new binary on its next start.

Placed after `--check`, so reporting that an update exists stays available on a
service-managed host; only performing one is refused.

## Detection

Ownership is read from the daemon's cgroup, which needs no external command and
no dbus. Two details decide whether it is right:

**The leaf of the cgroup path decides, not any ancestor.** A daemon started by
hand inside a systemd user session sits under
`/user.slice/.../user@1000.service/app.slice/session-3.scope` — an ancestor is
a `.service`, but the process belongs to a `.scope` and no unit manages it.
Matching any `.service` in the path would refuse to upgrade on every
interactively-started daemon.

**It cannot rely on the PID file.** `writePID` is reached only through
`runStart`'s fork path, so a `Type=simple` unit that execs the server directly
(`ExecStart=... --daemon --data ...`) never writes one — while systemd is
unmistakably managing the process. That is an ordinary way to run a
non-forking daemon, not a misconfiguration, so the guard must not depend on an
artifact it legitimately lacks. The PID file is used when present, since it
names the daemon for *this* data directory; otherwise any live process running
this same binary under a unit is enough to make a self-update unsafe.

## Scope

Only systemd is detected. launchd, OpenRC, s6 and Windows services report no
ownership, so behaviour there is exactly as before — this refuses only where it
can prove a manager exists, never on suspicion.

No `--force`. An escape hatch here would be a flag whose only use is to do the
unsafe thing, and the refusal already names the supported path. Happy to add
one if you would rather have it.

## Verification

- `gofmt -l` clean, `go vet ./cmd/muninn/` clean, full `cmd/muninn` suite green
  under `-race`.
- Both load-bearing tests were shown to fail without the code that makes them
  pass: matching an ancestor instead of the leaf fails
  `TestServiceUnitFromCgroup_InteractiveSessionIsNotManaged`, and dropping the
  process-table fallback fails
  `TestServiceManagerOwnsDaemon_FallsBackWhenNoPIDFile`.
- The cgroup and `/proc/<pid>/exe` shapes were read from a live systemd-managed
  v0.9.0 instance — effective `Type=simple`, no PIDFile, `ExecStart` running
  the server directly. Its cgroup is `0::/system.slice/muninndb.service` and
  `/proc/<pid>/exe` resolves to the installed binary, matching the fixtures
  used here; that host has no `muninn.pid`, which is what prompted the fallback.
- Not exercised: the guard end-to-end on that host, which would mean installing
  a built binary over a production one. Non-Linux behaviour is unchanged by
  construction (no /proc, no detection).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


---

Refs #600, the third of its four items. Kept separate from #748 (the rollback
binary and upgrade note) because this one makes a policy call — refusing an
operation that works today — and should be rejectable on its own without
holding up the mechanical half.

Both touch `cmd/muninn/upgrade.go`, so they will conflict textually: this adds
a block after the `--check` early return, #748 changes the release fetch and the
install step. Keep-both, not a redesign. Happy to rebase this onto whichever
lands first.

*(Edited after opening: an earlier revision described the reference host as a
`Type=forking` unit with a PIDFile it never received. That was my misreading of
the base unit file — a drop-in overrides it, and `systemctl show` reports the
effective config as `Type=simple` with no PIDFile. The corrected reasoning is
above and is the stronger case: the PID file is absent by design there, not by
misconfiguration.)*
