### PR TITLE
fix(enrich): parse errors carry a category, never the model's output (#641)

### DIFF
--- a/internal/plugin/enrich/parse.go
+++ b/internal/plugin/enrich/parse.go
@@ -3,7 +3,6 @@ package enrich
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/scrypster/muninndb/internal/plugin"
@@ -103,6 +102,7 @@ func extractJSON(s string) string {
 // ParseEntityResponse parses the JSON response from the entity extraction call.
 func ParseEntityResponse(raw string) ([]plugin.ExtractedEntity, error) {
 	raw = strings.TrimSpace(raw)
+	n := len(raw)
 	jsonStr := extractJSON(raw)
 
 	if rawEntities, ok, err := extractTopLevelField(jsonStr, "entities"); err == nil && ok {
@@ -111,23 +111,23 @@ func ParseEntityResponse(raw string) ([]plugin.ExtractedEntity, error) {
 		}
 		var entities []plugin.ExtractedEntity
 		if err := json.Unmarshal(rawEntities, &entities); err != nil {
-			return nil, fmt.Errorf("invalid entity response JSON: %s", truncateForError(jsonStr))
+			return nil, newParseError("entities", n, err)
 		}
 		return validateAndDedupeEntities(entities), nil
 	}
 
 	// Try to parse as direct array
 	var entities []plugin.ExtractedEntity
-	if err := json.Unmarshal([]byte(jsonStr), &entities); err == nil {
-		return validateAndDedupeEntities(entities), nil
+	if err := json.Unmarshal([]byte(jsonStr), &entities); err != nil {
+		return nil, newParseError("entities", n, err)
 	}
-
-	return nil, fmt.Errorf("invalid entity response JSON: %s", truncateForError(jsonStr))
+	return validateAndDedupeEntities(entities), nil
 }
 
 // ParseRelationshipResponse parses the JSON response from the relationship extraction call.
 func ParseRelationshipResponse(raw string) ([]plugin.ExtractedRelation, error) {
 	raw = strings.TrimSpace(raw)
+	n := len(raw)
 	jsonStr := extractJSON(raw)
 
 	if rawRelationships, ok, err := extractTopLevelField(jsonStr, "relationships"); err == nil && ok {
@@ -141,7 +141,7 @@ func ParseRelationshipResponse(raw string) ([]plugin.ExtractedRelation, error) {
 			Weight float32 `json:"weight"`
 		}
 		if err := json.Unmarshal(rawRelationships, &wrapper); err != nil {
-			return nil, fmt.Errorf("invalid relationship response JSON: %s", truncateForError(jsonStr))
+			return nil, newParseError("relationships", n, err)
 		}
 		var result []plugin.ExtractedRelation
 		for _, rel := range wrapper {
@@ -162,20 +162,19 @@ func ParseRelationshipResponse(raw string) ([]plugin.ExtractedRelation, error) {
 		Type   string  `json:"type"`
 		Weight float32 `json:"weight"`
 	}
-	if err := json.Unmarshal([]byte(jsonStr), &rawRels); err == nil {
-		var result []plugin.ExtractedRelation
-		for _, rel := range rawRels {
-			result = append(result, plugin.ExtractedRelation{
-				FromEntity: rel.From,
-				ToEntity:   rel.To,
-				RelType:    rel.Type,
-				Weight:     rel.Weight,
-			})
-		}
-		return validateRelationships(result), nil
+	if err := json.Unmarshal([]byte(jsonStr), &rawRels); err != nil {
+		return nil, newParseError("relationships", n, err)
 	}
-
-	return nil, fmt.Errorf("invalid relationship response JSON: %s", truncateForError(jsonStr))
+	var result []plugin.ExtractedRelation
+	for _, rel := range rawRels {
+		result = append(result, plugin.ExtractedRelation{
+			FromEntity: rel.From,
+			ToEntity:   rel.To,
+			RelType:    rel.Type,
+			Weight:     rel.Weight,
+		})
+	}
+	return validateRelationships(result), nil
 }
 
 func extractTopLevelField(jsonStr, field string) (json.RawMessage, bool, error) {
@@ -194,6 +193,7 @@ func isJSONNull(raw json.RawMessage) bool {
 // ParseClassificationResponse parses the JSON response from the classification call.
 func ParseClassificationResponse(raw string) (memType, typeLabel, category, subcategory string, tags []string, err error) {
 	raw = strings.TrimSpace(raw)
+	n := len(raw)
 	jsonStr := extractJSON(raw)
 
 	var result struct {
@@ -206,10 +206,10 @@ func ParseClassificationResponse(raw string) (memType, typeLabel, category, subc
 
 	err = json.Unmarshal([]byte(jsonStr), &result)
 	if err != nil {
-		return "", "", "", "", nil, fmt.Errorf("invalid classification response JSON: %s", truncateForError(jsonStr))
+		return "", "", "", "", nil, newParseError("classification", n, err)
 	}
 	if result.MemoryType == "" && result.TypeLabel == "" && result.Category == "" && result.Subcategory == "" && len(result.Tags) == 0 {
-		return "", "", "", "", nil, fmt.Errorf("classification response was empty")
+		return "", "", "", "", nil, emptyResultError("classification", n)
 	}
 
 	return result.MemoryType, result.TypeLabel, result.Category, result.Subcategory, result.Tags, nil
@@ -218,6 +218,7 @@ func ParseClassificationResponse(raw string) (memType, typeLabel, category, subc
 // ParseSummarizeResponse parses the JSON response from the summarization call.
 func ParseSummarizeResponse(raw string) (summary string, keyPoints []string, err error) {
 	raw = strings.TrimSpace(raw)
+	n := len(raw)
 	jsonStr := extractJSON(raw)
 
 	var result struct {
@@ -227,22 +228,13 @@ func ParseSummarizeResponse(raw string) (summary string, keyPoints []string, err
 
 	err = json.Unmarshal([]byte(jsonStr), &result)
 	if err != nil {
-		return "", nil, fmt.Errorf("invalid summarize response JSON: %s", truncateForError(jsonStr))
+		return "", nil, newParseError("summary", n, err)
 	}
 	if result.Summary == "" && len(result.KeyPoints) == 0 {
-		return "", nil, fmt.Errorf("summarize response was empty")
+		return "", nil, emptyResultError("summary", n)
 	}
 
 	return result.Summary, result.KeyPoints, nil
-}
-
-func truncateForError(s string) string {
-	const maxLen = 160
-	s = strings.TrimSpace(s)
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
 }
 
 // validateAndDedupeEntities validates entity fields and removes duplicates (keeping highest confidence).

--- a/internal/plugin/enrich/parse_error.go
+++ b/internal/plugin/enrich/parse_error.go
@@ -1,0 +1,72 @@
+package enrich
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ParseErrorCategory is a stable, payload-free classification of why a model
+// response could not be turned into structured output. The values are part of what
+// gets logged, so they are meant to be greppable and to stay put.
+type ParseErrorCategory string
+
+const (
+	// ParseErrUnmarshal — the response was not decodable into the expected shape.
+	ParseErrUnmarshal ParseErrorCategory = "unmarshal_failure"
+	// ParseErrTypeMismatch — decodable, but a field held the wrong JSON type.
+	ParseErrTypeMismatch ParseErrorCategory = "type_mismatch"
+	// ParseErrEmptyResult — decoded cleanly, but every field we need was empty.
+	ParseErrEmptyResult ParseErrorCategory = "empty_result"
+)
+
+// ParseError reports a failed parse of a model response with enough detail to
+// diagnose it and nothing derived from the response itself.
+//
+// The response is *not* carried, not even truncated. Model output is a function of
+// memory content, so a fragment of it in a log is a fragment of a user's memory in a
+// log — and these errors reach the log at warn level, not only under verbose. The
+// transport layer already holds this line (`providerHTTPError` drains the provider's
+// body specifically so it is never retained or logged); this is the parse layer
+// holding the same one.
+type ParseError struct {
+	// Stage is the pipeline call that failed: entities, relationships,
+	// classification, or summary.
+	Stage string
+	// Category is the payload-free reason.
+	Category ParseErrorCategory
+	// Field is the struct field the decoder rejected, when it named one. It comes
+	// from our own struct tags, never from the response.
+	Field string
+	// Bytes is the size of the response we failed on — enough to tell an empty reply
+	// from a wall of prose without reproducing either.
+	Bytes int
+}
+
+func (e *ParseError) Error() string {
+	if e.Field != "" {
+		return fmt.Sprintf("%s: %s at %q (%d bytes of model output)",
+			e.Stage, e.Category, e.Field, e.Bytes)
+	}
+	return fmt.Sprintf("%s: %s (%d bytes of model output)", e.Stage, e.Category, e.Bytes)
+}
+
+// newParseError classifies a decode failure without reading the payload.
+//
+// It reads *json.UnmarshalTypeError.Field, which is our schema, but deliberately not
+// its Value: the standard library renders that as descriptions like "number -5",
+// which would put a value from the response straight back into the message.
+func newParseError(stage string, respBytes int, err error) *ParseError {
+	pe := &ParseError{Stage: stage, Category: ParseErrUnmarshal, Bytes: respBytes}
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		pe.Category = ParseErrTypeMismatch
+		pe.Field = typeErr.Field
+	}
+	return pe
+}
+
+// emptyResultError reports a response that decoded but carried nothing usable.
+func emptyResultError(stage string, respBytes int) *ParseError {
+	return &ParseError{Stage: stage, Category: ParseErrEmptyResult, Bytes: respBytes}
+}

--- a/internal/plugin/enrich/parse_error_test.go
+++ b/internal/plugin/enrich/parse_error_test.go
@@ -1,0 +1,199 @@
+package enrich
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/config"
+	"github.com/scrypster/muninndb/internal/plugin"
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// canary stands in for what model output actually is: a function of the memory that
+// was enriched. If it reaches a log, so does the memory.
+const canary = "PATIENT-4417-DIAGNOSIS-CONFIDENTIAL"
+
+func TestParseError_MessageCarriesNoPayload(t *testing.T) {
+	// Each parser fed a response that cannot be decoded into its shape.
+	malformed := `{"entities": ["` + canary + `"], "relationships": ["` + canary +
+		`"], "memory_type": {"nested": "` + canary + `"}, "summary": ["` + canary + `"]}`
+
+	cases := []struct {
+		name  string
+		stage string
+		call  func(string) error
+	}{
+		{"entities", "entities", func(s string) error { _, err := ParseEntityResponse(s); return err }},
+		{"relationships", "relationships", func(s string) error { _, err := ParseRelationshipResponse(s); return err }},
+		{"classification", "classification", func(s string) error {
+			_, _, _, _, _, err := ParseClassificationResponse(s)
+			return err
+		}},
+		{"summary", "summary", func(s string) error { _, _, err := ParseSummarizeResponse(s); return err }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call(malformed)
+			if err == nil {
+				t.Fatal("expected a parse error")
+			}
+			if strings.Contains(err.Error(), canary) {
+				t.Errorf("model output leaked into the error: %s", err.Error())
+			}
+			var pe *ParseError
+			if !errors.As(err, &pe) {
+				t.Fatalf("error is not a *ParseError: %T", err)
+			}
+			if pe.Stage != tc.stage {
+				t.Errorf("stage = %q, want %q", pe.Stage, tc.stage)
+			}
+			if pe.Category == "" {
+				t.Error("parse error carries no category")
+			}
+			if pe.Bytes != len(malformed) {
+				t.Errorf("Bytes = %d, want %d", pe.Bytes, len(malformed))
+			}
+		})
+	}
+}
+
+// json.UnmarshalTypeError renders its Value as descriptions like "number -5", which
+// would put a value straight out of the response back into the message. Only Field
+// is safe to carry, and this pins that.
+func TestParseError_TypeMismatchNamesTheFieldNotTheValue(t *testing.T) {
+	resp := `{"entities": [{"name": "x", "type": "y", "confidence": "` + canary + `"}]}`
+
+	_, err := ParseEntityResponse(resp)
+	if err == nil {
+		t.Fatal("expected a parse error")
+	}
+	if strings.Contains(err.Error(), canary) {
+		t.Fatalf("the rejected value leaked into the error: %s", err.Error())
+	}
+	var pe *ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("error is not a *ParseError: %T", err)
+	}
+	if pe.Category != ParseErrTypeMismatch {
+		t.Errorf("category = %q, want %q", pe.Category, ParseErrTypeMismatch)
+	}
+	if pe.Field == "" {
+		t.Error("a type mismatch should name the field it rejected")
+	}
+}
+
+func TestParseError_EmptyResultIsItsOwnCategory(t *testing.T) {
+	// Decodes cleanly, carries nothing usable — a different failure from malformed
+	// output, and worth telling apart in a log.
+	if _, _, _, _, _, err := ParseClassificationResponse(`{}`); err == nil {
+		t.Error("expected an error for an empty classification")
+	} else {
+		var pe *ParseError
+		if !errors.As(err, &pe) || pe.Category != ParseErrEmptyResult {
+			t.Errorf("classification: got %v, want category %q", err, ParseErrEmptyResult)
+		}
+	}
+	if _, _, err := ParseSummarizeResponse(`{}`); err == nil {
+		t.Error("expected an error for an empty summary")
+	} else {
+		var pe *ParseError
+		if !errors.As(err, &pe) || pe.Category != ParseErrEmptyResult {
+			t.Errorf("summary: got %v, want category %q", err, ParseErrEmptyResult)
+		}
+	}
+}
+
+func TestParseError_SuccessfulParsingIsUnchanged(t *testing.T) {
+	entities, err := ParseEntityResponse(`{"entities": [{"name": "PostgreSQL", "type": "database", "confidence": 0.95}]}`)
+	if err != nil {
+		t.Fatalf("valid entity response failed to parse: %v", err)
+	}
+	if len(entities) != 1 || entities[0].Name != "PostgreSQL" {
+		t.Errorf("entities = %+v", entities)
+	}
+
+	summary, _, err := ParseSummarizeResponse(`{"summary": "A database."}`)
+	if err != nil {
+		t.Fatalf("valid summarize response failed to parse: %v", err)
+	}
+	if summary != "A database." {
+		t.Errorf("summary = %q", summary)
+	}
+}
+
+// captureLogs installs a buffer-backed default logger at debug level and returns the
+// buffer plus a restore func.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
+}
+
+// The behaviour the issue asks for, at the level it actually happens: Run's per-stage
+// warnings are emitted at warn level, not only under verbose, so an unredacted parse
+// error reaches a default-configured server's logs.
+func TestPipelineRun_DoesNotLogModelOutput(t *testing.T) {
+	for _, verbose := range []bool{false, true} {
+		name := "default_logs"
+		if verbose {
+			name = "verbose_logs"
+		}
+		t.Run(name, func(t *testing.T) {
+			buf := captureLogs(t)
+
+			mock := NewMockLLMProvider()
+			mock.customComplete = func(context.Context, string, string) (string, error) {
+				return `{"entities": ["` + canary + `"]}`, nil
+			}
+			pipeline := NewPipeline(mock, NewTokenBucketLimiter(100, 100))
+			v := verbose
+			pipeline.SetConfig(&config.PluginConfig{LLMVerboseLogs: &v})
+
+			_, err := pipeline.Run(context.Background(), &storage.Engram{})
+			if err == nil {
+				t.Fatal("expected the pipeline to fail on unparseable output")
+			}
+
+			logs := buf.String()
+			if strings.Contains(logs, canary) {
+				t.Errorf("model output reached the logs:\n%s", logs)
+			}
+			// The error the pipeline hands back is logged by callers too.
+			if strings.Contains(err.Error(), canary) {
+				t.Errorf("model output reached the returned error: %v", err)
+			}
+			// Redaction must not cost observability.
+			if !strings.Contains(logs, "entities") {
+				t.Errorf("logs no longer identify the failing stage:\n%s", logs)
+			}
+			if !strings.Contains(logs, string(ParseErrUnmarshal)) &&
+				!strings.Contains(logs, string(ParseErrTypeMismatch)) {
+				t.Errorf("logs carry no error category:\n%s", logs)
+			}
+		})
+	}
+}
+
+// #640/#643 draw the line between a transient provider failure and permanently
+// malformed output. Retyping parse errors must not move it.
+func TestParseError_RemainsPermanentNotRetryable(t *testing.T) {
+	_, err := ParseEntityResponse(`not-json`)
+	if err == nil {
+		t.Fatal("expected a parse error")
+	}
+	var provErr *plugin.ProviderError
+	if errors.As(err, &provErr) {
+		t.Fatalf("a parse error must not satisfy *plugin.ProviderError: %+v", provErr)
+	}
+	if shouldAbortPipeline(err) {
+		t.Error("a parse error must not abort the pipeline — other stages still run")
+	}
+}

--- a/internal/plugin/enrich/pipeline.go
+++ b/internal/plugin/enrich/pipeline.go
@@ -70,12 +70,19 @@ func (p *EnrichmentPipeline) recordParseError(ctx context.Context, callType stri
 	}
 	p.stats.TotalErrors.Add(1)
 	if llmstats.VerboseEnabled(p.verboseLogsFlag()) {
-		slog.InfoContext(ctx, "llm.parse_error",
+		attrs := []any{
 			"source", "llm",
 			"subsystem", "enrich",
 			"call_type", callType,
 			"error", err.Error(),
-		)
+		}
+		// Lift the classification out of the message so it can be filtered on
+		// without parsing prose.
+		var pe *ParseError
+		if errors.As(err, &pe) {
+			attrs = append(attrs, "category", string(pe.Category), "response_bytes", pe.Bytes)
+		}
+		slog.InfoContext(ctx, "llm.parse_error", attrs...)
 	}
 }
 


### PR DESCRIPTION
Enrichment parse errors embedded up to 160 bytes of the model's response via
`truncateForError`, and those errors are logged. Model output is a function of
memory content, so a fragment of it in a log is a fragment of a user's memory
in a log.

## One correction to the issue

The issue says the payload "may also appear in verbose LLM logs". It is not
limited to verbose. `Run` logs each failed stage with `slog.Warn(..., "err",
err)` — warn level, no flag — so on a default-configured server every parse
failure writes response bytes to the log. `recordParseError` and
`recordComplete` are the verbose-only paths on top of that. The aggregate
error returned by `Run` also carried the payload onward to its callers.

The regression test covers both levels, and it is the default-level subtest
that fails without the fix.

## The change

Parse failures now return a typed `*ParseError` carrying stage, a stable
category (`unmarshal_failure`, `type_mismatch`, `empty_result`), and the
response's size in bytes — enough to tell an empty reply from a wall of prose
without reproducing either. `truncateForError` is gone; nothing referenced it
elsewhere and it had no test coverage.

`recordParseError` additionally lifts `category` and `response_bytes` out as
log attributes, so the classification can be filtered on without parsing prose.

Two details worth flagging for review:

- A type mismatch reports `json.UnmarshalTypeError.Field` but deliberately not
  its `Value`. The standard library renders `Value` as descriptions like
  `"number -5"` — that would put a value from the response straight back into
  the message. `Field` comes from our own struct tags.
- The byte count is of the response as received, not of the extracted JSON, so
  "the model returned 4 KB and none of it parsed" stays visible.

This is the same line the transport layer already holds: `providerHTTPError`
drains the provider's body specifically so it is "never retain[ed] or log[ged]".
The parse layer was the inconsistent one.

I did not add an opt-in payload-dump mechanism. It would be new surface for a
diagnostic nobody has asked for yet, and the category plus size covers the
cases I can name. Happy to add one behind an explicit off-by-default flag if
you want it.

## Verification

- `gofmt -l` clean, `go vet ./internal/plugin/...` clean, `go build ./...`
  clean, `internal/plugin/...` green under `-race`.
- No existing test asserted on the old payload-bearing message, so nothing
  needed rewriting to accommodate this.
- RED-proven: restoring the pre-fix error for the entities path fails
  `TestParseError_MessageCarriesNoPayload/entities` and both subtests of
  `TestPipelineRun_DoesNotLogModelOutput`, on the canary string.
- `TestParseError_RemainsPermanentNotRetryable` pins the #640/#643 boundary: a
  parse error is still not a `*plugin.ProviderError` and still does not abort
  the pipeline, so malformed output stays permanent and transient provider
  failures stay retryable.
- `TestParseError_SuccessfulParsingIsUnchanged` pins that valid responses parse
  exactly as before.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


---

Closes #641. @dpearson2699 said on the issue this was free to pick up — shout if
that crossed anyone's plan and I will step back.

Independent of #748 / #749; touches no shared files.
