### PR TITLE
fix: full-confidence weight destruction, evolve provenance, and the measured recall ceiling

### DIFF
--- a/docs/internals/keyspace-registry.md
+++ b/docs/internals/keyspace-registry.md
@@ -44,7 +44,7 @@ prefix — see the vault-reuse note at the bottom).
 | 0x13 | ws | VaultWeights | storage-only since #618 |
 | 0x14 | ws+src(16)+dst(16) | AssocWeightIndex float32 | storage-only since #618 |
 | 0x15 | ws | BE int64 count | vault engram count ("sole user" per comment) |
-| 0x16 | ws+id(16)+ts(8)+seq(4) | provenance | async worker |
+| 0x16 | ws+id(16)+ts(8)+seq(4) | provenance entry (**JSON**, additively extensible) | async worker; the value is `provenance.ProvenanceEntry` marshalled with encoding/json, so a new *optional* field needs no version byte: old entries decode with the field ABSENT (never a zero value posing as data), and new entries decode on an old binary, which ignores the unknown key. `Details` (evolve's predecessor_id / reason / effective_at; extensible per-operation) was added this way. Renaming or retyping an existing field, or making a new field load-bearing for correctness, WOULD require a real format version |
 | 0x17 | ws | migration version+cursor | |
 | 0x18 | ws+ulid | quantize params + int8 embedding | ERF v2 vector |
 | **0x19** | siphash(opID)(8) → JSON receipt | idempotency | **shared with replication (see below) — safe only by JSON-vs-msgpack decode accident** |

--- a/internal/engine/activation/recall_queryset_measure_test.go
+++ b/internal/engine/activation/recall_queryset_measure_test.go
@@ -1,0 +1,1246 @@
+//go:build localassets
+
+package activation_test
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/engine/activation"
+	"github.com/scrypster/muninndb/internal/index/fts"
+	embedpkg "github.com/scrypster/muninndb/internal/plugin/embed"
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// ---------------------------------------------------------------------------
+// THE LABELED RECALL QUERY SET — the thing every abstention/floor tuning
+// decision in this repo has so far been made without.
+//
+// WHY THIS FILE EXISTS. b (COG-26's 0.520), the 0.6/0.4 combiner and the 0.1
+// engine threshold have each been moved on the evidence of a handful of
+// hand-picked probes. A hands-on evaluation then reported four straightforward
+// known-answer recall failures — two wrong abstentions on paraphrases, two
+// unresponsive answers where the system should have abstained. None of those
+// four shapes was represented in any in-tree measurement. A single-number
+// harness (abstention_gate_measure_test.go: 12 answerable / 16 unanswerable,
+// one difficulty, FTS stubbed empty) cannot tell you WHERE a change helps or
+// hurts, so every proposal arrives as an argument rather than a measurement.
+//
+// This file is the query set and the measuring instrument. It is the
+// deliverable whether or not any scoring change ships behind it.
+//
+// WHAT IS LABELED.
+//   48 synthetic engrams across five loosely-related domains (field research
+//   operations, programme/release decisions, telemetry & infrastructure,
+//   staff policy, lab & hardware). Loosely-related on purpose: a corpus of
+//   mutually unrelated notes makes abstention trivially easy and hides the
+//   only interesting failure — the topically-adjacent near miss.
+//
+//   30 ANSWERABLE queries, each with a gold engram, GRADED BY DIFFICULTY:
+//     - rqNearVerbatim: the query reuses the stored wording. The easy case;
+//       it exists to catch a change that buys hard-paraphrase recall by
+//       breaking the cases that already worked.
+//     - rqModerate: reworded, some content words survive. Both channels
+//       (semantic + lexical) carry partial signal.
+//     - rqHard: reformulated with essentially no content-word overlap. The
+//       semantic channel is the ONLY channel. This band contains the two
+//       reconstructed wrong-abstention failures (rqHard #1 and #2).
+//
+//   20 UNANSWERABLE queries, in three kinds, because "unanswerable" is not
+//   one problem:
+//     - rqOOD: out-of-domain nonsense. The easy case (and the only kind the
+//       previous harness had).
+//     - rqAdjacent: TOPICALLY ADJACENT but unanswerable — the corpus knows
+//       about release codenames but not about signing-key passwords. This is
+//       the shape that produced "returned a related-but-unresponsive memory";
+//       it is the hard case and the one an abstention gate is actually for.
+//     - rqStale: present-tense questions about live state ("which sensors are
+//       stale right now") whose answer is not, and cannot be, in a corpus of
+//       standing facts — the shape left behind after a valid-time filter
+//       correctly removes an expired fact. The correct answer is abstention,
+//       not the surrounding policy notes.
+//
+// READ BEFORE QUOTING A NUMBER.
+//   - ONE corpus, ONE embed model (bundled bge-small-en-v1.5), 50 queries. The
+//     absolute values are this corpus's; the DIFFERENCES between arms are what
+//     the file is for. Nothing here licenses tuning a shipped constant — see
+//     CLAUDE.md principle 11.
+//   - The rqStale labels are a judgment call and the honest place to disagree.
+//     Labelling "which sensors are stale at the moment" NONE asserts that
+//     returning the standing staleness RULE is a wrong answer to a question
+//     about current state. That is the behaviour the evaluation complained
+//     about, and it is why the band is broken out separately rather than
+//     folded into the headline FPR: a reader who thinks the rule IS a
+//     reasonable answer can discount that column and read the rqAdjacent one,
+//     where the corpus genuinely does not contain the answer at all.
+//   - CandidatesPerIndex is raised to 60 so the whole corpus is in every
+//     query's pool. Every miss reported here is therefore a GATE decision, not
+//     a retrieval-pool truncation.
+//   - Engram IDs are pinned (rqDeterministicULID) because ranking metrics are
+//     sensitive to score ties and the engine breaks ties by ID.
+//
+// PRIVACY. Every engram, query and label in this file is synthetic, authored
+// here, and describes no real person, system, credential or organisation. No
+// vault data, no user text, nothing copied from anywhere.
+// ---------------------------------------------------------------------------
+
+// rqCorpus is the labeled corpus. Order is load-bearing only in that engram
+// IDs are derived from the index (see rqBuildFixture) to keep tie-breaking
+// deterministic across runs.
+var rqCorpus = []struct{ concept, content string }{
+	// --- field research operations -----------------------------------------
+	{"Offline endurance of field kits", "Field researchers can operate approximately 72 hours offline before the survey kit must be resynchronised with the base station."},
+	{"Base station resynchronisation window", "Resynchronisation with the base station takes about forty minutes and must complete before the next survey window opens."},
+	{"Survey kit battery swap procedure", "Each survey kit carries two swappable battery packs; the depleted pack is rotated into the solar charger at the end of the daily transect."},
+	{"Transect sampling cadence", "Transects are walked twice daily, once at dawn and once two hours before dusk, to capture both activity peaks."},
+	{"Specimen labelling convention", "Specimen jars are labelled with the transect code, the ordinal sample number, and the collector's initials, in that order."},
+	{"Weather abort criteria for field days", "Field days are aborted when sustained wind exceeds forty knots or visibility drops below two hundred metres."},
+	{"Satellite uplink cost policy", "The satellite uplink is billed per megabyte, so bulk imagery is held on the kit and uploaded only from the base station."},
+	{"Field trauma kit contents", "Every field team carries a trauma kit with a tourniquet, a splint, and a snakebite pressure bandage."},
+	{"Radio check schedule", "Field teams call in a radio check on the hour; two missed checks trigger the overdue-party protocol."},
+	{"Camp waste carry-out rule", "All camp waste including greywater is carried out; nothing organic is buried at the survey sites."},
+
+	// --- programme decisions & releases ------------------------------------
+	{"Violet Basin siting decision", "After the second review the team chose the Violet Basin site for the northern station, accepting the longer approach road in exchange for year-round access."},
+	{"Release codename Amber Kestrel", "The autumn release ships under the codename Amber Kestrel; the codename is public and appears in the changelog."},
+	{"Codename rotation policy", "Release codenames rotate through a bird list; a codename is never reused across two consecutive years."},
+	{"Deferred decision on the eastern annex", "The eastern annex build was deferred a full cycle pending a geotechnical survey."},
+	{"Vendor selection for mast hardware", "Mast hardware was awarded to the second-lowest bidder because the lowest could not meet the galvanising specification."},
+	{"Decision log retention", "Decision records are retained for seven years and are never edited in place; corrections are appended as new entries."},
+	{"Approval threshold for capital spend", "Capital spend above forty thousand requires two signatures, one of which must be the programme lead."},
+	{"Change freeze around releases", "No configuration changes land in the seventy-two hours before a release cut."},
+	{"Rollback authority", "Any on-call engineer may roll back a release without further approval; the post-mortem is mandatory."},
+	{"Naming of the southern station", "The southern station was named Kettle Flats after the landform, over the objection that it duplicates a nearby toponym."},
+
+	// --- telemetry & infrastructure ----------------------------------------
+	{"Telemetry retention tiers", "Raw telemetry is kept hot for fourteen days, then rolled into hourly aggregates held for two years."},
+	{"Alert routing after hours", "Alerts raised outside business hours page the on-call rotation directly rather than filing a ticket."},
+	{"Sensor heartbeat interval", "Each sensor emits a heartbeat every thirty seconds; three consecutive misses mark the sensor as stale."},
+	{"Ingest backpressure behaviour", "When the ingest queue exceeds its high-water mark the collector sheds the lowest-priority streams first."},
+	{"Dashboard refresh cadence", "Operations dashboards refresh on a sixty-second cycle; a manual refresh is rate-limited to once per ten seconds."},
+	{"Metric naming scheme", "Metric names are dotted, lowercase, and end with the unit, so latency metrics end in milliseconds."},
+	{"Clock skew tolerance for ingest", "Samples arriving more than five minutes ahead of the collector clock are rejected as skewed."},
+	{"Cold storage export format", "Aggregates exported to cold storage are written as columnar files partitioned by day."},
+	{"Sampling rate for high-cardinality series", "High-cardinality series are sampled at one in ten to keep the index within budget."},
+	{"Synthetic probe coverage", "Synthetic probes exercise the read path from three regions every five minutes."},
+
+	// --- staff policy -------------------------------------------------------
+	{"Remote work expectation", "Staff are expected on site two days a week; the remaining days may be worked remotely."},
+	{"Field allowance eligibility", "A field allowance is payable for every night spent away from the home station, claimed on the monthly return."},
+	{"Training budget per person", "Each person has an annual training budget that does not roll over into the following year."},
+	{"On-call compensation", "On-call weeks are compensated as a flat stipend plus time off in lieu for any night call-out."},
+	{"Probation review timing", "New staff have a formal review at three months and again at six months before confirmation."},
+	{"Equipment loan agreement", "Personal loans of programme equipment require a signed agreement and are limited to fourteen days."},
+	{"Conference travel approval", "Conference travel needs approval from the line manager and, if international, from the programme lead."},
+	{"Parental leave top-up", "The programme tops up statutory parental leave to full pay for the first twelve weeks."},
+	{"Volunteer day allocation", "Everyone may take two paid volunteer days a year with a recognised conservation organisation."},
+
+	// --- lab & hardware -----------------------------------------------------
+	{"Autoclave cycle validation", "The autoclave is validated monthly with a biological indicator run at the longest cycle."},
+	{"Cold room temperature alarm", "The cold room alarms if it drifts outside two to eight degrees for more than fifteen minutes."},
+	{"Microscope objective cleaning", "Objectives are cleaned only with lens tissue and the approved solvent, never with ethanol."},
+	{"Balance calibration interval", "Analytical balances are calibrated by an external service every six months."},
+	{"Chemical waste segregation", "Halogenated and non-halogenated solvent waste go into separate labelled carboys."},
+	{"Fume hood face velocity", "Fume hood face velocity is checked annually and must fall between 0.4 and 0.6 metres per second."},
+	{"Glassware breakage reporting", "Broken glassware is logged so the consumables budget tracks actual attrition."},
+	{"Sample freezer inventory audit", "The minus eighty freezers are inventoried each quarter and unlabelled samples are discarded."},
+	{"Gas cylinder restraint rule", "Every gas cylinder is chained at two points regardless of size or how briefly it is in the room."},
+}
+
+// rqBand grades an answerable query by how much lexical help it gives.
+type rqBand int
+
+const (
+	rqNearVerbatim rqBand = iota
+	rqModerate
+	rqHard
+)
+
+func (b rqBand) String() string {
+	switch b {
+	case rqNearVerbatim:
+		return "near-verbatim"
+	case rqModerate:
+		return "moderate"
+	default:
+		return "hard-paraphrase"
+	}
+}
+
+var rqBands = []rqBand{rqNearVerbatim, rqModerate, rqHard}
+
+// rqAnswerable: 30 queries with a gold engram each, 10 per difficulty band.
+var rqAnswerable = []struct {
+	query string
+	gold  string
+	band  rqBand
+}{
+	// --- near-verbatim (10) -------------------------------------------------
+	{"how long can field researchers operate offline", "Offline endurance of field kits", rqNearVerbatim},
+	{"telemetry retention tiers", "Telemetry retention tiers", rqNearVerbatim},
+	{"sensor heartbeat interval", "Sensor heartbeat interval", rqNearVerbatim},
+	{"what is the release codename Amber Kestrel", "Release codename Amber Kestrel", rqNearVerbatim},
+	{"cold room temperature alarm range", "Cold room temperature alarm", rqNearVerbatim},
+	{"gas cylinder restraint rule", "Gas cylinder restraint rule", rqNearVerbatim},
+	{"approval threshold for capital spend", "Approval threshold for capital spend", rqNearVerbatim},
+	{"fume hood face velocity check", "Fume hood face velocity", rqNearVerbatim},
+	{"on-call compensation for night call-outs", "On-call compensation", rqNearVerbatim},
+	{"the Violet Basin siting decision", "Violet Basin siting decision", rqNearVerbatim},
+
+	// --- moderate paraphrase (10) ------------------------------------------
+	{"how many days a week do we have to be in the office", "Remote work expectation", rqModerate},
+	{"what happens if a sensor stops sending heartbeats", "Sensor heartbeat interval", rqModerate},
+	{"who is allowed to roll back a release", "Rollback authority", rqModerate},
+	{"how often are the analytical balances calibrated", "Balance calibration interval", rqModerate},
+	{"how should solvent waste be separated", "Chemical waste segregation", rqModerate},
+	{"when do we stop making configuration changes before shipping", "Change freeze around releases", rqModerate},
+	{"how are specimen jars labelled", "Specimen labelling convention", rqModerate},
+	{"what happens when the ingest queue gets too full", "Ingest backpressure behaviour", rqModerate},
+	{"how often do the operations dashboards update", "Dashboard refresh cadence", rqModerate},
+	{"when is a field day called off because of weather", "Weather abort criteria for field days", rqModerate},
+
+	// --- hard paraphrase, ~zero content-word overlap (10) -------------------
+	// #1 and #2 are the two reconstructed wrong-abstention failures.
+	{"How long can field researchers work while completely disconnected?", "Offline endurance of field kits", rqHard},
+	{"What was the basin decision?", "Violet Basin siting decision", rqHard},
+	{"if a couple of scheduled check-ins are missed, what kicks in", "Radio check schedule", rqHard},
+	{"can I take a piece of programme kit home for a month", "Equipment loan agreement", rqHard},
+	{"does unused money for courses carry into next year", "Training budget per person", rqHard},
+	{"what do people get for nights spent away from home", "Field allowance eligibility", rqHard},
+	{"how do we keep the bill down when sending pictures back from the bush", "Satellite uplink cost policy", rqHard},
+	{"is there any way to correct something already written in an old record", "Decision log retention", rqHard},
+	{"what happens to samples nobody put a name on", "Sample freezer inventory audit", rqHard},
+	{"how do we stop drowning in too many distinct label combinations", "Sampling rate for high-cardinality series", rqHard},
+}
+
+// rqKind grades an unanswerable query by how hard abstaining is.
+type rqKind int
+
+const (
+	rqOOD rqKind = iota
+	rqAdjacent
+	rqStale
+)
+
+func (k rqKind) String() string {
+	switch k {
+	case rqOOD:
+		return "out-of-domain"
+	case rqAdjacent:
+		return "topically-adjacent"
+	default:
+		return "present-tense/stale"
+	}
+}
+
+var rqKinds = []rqKind{rqOOD, rqAdjacent, rqStale}
+
+// rqUnanswerable: 20 queries whose gold answer is NONE.
+var rqUnanswerable = []struct {
+	query string
+	kind  rqKind
+	// note records WHY it is unanswerable and what it is adjacent to, so a
+	// future reader can tell a mislabelled query from a real leak.
+	note string
+}{
+	// --- topically adjacent but unanswerable (8) ----------------------------
+	// #1 is the reconstructed "deleted password -> returned the release
+	// codename memory" failure: the corpus has a codename, and knows nothing
+	// about any credential.
+	{"what is the password for the release signing key", rqAdjacent, "corpus has a public release CODENAME, no credential of any kind"},
+	{"what is the wifi password at the northern station", rqAdjacent, "corpus sites the northern station; no network credentials"},
+	{"who signed off the Violet Basin geotechnical report", rqAdjacent, "corpus records the siting decision and a deferred geotech survey, never a signatory"},
+	{"what is the serial number of the autoclave", rqAdjacent, "corpus has an autoclave validation policy, no asset identifiers"},
+	{"how many dollars is the field allowance per night", rqAdjacent, "corpus records allowance ELIGIBILITY, never a rate"},
+	{"what is the maximum wind speed the survey kit antenna can survive", rqAdjacent, "corpus has a wind ABORT criterion for people, not a hardware rating"},
+	{"which bird is next on the codename list", rqAdjacent, "corpus says codenames rotate through a bird list, never which bird"},
+	{"how much does a replacement battery pack cost", rqAdjacent, "corpus has the battery swap PROCEDURE, no pricing"},
+
+	// --- present-tense / live-state (4) ------------------------------------
+	// The shape left behind when a valid-time filter has correctly excluded an
+	// expired fact: the standing policy notes remain and must NOT be returned
+	// as if they answered a question about right now.
+	{"what is the ingest queue depth right now", rqStale, "standing backpressure policy exists; live depth does not"},
+	{"which sensors are stale at the moment", rqStale, "standing staleness RULE exists; current sensor status does not"},
+	{"which region is currently failing its synthetic probe", rqStale, "standing probe coverage exists; current failures do not"},
+	{"what is today's cold room temperature reading", rqStale, "standing alarm band exists; today's reading does not"},
+
+	// --- out-of-domain nonsense (8) ----------------------------------------
+	{"seating chart for the amphibian ballet recital", rqOOD, ""},
+	{"tasting notes for fermented basalt at the lighthouse gala", rqOOD, ""},
+	{"knitting pattern for a nine-sleeved reversible barometer cozy", rqOOD, ""},
+	{"warranty terms on a self-folding origami submarine hull", rqOOD, ""},
+	{"pruning guide for the ornamental clockspring hedge in winter", rqOOD, ""},
+	{"inventory count of left-handed metronomes in the archive annex", rqOOD, ""},
+	{"revised bylaws governing the ceremonial polishing of borrowed fog", rqOOD, ""},
+	{"nutritional breakdown of powdered moonlight sold by the furlong", rqOOD, ""},
+}
+
+// ---------------------------------------------------------------------------
+// FIXTURE
+// ---------------------------------------------------------------------------
+
+// rqFixedAge pins the fixture's AGE rather than its timestamp, for the reason
+// documented at abmFixedAge: pinning an absolute date pushes the ACT-R
+// base-level term out of the saturating regime and stops the harness from
+// reaching the condition it is meant to measure.
+const rqFixedAge = 5 * time.Minute
+
+func rqFixtureNow() time.Time { return time.Now().Add(-rqFixedAge) }
+
+// rqDeterministicULID builds a ULID whose 6-byte timestamp prefix is the
+// fixture instant and whose entropy is the corpus index. storage.NewULIDWithTime
+// draws real entropy, which makes score ties break differently on every run;
+// the ranking metrics here are sensitive to ties, so the IDs are pinned.
+func rqDeterministicULID(at time.Time, idx int) storage.ULID {
+	var u storage.ULID
+	ms := uint64(at.UnixMilli())
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], ms)
+	copy(u[0:6], buf[2:8])
+	binary.BigEndian.PutUint32(u[12:16], uint32(idx+1))
+	return u
+}
+
+// rqFixture wires the labeled corpus into a real ActivationEngine.
+//
+// withFTS selects the measurement CONDITION, and the two conditions answer
+// different questions:
+//
+//   - withFTS=true builds a real internal/index/fts index over the corpus, so
+//     ContentMatch's lexical channel carries real, calibrated coverage. This is
+//     what production recall actually does and the only condition under which
+//     a COMBINER change (how the two channels fuse) can be measured at all.
+//   - withFTS=false stubs FTS empty, which is the previous harness's condition:
+//     the semantic channel alone. It is retained because it isolates the floor.
+type rqFix struct {
+	eng       *activation.ActivationEngine
+	byConcept map[string]storage.ULID
+}
+
+// `now` is passed in rather than taken from rqFixtureNow() inside, because two
+// fixtures built for a counterfactual comparison must agree on their engram
+// IDs — and the IDs are derived from `now`. (Taking it internally silently
+// gave the two fixtures disjoint ID spaces, which made the fidelity check
+// compare nothing while reporting a pool-dependence bug that did not exist.)
+func rqBuildFixture(t *testing.T, embedder activation.Embedder, svc *embedpkg.EmbedService, withFTS bool, now time.Time) *rqFix {
+	t.Helper()
+	store := newStubStore()
+	vecs := make(map[storage.ULID][]float32, len(rqCorpus))
+	byConcept := make(map[string]storage.ULID, len(rqCorpus))
+
+	var ftsIndex activation.FTSIndex = &stubFTS{}
+	var ftsIdx *fts.Index
+	if withFTS {
+		dir := t.TempDir()
+		db, err := storage.OpenPebble(dir, storage.DefaultOptions())
+		if err != nil {
+			t.Fatalf("OpenPebble: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		ftsIdx = fts.New(db)
+		ftsIndex = activation.NewFTSAdapter(ftsIdx)
+	}
+
+	for i, n := range rqCorpus {
+		e := &storage.Engram{
+			ID:         rqDeterministicULID(now, i),
+			Concept:    n.concept,
+			Content:    n.content,
+			Confidence: 1.0,
+			Stability:  30.0,
+			CreatedAt:  now,
+		}
+		store.writeEngram(e)
+		if _, dup := byConcept[n.concept]; dup {
+			t.Fatalf("duplicate concept %q in rqCorpus — gold labels must be unique", n.concept)
+		}
+		byConcept[n.concept] = e.ID
+
+		// Production embeds "Concept + ' ' + Content" (retroactive.go:469).
+		vec, err := svc.Embed(context.Background(), []string{n.concept + " " + n.content})
+		if err != nil {
+			t.Fatalf("embed %q: %v", n.concept, err)
+		}
+		vecs[e.ID] = vec
+
+		if ftsIdx != nil {
+			if err := ftsIdx.IndexEngram([8]byte{}, [16]byte(e.ID), e.Concept, "", e.Content, nil); err != nil {
+				t.Fatalf("IndexEngram %q: %v", n.concept, err)
+			}
+		}
+	}
+
+	// Active-session condition, exactly as abmMeasureFixture: a primer engram
+	// standing in for "something the agent surfaced a moment ago", with every
+	// third corpus engram associated to it. Without this the Hebbian prior is
+	// 1.0 everywhere and half the scoring path is untested. Hot set chosen over
+	// SORTED concepts so it is the same third on every run.
+	primer := &storage.Engram{
+		ID:         rqDeterministicULID(now, len(rqCorpus)),
+		Concept:    "prior turn of this session",
+		Content:    "an unrelated memory surfaced a moment ago",
+		Confidence: 1.0, Stability: 30.0, CreatedAt: now,
+	}
+	store.writeEngram(primer)
+	hotKeys := make([]string, 0, len(byConcept))
+	for k := range byConcept {
+		hotKeys = append(hotKeys, k)
+	}
+	sort.Strings(hotKeys)
+	for i, k := range hotKeys {
+		if i%3 == 0 {
+			store.assocs[byConcept[k]] = []storage.Association{{TargetID: primer.ID, Weight: 1.0}}
+		}
+	}
+
+	eng := activation.New(store, ftsIndex, &bruteForceCosineIndex{vecs: vecs}, embedder)
+	t.Cleanup(eng.Close)
+	eng.AssocLog().Record(activation.LogEntry{
+		VaultID: 0, At: now, EngramIDs: []storage.ULID{primer.ID}, Scores: []float64{1.0},
+	})
+	return &rqFix{eng: eng, byConcept: byConcept}
+}
+
+// ---------------------------------------------------------------------------
+// PROBE — one pipeline run per query, from which every candidate arm is
+// evaluated OFFLINE and EXACTLY.
+//
+// The probe runs at SemanticBaseline=0 (the identity transform) with the
+// threshold effectively disabled, so EVERY candidate reports its raw cosine and
+// its lexical coverage — including the ones today's b=0.520 floor zeroes out,
+// which are exactly the ones a softer floor would rescue and which a probe at
+// b=0.520 could not even see.
+//
+// The remaining term is the ACT-R contextual prior. It cannot be read back as
+// Raw/ContentMatch: the reported Components.Raw has already been multiplied by
+// the per-query 1/maxRaw rescale (engine.go pass 2 overwrites Raw AFTER the
+// absolute gate is computed), so that ratio is prior x scale, not prior. It is
+// instead computed here from the ACT-R definition and the reported boosts:
+//
+//	prior = softplus(B(M) + ACTRHebScale*(hebbian + transition)) / (1 + ln 2)
+//
+// with B(M) pinned at its saturation cap. That pin is not an assumption about
+// the formula, it is a property of THIS fixture: every engram is 5 minutes old
+// (rqFixedAge) and B(M) = ln(n) - d*ln(age/n) exceeds the cap for anything
+// younger than ~73 minutes, so B(M) is the cap for every candidate in every
+// query. TestRecallQuerySet_ReconstructionFidelity verifies the result against
+// the live pipeline rather than trusting either step.
+//
+// prior is a property of the ENGRAM, not of the combiner, so any candidate
+// combiner f can be scored exactly as
+//
+//	ContentMatch' = f(cos, fts)
+//	Raw'          = ContentMatch' * prior
+//	Absolute'     = min(Raw', ContentMatch', 1) * Confidence
+//
+// with ranking by Raw'*Confidence, which is what the pipeline ranks by. No arm
+// re-runs the pipeline, every arm sees the identical candidate pool, and
+// nothing is simulated. TestRecallQuerySet_ReconstructionFidelity proves the
+// reconstruction reproduces the real b=0.520 pipeline bit-for-bit.
+// ---------------------------------------------------------------------------
+
+type rqCand struct {
+	id          storage.ULID
+	concept     string
+	cos, fts    float64
+	prior, conf float64
+	// reported by the pipeline, used only by the fidelity check
+	actualCM, actA, actRaw float64
+}
+
+// Mirrors of the ACT-R constants in activation/engine.go. Deliberately
+// duplicated rather than exported: if engine.go's values drift, the fidelity
+// test fails loudly here instead of this harness silently tracking them and
+// reporting numbers for a formula nobody reviewed.
+const (
+	rqACTRDenominator = 1.6931471805599453 // 1 + softplus(0) = 1 + ln 2
+	rqACTRHebScale    = 4.0                // resolvedWeights default
+)
+
+// rqBLevelCap is engine.go's bLevelCap: the unique B(M) at which
+// softplus(B(M)) = actrDenominator, i.e. where raw = ContentMatch exactly.
+var rqBLevelCap = math.Log(math.Exp(rqACTRDenominator) - 1)
+
+func rqSoftplus(x float64) float64 { return math.Log(1 + math.Exp(x)) }
+
+// rqPrior reconstructs the ACT-R contextual prior. See the block comment above
+// for why B(M) is the cap for every engram in this fixture.
+func rqPrior(hebbian, transition float64) float64 {
+	return rqSoftplus(rqBLevelCap+rqACTRHebScale*(hebbian+transition)) / rqACTRDenominator
+}
+
+func rqProbeAt(t *testing.T, f *rqFix, query string, baseline float64) []rqCand {
+	t.Helper()
+	res, err := f.eng.Run(context.Background(), &activation.ActivateRequest{
+		Context:    []string{query},
+		Threshold:  1e-9, // effectively disabled; nothing upstream depends on it
+		MaxResults: 200,
+		// The default is 30 per index, which would truncate a 49-engram corpus
+		// and make "the gold was not returned" ambiguous between the gate and
+		// the pool. 60 puts the whole corpus in every query's pool, so every
+		// miss reported here is a GATE decision.
+		CandidatesPerIndex: 60,
+		Weights: &activation.Weights{
+			SemanticSimilarity: 0.6,
+			FullTextRelevance:  0.4,
+			SemanticBaseline:   float32(baseline),
+			UseACTR:            true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run(%q): %v", query, err)
+	}
+	out := make([]rqCand, 0, len(res.Activations))
+	for _, s := range res.Activations {
+		c := s.Components
+		out = append(out, rqCand{
+			id:       s.Engram.ID,
+			concept:  s.Engram.Concept,
+			cos:      c.SemanticSimilarityRaw,
+			fts:      c.FullTextRelevance,
+			prior:    rqPrior(c.HebbianBoost, c.TransitionBoost),
+			conf:     c.Confidence,
+			actualCM: c.ContentMatch,
+			actA:     c.AbsoluteScore,
+			actRaw:   c.Raw,
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// CANDIDATE ARMS
+// ---------------------------------------------------------------------------
+
+// rqSemCal is the generalised COG-26 rescale with a gamma knee:
+//
+//	semCal = ((cos - b) / (1 - b))^gamma   clamped at 0
+//
+// gamma=1 is exactly today's rescaleSemantic. gamma<1 lifts the band just
+// above b (softens the knee); gamma>1 suppresses it.
+func rqSemCal(cos, b, gamma float64) float64 {
+	if b <= 0 || b >= 1 {
+		return math.Max(0, cos)
+	}
+	v := (cos - b) / (1 - b)
+	if v <= 0 {
+		return 0
+	}
+	if gamma == 1 {
+		return v
+	}
+	return math.Pow(v, gamma)
+}
+
+type rqArm struct {
+	name string
+	thr  float64
+	cm   func(cos, fts float64) float64
+}
+
+// rqEffectiveCosCutoff reports the cosine at which this arm's gate opens with
+// NO lexical support — the single number that fully determines the arm's
+// behaviour on a zero-overlap paraphrase. Computed by bisection on the arm's
+// own combiner, so it can never drift from it.
+func rqEffectiveCosCutoff(a rqArm) float64 {
+	lo, hi := 0.0, 1.0
+	if a.cm(hi, 0) < a.thr {
+		return math.NaN() // gate never opens on semantics alone
+	}
+	for i := 0; i < 60; i++ {
+		mid := (lo + hi) / 2
+		if a.cm(mid, 0) >= a.thr {
+			hi = mid
+		} else {
+			lo = mid
+		}
+	}
+	return hi
+}
+
+// rqEffectiveFTSCutoff is the same for the lexical channel with no semantic
+// support: the coverage a purely lexical hit needs to survive.
+func rqEffectiveFTSCutoff(a rqArm) float64 {
+	lo, hi := 0.0, 1.0
+	if a.cm(0, hi) < a.thr {
+		return math.NaN()
+	}
+	for i := 0; i < 60; i++ {
+		mid := (lo + hi) / 2
+		if a.cm(0, mid) >= a.thr {
+			hi = mid
+		} else {
+			lo = mid
+		}
+	}
+	return hi
+}
+
+func rqLinear(b, gamma float64) func(cos, fts float64) float64 {
+	return func(cos, fts float64) float64 { return 0.6*rqSemCal(cos, b, gamma) + 0.4*fts }
+}
+
+func rqNoisyOR(b, gamma float64) func(cos, fts float64) float64 {
+	return func(cos, fts float64) float64 {
+		s := math.Min(1, rqSemCal(cos, b, gamma))
+		f := math.Min(1, fts)
+		return 1 - (1-s)*(1-f)
+	}
+}
+
+func rqMax(b, gamma float64) func(cos, fts float64) float64 {
+	return func(cos, fts float64) float64 { return math.Max(rqSemCal(cos, b, gamma), fts) }
+}
+
+// rqArms — every candidate is (combiner, floor, threshold) as ONE unit,
+// because they are one calibration. An arm that changes the combiner without
+// re-deriving the threshold is not a candidate, it is a bug.
+//
+// The noisy-OR / max arms sit at threshold 0.1667 rather than 0.10 for a
+// derived reason, not a tuned one: at the measured bge-small out-of-domain
+// noise ceiling (cos 0.596) semCal is (0.596-0.520)/0.480 = 0.1583, and an
+// unweighted OR/max passes that straight through. 0.1667 is the smallest
+// round threshold above it, i.e. the value that keeps the noise ceiling
+// rejected — which happens to reproduce EXACTLY today's semantic-only cutoff
+// (cos >= 0.600), so those arms differ from CURRENT only in how a lexical hit
+// is treated.
+var rqArms = []rqArm{
+	{"CURRENT linear b=.520 thr=.10", 0.10, rqLinear(0.520, 1)},
+
+	// (c) threshold-only, for completeness.
+	{"T-only linear b=.520 thr=.08", 0.08, rqLinear(0.520, 1)},
+	{"T-only linear b=.520 thr=.06", 0.06, rqLinear(0.520, 1)},
+
+	// (a) softened knee / lowered floor. Held at thr=.10 so the floor is the
+	// only thing that moved.
+	{"Floor  linear b=.480 thr=.10", 0.10, rqLinear(0.480, 1)},
+	{"Floor  linear b=.440 thr=.10", 0.10, rqLinear(0.440, 1)},
+	{"Knee   linear b=.520 g=0.70 thr=.15", 0.15, rqLinear(0.520, 0.70)},
+	{"Knee   linear b=.450 g=1.50 thr=.10", 0.10, rqLinear(0.450, 1.50)},
+
+	// (b) combiner change WITH a re-derived threshold, as a coupled pair.
+	{"OR     noisy b=.520 thr=.1667", 0.1667, rqNoisyOR(0.520, 1)},
+	{"MAX          b=.520 thr=.1667", 0.1667, rqMax(0.520, 1)},
+
+	// (d) coupled: combiner + floor + threshold together.
+	{"OR     noisy b=.480 thr=.1667", 0.1667, rqNoisyOR(0.480, 1)},
+	{"OR     noisy b=.520 thr=.1400", 0.1400, rqNoisyOR(0.520, 1)},
+}
+
+// rqApply scores and gates one query's candidate pool under one arm, returning
+// the kept set in the pipeline's ranking order.
+func rqApply(cands []rqCand, a rqArm) []rqCand {
+	type sc struct {
+		c    rqCand
+		rank float64
+	}
+	kept := make([]sc, 0, len(cands))
+	for _, c := range cands {
+		cm := a.cm(c.cos, c.fts)
+		if cm <= 0 {
+			continue
+		}
+		raw := cm * c.prior
+		absolute := math.Min(math.Min(raw, cm), 1.0) * c.conf
+		if absolute < a.thr {
+			continue
+		}
+		kept = append(kept, sc{c, raw * c.conf})
+	}
+	sort.SliceStable(kept, func(i, j int) bool {
+		if kept[i].rank != kept[j].rank {
+			return kept[i].rank > kept[j].rank
+		}
+		return string(kept[i].c.id[:]) < string(kept[j].c.id[:])
+	})
+	out := make([]rqCand, len(kept))
+	for i, k := range kept {
+		out[i] = k.c
+	}
+	return out
+}
+
+// rqGateValue is the value the threshold is compared against, exposed so the
+// FP-margin metric can normalise a leak by its own arm's threshold.
+func rqGateValue(c rqCand, a rqArm) float64 {
+	cm := a.cm(c.cos, c.fts)
+	return math.Min(math.Min(cm*c.prior, cm), 1.0) * c.conf
+}
+
+func rqNDCG5(kept []rqCand, gold storage.ULID) float64 {
+	for r, c := range kept {
+		if r >= 5 {
+			break
+		}
+		if c.id == gold {
+			return 1.0 / math.Log2(float64(r)+2.0)
+		}
+	}
+	return 0
+}
+
+// ---------------------------------------------------------------------------
+// RESULT ACCUMULATION
+// ---------------------------------------------------------------------------
+
+type rqBandCell struct {
+	n         int
+	ndcgSum   float64
+	goldFound int
+}
+
+type rqKindCell struct {
+	n        int
+	falsePos int
+	depthSum float64
+	topSum   float64 // sum of top kept gate value on leaking queries
+}
+
+type rqArmResult struct {
+	bands map[rqBand]*rqBandCell
+	kinds map[rqKind]*rqKindCell
+	// goldMissed records, per band, which queries lost their gold entirely —
+	// the list a maintainer actually needs when a number moves.
+	goldMissed map[rqBand][]string
+}
+
+func newRQArmResult() *rqArmResult {
+	r := &rqArmResult{
+		bands:      map[rqBand]*rqBandCell{},
+		kinds:      map[rqKind]*rqKindCell{},
+		goldMissed: map[rqBand][]string{},
+	}
+	for _, b := range rqBands {
+		r.bands[b] = &rqBandCell{}
+	}
+	for _, k := range rqKinds {
+		r.kinds[k] = &rqKindCell{}
+	}
+	return r
+}
+
+func (r *rqArmResult) totals() (ndcg, goldPct float64, n int) {
+	var sum float64
+	var found int
+	for _, b := range rqBands {
+		c := r.bands[b]
+		n += c.n
+		sum += c.ndcgSum
+		found += c.goldFound
+	}
+	if n == 0 {
+		return 0, 0, 0
+	}
+	return sum / float64(n), 100 * float64(found) / float64(n), n
+}
+
+func (r *rqArmResult) fpr() (pct float64, fp, n int) {
+	for _, k := range rqKinds {
+		c := r.kinds[k]
+		n += c.n
+		fp += c.falsePos
+	}
+	if n == 0 {
+		return 0, 0, 0
+	}
+	return 100 * float64(fp) / float64(n), fp, n
+}
+
+// topFPMargin is the mean of (top kept gate value / this arm's threshold) over
+// leaking queries. Raw gate values are NOT comparable across arms whose
+// thresholds differ — an arm at thr=.1667 leaking at .17 is barely leaking,
+// an arm at thr=.10 leaking at .17 is leaking confidently. The margin is the
+// comparable quantity, and it is the one the acceptance rule is stated on.
+func (r *rqArmResult) topFPMargin(thr float64) float64 {
+	var sum float64
+	var n int
+	for _, k := range rqKinds {
+		sum += r.kinds[k].topSum
+		n += r.kinds[k].falsePos
+	}
+	if n == 0 {
+		return 0
+	}
+	return (sum / float64(n)) / thr
+}
+
+func (r *rqArmResult) rawTopFP() float64 {
+	var sum float64
+	var n int
+	for _, k := range rqKinds {
+		sum += r.kinds[k].topSum
+		n += r.kinds[k].falsePos
+	}
+	if n == 0 {
+		return 0
+	}
+	return sum / float64(n)
+}
+
+// rqEvaluate runs the full labeled set through every arm.
+func rqEvaluate(t *testing.T, f *rqFix) map[string]*rqArmResult {
+	t.Helper()
+	results := map[string]*rqArmResult{}
+	for _, a := range rqArms {
+		results[a.name] = newRQArmResult()
+	}
+
+	for _, q := range rqAnswerable {
+		gold, ok := f.byConcept[q.gold]
+		if !ok {
+			t.Fatalf("gold concept %q is not in rqCorpus — label drift", q.gold)
+		}
+		cands := rqProbeAt(t, f, q.query, 0)
+		for _, a := range rqArms {
+			r := results[a.name]
+			kept := rqApply(cands, a)
+			cell := r.bands[q.band]
+			cell.n++
+			cell.ndcgSum += rqNDCG5(kept, gold)
+			hit := false
+			for _, c := range kept {
+				if c.id == gold {
+					hit = true
+					break
+				}
+			}
+			if hit {
+				cell.goldFound++
+			} else {
+				r.goldMissed[q.band] = append(r.goldMissed[q.band], q.query)
+			}
+		}
+	}
+
+	for _, q := range rqUnanswerable {
+		cands := rqProbeAt(t, f, q.query, 0)
+		for _, a := range rqArms {
+			r := results[a.name]
+			kept := rqApply(cands, a)
+			cell := r.kinds[q.kind]
+			cell.n++
+			if len(kept) > 0 {
+				cell.falsePos++
+				cell.depthSum += float64(len(kept))
+				cell.topSum += rqGateValue(kept[0], a)
+			}
+		}
+	}
+	return results
+}
+
+func rqReport(t *testing.T, title string, results map[string]*rqArmResult) {
+	t.Helper()
+	t.Log("")
+	t.Logf("================ %s ================", title)
+	t.Logf("corpus=%d engrams | answerable=%d (10 per band) | unanswerable=%d (8 adjacent / 4 stale / 8 OOD)",
+		len(rqCorpus), len(rqAnswerable), len(rqUnanswerable))
+	t.Log("")
+	t.Logf("%-38s %7s %7s | %-17s %-17s %-17s | %6s %6s %6s %6s | %6s %6s",
+		"arm", "cosCut", "ftsCut", "near-verbatim", "moderate", "hard-paraphrase",
+		"FPR", "adj", "stale", "ood", "topFP", "margin")
+	t.Logf("%-38s %7s %7s | %-17s %-17s %-17s | %6s %6s %6s %6s | %6s %6s",
+		"", "", "", "gold%/ndcg", "gold%/ndcg", "gold%/ndcg", "%", "%", "%", "%", "abs", "xthr")
+	for _, a := range rqArms {
+		r := results[a.name]
+		cells := make([]string, 0, 3)
+		for _, b := range rqBands {
+			c := r.bands[b]
+			cells = append(cells, fmt.Sprintf("%5.1f%% / %.4f",
+				100*float64(c.goldFound)/float64(max1(c.n)), c.ndcgSum/float64(max1(c.n))))
+		}
+		fprPct, _, _ := r.fpr()
+		kindPct := func(k rqKind) float64 {
+			c := r.kinds[k]
+			if c.n == 0 {
+				return 0
+			}
+			return 100 * float64(c.falsePos) / float64(c.n)
+		}
+		t.Logf("%-38s %7.4f %7.4f | %-17s %-17s %-17s | %5.1f%% %5.1f%% %5.1f%% %5.1f%% | %6.4f %6.2f",
+			a.name, rqEffectiveCosCutoff(a), rqEffectiveFTSCutoff(a),
+			cells[0], cells[1], cells[2],
+			fprPct, kindPct(rqAdjacent), kindPct(rqStale), kindPct(rqOOD),
+			r.rawTopFP(), r.topFPMargin(a.thr))
+	}
+
+	// The overall line, for continuity with abstention_gate_measure_test.go.
+	t.Log("")
+	for _, a := range rqArms {
+		r := results[a.name]
+		ndcg, goldPct, _ := r.totals()
+		fprPct, fp, n := r.fpr()
+		t.Logf("  %-38s overall NDCG@5=%.4f gold-found=%.1f%%  FPR=%.1f%% (%d/%d)",
+			a.name, ndcg, goldPct, fprPct, fp, n)
+	}
+
+	// The misses on the CURRENT arm, named. This is the list the evaluation
+	// complaint was really about.
+	cur := results[rqArms[0].name]
+	t.Log("")
+	t.Log("  CURRENT arm — answerable queries whose gold was dropped entirely:")
+	for _, b := range rqBands {
+		for _, q := range cur.goldMissed[b] {
+			t.Logf("    [%-15s] %s", b, q)
+		}
+	}
+}
+
+func max1(n int) int {
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// ---------------------------------------------------------------------------
+// THE MEASUREMENT
+// ---------------------------------------------------------------------------
+
+// TestMeasureRecallQuerySet reports the labeled set's numbers for every
+// candidate arm, in both the FTS-live condition (what production does) and the
+// semantic-only condition (what the previous harness measured).
+//
+// It is a MEASUREMENT, not a gate: it asserts only the invariants that make
+// the numbers meaningful (labels resolve, the CURRENT arm is present, no arm
+// achieves the degenerate "keep nothing" or "keep everything"). The acceptance
+// rule is enforced separately in TestRecallQuerySet_AcceptanceRule so the
+// pre-commitment is legible as its own artifact.
+func TestMeasureRecallQuerySet(t *testing.T) {
+	embedder, svc := realBGEEmbedder(t)
+
+	now := rqFixtureNow()
+
+	ftsLive := rqEvaluate(t, rqBuildFixture(t, embedder, svc, true, now))
+	rqReport(t, "FTS LIVE (production condition: both channels carry signal)", ftsLive)
+
+	semOnly := rqEvaluate(t, rqBuildFixture(t, embedder, svc, false, now))
+	rqReport(t, "SEMANTIC ONLY (FTS stubbed empty — the previous harness's condition)", semOnly)
+
+	// Sanity: the measurement is only meaningful if the arms actually differ.
+	cur, _, _ := ftsLive[rqArms[0].name].totals()
+	for _, a := range rqArms[1:] {
+		if n, _, _ := ftsLive[a.name].totals(); n == cur {
+			t.Logf("NOTE: arm %q is indistinguishable from CURRENT on overall NDCG (%.4f) — "+
+				"expected for arms that differ only in the lexical channel when few queries have one", a.name, n)
+		}
+	}
+}
+
+// TestRecallQuerySet_ReconstructionFidelity proves the offline machinery.
+//
+// Every candidate arm above is evaluated from a SemanticBaseline=0 probe, with
+// ContentMatch and the ACT-R prior reconstructed arithmetically. If that
+// reconstruction is not exact, every number in the report is fiction. So: run
+// the SAME query set against a SECOND, independently built fixture at the real
+// b=0.520 and require three things of every candidate of every query.
+//
+//  1. GATE VALUE. The reconstructed ContentMatch and AbsoluteScore match the
+//     pipeline's own reported values. This is what the FPR / gold-found
+//     columns depend on.
+//  2. POOL INDEPENDENCE. A candidate the probe saw but the real run did not
+//     must be one the real run's gate zeroed (reconstructed ContentMatch = 0),
+//     never one the pool dropped — otherwise the arms are not seeing the same
+//     candidates and the counterfactual is invalid.
+//  3. RANKING. The order induced by the reconstructed Raw' = ContentMatch x
+//     prior reproduces the pipeline's own returned order. This is the check
+//     that actually tests the reconstructed prior: the pipeline's reported Raw
+//     is the prior times a per-query 1/maxRaw rescale, and a positive per-query
+//     constant cannot change an order — so agreeing on the ORDER is exactly the
+//     claim the NDCG@5 column needs, and a wrong ACTRHebScale, a wrong cap
+//     assumption or a wrong softplus would all break it.
+//
+// Two separate fixtures (rather than two passes over one) because eng.Run
+// mutates session state — a second pass over the same engine would not be
+// comparing like with like.
+func TestRecallQuerySet_ReconstructionFidelity(t *testing.T) {
+	embedder, svc := realBGEEmbedder(t)
+	now := rqFixtureNow()
+	probeFix := rqBuildFixture(t, embedder, svc, true, now)
+	realFix := rqBuildFixture(t, embedder, svc, true, now)
+
+	queries := make([]string, 0, len(rqAnswerable)+len(rqUnanswerable))
+	for _, q := range rqAnswerable {
+		queries = append(queries, q.query)
+	}
+	for _, q := range rqUnanswerable {
+		queries = append(queries, q.query)
+	}
+
+	const tol = 1e-6
+	current := rqArms[0]
+	checked, ordered := 0, 0
+	for _, q := range queries {
+		probe := rqProbeAt(t, probeFix, q, 0)
+		live := rqProbeAt(t, realFix, q, semanticBaselineBGE)
+
+		byID := make(map[storage.ULID]rqCand, len(live))
+		for _, c := range live {
+			byID[c.id] = c
+		}
+		reconstructed := make(map[storage.ULID]float64, len(probe))
+		for _, p := range probe {
+			cm := current.cm(p.cos, p.fts)
+			reconstructed[p.id] = cm * p.prior * p.conf
+			r, ok := byID[p.id]
+			if !ok {
+				// (2) pool independence.
+				if cm > tol {
+					t.Errorf("query %q: candidate %q has reconstructed ContentMatch=%.6f but is ABSENT "+
+						"from the real b=%.3f run — the candidate pool is not baseline-independent and "+
+						"the offline counterfactual is invalid", q, p.concept, cm, semanticBaselineBGE)
+				}
+				continue
+			}
+			// (1) gate value.
+			checked++
+			if math.Abs(cm-r.actualCM) > tol {
+				t.Errorf("query %q candidate %q: reconstructed ContentMatch=%.9f, pipeline reported %.9f",
+					q, p.concept, cm, r.actualCM)
+			}
+			if got := rqGateValue(p, current); math.Abs(got-r.actA) > tol {
+				t.Errorf("query %q candidate %q: reconstructed AbsoluteScore=%.9f, pipeline reported %.9f "+
+					"(cos=%.4f fts=%.4f prior=%.4f)", q, p.concept, got, r.actA, p.cos, p.fts, p.prior)
+			}
+		}
+
+		// (3) ranking. live is already in the pipeline's returned order.
+		for i := 1; i < len(live); i++ {
+			hi, hiOK := reconstructed[live[i-1].id]
+			lo, loOK := reconstructed[live[i].id]
+			if !hiOK || !loOK {
+				continue
+			}
+			ordered++
+			if hi < lo-tol {
+				t.Errorf("query %q: reconstructed ranking disagrees with the pipeline — %q (recon %.6f) "+
+					"is returned above %q (recon %.6f). The reconstructed ACT-R prior is wrong, so every "+
+					"NDCG@5 number in this file is wrong with it.",
+					q, live[i-1].concept, hi, live[i].concept, lo)
+			}
+		}
+	}
+	if checked == 0 || ordered == 0 {
+		t.Fatalf("fidelity check compared too little (%d scorings, %d adjacent pairs) — it proves nothing",
+			checked, ordered)
+	}
+	t.Logf("reconstruction fidelity: %d candidate scorings and %d adjacent ranking pairs across %d "+
+		"queries reproduced the real b=%.3f pipeline", checked, ordered, len(queries), semanticBaselineBGE)
+}
+
+// ---------------------------------------------------------------------------
+// THE PRE-COMMITTED ACCEPTANCE RULE
+//
+// Written down BEFORE the numbers above were looked at. A candidate ships only
+// if ALL of the following hold in the FTS-LIVE condition:
+//
+//	(1) hard-paraphrase gold-found improves by at least +20.0 percentage points
+//	    over CURRENT — i.e. at least 2 of the 10 hard queries that abstain today
+//	    come back. "Materially" needs a number; this is the number. A +10pp
+//	    (one query) move on a 10-query band is one query, not an effect.
+//	(2) overall FPR does not exceed CURRENT's by more than 2.0 percentage points.
+//	(3) the top-false-positive MARGIN (top kept gate value / that arm's own
+//	    threshold, averaged over leaking queries) does not rise above CURRENT's.
+//	    Raw gate values are not comparable across arms with different
+//	    thresholds; the margin is.
+//	(4) neither the near-verbatim nor the moderate band LOSES gold-found. A
+//	    change that trades working recall for hard recall is the same defect
+//	    from the other side.
+//
+// If nothing passes, the honest negative result ships and the scoring path is
+// left alone. That outcome is a success of this file, not a failure of it.
+// ---------------------------------------------------------------------------
+
+const (
+	rqRuleHardGain   = 20.0 // percentage points, condition (1)
+	rqRuleFPRSlack   = 2.0  // percentage points, condition (2)
+	rqRuleMarginSlop = 1e-9 // condition (3) is "does not rise"
+)
+
+func TestRecallQuerySet_AcceptanceRule(t *testing.T) {
+	embedder, svc := realBGEEmbedder(t)
+	results := rqEvaluate(t, rqBuildFixture(t, embedder, svc, true, rqFixtureNow()))
+
+	current := rqArms[0]
+	cur := results[current.name]
+	curHard := 100 * float64(cur.bands[rqHard].goldFound) / float64(max1(cur.bands[rqHard].n))
+	curNear := 100 * float64(cur.bands[rqNearVerbatim].goldFound) / float64(max1(cur.bands[rqNearVerbatim].n))
+	curMod := 100 * float64(cur.bands[rqModerate].goldFound) / float64(max1(cur.bands[rqModerate].n))
+	curFPR, _, _ := cur.fpr()
+	curMargin := cur.topFPMargin(current.thr)
+
+	t.Logf("CURRENT baseline: hard gold-found=%.1f%% near=%.1f%% moderate=%.1f%% FPR=%.1f%% FP-margin=%.2fx",
+		curHard, curNear, curMod, curFPR, curMargin)
+	t.Logf("rule: hard >= %.1f%% (+%.1fpp), FPR <= %.1f%% (+%.1fpp), margin <= %.2fx, near/moderate not below %.1f%%/%.1f%%",
+		curHard+rqRuleHardGain, rqRuleHardGain, curFPR+rqRuleFPRSlack, rqRuleFPRSlack, curMargin, curNear, curMod)
+
+	var passed []string
+	for _, a := range rqArms[1:] {
+		r := results[a.name]
+		hard := 100 * float64(r.bands[rqHard].goldFound) / float64(max1(r.bands[rqHard].n))
+		near := 100 * float64(r.bands[rqNearVerbatim].goldFound) / float64(max1(r.bands[rqNearVerbatim].n))
+		mod := 100 * float64(r.bands[rqModerate].goldFound) / float64(max1(r.bands[rqModerate].n))
+		fpr, _, _ := r.fpr()
+		margin := r.topFPMargin(a.thr)
+
+		var fails []string
+		if hard < curHard+rqRuleHardGain-1e-9 {
+			fails = append(fails, fmt.Sprintf("(1) hard gold-found %.1f%% < %.1f%%", hard, curHard+rqRuleHardGain))
+		}
+		if fpr > curFPR+rqRuleFPRSlack+1e-9 {
+			fails = append(fails, fmt.Sprintf("(2) FPR %.1f%% > %.1f%%", fpr, curFPR+rqRuleFPRSlack))
+		}
+		if margin > curMargin+rqRuleMarginSlop {
+			fails = append(fails, fmt.Sprintf("(3) FP-margin %.2fx > %.2fx", margin, curMargin))
+		}
+		if near < curNear-1e-9 || mod < curMod-1e-9 {
+			fails = append(fails, fmt.Sprintf("(4) near/moderate %.1f%%/%.1f%% below %.1f%%/%.1f%%", near, mod, curNear, curMod))
+		}
+		if len(fails) == 0 {
+			passed = append(passed, a.name)
+			t.Logf("PASS %-38s hard=%.1f%% FPR=%.1f%% margin=%.2fx", a.name, hard, fpr, margin)
+		} else {
+			t.Logf("fail %-38s %v", a.name, fails)
+		}
+	}
+
+	// COMPLETENESS, in the other direction. The rule above was pre-committed
+	// against the hypothesis that the dominant defect is FALSE ABSTENTION on
+	// hard paraphrases. The measurement says otherwise (see the FPR-by-kind
+	// columns), so a rule aimed only at recall could "correctly" reject a
+	// candidate that fixed the real problem. The goalposts are NOT moved —
+	// what ships is still decided by the pre-committed rule — but a strictly
+	// DOMINATING arm (no metric worse, at least one better) would be a free
+	// win in any direction, and its absence has to be established rather than
+	// assumed. This block reports it; it does not gate on it.
+	var dominating []string
+	for _, a := range rqArms[1:] {
+		r := results[a.name]
+		hard := 100 * float64(r.bands[rqHard].goldFound) / float64(max1(r.bands[rqHard].n))
+		near := 100 * float64(r.bands[rqNearVerbatim].goldFound) / float64(max1(r.bands[rqNearVerbatim].n))
+		mod := 100 * float64(r.bands[rqModerate].goldFound) / float64(max1(r.bands[rqModerate].n))
+		fpr, _, _ := r.fpr()
+		margin := r.topFPMargin(a.thr)
+		// NDCG is part of the comparison, not just gold-found. An arm can keep
+		// every gold answer and still bury it below three near-misses; without
+		// this the dominance report calls that a free win.
+		noWorse := hard >= curHard-1e-9 && near >= curNear-1e-9 && mod >= curMod-1e-9 &&
+			fpr <= curFPR+1e-9 && margin <= curMargin+1e-9
+		better := hard > curHard+1e-9 || fpr < curFPR-1e-9 || margin < curMargin-1e-9
+		for _, b := range rqBands {
+			cc, rc := cur.bands[b], r.bands[b]
+			curN := cc.ndcgSum / float64(max1(cc.n))
+			armN := rc.ndcgSum / float64(max1(rc.n))
+			if armN < curN-1e-9 {
+				noWorse = false
+			}
+			if armN > curN+1e-9 {
+				better = true
+			}
+		}
+		if noWorse && better {
+			dominating = append(dominating, a.name)
+		}
+	}
+	if len(dominating) == 0 {
+		t.Log("no candidate arm DOMINATES current either (every arm that improves one metric loses " +
+			"another) — the trade is real, not an artifact of which direction the rule was written for")
+	} else {
+		t.Logf("NOTE: %v dominate(s) CURRENT on every metric measured here. It still does NOT ship on "+
+			"this evidence, and the reasons are worth writing down: it fails the pre-committed rule "+
+			"(no material hard-paraphrase gain), it leaves the actual defect untouched (the adjacent "+
+			"and present-tense false positives are unchanged), and its gain is confined to ranking "+
+			"quality and leak confidence on ONE 50-query synthetic set. Adopting a floor/exponent "+
+			"because it won on one corpus is exactly the failure CLAUDE.md principle 11 names — a "+
+			"number tuned on one sample vault imposing that vault's shape on every other. It is "+
+			"recorded here as the one candidate worth re-deriving properly, per-vault, if this line "+
+			"of work is picked up.", dominating)
+	}
+
+	if len(passed) == 0 {
+		t.Log("")
+		t.Log("VERDICT: no candidate passes the pre-committed rule. The honest negative result is the " +
+			"finding, and it has two parts. (i) On the recall side, the semantic-only gate is a single " +
+			"effective COSINE CUTOFF (the cosCut column) — combiner SHAPE is irrelevant when the lexical " +
+			"channel is silent, so every floor/knee/threshold variant just slides along one ROC and the " +
+			"hard-paraphrase recall it buys is paid for immediately in false positives. (ii) The bigger " +
+			"finding is that the recall side was the wrong side: at the shipped calibration hard-paraphrase " +
+			"gold-found is already high, while the false-positive rate on TOPICALLY-ADJACENT and " +
+			"PRESENT-TENSE queries is 87.5% and 100%. The 6.2% FPR quoted from the previous harness is a " +
+			"measurement on out-of-domain nonsense only — the easy kind — and it does not generalise to " +
+			"the kind of unanswerable query an agent actually asks. No arm in this family fixes that " +
+			"either. Nothing ships behind an argument; if a future candidate passes, this test names it.")
+		return
+	}
+	t.Log("")
+	t.Logf("VERDICT: %d candidate(s) pass the pre-committed rule: %v. Landing one requires the coupled "+
+		"change (combiner + floor + threshold together) and a re-derivation of COG-26's b commentary.",
+		len(passed), passed)
+}
+
+// TestRecallQuerySet_ReportedFailureShapes runs the four specific shapes the
+// hands-on evaluation reported and records what the SHIPPED calibration
+// actually does with each, one query at a time. The aggregate table above says
+// where the failures live; this says whether the reported ones reproduce.
+//
+// Two of the four are asserted (they pass today, and this is the regression
+// guard). Two are logged, not asserted: they are open defects at the shipped
+// calibration, and a test that fails on a known unfixed defect is a permanently
+// red test, which teaches a team to ignore it. The aggregate FPR columns in
+// TestMeasureRecallQuerySet are where those two are actually tracked.
+func TestRecallQuerySet_ReportedFailureShapes(t *testing.T) {
+	embedder, svc := realBGEEmbedder(t)
+	f := rqBuildFixture(t, embedder, svc, true, rqFixtureNow())
+	current := rqArms[0]
+
+	find := func(query string) []rqCand { return rqApply(rqProbeAt(t, f, query, 0), current) }
+	rankOf := func(kept []rqCand, gold storage.ULID) int {
+		for i, c := range kept {
+			if c.id == gold {
+				return i + 1
+			}
+		}
+		return -1
+	}
+
+	// (1) and (2): the two reported WRONG ABSTENTIONS. Both are reconstructed
+	// in the hard-paraphrase band. Both are answered correctly here — which is
+	// itself a finding: the reported failures are not reproducible from the
+	// query shape alone, so whatever produced them was a property of that
+	// vault's content (competing near-neighbours) rather than of the floor.
+	for _, tc := range []struct{ query, gold string }{
+		{"How long can field researchers work while completely disconnected?", "Offline endurance of field kits"},
+		{"What was the basin decision?", "Violet Basin siting decision"},
+	} {
+		kept := find(tc.query)
+		r := rankOf(kept, f.byConcept[tc.gold])
+		if r < 1 {
+			t.Errorf("REGRESSION: %q no longer returns %q at the shipped calibration (%d results kept). "+
+				"This query answered correctly when the labeled set was built; a floor or threshold "+
+				"change has re-introduced the reported wrong-abstention.", tc.query, tc.gold, len(kept))
+			continue
+		}
+		t.Logf("wrong-abstention shape ANSWERED: %-60q -> %s at rank %d", tc.query, tc.gold, r)
+	}
+
+	// (3) and (4): the two reported UNRESPONSIVE ANSWERS, where abstention was
+	// the correct behaviour. Both still leak.
+	for _, q := range []string{
+		"what is the password for the release signing key",
+		"what is the ingest queue depth right now",
+	} {
+		kept := find(q)
+		if len(kept) == 0 {
+			t.Logf("FIXED: %q now abstains — update this test and the FPR columns above", q)
+			continue
+		}
+		t.Logf("OPEN DEFECT, unanswerable query returns %d result(s): %-50q -> top=%q gate=%.4f "+
+			"(threshold %.4f)", len(kept), q, kept[0].concept, rqGateValue(kept[0], current), current.thr)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -3601,7 +3601,20 @@ func (e *Engine) EvolveAt(ctx context.Context, vault, oldID, newContent, reason 
 	batch := e.store.NewBatch()
 	defer batch.Discard()
 
-	if err := batch.WriteEngramOp(ctx, wsPrefix, newEng, "evolve"); err != nil {
+	// The successor's provenance entry carries what changed and why, not just
+	// the verb: an "evolve" entry with only a timestamp, a source and the word
+	// "evolve" records the one thing the reader already knew. It is recorded on
+	// the SUCCESSOR because that is the engram a reader holds after an evolve
+	// (the predecessor is soft-deleted and hidden from the present), and
+	// predecessor_id is the exact mirror of read's superseded_by. reason is
+	// passed through verbatim — empty when the caller gave none, never
+	// backfilled with a plausible-looking string.
+	evolveDetails := &provenance.Details{
+		PredecessorID: oldULID.String(),
+		Reason:        reason,
+		EffectiveAt:   &effectiveAt,
+	}
+	if err := batch.WriteEngramOpDetails(ctx, wsPrefix, newEng, "evolve", evolveDetails); err != nil {
 		return storage.ULID{}, fmt.Errorf("evolve: batch write new engram: %w", err)
 	}
 	if err := batch.WriteAssociation(ctx, wsPrefix, newULID, oldULID, supersedes); err != nil {

--- a/internal/engine/engine_evolve_provenance_test.go
+++ b/internal/engine/engine_evolve_provenance_test.go
@@ -1,0 +1,137 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/provenance"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// waitForProvenance polls the audit trail until an entry with the given
+// operation appears. The provenance worker is async with no exported drain, so
+// this polls the observable itself (bounded) rather than sleeping a guess.
+func waitForProvenance(t *testing.T, eng *Engine, vault, id, op string) provenance.ProvenanceEntry {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		entries, err := eng.GetProvenance(ctx, vault, id)
+		if err != nil {
+			t.Fatalf("GetProvenance: %v", err)
+		}
+		for _, e := range entries {
+			if e.Operation == op {
+				return e
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("no provenance entry with operation %q for %s within 5s", op, id)
+	return provenance.ProvenanceEntry{}
+}
+
+// TestEvolve_ProvenanceRecordsWhatChangedAndWhy is the defect test.
+// muninn_provenance promises "who wrote it, what changed, and why"; for the one
+// operation whose entire meaning is what-changed-and-why, the entry carried a
+// timestamp, a source and the verb "evolve" and nothing else. The successor's
+// entry must carry the predecessor it replaced, the caller's reason, and the
+// valid-time boundary the change took effect at.
+//
+// The successor is the side that records it: the successor is the live engram a
+// reader holds after an evolve (the predecessor is soft-deleted and hidden from
+// the present), and predecessor_id mirrors read's superseded_by pointing the
+// other way, so the pair of records is symmetric and neither invents a fact.
+func TestEvolve_ProvenanceRecordsWhatChangedAndWhy(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "test", Concept: "Deploy target", Content: "deploys go to us-west-1",
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	effectiveAt := time.Now().Add(1 * time.Minute).UTC().Truncate(time.Millisecond)
+	reason := "region migration completed"
+
+	newID, err := eng.EvolveAt(ctx, "test", resp.ID, "deploys go to us-east-2", reason, nil, "", nil, nil, effectiveAt)
+	if err != nil {
+		t.Fatalf("EvolveAt: %v", err)
+	}
+
+	entry := waitForProvenance(t, eng, "test", newID.String(), "evolve")
+	if entry.Details == nil {
+		t.Fatal("evolve provenance entry carries no Details — no predecessor, no reason, no effective_at")
+	}
+	if entry.Details.PredecessorID != resp.ID {
+		t.Errorf("PredecessorID = %q, want %q", entry.Details.PredecessorID, resp.ID)
+	}
+	if entry.Details.Reason != reason {
+		t.Errorf("Reason = %q, want %q", entry.Details.Reason, reason)
+	}
+	if entry.Details.EffectiveAt == nil {
+		t.Fatal("EffectiveAt is absent, want the valid-time boundary")
+	}
+	if !entry.Details.EffectiveAt.Equal(effectiveAt) {
+		t.Errorf("EffectiveAt = %v, want %v", entry.Details.EffectiveAt.UTC(), effectiveAt)
+	}
+}
+
+// TestEvolve_ProvenanceOmitsEmptyReason pins that a reason-less evolve records
+// absence as absence: predecessor and effective_at are still known and recorded,
+// the reason field stays empty rather than being invented.
+func TestEvolve_ProvenanceOmitsEmptyReason(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "test", Concept: "Coffee order", Content: "flat white",
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	newID, err := eng.Evolve(ctx, "test", resp.ID, "cortado", "", nil, "")
+	if err != nil {
+		t.Fatalf("Evolve: %v", err)
+	}
+
+	entry := waitForProvenance(t, eng, "test", newID.String(), "evolve")
+	if entry.Details == nil {
+		t.Fatal("evolve provenance entry carries no Details")
+	}
+	if entry.Details.PredecessorID != resp.ID {
+		t.Errorf("PredecessorID = %q, want %q", entry.Details.PredecessorID, resp.ID)
+	}
+	if entry.Details.Reason != "" {
+		t.Errorf("Reason = %q, want empty — no reason was given", entry.Details.Reason)
+	}
+	if entry.Details.EffectiveAt == nil {
+		t.Error("EffectiveAt is absent — evolve always has a boundary, defaulted to the evolve moment")
+	}
+}
+
+// TestWrite_ProvenanceHasNoDetails pins the other half: a plain create records
+// no details, and must not gain an empty ones.
+func TestWrite_ProvenanceHasNoDetails(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "test", Concept: "Plain", Content: "nothing changed here",
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	entry := waitForProvenance(t, eng, "test", resp.ID, "create")
+	if entry.Details != nil {
+		t.Errorf("create entry carries Details %+v, want nil", entry.Details)
+	}
+}

--- a/internal/engine/engine_recall_mode_threshold_test.go
+++ b/internal/engine/engine_recall_mode_threshold_test.go
@@ -165,6 +165,15 @@ func TestActivate_ACTRVaultDefaultRecallMode_PresetThresholdUnchanged(t *testing
 	// the SET — a preset failing to apply changes threshold/hops and therefore
 	// membership — so order and score identity, which were only ever true while
 	// full-weight learning was being destroyed on write, are no longer asserted.
+	//
+	// Set equality alone would be a WEAK guard (review finding: a resolution
+	// bug that changes only score-affecting parameters could slip through if no
+	// fixture candidate happens to straddle the two thresholds). It is not
+	// alone: the resolution function itself is pinned exhaustively at unit
+	// level in recall_mode_preset_test.go (threshold applies on ACT-R, abstains
+	// under rrf, hops apply when unset, caller-explicit always wins, scalar
+	// fill rules). This end-to-end set check guards the WIRING; the unit pins
+	// guard the RESOLUTION.
 	require.ElementsMatch(t, idsOf(explicitResp), idsOf(zeroResp),
 		"ACT-R vault-default mode must resolve to the preset's explicit equivalent — #704 must not touch non-rrf vaults")
 	require.NotEmpty(t, zeroResp.Activations, "sanity: the ACT-R control fixture must return results at all")

--- a/internal/engine/engine_recall_mode_threshold_test.go
+++ b/internal/engine/engine_recall_mode_threshold_test.go
@@ -154,14 +154,19 @@ func TestActivate_ACTRVaultDefaultRecallMode_PresetThresholdUnchanged(t *testing
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, len(explicitResp.Activations), len(zeroResp.Activations),
+	// SET comparison, deliberately order-insensitive. The WeightComplement(1.0)
+	// fix made full-weight association edges readable for the first time, so a
+	// recall's in-memory session learning (the activation log feeding
+	// phase4/4.5 boosts — recorded unconditionally, in every mode) now re-ranks
+	// the NEXT call: consecutive equivalent calls return the same candidate SET
+	// in shifting order ("strengthens with use", finally functioning; verified
+	// with a three-run probe — identical IDs, rotated). The property this test
+	// protects (#704: zero resolves to the preset's explicit spelling) lives in
+	// the SET — a preset failing to apply changes threshold/hops and therefore
+	// membership — so order and score identity, which were only ever true while
+	// full-weight learning was being destroyed on write, are no longer asserted.
+	require.ElementsMatch(t, idsOf(explicitResp), idsOf(zeroResp),
 		"ACT-R vault-default mode must resolve to the preset's explicit equivalent — #704 must not touch non-rrf vaults")
-	for i := range zeroResp.Activations {
-		require.Equal(t, explicitResp.Activations[i].ID, zeroResp.Activations[i].ID,
-			"result order/identity at index %d must be unchanged for the ACT-R path", i)
-		require.InDelta(t, explicitResp.Activations[i].Score, zeroResp.Activations[i].Score, 1e-9,
-			"score at index %d must be unchanged for the ACT-R path", i)
-	}
 	require.NotEmpty(t, zeroResp.Activations, "sanity: the ACT-R control fixture must return results at all")
 }
 
@@ -203,14 +208,9 @@ func TestActivate_ACTRExplicitWireMode_AppliesPreset(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, len(explicitResp.Activations), len(modeResp.Activations),
+	// Set comparison — see the sibling test's comment for the full story.
+	require.ElementsMatch(t, idsOf(explicitResp), idsOf(modeResp),
 		"explicit wire Mode=deep must resolve to deep's explicit equivalent")
-	for i := range modeResp.Activations {
-		require.Equal(t, explicitResp.Activations[i].ID, modeResp.Activations[i].ID,
-			"result order/identity at index %d must match the explicit-equivalent call", i)
-		require.InDelta(t, explicitResp.Activations[i].Score, modeResp.Activations[i].Score, 1e-9,
-			"score at index %d must match the explicit-equivalent call", i)
-	}
 	require.NotEmpty(t, modeResp.Activations, "sanity: the fixture must return results at all")
 }
 
@@ -269,4 +269,13 @@ func TestActivate_ACTRExplicitSemanticMode_MatchesStampedEquivalent(t *testing.T
 		require.InDelta(t, explicitResp.Activations[i].Score, modeResp.Activations[i].Score, 1e-9,
 			"score at index %d must match the stamped-equivalent call", i)
 	}
+}
+
+// idsOf extracts activation IDs for order-insensitive set comparison.
+func idsOf(r *mbp.ActivateResponse) []string {
+	out := make([]string, len(r.Activations))
+	for i, a := range r.Activations {
+		out[i] = a.ID
+	}
+	return out
 }

--- a/internal/engine/engine_rrf_threshold_test.go
+++ b/internal/engine/engine_rrf_threshold_test.go
@@ -127,6 +127,20 @@ func TestActivate_ACTRDefaultThreshold_Unaffected(t *testing.T) {
 
 	writeRRFThresholdFixture(t, eng, ctx, vault)
 
+	// STEADY-STATE WARMUP. The WeightComplement(1.0) fix made full-weight
+	// association edges readable for the first time — before it, the fixture's
+	// declared weight-1.0 relationships round-tripped to 0, so recall-to-recall
+	// transition boosts had nothing to act on and any two calls in a session
+	// were accidentally identical. Post-fix, the FIRST recall's session learning
+	// re-ranks the second (verified: run1 differs, run2==run3 — "strengthens
+	// with use" working as promised). These tests assert THRESHOLD-RESOLUTION
+	// equivalence, not learning behaviour, so they compare in the steady state
+	// a warmup call establishes.
+	if _, err := eng.Activate(ctx, &mbp.ActivateRequest{Vault: vault,
+		Context: []string{"thermal calibration widget"}, Threshold: 0.1, MaxResults: 10}); err != nil {
+		t.Fatalf("warmup: %v", err)
+	}
+
 	zeroResp, err := eng.Activate(ctx, &mbp.ActivateRequest{
 		Vault:      vault,
 		Context:    []string{"thermal calibration widget"},

--- a/internal/engine/engine_traverse_weight_test.go
+++ b/internal/engine/engine_traverse_weight_test.go
@@ -1,0 +1,61 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// Explicit link weights arrived as 0 in traverse.
+//
+// Two independent evaluation rounds observed it: muninn_decide's evidence
+// links "supports edges ... weight 0, oddly", and an explicit
+// link(contradicts, weight=1.0) whose traverse edge reported 0. The weight IS
+// persisted (it lives in the association key as a complement and
+// WriteAssociation stores it three ways), so the loss is on a read path — and
+// a declared weight surfacing as 0 tells the caller their declaration was
+// ignored, which is this project's silent-substitution class on the exact
+// channel (declared edges) it treats as ground truth.
+func TestTraverse_ReportsDeclaredLinkWeight(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+	const vault = "traverse-weight"
+
+	a, err := eng.Write(ctx, &mbp.WriteRequest{Vault: vault, Content: "the ingest queue is bounded at four thousand", Concept: "queue bound"})
+	if err != nil {
+		t.Fatalf("write A: %v", err)
+	}
+	b, err := eng.Write(ctx, &mbp.WriteRequest{Vault: vault, Content: "the ingest queue is unbounded", Concept: "queue unbounded"})
+	if err != nil {
+		t.Fatalf("write B: %v", err)
+	}
+
+	if _, err := eng.Link(ctx, &mbp.LinkRequest{
+		Vault: vault, SourceID: b.ID, TargetID: a.ID,
+		RelType: uint16(storage.RelContradicts), Weight: 1.0,
+	}); err != nil {
+		t.Fatalf("link: %v", err)
+	}
+
+	_, edges, err := eng.Traverse(ctx, vault, b.ID, 1, 10, false)
+	if err != nil {
+		t.Fatalf("traverse: %v", err)
+	}
+	aULID, _ := storage.ParseULID(a.ID)
+	found := false
+	for _, e := range edges {
+		if e.To == aULID && e.RelType == storage.RelContradicts {
+			found = true
+			if e.Weight != 1.0 {
+				t.Fatalf("declared contradicts link weight 1.0 surfaced as %v in traverse — the "+
+					"caller's declaration is being silently zeroed on the read path", e.Weight)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("contradicts edge not found in traverse at all; edges=%v", edges)
+	}
+}

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -657,6 +657,17 @@ func (a *mcpEngineAdapter) GetProvenance(ctx context.Context, vault, id string) 
 			Operation: e.Operation,
 			Note:      e.Note,
 		}
+		// Operation-specific details, when the record carries them. Legacy
+		// entries — and operations that record none — leave these unset, and
+		// omitempty keeps them out of the response entirely: an unknown
+		// predecessor or reason is reported as absent, never as empty.
+		if d := e.Details; d != nil {
+			result[i].PredecessorID = d.PredecessorID
+			result[i].Reason = d.Reason
+			if d.EffectiveAt != nil {
+				result[i].EffectiveAt = d.EffectiveAt.UTC().Format(time.RFC3339)
+			}
+		}
 	}
 	return result, nil
 }

--- a/internal/mcp/handlers_provenance_details_test.go
+++ b/internal/mcp/handlers_provenance_details_test.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type provenanceDetailsEngine struct{ fakeEngine }
+
+func (e *provenanceDetailsEngine) GetProvenance(_ context.Context, _, _ string) ([]ProvenanceEntry, error) {
+	return []ProvenanceEntry{
+		// A legacy-shaped entry: nothing but the verb.
+		{Timestamp: time.Unix(1700000000, 0).UTC().Format(time.RFC3339), Source: "human", Operation: "create"},
+		// An evolve entry carrying what changed and why.
+		{
+			Timestamp:     time.Unix(1700000100, 0).UTC().Format(time.RFC3339),
+			Source:        "human",
+			Operation:     "evolve",
+			PredecessorID: "01OLDULID",
+			Reason:        "region migration completed",
+			EffectiveAt:   time.Unix(1700000050, 0).UTC().Format(time.RFC3339),
+		},
+	}, nil
+}
+
+// TestHandleProvenance_EvolveDetailsSurfaced pins that muninn_provenance
+// actually reports predecessor_id/reason/effective_at, and that an entry
+// without them omits the keys entirely rather than emitting empty strings a
+// caller could mistake for "no predecessor" / "no reason given".
+func TestHandleProvenance_EvolveDetailsSurfaced(t *testing.T) {
+	srv := New(":0", &provenanceDetailsEngine{}, "", nil, nil, nil)
+	w := postRPC(t, srv, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"muninn_provenance","arguments":{"vault":"default","id":"01NEWULID"}}}`)
+	if w.Code != 200 {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeResp(t, w.Body.String())
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	content := extractInnerJSON(t, resp)
+	entries, ok := content["entries"].([]any)
+	if !ok || len(entries) != 2 {
+		t.Fatalf("want 2 entries, got %T %v", content["entries"], content["entries"])
+	}
+
+	created := entries[0].(map[string]any)
+	for _, k := range []string{"predecessor_id", "reason", "effective_at"} {
+		if _, present := created[k]; present {
+			t.Errorf("create entry emitted %q (%v); an unrecorded field must be omitted", k, created[k])
+		}
+	}
+
+	evolved := entries[1].(map[string]any)
+	if evolved["predecessor_id"] != "01OLDULID" {
+		t.Errorf("predecessor_id = %v, want 01OLDULID", evolved["predecessor_id"])
+	}
+	if evolved["reason"] != "region migration completed" {
+		t.Errorf("reason = %v", evolved["reason"])
+	}
+	if evolved["effective_at"] != time.Unix(1700000050, 0).UTC().Format(time.RFC3339) {
+		t.Errorf("effective_at = %v", evolved["effective_at"])
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -944,7 +944,7 @@ func allToolDefinitions() []ToolDefinition {
 		// Provenance audit trail
 		{
 			Name:        "muninn_provenance",
-			Description: "Returns the ordered audit trail for an engram — who wrote it, what changed, and why.",
+			Description: "Returns the ordered audit trail for an engram — who wrote it, what changed, and why. Each entry has a timestamp, source, agent_id and operation; evolve entries also carry predecessor_id (the version this replaced), reason, and effective_at (when the change became true, as opposed to when it was written). Fields are omitted when the operation recorded none — an omitted field means unrecorded, not empty.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -520,12 +520,24 @@ type AssociationParams struct {
 }
 
 // ProvenanceEntry is a single audit log record returned by muninn_provenance.
+//
+// The trailing three fields are the operation-specific "what changed and why".
+// They are omitted whenever the recorded operation carries none — including for
+// every entry written before the record format carried them. An omitted field
+// means unknown, never "empty": absence must not be read as a claim.
 type ProvenanceEntry struct {
 	Timestamp string `json:"timestamp"` // RFC3339
 	Source    string `json:"source"`    // "human", "llm", "inferred", etc.
 	AgentID   string `json:"agent_id,omitempty"`
 	Operation string `json:"operation"` // "write", "update", "read", etc.
 	Note      string `json:"note,omitempty"`
+	// PredecessorID is the engram this version replaced (evolve).
+	PredecessorID string `json:"predecessor_id,omitempty"`
+	// Reason is the caller-supplied justification for the change (evolve).
+	Reason string `json:"reason,omitempty"`
+	// EffectiveAt is the valid-time instant the change took effect (RFC3339) —
+	// distinct from timestamp, which is when the write happened.
+	EffectiveAt string `json:"effective_at,omitempty"`
 }
 
 // ProvenanceResult is the response from muninn_provenance.

--- a/internal/provenance/details_test.go
+++ b/internal/provenance/details_test.go
@@ -1,0 +1,170 @@
+package provenance
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/storage/keys"
+	"github.com/scrypster/muninndb/internal/types"
+)
+
+func openTestStore(t *testing.T) (*Store, *pebble.DB) {
+	t.Helper()
+	db, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	if err != nil {
+		t.Fatalf("pebble.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return NewStore(db), db
+}
+
+// TestProvenance_DetailsRoundTrip pins that an entry carrying evolve's
+// what-changed-and-why survives a write/read cycle intact, including the
+// valid-time boundary (which is NOT the write timestamp).
+func TestProvenance_DetailsRoundTrip(t *testing.T) {
+	store, _ := openTestStore(t)
+	ctx := context.Background()
+	ws := keys.VaultPrefix("test-vault")
+	id := [16]byte(types.NewULID())
+
+	effective := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	pred := types.NewULID().String()
+
+	if err := store.Append(ctx, ws, id, ProvenanceEntry{
+		Timestamp: time.Now(),
+		Source:    SourceHuman,
+		AgentID:   "user:test",
+		Operation: "evolve",
+		Details: &Details{
+			PredecessorID: pred,
+			Reason:        "the deploy target moved to us-east-2",
+			EffectiveAt:   &effective,
+		},
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	entries, err := store.Get(ctx, ws, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	d := entries[0].Details
+	if d == nil {
+		t.Fatal("Details is nil — the what-changed-and-why did not survive the round trip")
+	}
+	if d.PredecessorID != pred {
+		t.Errorf("PredecessorID = %q, want %q", d.PredecessorID, pred)
+	}
+	if d.Reason != "the deploy target moved to us-east-2" {
+		t.Errorf("Reason = %q", d.Reason)
+	}
+	if d.EffectiveAt == nil || !d.EffectiveAt.Equal(effective) {
+		t.Errorf("EffectiveAt = %v, want %v", d.EffectiveAt, effective)
+	}
+}
+
+// TestProvenance_LegacyEntryDecodes writes a hand-built pre-Details record —
+// byte-for-byte the format entries already on disk use — straight into Pebble
+// under the 0x16 key, then reads it back through the new decoder. The legacy
+// entry must decode with every old field intact and Details ABSENT (nil), not
+// an empty struct: an unknown predecessor reported as a known-empty one is the
+// silently-wrong failure this whole change exists to remove.
+func TestProvenance_LegacyEntryDecodes(t *testing.T) {
+	store, db := openTestStore(t)
+	ctx := context.Background()
+	ws := keys.VaultPrefix("test-vault")
+	id := [16]byte(types.NewULID())
+
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	legacy := []byte(`{"Timestamp":"2026-01-02T03:04:05Z","Source":1,"AgentID":"user:mj","Operation":"evolve","Note":"legacy"}`)
+
+	// Sanity: this really is the old shape — no Details key at all.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(legacy, &raw); err != nil {
+		t.Fatalf("fixture is not valid JSON: %v", err)
+	}
+	if _, ok := raw["Details"]; ok {
+		t.Fatal("fixture is not a legacy entry — it already carries Details")
+	}
+
+	key := keys.ProvenanceSuffixKey(ws, id, uint64(ts.UnixNano()), 1)
+	if err := db.Set(key, legacy, pebble.Sync); err != nil {
+		t.Fatalf("Set legacy entry: %v", err)
+	}
+
+	entries, err := store.Get(ctx, ws, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1 — a legacy entry must still decode", len(entries))
+	}
+	e := entries[0]
+	if !e.Timestamp.Equal(ts) {
+		t.Errorf("Timestamp = %v, want %v", e.Timestamp, ts)
+	}
+	if e.Source != SourceHuman || e.AgentID != "user:mj" || e.Operation != "evolve" || e.Note != "legacy" {
+		t.Errorf("legacy fields did not survive: %+v", e)
+	}
+	if e.Details != nil {
+		t.Errorf("Details = %+v, want nil — a legacy entry knows no predecessor/reason and must not claim one", e.Details)
+	}
+}
+
+// TestProvenance_NewEntryIsOldBinaryReadable pins the other compat direction:
+// a Details-carrying entry must still decode into the pre-Details struct shape
+// (an older binary ignores the unknown key rather than failing the read).
+func TestProvenance_NewEntryIsOldBinaryReadable(t *testing.T) {
+	effective := time.Now()
+	blob, err := json.Marshal(ProvenanceEntry{
+		Timestamp: time.Now(),
+		Source:    SourceHuman,
+		AgentID:   "user:test",
+		Operation: "evolve",
+		Details:   &Details{PredecessorID: "01ABC", Reason: "why", EffectiveAt: &effective},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	// The pre-Details struct, as an old binary would define it.
+	var old struct {
+		Timestamp time.Time
+		Source    SourceType
+		AgentID   string
+		Operation string
+		Note      string
+	}
+	if err := json.Unmarshal(blob, &old); err != nil {
+		t.Fatalf("a new entry must decode on an old binary, got: %v", err)
+	}
+	if old.Operation != "evolve" || old.AgentID != "user:test" {
+		t.Errorf("old-shape decode lost fields: %+v", old)
+	}
+}
+
+// TestProvenance_DetailsOmittedWhenUnset pins that entries with no details add
+// no bytes and no empty object to the stored record.
+func TestProvenance_DetailsOmittedWhenUnset(t *testing.T) {
+	blob, err := json.Marshal(ProvenanceEntry{
+		Timestamp: time.Now(),
+		Source:    SourceInferred,
+		Operation: "update-relevance",
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(blob, &raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if _, ok := raw["Details"]; ok {
+		t.Errorf("Details key present on an entry that has none: %s", blob)
+	}
+}

--- a/internal/provenance/types.go
+++ b/internal/provenance/types.go
@@ -16,10 +16,46 @@ const (
 )
 
 // ProvenanceEntry records a single create/update event on an engram.
+//
+// Wire format: the value stored under the 0x16 provenance key is this struct
+// marshalled with encoding/json (see Store.Append). That makes the record
+// additively extensible in both directions and is why Details can be added
+// without a version byte: an entry written before Details existed decodes on a
+// new binary with Details == nil (absent, never a zero-value pretending to be
+// data), and an entry carrying Details decodes on an older binary that simply
+// ignores the unknown key. Only two changes would break that contract and need
+// a real format version: renaming/retyping an existing field, or making a new
+// field load-bearing for correctness rather than informational.
 type ProvenanceEntry struct {
 	Timestamp time.Time
 	Source    SourceType
 	AgentID   string // e.g. "user:mj", "ollama:llama3.2", "consolidation-worker"
 	Operation string // "create", "evolve", "update-relevance", "update-meta", "update-trust", "stamp-valid-until", "merge", "promote"
 	Note      string // optional free text
+	// Details carries the operation-specific "what changed and why" that the
+	// verb alone cannot express. Nil for operations that record none, and for
+	// every entry written before the field existed — absence is absence.
+	Details *Details `json:"Details,omitempty"`
+}
+
+// Details is the extensible, operation-specific payload of a ProvenanceEntry.
+//
+// Every field is optional and omitted when unset, so an operation populates
+// only what it actually knows. Today only "evolve" fills it in; forget
+// (not_true_since), consolidate (the merged source IDs) and friends can add
+// their own fields here later without another format decision — that is the
+// point of the shape. Pointer/omitempty rather than value types throughout:
+// an absent effective_at must read as absent, never as the zero time.
+type Details struct {
+	// PredecessorID is the engram this version superseded (evolve). It is the
+	// storage-side mirror of the RelSupersedes edge, recorded on the successor
+	// so the successor's own audit trail answers "what did this replace".
+	PredecessorID string `json:"predecessor_id,omitempty"`
+	// Reason is the caller-supplied justification for the change (evolve's
+	// reason argument) — the "why" the tool description promises.
+	Reason string `json:"reason,omitempty"`
+	// EffectiveAt is the valid-time boundary the change took effect at: the
+	// successor's ValidFrom and the predecessor's ValidUntil. Distinct from
+	// Timestamp, which is when the write happened.
+	EffectiveAt *time.Time `json:"effective_at,omitempty"`
 }

--- a/internal/storage/assoc_legacy_fullweight_test.go
+++ b/internal/storage/assoc_legacy_fullweight_test.go
@@ -106,13 +106,30 @@ func TestUpdateAssocWeight_PreFixInteriorWeightEdgeSurvives(t *testing.T) {
 	a := writeConfPathAssocEngram(t, store, ws, "interior edge source")
 	b := writeConfPathAssocEngram(t, store, ws, "interior edge target")
 
-	// Written with the CURRENT encoder — byte-identical to the legacy bytes at
-	// 0.8, which is exactly what the byte-compat pin in the keys package
-	// guarantees. If that pin ever breaks, this test breaks with it.
+	// Written with the current encoder, THEN relocated to independently
+	// hardcoded legacy bytes. The Tier-3 second pass proved the naive version
+	// of this test (write + update, both with the current encoder) passes even
+	// under the float64 byte-compat regression — writer and deleter are
+	// self-consistent, so nothing is ever missed. Standing alone requires the
+	// on-disk key to sit at bytes this test derives WITHOUT calling
+	// WeightComplement: the legacy complement of 0.8 is
+	// 0xFFFFFFFF - uint32(0.8 * 2^32) = 858993407 = 0x3333_32FF.
 	if err := store.WriteAssociation(ctx, ws, a, b, &Association{
 		TargetID: b, RelType: RelSupports, Weight: 0.8, Confidence: 1.0, CreatedAt: time.Now(),
 	}); err != nil {
 		t.Fatalf("WriteAssociation: %v", err)
+	}
+	// Independently-derived legacy bytes for 0.8 (no WeightComplement call).
+	legacy08 := [4]byte{0x33, 0x33, 0x32, 0xFF}
+	// The current encoder must place the key at exactly these bytes; if it
+	// does not, the write above is already at a non-legacy position and this
+	// test's premise (a PRE-FIX edge) is void — fail loudly rather than pass
+	// vacuously.
+	fwdKey := keys.AssocFwdKey(ws, [16]byte(a), 0.8, [16]byte(b))
+	if got := [4]byte(fwdKey[25:29]); got != legacy08 {
+		t.Fatalf("current encoder places weight 0.8 at complement %x, legacy bytes are %x — "+
+			"byte-compatibility is broken and every assertion below would be self-consistent "+
+			"rather than cross-era", got, legacy08)
 	}
 
 	if err := store.UpdateAssocWeight(ctx, ws, a, b, 0.85, 1); err != nil {

--- a/internal/storage/assoc_legacy_fullweight_test.go
+++ b/internal/storage/assoc_legacy_fullweight_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/scrypster/muninndb/internal/storage/keys"
 )
@@ -86,4 +87,54 @@ func writeConfPathAssocEngram(t *testing.T, store *PebbleStore, ws [8]byte, cont
 		t.Fatalf("WriteEngram: %v", err)
 	}
 	return id
+}
+
+// The cross-era survival scenario from the adversarial review, pinned at the
+// store level: a PRE-FIX interior-weight edge (0.8 — written with the legacy
+// encoder, which is byte-identical to the fixed one on (0,1)) must survive one
+// weight update with its metadata intact and exactly one key. The reviewer
+// proved that the first (float64) version of the encoder fix failed this
+// end-to-end: the recomputed delete missed the pre-fix key, the metadata read
+// missed too, and the update wrote a duplicate edge with relType silently
+// reset to 0.
+func TestUpdateAssocWeight_PreFixInteriorWeightEdgeSurvives(t *testing.T) {
+	store, cleanup := newTestStoreHelper(t)
+	defer cleanup()
+	ctx := context.Background()
+	ws := [8]byte{8}
+
+	a := writeConfPathAssocEngram(t, store, ws, "interior edge source")
+	b := writeConfPathAssocEngram(t, store, ws, "interior edge target")
+
+	// Written with the CURRENT encoder — byte-identical to the legacy bytes at
+	// 0.8, which is exactly what the byte-compat pin in the keys package
+	// guarantees. If that pin ever breaks, this test breaks with it.
+	if err := store.WriteAssociation(ctx, ws, a, b, &Association{
+		TargetID: b, RelType: RelSupports, Weight: 0.8, Confidence: 1.0, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	if err := store.UpdateAssocWeight(ctx, ws, a, b, 0.85, 1); err != nil {
+		t.Fatalf("UpdateAssocWeight: %v", err)
+	}
+
+	assocs, err := store.GetAssociations(ctx, ws, []ULID{a}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+	count := 0
+	for _, e := range assocs[a] {
+		if e.TargetID == b {
+			count++
+			if e.RelType != RelSupports {
+				t.Errorf("relType = %v after update, want RelSupports — metadata was reset, meaning "+
+					"the recomputed key missed the stored one", e.RelType)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("pair has %d edges after one update, want exactly 1 — the old key was not deleted "+
+			"(encoder byte-compatibility broken)", count)
+	}
 }

--- a/internal/storage/assoc_legacy_fullweight_test.go
+++ b/internal/storage/assoc_legacy_fullweight_test.go
@@ -1,0 +1,89 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage/keys"
+)
+
+// Pre-fix full-weight edges live at the WRONG key position, and an update must
+// not leave them behind as duplicates.
+//
+// The old WeightComplement overflowed for weight exactly 1.0 (float32(MaxUint32)
+// rounds up to 2^32; the uint32 conversion of 2^32 is implementation-defined
+// and produced 0 on arm64), so a 1.0-weight association was written at the
+// byte position of weight 0.0 and read back as weight 0. After the encode fix,
+// a weight update recomputes the CORRECT old-key position, whose delete would
+// miss the legacy location entirely — leaving a stale duplicate edge that
+// still reads as 0. deleteLegacyFullWeightKeys closes that.
+func TestUpdateAssocWeight_CleansLegacyFullWeightKey(t *testing.T) {
+	store, cleanup := newTestStoreHelper(t)
+	defer cleanup()
+	ctx := context.Background()
+	ws := [8]byte{7}
+
+	a := writeConfPathAssocEngram(t, store, ws, "edge source")
+	b := writeConfPathAssocEngram(t, store, ws, "edge target")
+
+	// Simulate the PRE-FIX on-disk state by hand: the 0x14 weight index holds
+	// the true 1.0 (it always stored raw float bits, correctly), while the
+	// 0x03/0x04 keys sit at the weight-0.0 position (the overflow artifact).
+	if err := store.UpdateAssocWeight(ctx, ws, a, b, 1.0, 1); err != nil {
+		t.Fatalf("seed UpdateAssocWeight: %v", err)
+	}
+	// Move the fwd/rev keys to the legacy (buggy) position to recreate the
+	// pre-fix layout: read the correctly-placed value, rewrite at weight-0.0
+	// position, delete the correct position.
+	fwdCorrect := keys.AssocFwdKey(ws, [16]byte(a), 1.0, [16]byte(b))
+	val, closer, err := store.db.Get(fwdCorrect)
+	if err != nil {
+		t.Fatalf("read seeded fwd key: %v", err)
+	}
+	valCopy := append([]byte(nil), val...)
+	_ = closer.Close()
+	batch := store.db.NewBatch()
+	_ = batch.Set(keys.AssocFwdKey(ws, [16]byte(a), 0.0, [16]byte(b)), valCopy, nil)
+	_ = batch.Set(keys.AssocRevKey(ws, [16]byte(b), 0.0, [16]byte(a)), valCopy, nil)
+	_ = batch.Delete(fwdCorrect, nil)
+	_ = batch.Delete(keys.AssocRevKey(ws, [16]byte(b), 1.0, [16]byte(a)), nil)
+	if err := batch.Commit(nil); err != nil {
+		t.Fatalf("simulate legacy layout: %v", err)
+	}
+
+	// A post-fix weight update on the pair. The 0x14 index says oldWeight=1.0,
+	// so the delete recomputes the CORRECT 1.0 position — the compat helper
+	// must also clear the legacy 0.0 position or the stale edge survives.
+	if err := store.UpdateAssocWeight(ctx, ws, a, b, 0.7, 1); err != nil {
+		t.Fatalf("UpdateAssocWeight: %v", err)
+	}
+
+	assocs, err := store.GetAssociations(ctx, ws, []ULID{a}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+	edges := assocs[a]
+	count := 0
+	for _, e := range edges {
+		if e.TargetID == b {
+			count++
+			if e.Weight == 0 {
+				t.Errorf("stale legacy full-weight key survived the update (edge reads weight 0)")
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("pair has %d edges after update, want exactly 1 — the legacy key position was not cleaned", count)
+	}
+}
+
+func writeConfPathAssocEngram(t *testing.T, store *PebbleStore, ws [8]byte, content string) ULID {
+	t.Helper()
+	id, err := store.WriteEngram(context.Background(), ws, &Engram{
+		Concept: "legacy-weight fixture", Content: content, State: StateActive, Confidence: 1.0,
+	})
+	if err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+	return id
+}

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -579,6 +579,11 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 		batch := ps.db.NewBatch()
 		defer batch.Close()
 		for _, e := range chunk {
+			// e.oldW is decoded from the scanned KEY, so this delete depends on
+			// encode(decode(k)) == k for encoder-produced complements — pinned
+			// exhaustively (all float32 in [0,1]) by the byte-compat tests in
+			// storage/keys. If that identity ever breaks, this delete misses and
+			// decay grows duplicate keys unboundedly.
 			_ = batch.Delete(keys.AssocFwdKey(wsPrefix, e.src, e.oldW, e.dst), nil)
 			_ = batch.Delete(keys.AssocRevKey(wsPrefix, e.dst, e.oldW, e.src), nil)
 			deleteLegacyFullWeightKeys(batch, wsPrefix, e.src, e.dst, e.oldW)

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -347,6 +347,23 @@ func (ps *PebbleStore) getAssocValueFull(wsPrefix [8]byte, a, b ULID) (RelType, 
 // If the edge was previously restored (restoredAt != 0), restoredAt is cleared once
 // the edge re-establishes itself: 3+ co-activations post-restore OR weight exceeds
 // restoreWeight * 1.5 (where restoreWeight = existingPeak * 0.25).
+
+// deleteLegacyFullWeightKeys removes the PRE-FIX key locations for a
+// full-weight edge. The old WeightComplement overflowed for weight exactly 1.0
+// and produced the byte pattern of weight 0.0, so every pre-fix 1.0-weight
+// association lives at the weight-0.0 key position. A post-fix update that
+// deletes only the CORRECT position would leave that stale key behind — a
+// duplicate edge that still reads as weight 0. Deleting the 0.0 position for a
+// pair whose true weight is 1.0 is safe: the 0x14 weight index is one value
+// per pair, so a pair cannot legitimately hold both a 1.0 and a 0.0 edge.
+func deleteLegacyFullWeightKeys(batch *pebble.Batch, wsPrefix [8]byte, a, b [16]byte, trueWeight float32) {
+	if trueWeight != 1.0 {
+		return
+	}
+	_ = batch.Delete(keys.AssocFwdKey(wsPrefix, a, 0.0, b), nil)
+	_ = batch.Delete(keys.AssocRevKey(wsPrefix, b, 0.0, a), nil)
+}
+
 func (ps *PebbleStore) UpdateAssocWeight(ctx context.Context, wsPrefix [8]byte, a, b ULID, weight float32, countDelta uint32) error {
 	batch := ps.db.NewBatch()
 	defer batch.Close()
@@ -360,6 +377,7 @@ func (ps *PebbleStore) UpdateAssocWeight(ctx context.Context, wsPrefix [8]byte, 
 	if oldWeight > 0 {
 		batch.Delete(keys.AssocFwdKey(wsPrefix, [16]byte(a), oldWeight, [16]byte(b)), nil)
 		batch.Delete(keys.AssocRevKey(wsPrefix, [16]byte(b), oldWeight, [16]byte(a)), nil)
+		deleteLegacyFullWeightKeys(batch, wsPrefix, [16]byte(a), [16]byte(b), oldWeight)
 	}
 
 	// Preserve existing metadata; set lastActivated = now (Hebbian update = activation).
@@ -437,6 +455,7 @@ func (ps *PebbleStore) UpdateAssocWeightBatch(ctx context.Context, updates []Ass
 		if oldWeight > 0 {
 			batch.Delete(keys.AssocFwdKey(update.WS, update.Src, oldWeight, update.Dst), nil)
 			batch.Delete(keys.AssocRevKey(update.WS, update.Dst, oldWeight, update.Src), nil)
+			deleteLegacyFullWeightKeys(batch, update.WS, update.Src, update.Dst, oldWeight)
 		}
 
 		// PeakWeight is monotonically non-decreasing: max(existingPeak, newWeight).
@@ -562,6 +581,7 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 		for _, e := range chunk {
 			_ = batch.Delete(keys.AssocFwdKey(wsPrefix, e.src, e.oldW, e.dst), nil)
 			_ = batch.Delete(keys.AssocRevKey(wsPrefix, e.dst, e.oldW, e.src), nil)
+			deleteLegacyFullWeightKeys(batch, wsPrefix, e.src, e.dst, e.oldW)
 			if e.archive {
 				// Move to 0x25 archive namespace. Write archive value, delete live
 				// weight index; fwd/rev keys already deleted above.

--- a/internal/storage/batch.go
+++ b/internal/storage/batch.go
@@ -41,7 +41,8 @@ type pebbleStoreBatch struct {
 type batchPendingItem struct {
 	wsPrefix  [8]byte
 	eng       *Engram
-	operation string // provenance verb: "create" (default), "evolve", etc.
+	operation string              // provenance verb: "create" (default), "evolve", etc.
+	details   *provenance.Details // optional per-operation "what changed and why"; nil for plain creates
 }
 
 // NewBatch returns a new StoreBatch that queues engram writes atomically.
@@ -68,6 +69,15 @@ func (b *pebbleStoreBatch) WriteEngram(ctx context.Context, wsPrefix [8]byte, en
 // provenance reads "evolve", not "create" (the write-path verb was
 // previously discarded — see issue tracked in the provenance-verb work).
 func (b *pebbleStoreBatch) WriteEngramOp(ctx context.Context, wsPrefix [8]byte, eng *Engram, operation string) error {
+	return b.WriteEngramOpDetails(ctx, wsPrefix, eng, operation, nil)
+}
+
+// WriteEngramOpDetails is WriteEngramOp with an optional operation-specific
+// details payload attached to the provenance entry. Evolve uses it to record
+// what the successor replaced, why, and from which valid-time instant — the
+// verb alone said an update happened but never what changed or why. nil details
+// is exactly WriteEngramOp: no payload is recorded, and none is invented.
+func (b *pebbleStoreBatch) WriteEngramOpDetails(ctx context.Context, wsPrefix [8]byte, eng *Engram, operation string, details *provenance.Details) error {
 	// Apply defaults — same as PebbleStore.WriteEngram.
 	if eng.ID == (ULID{}) {
 		if !eng.CreatedAt.IsZero() {
@@ -157,7 +167,7 @@ func (b *pebbleStoreBatch) WriteEngramOp(ctx context.Context, wsPrefix [8]byte, 
 	laKey := keys.LastAccessIndexKey(wsPrefix, laMillis, id16)
 	b.batch.Set(laKey, nil, nil)
 
-	b.pendingItems = append(b.pendingItems, batchPendingItem{wsPrefix: wsPrefix, eng: eng, operation: operation})
+	b.pendingItems = append(b.pendingItems, batchPendingItem{wsPrefix: wsPrefix, eng: eng, operation: operation, details: details})
 	return nil
 }
 
@@ -364,6 +374,7 @@ func (b *pebbleStoreBatch) Commit() error {
 				Source:    provenance.SourceHuman,
 				AgentID:   eng.CreatedBy,
 				Operation: op,
+				Details:   item.details,
 			})
 		}
 	}

--- a/internal/storage/keys/keys.go
+++ b/internal/storage/keys/keys.go
@@ -535,10 +535,39 @@ func TransitionPrefixForSrc(ws [8]byte, src [16]byte) []byte {
 
 // WeightComplement computes the weight complement for descending sort order.
 func WeightComplement(weight float32) [4]byte {
-	w := uint32(weight * float32(math.MaxUint32))
+	// Compute in float64 and clamp. The old form — uint32(weight *
+	// float32(math.MaxUint32)) — was undefined for weight exactly 1.0:
+	// float32(MaxUint32) rounds UP to 2^32 (4294967295 is not representable in
+	// float32), so 1.0*2^32 overflows the uint32 conversion, which Go leaves
+	// implementation-defined; on arm64 it produced 0. Complement of 0 is
+	// MaxUint32 — the byte pattern of weight 0.0 — so a full-confidence
+	// declared link (weight exactly 1.0) round-tripped to weight 0. Only 1.0
+	// triggered it (float32 granularity puts the next value at 0.99999994,
+	// which is safe), which is precisely why Hebbian's 0.3-0.8 edges displayed
+	// fine while decide's evidence links and explicit contradicts/supersedes
+	// declarations — the STRONGEST edges in the system — surfaced as weight 0.
+	f := float64(weight)
+	if f < 0 {
+		f = 0
+	} else if f > 1 {
+		f = 1
+	}
+	w := uint32(f * float64(math.MaxUint32))
 	c := uint32(math.MaxUint32) - w
 	var buf [4]byte
 	binary.BigEndian.PutUint32(buf[:], c)
+	return buf
+}
+
+// LegacyFullWeightComplement is the byte pattern the PRE-FIX WeightComplement
+// produced for weight exactly 1.0 (uint32 overflow -> 0 -> complement
+// MaxUint32) — byte-identical to the CORRECT complement of weight 0.0. Delete
+// paths that rebuild a key from a recomputed complement must also delete this
+// location when the true weight is 1.0, or every pre-fix full-weight edge
+// leaves a stale duplicate key behind on its first update.
+func LegacyFullWeightComplement() [4]byte {
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], math.MaxUint32)
 	return buf
 }
 

--- a/internal/storage/keys/keys.go
+++ b/internal/storage/keys/keys.go
@@ -535,39 +535,48 @@ func TransitionPrefixForSrc(ws [8]byte, src [16]byte) []byte {
 
 // WeightComplement computes the weight complement for descending sort order.
 func WeightComplement(weight float32) [4]byte {
-	// Compute in float64 and clamp. The old form — uint32(weight *
-	// float32(math.MaxUint32)) — was undefined for weight exactly 1.0:
-	// float32(MaxUint32) rounds UP to 2^32 (4294967295 is not representable in
-	// float32), so 1.0*2^32 overflows the uint32 conversion, which Go leaves
-	// implementation-defined; on arm64 it produced 0. Complement of 0 is
-	// MaxUint32 — the byte pattern of weight 0.0 — so a full-confidence
-	// declared link (weight exactly 1.0) round-tripped to weight 0. Only 1.0
-	// triggered it (float32 granularity puts the next value at 0.99999994,
-	// which is safe), which is precisely why Hebbian's 0.3-0.8 edges displayed
-	// fine while decide's evidence links and explicit contradicts/supersedes
-	// declarations — the STRONGEST edges in the system — surfaced as weight 0.
-	f := float64(weight)
-	if f < 0 {
-		f = 0
-	} else if f > 1 {
-		f = 1
+	// BYTE-COMPATIBLE with every key ever written for weights in (0,1), and
+	// explicitly saturated at the endpoints.
+	//
+	// History, because this function has now been wrong twice in opposite
+	// directions:
+	//
+	//  1. The ORIGINAL form, uint32(weight * float32(math.MaxUint32)), was
+	//     undefined for weight exactly 1.0 — float32(MaxUint32) rounds UP to
+	//     2^32, the multiply lands on 2^32, and the uint32 conversion of an
+	//     out-of-range float is implementation-defined (0 on arm64). A
+	//     full-confidence edge was therefore written at the weight-0.0 key
+	//     position and read back as 0: decide's evidence links, explicit 1.0
+	//     declarations, and LTP-saturated learning were silently destroyed.
+	//  2. The FIRST fix computed uint32(f * float64(math.MaxUint32)). Correct
+	//     at 1.0 — and byte-INCOMPATIBLE at essentially every other weight,
+	//     because float32(MaxUint32)==2^32 while float64(MaxUint32)==2^32-1:
+	//     the two multipliers disagree by ~1 integer step for all interior
+	//     weights (0 identical encodings in 1M samples). Every recomputed-key
+	//     delete (Hebbian updates, decay, engram-delete cascade) would have
+	//     missed every pre-fix key on every existing vault: metadata silently
+	//     reset, permanent duplicate edges, unbounded decay key growth. Caught
+	//     by adversarial review before it shipped.
+	//
+	// The correct form keeps the ORIGINAL expression on the open interval —
+	// byte-identical to every existing on-disk key — and handles only the
+	// endpoints explicitly. 0.99999994 (the largest float32 below 1.0) stays
+	// on the legacy path and encodes safely to 4294967040. The endpoint
+	// saturation gives 1.0 -> complement 0 (sorts first, decodes to exactly
+	// 1.0). Pinned by a cross-era byte-compatibility test that reproduces the
+	// legacy bytes for interior weights.
+	var w uint32
+	switch {
+	case weight >= 1.0:
+		w = math.MaxUint32
+	case weight <= 0:
+		w = 0
+	default:
+		w = uint32(weight * float32(math.MaxUint32)) // legacy expression: byte-identical on (0,1)
 	}
-	w := uint32(f * float64(math.MaxUint32))
 	c := uint32(math.MaxUint32) - w
 	var buf [4]byte
 	binary.BigEndian.PutUint32(buf[:], c)
-	return buf
-}
-
-// LegacyFullWeightComplement is the byte pattern the PRE-FIX WeightComplement
-// produced for weight exactly 1.0 (uint32 overflow -> 0 -> complement
-// MaxUint32) — byte-identical to the CORRECT complement of weight 0.0. Delete
-// paths that rebuild a key from a recomputed complement must also delete this
-// location when the true weight is 1.0, or every pre-fix full-weight edge
-// leaves a stale duplicate key behind on its first update.
-func LegacyFullWeightComplement() [4]byte {
-	var buf [4]byte
-	binary.BigEndian.PutUint32(buf[:], math.MaxUint32)
 	return buf
 }
 

--- a/internal/storage/keys/weight_roundtrip_test.go
+++ b/internal/storage/keys/weight_roundtrip_test.go
@@ -1,0 +1,12 @@
+package keys
+
+import "testing"
+
+func TestWeightComplement_FullWeightRoundTrips(t *testing.T) {
+	for _, w := range []float32{0, 0.3, 0.8, 0.9999999, 1.0} {
+		got := WeightFromComplement(WeightComplement(w))
+		if diff := got - w; diff > 1e-6 || diff < -1e-6 {
+			t.Errorf("weight %v round-trips to %v", w, got)
+		}
+	}
+}

--- a/internal/storage/keys/weight_roundtrip_test.go
+++ b/internal/storage/keys/weight_roundtrip_test.go
@@ -1,12 +1,60 @@
 package keys
 
-import "testing"
+import (
+	"encoding/binary"
+	"testing"
+)
 
 func TestWeightComplement_FullWeightRoundTrips(t *testing.T) {
 	for _, w := range []float32{0, 0.3, 0.8, 0.9999999, 1.0} {
 		got := WeightFromComplement(WeightComplement(w))
 		if diff := got - w; diff > 1e-6 || diff < -1e-6 {
 			t.Errorf("weight %v round-trips to %v", w, got)
+		}
+	}
+}
+
+// legacyWeightComplement reproduces the ORIGINAL (pre-fix) encoder verbatim so
+// the byte-compatibility contract is pinned against real history, not against
+// whatever the current implementation happens to produce. Undefined at 1.0 by
+// design — that is the one input the fixed encoder is allowed to differ on.
+func legacyWeightComplement(weight float32) [4]byte {
+	w := uint32(weight * float32(4294967295))
+	c := uint32(4294967295) - w
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], c)
+	return buf
+}
+
+// The fixed encoder must be BYTE-IDENTICAL to the legacy one for every weight
+// in (0,1). The first attempt at the 1.0 fix used a float64 multiplier that
+// disagreed with legacy by one integer step at essentially every interior
+// weight — which would have made every recomputed-key delete (Hebbian update,
+// decay, engram-delete cascade) miss every pre-fix key on every existing
+// vault: metadata silently reset, permanent duplicate edges, unbounded decay
+// key growth. Caught by adversarial review; this pin makes the regression
+// unreintroducible.
+func TestWeightComplement_ByteCompatibleWithLegacyKeys(t *testing.T) {
+	// Fixed table across the operating range, plus a deterministic sweep.
+	for _, w := range []float32{1e-7, 0.001, 0.01, 0.05, 0.1, 0.3, 0.5, 0.7, 0.8, 0.9, 0.95, 0.99, 0.999, 0.99999994} {
+		if got, want := WeightComplement(w), legacyWeightComplement(w); got != want {
+			t.Errorf("weight %v: fixed encoder %v != legacy bytes %v — pre-fix on-disk keys at this "+
+				"weight become unreachable to recomputed-key deletes", w, got, want)
+		}
+	}
+	for i := 1; i < 100000; i++ {
+		w := float32(i) / 100001.0
+		if got, want := WeightComplement(w), legacyWeightComplement(w); got != want {
+			t.Fatalf("sweep: weight %v diverges from legacy bytes", w)
+		}
+	}
+	// And decode->re-encode must be an exact identity across the range decay
+	// depends on (the float64 attempt failed this for ~54%% of weights below
+	// 0.01).
+	for i := 1; i < 100000; i++ {
+		w := float32(i) / 100001.0
+		if re := WeightComplement(WeightFromComplement(WeightComplement(w))); re != WeightComplement(w) {
+			t.Fatalf("decode->re-encode not an identity at weight %v", w)
 		}
 	}
 }

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"context"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/provenance"
 )
 
 // AssocWeightUpdate represents a single association weight update for batching.
@@ -31,6 +33,10 @@ type StoreBatch interface {
 	// WriteEngram, except the provenance entry records operation as the
 	// originating verb (e.g. "evolve") instead of the hardcoded "create".
 	WriteEngramOp(ctx context.Context, wsPrefix [8]byte, eng *Engram, operation string) error
+	// WriteEngramOpDetails is WriteEngramOp with an optional operation-specific
+	// details payload (predecessor, reason, effective_at) attached to the
+	// provenance entry. nil details behaves exactly like WriteEngramOp.
+	WriteEngramOpDetails(ctx context.Context, wsPrefix [8]byte, eng *Engram, operation string, details *provenance.Details) error
 	// WriteAssociation queues association forward (0x03), reverse (0x04) keys into the batch.
 	WriteAssociation(ctx context.Context, wsPrefix [8]byte, src, dst ULID, assoc *Association) error
 	// WriteOrdinal queues the ordinal key for (parentID, childID) into the batch.


### PR DESCRIPTION
The three items from the round-4 evaluation verdict ("recall is the load-bearing feature"), each resolved on its own evidence. Five commits, two full adversarial review passes (G6 satisfied — this touches on-disk key format).

## 1. Full-confidence declarations were being destroyed (`57713a2` + `4b2aa5a`)

"Link weights arrive as 0 in traverse" turned out to be `WeightComplement(1.0)` overflowing: `float32(MaxUint32)` rounds up to 2³², the uint32 conversion of 2³² is implementation-defined (0 on arm64), and the complement collapsed to the weight-0.0 byte pattern. **Only exactly 1.0 triggered it** — which is why Hebbian's 0.3–0.8 edges looked fine while the strongest edges in the system (decide's evidence links, explicit 1.0 declarations, LTP-saturated learning) silently read as 0.

Consequence worth reading twice: with full-weight edges readable, **recall-to-recall session learning works for the first time** — consecutive equivalent recalls now return the same candidate set in shifting order. Three preset tests were pinning the old accidental determinism; they now assert set equality (wiring), with resolution pinned exhaustively at unit level.

**The first version of this fix was blocked in review for a worse bug than the one it fixed**: a float64 multiplier that was byte-incompatible with every existing key at every interior weight — silent corruption of every existing vault on first touch. The rework keeps the legacy expression verbatim on (0,1) and saturates only the endpoints. Pinned three ways: byte-identity against the *legacy encoder reimplemented in the test* (table + 100k sweep), the decode→re-encode identity, and the reviewer's end-to-end corruption scenario at independently-hardcoded legacy key bytes (the naive version of that test was RED-proven to pass both ways). The second pass verified byte-identity over 152M samples and the identity **exhaustively over all 1,065,353,217 float32 values in [0,1]**.

Follow-up filed and mechanism-corrected in review: #756 — pre-fix 1.0-edges are *destroyed or clamped* by decay, and the repair window closes per-edge on every decay pass. The startup repair should land soon.

## 2. Evolve provenance answers "what changed and why" (`7b8874e`)

`operation: evolve` entries now carry `predecessor_id`, `reason`, and `effective_at`. JSON value format is additively extensible — legacy entries decode with the fields **absent, never zero-values posing as data**; the registry row documents exactly which future changes would need a real version byte. RED-verified; live-verified on a sandbox. Residual: the predecessor's trail still ends at `create` (easy follow-up).

## 3. The recall paraphrase tail — measured to its structural ceiling (`6552809`)

The labeled query set this tuning always needed: 48 engrams over deliberately-adjacent domains, 30 answerable paraphrases in three difficulty bands, 20 unanswerable including the hard kinds. Findings:

- The reported wrong-abstentions **don't reproduce** — both answer at rank 1; they were vault-content artifacts.
- The real number: **topically-adjacent unanswerable FPR is 87.5%, present-tense/live 100%** (the celebrated 6.2% was an out-of-domain-nonsense figure).
- Structural: with the lexical channel silent, the gate reduces to a single cosine cutoff — every floor/knee/combiner variant slides one ROC. **Nine candidates measured against a pre-committed rule; none passed; nothing shipped.** One weakly-dominant variant was identified and deliberately not adopted (principle 11).

"Is this responsive, not merely related?" is not computable from cosine + lexical coverage. Closing the decoy leak needs a responsiveness signal — its own design increment, not a tuning pass.

Also found while building the harness (confirmed by review, pre-existing): `Components.Raw` is overwritten post-rescale, so explain's component card is internally inconsistent when the rescale fired.

## Review trail

- First pass: **blocked** the weight fix (byte-incompat), verified provenance + measurement.
- Second pass (G6): **approved** the rework with three required changes, all executed: #755 corrected and **closed** (its central claim was false — the log has been ReadOnly-gated since the initial commit; the first pass and the coordinator propagated an unverified mechanism), #756's mechanism rewritten (two destruction paths; expiring repair window), and the cross-era test made to stand alone.

Full suite green; `-race` green on storage/activation/engine. Synthetic fixtures only throughout.
