### PR TITLE
chore(gitignore): keep the contributor PR vetter maintainer-private

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,11 @@ sdk/php/vendor/
 .claude/skills/review-pr/
 .claude/skills/merge-orchestration/
 
+# Maintainer-private agent: encodes what we look for when a change might serve its
+# author rather than the community, plus the security walk and the contributor-response
+# voice. Publishing it would publish the test answers. Same tier as the skills above.
+.claude/agents/contributor-pr-vetter.md
+
 # Design records that cannot be published: ones naming real people, client or
 # tenant data, commercial terms, or competitive strategy. Everything else in
 # .claude/deep-review/ IS published — see the README there for the triage rule.


### PR DESCRIPTION
One line in `.gitignore`. The agent itself is not in this diff and never will be — that is the point.

Same tier as `review-pr` and `merge-orchestration`, which are already private for the same reason: they describe how we vet, and a change that describes what we look for when someone might be gaming the process shouldn't be published alongside the process.

The three agents merged in #791 (`increment-designer`, `increment-builder`, `vault-measurer`) stay public deliberately — they encode engineering discipline and a privacy commitment, and being able to read them is a feature for contributors. This one is different in kind.