### PR TITLE
test(engine): stop TestStartImport_OrphanedVaultCleanup misreporting a timeout as a cleanup bug

### DIFF
--- a/internal/engine/engine_export_test.go
+++ b/internal/engine/engine_export_test.go
@@ -179,20 +179,43 @@ func TestStartImport_OrphanedVaultCleanup(t *testing.T) {
 		t.Fatalf("StartImport: %v", err)
 	}
 
-	// Wait for job to fail.
-	deadline := time.Now().Add(10 * time.Second)
+	// Wait for the job to fail.
+	//
+	// The timeout MUST be detected. Previously this loop simply exited when the
+	// deadline passed and the test carried on to assert the vault was cleaned
+	// up — but cleanup only runs after the job reaches StatusError, so a slow
+	// runner produced "orphaned vault name still registered after failed
+	// import", blaming the cleanup path for what was really "the job had not
+	// finished yet". That misattribution turned a timing flake into a hunt for a
+	// non-existent cleanup bug, and it failed CI on a docs-only commit.
+	//
+	// Waiting longer alone would not fix it: the defect is that an unmet
+	// precondition was reported as a failed assertion. Now the timeout fails on
+	// its own terms, and the budget is generous because this asserts a
+	// CORRECTNESS property (cleanup happens), not a latency one.
+	const importFailDeadline = 60 * time.Second
+	deadline := time.Now().Add(importFailDeadline)
+	failed := false
+	var lastStatus vaultjob.Status
 	for time.Now().Before(deadline) {
 		j, ok := eng.GetVaultJob(job.ID)
 		if !ok {
 			t.Fatalf("job %q not found", job.ID)
 		}
-		if j.GetStatus() == vaultjob.StatusError {
+		lastStatus = j.GetStatus()
+		if lastStatus == vaultjob.StatusError {
+			failed = true
 			break
 		}
-		if j.GetStatus() == vaultjob.StatusDone {
+		if lastStatus == vaultjob.StatusDone {
 			t.Fatal("expected job to fail with bad data, but it succeeded")
 		}
 		time.Sleep(50 * time.Millisecond)
+	}
+	if !failed {
+		t.Fatalf("import job %q did not reach StatusError within %v (last status %v) — the cleanup "+
+			"assertion below is only meaningful once the job has failed, so this is a timeout, not a "+
+			"cleanup defect", job.ID, importFailDeadline, lastStatus)
 	}
 
 	// Vault name must NOT appear in the listing.


### PR DESCRIPTION
## The problem

This failed CI on `ebdc1a1` — a **docs-only** commit (the decision-record merge). A markdown change cannot break an engine test, and the test passes 3/3 locally at that exact commit. It is a flake, and it left `develop`'s HEAD red.

## Why it flaked, and why waiting longer isn't the fix

The wait loop exited **silently** when its 10s deadline passed:

```go
deadline := time.Now().Add(10 * time.Second)
for time.Now().Before(deadline) { ... }   // no timeout detection
// then asserts the orphaned vault was cleaned up
```

But cleanup only runs once the import job reaches `StatusError`. On a loaded runner the job hasn't failed yet, so the assertion fires with:

```
orphaned vault name still registered after failed import
```

…blaming the cleanup path for what is really *"the job has not finished"*. That misattribution turns a timing flake into a hunt for a cleanup bug that does not exist.

**The defect is not the duration — it is that an unmet precondition was reported as a failed assertion.**

## The change

- The timeout now **fails on its own terms** and names the last observed status, so the next reader sees a timeout, not a phantom cleanup bug.
- Budget raised 10s → 60s. This test asserts a **correctness** property (cleanup happens after failure), not a latency one, so there is no reason for it to be tight.

## Context: third timing flake this week

Same root shape each time — a timing assumption that reports the wrong cause when violated:

| | |
|---|---|
| currency latency budget (#744) | 2.8x/4.2x headroom on a shared runner; failed at 54.5ms vs 50ms |
| abstention measurement harness | non-deterministic baseline (map-ordered hot set + wall-clock `CreatedAt`) |
| **this** | silent timeout misreported as a cleanup failure |

A red HEAD on a docs commit is the signal that trains people to stop reading CI, which is why this is worth its own PR rather than a re-run.

Test-only change.