### PR TITLE
feat(embed): canonical corpus + reproducible anisotropy baseline (#719)

### DIFF
--- a/docs/internals/anisotropy-calibration.md
+++ b/docs/internals/anisotropy-calibration.md
@@ -1,0 +1,92 @@
+# Measuring an embedding model's noise baseline
+
+The semantic-abstention floor (COG-26) rescales cosine by a per-model constant
+`b`, held in `noiseBaselineRegistry` (`internal/plugin/embed/baseline.go`). `b`
+is the point above which a cosine is evidence of relevance rather than an
+artefact of the model's anisotropy.
+
+This document is the procedure for deriving `b` for a model, so the constant is
+a reproducible property of the model rather than a measurement of whichever
+corpus happened to be at hand. Re-derive; do not hand-edit.
+
+## Why a canonical corpus
+
+A baseline derived from a deployment's own vault characterizes that vault's
+subject matter as much as the model. Two consequences:
+
+- It cannot be reproduced by anyone else, so it cannot be reviewed — only trusted.
+- It travels: a constant measured on one corpus ships to every deployment,
+  including those whose text looks nothing like it.
+
+`internal/plugin/embed/anisotropy_corpus.jsonl` is the fixed alternative: 160
+short general-knowledge statements across 20 unrelated domains, 8 per domain,
+carrying no proper nouns tied to any organization. It ships in the repo, so a
+change to a constant arrives as a diff alongside the corpus that produced it.
+
+## The statistic
+
+For corpus entries `e_i` with embeddings `v_i`:
+
+1. L2-normalize every `v_i`. (Cosine is scale-invariant, so this also makes the
+   result independent of whether the backend returns unit vectors — Ollama's
+   `/api/embed` and `/api/embeddings` differ on exactly this for the same model
+   and input.)
+2. Take the cosine of every pair `(i, j)`, `i < j`, **where `domain(i) != domain(j)`**.
+3. `b = μ + kσ` over that population.
+
+`AnisotropyBaseline` in `internal/plugin/embed/anisotropy.go` implements this.
+
+### Same-domain pairs are excluded, and that is not a detail
+
+A corpus of *N* sentences over *D* domains does not supply *N(N−1)/2* unrelated
+pairs. Within-domain pairs are related by construction and sit measurably
+higher, so including them inflates `b` and makes recall abstain more than the
+operator asked for. The contamination scales with the square of per-domain
+depth: at 8 sentences per domain it is 4.4% of pairs; at 20 it is 9.5%.
+
+This is why the corpus format carries a `domain` label per line. A corpus
+shipped as bare text cannot be calibrated correctly, only approximately.
+
+## k is a policy choice, not a measurement
+
+`μ` and `σ` are properties of the model. `k` is not — it is the only part of
+`μ+kσ` that encodes a product decision, and it trades false-admits against
+false-abstains. It therefore belongs in one documented place with a per-vault
+override (`SemanticFloor`), never as a per-model value, which would hide a
+policy choice inside a measurement.
+
+To choose or defend a `k`, report what it excludes on the corpus, e.g.:
+
+| k | share of unrelated pairs at or above the floor |
+|---|---|
+| 1.0 | ~16% |
+| 1.3 | ~10% |
+| 2.0 | ~3% |
+| 3.0 | ~0.3% |
+
+(Indicative figures from one 1024-dim model; recompute per model.)
+
+## What a registry entry must record
+
+`b` alone is not reproducible. Two callers can both honestly say
+`bge-small-en-v1.5` and be entitled to different constants: pooling (CLS vs
+mean), whether an instruction prefix is prepended (bge v1.5 uses one for
+queries; bge-m3 does not), truncation, and quantization all move the
+distribution.
+
+So a characterization should carry: model identifier, backend/runtime, pooling,
+prefix convention, dimension, corpus size and pair count, `μ`, `σ`, `k`, the
+resulting `b`, and a hash of the corpus used. `AnisotropyResult` holds the
+numeric part of that.
+
+## Protocol divergence to be aware of
+
+The shipped `bge-small-en-v1.5` value (`b = 0.520`, μ=0.450 σ=0.054) was derived
+from **432 nonsense-query × real-passage pairs** — a query→passage distribution.
+The procedure above measures **random cross-domain sentence pairs**. Both
+estimate "cosine between unrelated text", but they are different populations and
+their numbers are not interchangeable.
+
+Whichever is adopted, it should be adopted for every model in the registry;
+mixing them makes the entries incomparable to each other, which defeats the
+purpose of having a registry.

--- a/internal/plugin/embed/anisotropy.go
+++ b/internal/plugin/embed/anisotropy.go
@@ -1,0 +1,204 @@
+package embed
+
+import (
+	"bufio"
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+)
+
+// The reproducible half of the noise-baseline story (#719).
+//
+// noiseBaselineRegistry carries a per-model constant b = μ+kσ of the cosine
+// distribution over *unrelated* text. Those constants decide when recall
+// abstains, so where they come from matters as much as what they are: a value
+// derived from one deployment's corpus characterizes that corpus as much as it
+// characterizes the model.
+//
+// This file supplies the model-only half — a fixed corpus that ships with the
+// repo, and the statistic computed over it — so a baseline can be re-derived by
+// anyone, for any embedder, and reviewed as a diff rather than trusted.
+
+//go:embed anisotropy_corpus.jsonl
+var anisotropyCorpusRaw []byte
+
+// CorpusEntry is one line of the calibration corpus.
+//
+// Domain exists to be excluded, not to be embedded: see AnisotropyBaseline.
+type CorpusEntry struct {
+	Domain string `json:"domain"`
+	Text   string `json:"text"`
+}
+
+// AnisotropyCorpus returns the embedded calibration corpus in file order.
+//
+// The corpus is deliberately mundane general knowledge across unrelated
+// domains, with no proper nouns tied to any organization, so that it can ship
+// in a public repo and so that no deployment's own vocabulary leaks into a
+// constant that ships to every deployment.
+func AnisotropyCorpus() ([]CorpusEntry, error) {
+	var out []CorpusEntry
+	sc := bufio.NewScanner(bytes.NewReader(anisotropyCorpusRaw))
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var e CorpusEntry
+		if err := json.Unmarshal(line, &e); err != nil {
+			return nil, fmt.Errorf("calibration corpus: %w", err)
+		}
+		if e.Domain == "" || e.Text == "" {
+			return nil, fmt.Errorf("calibration corpus: entry missing domain or text")
+		}
+		out = append(out, e)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("calibration corpus: %w", err)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("calibration corpus is empty")
+	}
+	return out, nil
+}
+
+// AnisotropyResult is a model characterization plus the context needed to
+// reproduce or invalidate it.
+//
+// The provenance fields are not decoration. Two callers can both honestly say
+// "bge-small-en-v1.5" and be entitled to different constants: pooling, whether
+// an instruction prefix is prepended, truncation, and quantization all move the
+// distribution. A registry keyed on a model name alone silently merges them.
+type AnisotropyResult struct {
+	Model      string  `json:"model"`
+	Dim        int     `json:"dim"`
+	NPairs     int     `json:"n_pairs"`
+	Mean       float64 `json:"mean"`
+	StdDev     float64 `json:"stddev"`
+	K          float64 `json:"k"`
+	Baseline   float64 `json:"baseline"` // μ + kσ — the value a registry entry carries
+	CorpusSize int     `json:"corpus_size"`
+	// Percentiles of the unrelated-pair distribution, for judging how much of
+	// it a given k actually excludes.
+	P95 float64 `json:"p95"`
+	P99 float64 `json:"p99"`
+	Max float64 `json:"max"`
+}
+
+// AnisotropyBaseline computes μ+kσ of the cosine distribution over unrelated
+// pairs of the corpus.
+//
+// vectors must be parallel to entries. Vectors need not be normalized; cosine
+// normalizes internally, which also means the result is invariant to whether a
+// backend returns unit vectors (Ollama's two embed endpoints differ on exactly
+// this for the same model and input).
+//
+// Same-domain pairs are EXCLUDED. A corpus of N sentences over D domains does
+// not yield N(N-1)/2 unrelated pairs — the within-domain pairs are related by
+// construction and sit measurably higher, so counting them inflates the
+// baseline and makes recall abstain more than the operator asked for. The
+// contamination grows with the square of per-domain depth, so it cannot be
+// dismissed as small in general even where it is small for one corpus.
+func AnisotropyBaseline(entries []CorpusEntry, vectors [][]float32, k float64) (AnisotropyResult, error) {
+	if len(entries) != len(vectors) {
+		return AnisotropyResult{}, fmt.Errorf("anisotropy: %d entries but %d vectors", len(entries), len(vectors))
+	}
+	if len(entries) < 2 {
+		return AnisotropyResult{}, fmt.Errorf("anisotropy: need at least 2 corpus entries, got %d", len(entries))
+	}
+	dim := len(vectors[0])
+	unit := make([][]float64, len(vectors))
+	for i, v := range vectors {
+		if len(v) != dim {
+			return AnisotropyResult{}, fmt.Errorf("anisotropy: vector %d has dim %d, expected %d", i, len(v), dim)
+		}
+		u, err := normalize(v)
+		if err != nil {
+			return AnisotropyResult{}, fmt.Errorf("anisotropy: vector %d: %w", i, err)
+		}
+		unit[i] = u
+	}
+
+	var cosines []float64
+	for i := 0; i < len(unit); i++ {
+		for j := i + 1; j < len(unit); j++ {
+			if entries[i].Domain == entries[j].Domain {
+				continue // related by construction
+			}
+			cosines = append(cosines, dot(unit[i], unit[j]))
+		}
+	}
+	if len(cosines) == 0 {
+		return AnisotropyResult{}, fmt.Errorf("anisotropy: corpus has no cross-domain pairs (every entry shares one domain)")
+	}
+
+	mean := 0.0
+	for _, c := range cosines {
+		mean += c
+	}
+	mean /= float64(len(cosines))
+	varsum := 0.0
+	for _, c := range cosines {
+		d := c - mean
+		varsum += d * d
+	}
+	sd := math.Sqrt(varsum / float64(len(cosines)))
+
+	sorted := append([]float64(nil), cosines...)
+	sort.Float64s(sorted)
+
+	return AnisotropyResult{
+		Dim:        dim,
+		NPairs:     len(cosines),
+		Mean:       mean,
+		StdDev:     sd,
+		K:          k,
+		Baseline:   mean + k*sd,
+		CorpusSize: len(entries),
+		P95:        percentile(sorted, 0.95),
+		P99:        percentile(sorted, 0.99),
+		Max:        sorted[len(sorted)-1],
+	}, nil
+}
+
+func normalize(v []float32) ([]float64, error) {
+	sum := 0.0
+	out := make([]float64, len(v))
+	for i, x := range v {
+		f := float64(x)
+		out[i] = f
+		sum += f * f
+	}
+	n := math.Sqrt(sum)
+	if n == 0 || math.IsNaN(n) || math.IsInf(n, 0) {
+		return nil, fmt.Errorf("zero or non-finite vector")
+	}
+	for i := range out {
+		out[i] /= n
+	}
+	return out, nil
+}
+
+func dot(a, b []float64) float64 {
+	s := 0.0
+	for i := range a {
+		s += a[i] * b[i]
+	}
+	return s
+}
+
+// percentile returns the p-quantile of an ascending slice using nearest-rank.
+func percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	i := int(p * float64(len(sorted)))
+	if i >= len(sorted) {
+		i = len(sorted) - 1
+	}
+	return sorted[i]
+}

--- a/internal/plugin/embed/anisotropy_corpus.jsonl
+++ b/internal/plugin/embed/anisotropy_corpus.jsonl
@@ -1,0 +1,160 @@
+{"domain":"volcanology","text":"Basaltic lava flows travel further than andesitic ones because their lower silica content reduces viscosity."}
+{"domain":"volcanology","text":"Tephra layers deposited by a single eruption can serve as regional time markers in sediment cores."}
+{"domain":"volcanology","text":"Harmonic tremor often precedes an eruption as magma forces its way through fractured country rock."}
+{"domain":"volcanology","text":"A caldera forms when the roof of an emptied magma chamber collapses under its own weight."}
+{"domain":"volcanology","text":"Pyroclastic density currents can exceed two hundred kilometres per hour and hug the ground surface."}
+{"domain":"volcanology","text":"Sulphur dioxide flux measured at the summit is a routine proxy for shallow magma degassing."}
+{"domain":"volcanology","text":"Phreatomagmatic eruptions occur where rising magma meets groundwater and flashes it to steam."}
+{"domain":"volcanology","text":"Lava domes grow by endogenous inflation as well as by extrusion of stiff spines at the surface."}
+{"domain":"beekeeping","text":"A queen excluder keeps the laying queen out of the honey supers while allowing workers to pass."}
+{"domain":"beekeeping","text":"Colonies raise emergency queen cells when they lose their queen without warning."}
+{"domain":"beekeeping","text":"Varroa mites weaken colonies by feeding on the fat body of developing and adult bees."}
+{"domain":"beekeeping","text":"Bearding on the hive front in hot weather is usually temperature regulation rather than swarming."}
+{"domain":"beekeeping","text":"Nectar must be reduced below about eighteen percent moisture before bees cap the cell."}
+{"domain":"beekeeping","text":"A nucleus colony lets a beekeeper build up stock without splitting a productive hive outright."}
+{"domain":"beekeeping","text":"Propolis collected from tree resin seals small gaps and has antimicrobial properties."}
+{"domain":"beekeeping","text":"Winter clusters generate heat by shivering flight muscles without moving the wings."}
+{"domain":"railway signalling","text":"Absolute block working permits only one train in a section between two signal boxes at a time."}
+{"domain":"railway signalling","text":"Track circuits detect a train by the axles short-circuiting a current fed along the rails."}
+{"domain":"railway signalling","text":"An interlocking prevents a signaller from setting conflicting routes across the same junction."}
+{"domain":"railway signalling","text":"Automatic warning systems give an audible indication in the cab when a distant signal is at caution."}
+{"domain":"railway signalling","text":"Axle counters replace track circuits where poor ballast conditions make shunting unreliable."}
+{"domain":"railway signalling","text":"Overlap distance beyond a stop signal accounts for a driver overrunning at low speed."}
+{"domain":"railway signalling","text":"Moving block signalling spaces trains by braking distance rather than by fixed sections."}
+{"domain":"railway signalling","text":"Facing point locks must be proved before a route through the points can be signalled clear."}
+{"domain":"jazz history","text":"Bebop tempos and altered harmony moved the music away from danceable big band arrangements."}
+{"domain":"jazz history","text":"Modal playing reduced the rate of chord change and gave soloists longer harmonic fields."}
+{"domain":"jazz history","text":"The rhythm section's shift to walking bass freed the drummer from strict timekeeping on the bass drum."}
+{"domain":"jazz history","text":"Recording length limits of early discs shaped solo structure for a generation of players."}
+{"domain":"jazz history","text":"Territory bands circulating through the midwest spread arranging conventions between regional scenes."}
+{"domain":"jazz history","text":"Free improvisation abandoned fixed chorus lengths and predetermined harmonic sequences entirely."}
+{"domain":"jazz history","text":"Cool styles favoured lighter articulation and lower dynamic range than the preceding idiom."}
+{"domain":"jazz history","text":"Small group formats became economically necessary as large touring ensembles grew unaffordable."}
+{"domain":"textile manufacturing","text":"Ring spinning imparts twist and winds yarn onto a bobbin in a single continuous operation."}
+{"domain":"textile manufacturing","text":"Mercerising cotton under tension increases lustre and improves dye uptake."}
+{"domain":"textile manufacturing","text":"Warp threads run the length of woven cloth and take most of the loom tension."}
+{"domain":"textile manufacturing","text":"Carding aligns fibres and removes short lengths before drawing reduces the sliver to roving."}
+{"domain":"textile manufacturing","text":"Shuttleless looms insert weft with air or water jets at far higher rates than a flying shuttle."}
+{"domain":"textile manufacturing","text":"Fabric weight per square metre remains the primary specification in most supply contracts."}
+{"domain":"textile manufacturing","text":"Sizing the warp with starch reduces abrasion damage during weaving and is washed out afterwards."}
+{"domain":"textile manufacturing","text":"Staple length governs how smooth and strong the resulting spun yarn can be."}
+{"domain":"maritime law","text":"General average apportions loss among all parties when cargo is sacrificed to save the voyage."}
+{"domain":"maritime law","text":"A vessel's flag state holds primary regulatory jurisdiction over conditions aboard."}
+{"domain":"maritime law","text":"Salvage awards depend on the danger faced and the value of the property preserved."}
+{"domain":"maritime law","text":"Bills of lading function simultaneously as receipt, contract evidence, and document of title."}
+{"domain":"maritime law","text":"Innocent passage through territorial waters may not prejudice the peace or security of the coastal state."}
+{"domain":"maritime law","text":"Charterparty disputes commonly turn on laytime and the calculation of demurrage."}
+{"domain":"maritime law","text":"Limitation of liability funds cap an owner's exposure by reference to vessel tonnage."}
+{"domain":"maritime law","text":"Port state control inspections may detain a ship that fails to meet convention standards."}
+{"domain":"ornithology","text":"Moult sequence in the primaries provides a reliable indication of age in many passerines."}
+{"domain":"ornithology","text":"Nocturnal migrants orient using a combination of stellar cues and the geomagnetic field."}
+{"domain":"ornithology","text":"Brood parasites lay in host nests and shift rearing costs onto another species entirely."}
+{"domain":"ornithology","text":"Bill morphology tracks diet closely enough to predict foraging strategy in unfamiliar taxa."}
+{"domain":"ornithology","text":"Song learning in some families requires exposure to a tutor within a limited early window."}
+{"domain":"ornithology","text":"Ringing recoveries remain the primary evidence for individual movement over long distances."}
+{"domain":"ornithology","text":"Countershading reduces visual detection by flattening the apparent form of the body."}
+{"domain":"ornithology","text":"Clutch size often varies with latitude even within a single widespread species."}
+{"domain":"glassblowing","text":"Gathering molten glass on the pipe requires steady rotation to keep the mass concentric."}
+{"domain":"glassblowing","text":"Annealing relieves internal stress by cooling the finished piece slowly through the strain point."}
+{"domain":"glassblowing","text":"Marvering shapes and cools the gather against a flat plate before further inflation."}
+{"domain":"glassblowing","text":"Colour is commonly introduced as crushed frit picked up onto the hot surface."}
+{"domain":"glassblowing","text":"The punty transfers the work so the original opening can be finished."}
+{"domain":"glassblowing","text":"Soda lime glass has a longer working range than borosilicate at the same temperature."}
+{"domain":"glassblowing","text":"Optic moulds impart a ribbed pattern that survives subsequent expansion of the bubble."}
+{"domain":"glassblowing","text":"Devitrification appears as surface crystallisation when glass is held too long at working heat."}
+{"domain":"monetary policy","text":"Open market operations adjust reserve quantities and steer the overnight rate toward its target."}
+{"domain":"monetary policy","text":"Forward guidance attempts to shape expectations about the future path of short rates."}
+{"domain":"monetary policy","text":"Reserve requirements have declined in importance relative to interest paid on reserves."}
+{"domain":"monetary policy","text":"An inverted yield curve reflects market expectations of falling rates further out."}
+{"domain":"monetary policy","text":"Sterilised intervention changes currency composition without altering the domestic monetary base."}
+{"domain":"monetary policy","text":"Transmission lags mean policy changes affect output well after they are announced."}
+{"domain":"monetary policy","text":"Inflation targeting frameworks generally publish a numerical objective and a tolerance band."}
+{"domain":"monetary policy","text":"The effective lower bound constrains conventional easing once nominal rates approach zero."}
+{"domain":"typography","text":"Optical sizes adjust stroke contrast and spacing so a face reads well at its intended size."}
+{"domain":"typography","text":"Kerning corrects spacing between specific glyph pairs rather than across the whole run."}
+{"domain":"typography","text":"Hinting instructs the rasteriser how to snap outlines to a coarse pixel grid."}
+{"domain":"typography","text":"Measure that runs much beyond seventy characters makes the return sweep harder for the eye."}
+{"domain":"typography","text":"Old style figures share the lowercase x-height and sit more evenly within running text."}
+{"domain":"typography","text":"Ligatures resolve collisions between adjacent letterforms such as the f and the following i."}
+{"domain":"typography","text":"Leading set too tight makes ascenders and descenders of adjacent lines interfere."}
+{"domain":"typography","text":"A superfamily pairs serif and sans designs on shared proportions and vertical metrics."}
+{"domain":"forestry","text":"Continuous cover approaches maintain canopy while removing individual stems selectively."}
+{"domain":"forestry","text":"Thinning concentrates increment on retained stems and improves final crop quality."}
+{"domain":"forestry","text":"Coppice rotations exploit the ability of certain broadleaves to regrow from cut stools."}
+{"domain":"forestry","text":"Site index expresses productive capacity as height attained at a reference age."}
+{"domain":"forestry","text":"Deadwood retention supports saproxylic species that depend on decaying timber."}
+{"domain":"forestry","text":"Windthrow risk rises sharply once a stand exceeds a critical height to spacing ratio."}
+{"domain":"forestry","text":"Natural regeneration reduces establishment cost but gives less control over species mix."}
+{"domain":"forestry","text":"Increment borers sample radial growth without felling the tree being measured."}
+{"domain":"epidemiology","text":"The basic reproduction number describes expected secondary cases in a fully susceptible population."}
+{"domain":"epidemiology","text":"Case control designs sample on outcome and look backwards at exposure history."}
+{"domain":"epidemiology","text":"Confounding arises when a third factor is associated with both exposure and outcome."}
+{"domain":"epidemiology","text":"Serial interval measures the time between symptom onset in successive cases in a chain."}
+{"domain":"epidemiology","text":"Screening programmes must weigh detection benefit against harms from false positives."}
+{"domain":"epidemiology","text":"Attack rates are computed over the population at risk rather than the whole population."}
+{"domain":"epidemiology","text":"Ecological studies compare aggregates and cannot support inference about individuals."}
+{"domain":"epidemiology","text":"Vaccine efficacy from trials often exceeds effectiveness observed in routine use."}
+{"domain":"chess","text":"Doubled pawns lose flexibility but can open a file for the rooks behind them."}
+{"domain":"chess","text":"An outpost is a square that cannot be challenged by an enemy pawn."}
+{"domain":"chess","text":"Zugzwang describes a position where any legal move worsens the mover's standing."}
+{"domain":"chess","text":"Opposite coloured bishops increase drawing chances in simplified endings."}
+{"domain":"chess","text":"Development advantage is transient and must be converted before the opponent catches up."}
+{"domain":"chess","text":"The minority attack aims to create a weakness on the side where one has fewer pawns."}
+{"domain":"chess","text":"Rook endings are drawn more often than material counts alone would suggest."}
+{"domain":"chess","text":"Prophylactic moves address the opponent's intention rather than advancing one's own plan."}
+{"domain":"cartography","text":"Every projection distorts some combination of area, shape, distance, and direction."}
+{"domain":"cartography","text":"Generalisation removes detail so that features remain legible at reduced scale."}
+{"domain":"cartography","text":"Contour interval must suit both terrain relief and the intended reading distance."}
+{"domain":"cartography","text":"Datum differences can displace coordinates by hundreds of metres if ignored."}
+{"domain":"cartography","text":"Choropleth shading invites misreading when the underlying units differ greatly in size."}
+{"domain":"cartography","text":"Label placement is constrained by feature geometry and by collision with other labels."}
+{"domain":"cartography","text":"Rhumb lines cross every meridian at a constant angle and appear straight on a Mercator sheet."}
+{"domain":"cartography","text":"Hypsometric tinting conveys elevation bands through a graduated colour sequence."}
+{"domain":"ceramics","text":"Bisque firing drives off chemically bound water and makes the ware safe to glaze."}
+{"domain":"ceramics","text":"Glaze fit depends on matching thermal expansion between body and coating."}
+{"domain":"ceramics","text":"Reduction atmospheres starve the kiln of oxygen and alter metallic oxide colours."}
+{"domain":"ceramics","text":"Wedging removes air pockets and aligns platelets before throwing begins."}
+{"domain":"ceramics","text":"Grog added to a clay body reduces shrinkage and improves resistance to thermal shock."}
+{"domain":"ceramics","text":"Crazing appears when the glaze contracts more than the body beneath it."}
+{"domain":"ceramics","text":"Slip casting reproduces complex forms that would be impractical to throw."}
+{"domain":"ceramics","text":"Vitrification closes porosity as the body approaches its maturing temperature."}
+{"domain":"civil engineering","text":"Prestressing introduces compression that offsets tensile stresses under service loading."}
+{"domain":"civil engineering","text":"Settlement of foundations matters less in absolute terms than differentially across a structure."}
+{"domain":"civil engineering","text":"Expansion joints accommodate thermal movement that would otherwise induce restraint forces."}
+{"domain":"civil engineering","text":"Scour around bridge piers remains a leading cause of failure in river crossings."}
+{"domain":"civil engineering","text":"Compaction increases density and reduces the void ratio of placed fill."}
+{"domain":"civil engineering","text":"Redundant structural systems retain capacity after the loss of a single member."}
+{"domain":"civil engineering","text":"Cover to reinforcement protects steel from carbonation and chloride ingress."}
+{"domain":"civil engineering","text":"Serviceability limits on deflection often govern design before ultimate strength does."}
+{"domain":"immunology","text":"Clonal selection expands lymphocytes whose receptors bind the encountered antigen."}
+{"domain":"immunology","text":"Antigen presentation on class one molecules signals the state of the cell interior."}
+{"domain":"immunology","text":"Affinity maturation improves antibody binding through iterative mutation and selection."}
+{"domain":"immunology","text":"Complement activation proceeds through cascades converging on a shared membrane attack complex."}
+{"domain":"immunology","text":"Regulatory populations suppress responses that would otherwise damage host tissue."}
+{"domain":"immunology","text":"Innate receptors recognise conserved molecular patterns rather than specific epitopes."}
+{"domain":"immunology","text":"Memory populations persist long after the initiating exposure has been cleared."}
+{"domain":"immunology","text":"Thymic selection removes developing cells that react too strongly against self."}
+{"domain":"astronomy","text":"Parallax gives direct distances to nearby stars without assuming intrinsic brightness."}
+{"domain":"astronomy","text":"Metallicity in stellar spectra traces enrichment by earlier generations of stars."}
+{"domain":"astronomy","text":"Transit depth scales with the square of the planet to star radius ratio."}
+{"domain":"astronomy","text":"Adaptive optics corrects wavefront distortion introduced by atmospheric turbulence."}
+{"domain":"astronomy","text":"Globular clusters contain old populations with little ongoing star formation."}
+{"domain":"astronomy","text":"Redshift of distant galaxies increases with distance across the observable volume."}
+{"domain":"astronomy","text":"Spectroscopic binaries are identified by periodic Doppler shifts in their absorption lines."}
+{"domain":"astronomy","text":"Interstellar extinction reddens starlight by scattering shorter wavelengths preferentially."}
+{"domain":"cooking","text":"Resting roasted meat lets juices redistribute before the fibres are cut across."}
+{"domain":"cooking","text":"Emulsions hold together when an agent keeps dispersed droplets from coalescing."}
+{"domain":"cooking","text":"Browning develops flavour compounds that simple boiling cannot produce."}
+{"domain":"cooking","text":"Salting early draws moisture out and then reabsorbs it as seasoned brine."}
+{"domain":"cooking","text":"Gluten development gives dough the elasticity needed to trap fermentation gases."}
+{"domain":"cooking","text":"Acid added late preserves brightness that prolonged heating would dull."}
+{"domain":"cooking","text":"Low temperature cooking narrows the gradient between surface and centre doneness."}
+{"domain":"cooking","text":"Starch gelatinisation thickens sauces only once a sufficient temperature is reached."}
+{"domain":"paleontology","text":"Trace fossils record behaviour rather than the anatomy of the organism that made them."}
+{"domain":"paleontology","text":"Lagerstätten preserve soft tissue that ordinary depositional settings destroy."}
+{"domain":"paleontology","text":"Biostratigraphy correlates strata using the ranges of short-lived index taxa."}
+{"domain":"paleontology","text":"Taphonomic bias favours hard parts and shallow marine settings in the record."}
+{"domain":"paleontology","text":"Phylogenetic bracketing infers soft tissue traits from living relatives on either side."}
+{"domain":"paleontology","text":"Growth series show that many named forms were juveniles of known species."}
+{"domain":"paleontology","text":"Permineralisation replaces void space with mineral while retaining cellular detail."}
+{"domain":"paleontology","text":"Mass extinction boundaries are defined by turnover rather than by absolute diversity."}

--- a/internal/plugin/embed/anisotropy_test.go
+++ b/internal/plugin/embed/anisotropy_test.go
@@ -1,0 +1,187 @@
+package embed
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestAnisotropyCorpus_LoadsAndIsDiverse(t *testing.T) {
+	entries, err := AnisotropyCorpus()
+	if err != nil {
+		t.Fatalf("AnisotropyCorpus: %v", err)
+	}
+	if len(entries) < 100 {
+		t.Errorf("corpus has %d entries; too small for a stable sigma", len(entries))
+	}
+	domains := map[string]int{}
+	for _, e := range entries {
+		domains[e.Domain]++
+	}
+	if len(domains) < 10 {
+		t.Errorf("corpus spans %d domains; a baseline over few domains characterizes the domains, not the model", len(domains))
+	}
+	// Every domain should be represented comparably, or the cross-domain pair
+	// population is dominated by whichever domain is over-represented.
+	for d, n := range domains {
+		if n < 2 {
+			t.Errorf("domain %q has %d entries", d, n)
+		}
+	}
+	// Duplicate text would be a same-pair masquerading as a cross-domain pair.
+	seen := map[string]bool{}
+	for _, e := range entries {
+		if seen[e.Text] {
+			t.Errorf("duplicate corpus text: %q", e.Text)
+		}
+		seen[e.Text] = true
+	}
+}
+
+// synthetic vectors: same-domain entries are made deliberately similar, so a
+// baseline that fails to exclude them is measurably inflated.
+func syntheticVectors(entries []CorpusEntry, seed int64) [][]float32 {
+	r := rand.New(rand.NewSource(seed))
+	const dim = 64
+	base := map[string][]float32{}
+	out := make([][]float32, len(entries))
+	for i, e := range entries {
+		if _, ok := base[e.Domain]; !ok {
+			b := make([]float32, dim)
+			for j := range b {
+				b[j] = float32(r.NormFloat64())
+			}
+			base[e.Domain] = b
+		}
+		v := make([]float32, dim)
+		for j := range v {
+			// heavy shared component within a domain, small individual noise
+			v[j] = base[e.Domain][j] + float32(r.NormFloat64())*0.2
+		}
+		out[i] = v
+	}
+	return out
+}
+
+// The property the exclusion exists for: including same-domain pairs raises the
+// baseline. If AnisotropyBaseline ever stops excluding them, this fails.
+func TestAnisotropyBaseline_ExcludesSameDomainPairs(t *testing.T) {
+	entries, err := AnisotropyCorpus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vecs := syntheticVectors(entries, 42)
+
+	got, err := AnisotropyBaseline(entries, vecs, 1.3)
+	if err != nil {
+		t.Fatalf("AnisotropyBaseline: %v", err)
+	}
+
+	// Recompute deliberately WITHOUT the exclusion. Giving every entry its own
+	// unique domain means no pair is ever same-domain, so all N(N-1)/2 pairs
+	// are counted — which is exactly what a corpus shipped without domain
+	// labels would produce.
+	flat := make([]CorpusEntry, len(entries))
+	for i, e := range entries {
+		flat[i] = CorpusEntry{Domain: fmt.Sprintf("unique-%d", i), Text: e.Text}
+	}
+	unfiltered, err := AnisotropyBaseline(flat, vecs, 1.3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !(unfiltered.Mean > got.Mean) {
+		t.Errorf("same-domain contamination did not raise the mean: filtered=%.4f unfiltered=%.4f\n"+
+			"(the exclusion is what keeps related pairs out of an 'unrelated pair' statistic)",
+			got.Mean, unfiltered.Mean)
+	}
+	if got.NPairs >= unfiltered.NPairs {
+		t.Errorf("filtered pair count %d should be below unfiltered %d", got.NPairs, unfiltered.NPairs)
+	}
+}
+
+func TestAnisotropyBaseline_IsScaleInvariant(t *testing.T) {
+	entries, err := AnisotropyCorpus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vecs := syntheticVectors(entries, 7)
+	a, err := AnisotropyBaseline(entries, vecs, 1.3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Scale every vector by 10 — cosine must not move. This is the property
+	// that makes the result independent of whether a backend returns unit
+	// vectors (Ollama's /api/embed and /api/embeddings differ on exactly this).
+	scaled := make([][]float32, len(vecs))
+	for i, v := range vecs {
+		s := make([]float32, len(v))
+		for j, x := range v {
+			s[j] = x * 10
+		}
+		scaled[i] = s
+	}
+	b, err := AnisotropyBaseline(entries, scaled, 1.3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if math.Abs(a.Baseline-b.Baseline) > 1e-9 {
+		t.Errorf("baseline moved under scaling: %.12f vs %.12f", a.Baseline, b.Baseline)
+	}
+}
+
+func TestAnisotropyBaseline_KIsMonotone(t *testing.T) {
+	entries, err := AnisotropyCorpus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vecs := syntheticVectors(entries, 11)
+	var prev float64 = -2
+	for _, k := range []float64{0, 1.0, 1.3, 2.0, 3.0} {
+		r, err := AnisotropyBaseline(entries, vecs, k)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if r.Baseline <= prev {
+			t.Errorf("baseline not increasing in k: k=%v gave %.4f, previous %.4f", k, r.Baseline, prev)
+		}
+		prev = r.Baseline
+	}
+}
+
+func TestAnisotropyBaseline_Rejects(t *testing.T) {
+	entries := []CorpusEntry{{Domain: "a", Text: "x"}, {Domain: "b", Text: "y"}}
+	if _, err := AnisotropyBaseline(entries, [][]float32{{1, 0}}, 1.3); err == nil {
+		t.Error("mismatched entry/vector counts must be rejected")
+	}
+	if _, err := AnisotropyBaseline(entries, [][]float32{{1, 0}, {1, 0, 0}}, 1.3); err == nil {
+		t.Error("ragged vector dimensions must be rejected")
+	}
+	if _, err := AnisotropyBaseline(entries, [][]float32{{0, 0}, {1, 0}}, 1.3); err == nil {
+		t.Error("a zero vector has no direction and must be rejected, not silently scored")
+	}
+	single := []CorpusEntry{{Domain: "a", Text: "x"}, {Domain: "a", Text: "y"}}
+	if _, err := AnisotropyBaseline(single, [][]float32{{1, 0}, {0, 1}}, 1.3); err == nil {
+		t.Error("a corpus with no cross-domain pairs must be rejected rather than return a baseline over zero pairs")
+	}
+}
+
+// Rescale is what consumes the baseline; pin the relationship so a change to
+// one is not made without looking at the other.
+func TestAnisotropyBaseline_FeedsRescale(t *testing.T) {
+	entries, err := AnisotropyCorpus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := AnisotropyBaseline(entries, syntheticVectors(entries, 3), 1.3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if Rescale(r.Baseline, r.Baseline) != 0 {
+		t.Error("a cosine exactly at the baseline must rescale to 0")
+	}
+	if got := Rescale(1.0, r.Baseline); math.Abs(got-1.0) > 1e-9 {
+		t.Errorf("a perfect cosine must survive rescaling: got %v", got)
+	}
+}


### PR DESCRIPTION
The model-only half of #719: a fixed corpus that ships with the repo, and the
statistic computed over it, so a `noiseBaselineRegistry` value can be
re-derived by anyone for any embedder and reviewed as a diff rather than
trusted.

Deliberately does NOT touch the registry, and does not add a CLI surface —
see "what this leaves open" below.

## What lands

- `internal/plugin/embed/anisotropy_corpus.jsonl` — 160 short general-knowledge
  statements over 20 unrelated domains, 8 per domain, no proper nouns tied to
  any organization, embedded via `go:embed`. Written for this purpose.
- `internal/plugin/embed/anisotropy.go` — `AnisotropyCorpus()` and
  `AnisotropyBaseline(entries, vectors, k) → AnisotropyResult`, carrying μ, σ,
  b=μ+kσ, pair count, and p95/p99/max of the unrelated-pair distribution.
- `docs/internals/anisotropy-calibration.md` — the protocol.

## Three things the measurement forced

**Same-domain pairs must be excluded, and the corpus format has to support
that.** A corpus of N sentences over D domains does not supply N(N−1)/2
unrelated pairs — within-domain pairs are related by construction and sit
measurably higher, so counting them inflates b and makes recall abstain more
than the operator asked for. The contamination scales with the square of
per-domain depth: 4.4% of pairs at 8 sentences per domain, 9.5% at 20. This is
why the corpus carries a `domain` label per line; a corpus shipped as bare text
can only be calibrated approximately.

**k is the only part of μ+kσ that encodes a product decision.** μ and σ are
model properties; k trades false-admits against false-abstains. The doc records
it as one global default with the per-vault `SemanticFloor` override, and asks
that a chosen k be defended by reporting what share of unrelated pairs it
admits — because "μ+1.3σ" reads like "almost nothing gets through" and on a
1024-dim model I measured it is about one unrelated pair in ten.

**b belongs to the model *and its implementation*.** Pooling, instruction-prefix
convention (bge v1.5 uses one for queries, bge-m3 does not), truncation and
quantization all move the distribution, so two callers can both honestly say
"bge-small-en-v1.5" and be entitled to different constants. `AnisotropyResult`
carries the numeric provenance; the doc lists the rest.

Relatedly, `AnisotropyBaseline` normalizes internally rather than trusting the
caller, because Ollama's `/api/embed` and `/api/embeddings` return normalized
and unnormalized vectors for the same model and input. There is a test pinning
scale-invariance.

## A protocol divergence worth settling before more entries land

The shipped `bge-small-en-v1.5` value (b=0.520, μ=0.450 σ=0.054) came from 432
nonsense-query × real-passage pairs — a query→passage distribution. This
procedure measures random cross-domain sentence pairs. Both estimate "cosine
between unrelated text", but they are different populations and the numbers are
not interchangeable. Whichever you prefer should be used for every entry, or
the registry stops being comparable to itself.

I have a bge-m3 (1024-dim, Ollama) characterization under this procedure —
cross-domain μ=0.4111 σ=0.0578 over 12,160 pairs, b=0.4863 at k=1.3 — but
deliberately did not add it to the registry: it would change runtime behaviour
for bge-m3 users on the strength of a protocol that differs from the one behind
the existing entry. It belongs there once the protocol question is settled.

## What this leaves open

`muninn calibrate-model` is not here. Wiring it needs a decision I would rather
take from you than guess: an operator-invoked command that writes a registry
entry, or a build-time step that regenerates a checked-in table. I lean to the
latter for shipped models — the constants stay reviewable in a diff and
reproducible in CI — with the command available for characterizing a model you
do not ship, which is the case I actually have. Say which and I will add it.

## Verification

- `gofmt -l` clean, `go vet ./internal/plugin/embed/` clean, `go build ./...`
  clean, package green under `-race`.
- `TestAnisotropyBaseline_ExcludesSameDomainPairs` is the load-bearing one and
  is constructed so it fails if the exclusion is removed: it recomputes with
  every entry given a unique domain (so no pair is ever same-domain, i.e. all
  N(N−1)/2 pairs count) and asserts the mean rises. My first version of that
  test relabelled into two alternating domains, which still excludes
  same-parity pairs and so proved nothing — it reported fewer pairs, not more.
- Corpus invariants are tested too (size, domain spread, no duplicate text),
  since a duplicated line would be a same-pair masquerading as a cross-domain
  one.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


---

Refs #719. Complements the measurement I posted on the issue.

Scoped to the library + corpus + protocol on purpose: the CLI shape is a design
call that is yours, and I did not want a speculative command to be the reason
the reproducible-corpus part is hard to review. Happy to add
`muninn calibrate-model` in whichever shape you pick, on this branch or a
follow-up.
