### PR TITLE
fix(storage): four association-layer defects — read laundering, unchecked iterators, stale caches, aliasing (#804, #808, #818, #820)

### DIFF
--- a/internal/storage/assoc_cache_alias_820_test.go
+++ b/internal/storage/assoc_cache_alias_820_test.go
@@ -1,0 +1,131 @@
+package storage
+
+import (
+	"context"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// #820 — GetAssociations' own doc comment states the rule ("Return copies of
+// cached slices to prevent callers from mutating the cache") and the cache-HIT
+// path honours it. The cache-MISS path handed back the very slice it had just
+// stored, so the first caller after a miss owned a live view of the cache entry
+// for the rest of the 2s TTL.
+//
+// The identical defect on the reverse cache was fixed at the source in #800
+// (TestRankingReverseEdges_MissPathDoesNotAliasTheCache); this is its forward
+// twin, plus the under-serve trap the same ticket names.
+// ---------------------------------------------------------------------------
+
+// TestGetAssociations_MissPathDoesNotAliasTheCache mutates what the miss path
+// returned and then reads through the cache. Nothing in the tree mutates a
+// returned association today, which is exactly why this is worth pinning: the
+// ownership contract is a property of today's callers, not of the function.
+func TestGetAssociations_MissPathDoesNotAliasTheCache(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("assoc-miss-alias")
+
+	src, dst := NewULID(), NewULID()
+	mustWriteAssoc(t, store, ws, src, dst, 0.7, RelCoActivated)
+
+	fresh := newFreshStore(t, store.db)
+
+	miss, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("cold GetAssociations: %v", err)
+	}
+	if len(miss[src]) != 1 {
+		t.Fatalf("fixture broken: %d edges on the miss path, want 1", len(miss[src]))
+	}
+
+	// A caller doing what the returned value's type allows.
+	miss[src][0].Weight = 42.0
+	miss[src][0].TargetID = NewULID()
+
+	hit, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("warm GetAssociations: %v", err)
+	}
+	if len(hit[src]) != 1 {
+		t.Fatalf("warm read returned %d edges, want 1", len(hit[src]))
+	}
+	if hit[src][0].Weight == 42.0 || hit[src][0].TargetID != dst {
+		t.Errorf("the miss path published the cache's backing array: warm read returns target=%v weight=%v, want target=%v weight=0.7",
+			hit[src][0].TargetID, hit[src][0].Weight, dst)
+	}
+}
+
+// TestGetAssociations_CacheDoesNotUnderServeALargerCap is the trap the same
+// ticket names: the forward cache stored the list it built UNDER the caller's
+// maxPerNode with no record that it was truncated, so a later caller asking for
+// MORE was silently served the shorter list. The reverse cache already records
+// `truncated` and re-scans (TestGetRankingNeighbors_CacheDoesNotUnderServeALargerCap).
+func TestGetAssociations_CacheDoesNotUnderServeALargerCap(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("assoc-underserve")
+
+	src := NewULID()
+	for _, w := range []float32{0.9, 0.6, 0.3} {
+		mustWriteAssoc(t, store, ws, src, NewULID(), w, RelCoActivated)
+	}
+
+	fresh := newFreshStore(t, store.db)
+
+	small, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 1)
+	if err != nil {
+		t.Fatalf("capped GetAssociations: %v", err)
+	}
+	if len(small[src]) != 1 {
+		t.Fatalf("fixture broken: cap 1 returned %d edges", len(small[src]))
+	}
+
+	large, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	if err != nil {
+		t.Fatalf("uncapped GetAssociations: %v", err)
+	}
+	if len(large[src]) != 3 {
+		t.Errorf("a warm entry cached under a SMALLER cap under-served a larger one: got %d edges, want 3", len(large[src]))
+	}
+
+	// maxPerNode <= 0 means uncapped, and must not be served from a capped entry either.
+	unbounded, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 0)
+	if err != nil {
+		t.Fatalf("uncapped GetAssociations: %v", err)
+	}
+	if len(unbounded[src]) != 3 {
+		t.Errorf("an uncapped read was served a capped cache entry: got %d edges, want 3", len(unbounded[src]))
+	}
+}
+
+// TestAssociationsForOne_CacheDoesNotUnderServeALargerCap pins the same
+// property on the single-source reader, which shares assocCache with
+// GetAssociations — so either one can plant the short entry the other serves.
+func TestAssociationsForOne_CacheDoesNotUnderServeALargerCap(t *testing.T) {
+	store := newTestStore(t)
+	ws := store.VaultPrefix("assoc-one-underserve")
+
+	src := NewULID()
+	for _, w := range []float32{0.9, 0.6, 0.3} {
+		mustWriteAssoc(t, store, ws, src, NewULID(), w, RelCoActivated)
+	}
+
+	fresh := newFreshStore(t, store.db)
+
+	small, err := fresh.associationsForOne(ws, src, 1)
+	if err != nil {
+		t.Fatalf("capped associationsForOne: %v", err)
+	}
+	if len(small) != 1 {
+		t.Fatalf("fixture broken: cap 1 returned %d edges", len(small))
+	}
+
+	large, err := fresh.associationsForOne(ws, src, 10)
+	if err != nil {
+		t.Fatalf("uncapped associationsForOne: %v", err)
+	}
+	if len(large) != 3 {
+		t.Errorf("a warm entry cached under a SMALLER cap under-served a larger one: got %d edges, want 3", len(large))
+	}
+}

--- a/internal/storage/assoc_cache_evict_818_test.go
+++ b/internal/storage/assoc_cache_evict_818_test.go
@@ -1,0 +1,206 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// #818 — three edge-mutating sites evicted neither association cache, so an
+// edge could be invisible (or visible at a stale weight) from one endpoint for
+// up to the 2s TTL. Same observable shape as COG-31, at 2 seconds instead of
+// forever.
+//
+// Each test warms the cache it is about, mutates through the site under test,
+// and reads back through the SAME store — the eviction is the only mechanism
+// that can make the read correct, because the TTL has not expired.
+// ---------------------------------------------------------------------------
+
+// TestDeleteEngram_ReverseCacheInvalidated: DeleteEngram evicts assocCache for
+// every source that named the dead engram (#803), but never touched
+// revAssocCache — so the dead engram stayed reachable INTO its former targets.
+func TestDeleteEngram_ReverseCacheInvalidated(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("delete-evicts-reverse")
+
+	a, b := NewULID(), NewULID()
+	mustWriteAssoc(t, store, ws, a, b, 0.7, RelCoActivated)
+
+	// Warm the REVERSE cache for B: it holds the inbound edge from A.
+	warm, err := store.GetRankingNeighbors(ctx, ws, []ULID{b}, 10)
+	if err != nil {
+		t.Fatalf("warm GetRankingNeighbors: %v", err)
+	}
+	if !containsTarget(warm[b], a) {
+		t.Fatalf("fixture broken: reverse edge a->b not visible from b: %v", targetsOf(warm[b]))
+	}
+
+	if err := store.DeleteEngram(ctx, ws, a); err != nil {
+		t.Fatalf("DeleteEngram: %v", err)
+	}
+
+	got, err := store.GetRankingNeighbors(ctx, ws, []ULID{b}, 10)
+	if err != nil {
+		t.Fatalf("GetRankingNeighbors: %v", err)
+	}
+	if containsTarget(got[b], a) {
+		t.Error("revAssocCache still names the hard-deleted engram: traversal from b hops to an id that can never materialise")
+	}
+}
+
+// TestDecayAssocWeights_BothCachesInvalidated: decay rewrites every edge it
+// touches at a new weight and archives others, and evicted neither cache — so
+// ranking kept scoring on pre-decay weights for the TTL.
+func TestDecayAssocWeights_BothCachesInvalidated(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("decay-evicts-caches")
+
+	a, b := NewULID(), NewULID()
+	seedEndpoints(t, store, ws, a, b)
+
+	// Anchor the edge explicitly: with LastActivated == 0 and a zero CreatedAt
+	// the first decay pass only ADOPTS the edge (stamps the anchor, leaves the
+	// weight), which would make this test assert nothing.
+	base := time.Unix(1750000000, 0)
+	if err := store.WriteAssociation(ctx, ws, a, b, &Association{
+		TargetID:      b,
+		Weight:        0.8,
+		PeakWeight:    0.8,
+		RelType:       RelCoActivated,
+		CreatedAt:     base,
+		LastActivated: int32(base.Unix()),
+	}); err != nil {
+		t.Fatalf("WriteAssociation: %v", err)
+	}
+
+	// Warm FORWARD (keyed on src=a) and REVERSE (keyed on dst=b).
+	if got, err := store.GetAssociations(ctx, ws, []ULID{a}, 10); err != nil {
+		t.Fatalf("warm GetAssociations: %v", err)
+	} else if w := weightOfTarget(t, got[a], b); w != 0.8 {
+		t.Fatalf("fixture broken: warm forward weight %v, want 0.8", w)
+	}
+	if got, err := store.GetRankingNeighbors(ctx, ws, []ULID{b}, 10); err != nil {
+		t.Fatalf("warm GetRankingNeighbors: %v", err)
+	} else if w := weightOfTarget(t, got[b], a); w != 0.8 {
+		t.Fatalf("fixture broken: warm reverse weight %v, want 0.8", w)
+	}
+
+	// Two half-lives of simulated elapsed time: ceiling = 0.8 * 2^-2 = 0.2.
+	// Injected clock, not a sleep — decay is a pure function of elapsed time.
+	halfLife := time.Hour
+	store.decayNow = func() time.Time { return base.Add(2 * halfLife) }
+	if _, err := store.DecayAssocWeights(ctx, ws, halfLife, 0.05, 0); err != nil {
+		t.Fatalf("DecayAssocWeights: %v", err)
+	}
+	store.decayNow = nil
+
+	// On-disk truth, read through neither cache.
+	onDisk, err := store.GetAssocWeight(ctx, ws, a, b)
+	if err != nil {
+		t.Fatalf("GetAssocWeight: %v", err)
+	}
+	if onDisk > 0.25 || onDisk < 0.15 {
+		t.Fatalf("fixture broken: decay did not move the on-disk weight (%v), so neither cache can be stale", onDisk)
+	}
+
+	got, err := store.GetAssociations(ctx, ws, []ULID{a}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+	if w := weightOfTarget(t, got[a], b); w != onDisk {
+		t.Errorf("forward cache served a pre-decay weight: got %v, want %v", w, onDisk)
+	}
+
+	rev, err := store.GetRankingNeighbors(ctx, ws, []ULID{b}, 10)
+	if err != nil {
+		t.Fatalf("GetRankingNeighbors: %v", err)
+	}
+	if w := weightOfTarget(t, rev[b], a); w != onDisk {
+		t.Errorf("reverse cache served a pre-decay weight: got %v, want %v", w, onDisk)
+	}
+}
+
+// TestBatchWriteAssociation_BothCachesInvalidated: the batch writer sets 0x03
+// and 0x04 and evicted neither cache, so an edge written through a batch was
+// invisible from BOTH endpoints for the TTL. Eviction must be deferred to
+// Commit — a discarded batch must evict nothing.
+func TestBatchWriteAssociation_BothCachesInvalidated(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("batch-write-evicts")
+
+	a, b := NewULID(), NewULID()
+	seedEndpoints(t, store, ws, a, b)
+
+	// Warm both caches with the pre-write (empty) truth.
+	if got, err := store.GetAssociations(ctx, ws, []ULID{a}, 10); err != nil {
+		t.Fatalf("warm GetAssociations: %v", err)
+	} else if len(got[a]) != 0 {
+		t.Fatalf("fixture broken: a already has %d edges", len(got[a]))
+	}
+	if got, err := store.GetRankingNeighbors(ctx, ws, []ULID{b}, 10); err != nil {
+		t.Fatalf("warm GetRankingNeighbors: %v", err)
+	} else if len(got[b]) != 0 {
+		t.Fatalf("fixture broken: b already has %d neighbors", len(got[b]))
+	}
+
+	batch := store.NewBatch()
+	if err := batch.WriteAssociation(ctx, ws, a, b, &Association{
+		TargetID: b, Weight: 0.6, RelType: RelCoActivated,
+	}); err != nil {
+		t.Fatalf("batch WriteAssociation: %v", err)
+	}
+	if err := batch.Commit(); err != nil {
+		t.Fatalf("batch Commit: %v", err)
+	}
+
+	fwd, err := store.GetAssociations(ctx, ws, []ULID{a}, 10)
+	if err != nil {
+		t.Fatalf("GetAssociations: %v", err)
+	}
+	if !containsTarget(fwd[a], b) {
+		t.Error("forward cache still says a has no edges after a committed batch write")
+	}
+
+	rev, err := store.GetRankingNeighbors(ctx, ws, []ULID{b}, 10)
+	if err != nil {
+		t.Fatalf("GetRankingNeighbors: %v", err)
+	}
+	if !containsTarget(rev[b], a) {
+		t.Error("reverse cache still says b has no inbound edges after a committed batch write")
+	}
+}
+
+// TestBatchWriteAssociation_DiscardEvictsNothing is the other half of the
+// deferred-eviction contract: a batch that never lands must not invalidate a
+// correct cache entry. Cheap to get wrong by evicting at queue time.
+func TestBatchWriteAssociation_DiscardEvictsNothing(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("batch-discard-evicts")
+
+	a, b := NewULID(), NewULID()
+	seedEndpoints(t, store, ws, a, b)
+
+	if _, err := store.GetAssociations(ctx, ws, []ULID{a}, 10); err != nil {
+		t.Fatalf("warm GetAssociations: %v", err)
+	}
+	if _, cached := store.assocCache.Get(assocCacheKey(ws, a)); !cached {
+		t.Fatal("fixture broken: the warming read cached nothing")
+	}
+
+	batch := store.NewBatch()
+	if err := batch.WriteAssociation(ctx, ws, a, b, &Association{
+		TargetID: b, Weight: 0.6, RelType: RelCoActivated,
+	}); err != nil {
+		t.Fatalf("batch WriteAssociation: %v", err)
+	}
+	batch.Discard()
+
+	if _, cached := store.assocCache.Get(assocCacheKey(ws, a)); !cached {
+		t.Error("a discarded batch evicted the forward cache — eviction must be deferred to Commit")
+	}
+}

--- a/internal/storage/assoc_iter_error_test.go
+++ b/internal/storage/assoc_iter_error_test.go
@@ -1,0 +1,146 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/prefix"
+)
+
+// ---------------------------------------------------------------------------
+// #808 — a forward-association scan that FAILS PARTWAY THROUGH must not be
+// served, or cached, as a short-but-complete edge list.
+//
+// The fault seam is the iterator sibling of readFault: readFault mediates point
+// reads only, and no arrangement of a real Pebble DB makes a scan stop early
+// AND report an error without corrupting an .sst. See scan_iter.go.
+// ---------------------------------------------------------------------------
+
+var errInjectedScan = errors.New("injected pebble scan failure")
+
+// truncatingIter wraps a real scan and makes it stop after `remaining` keys,
+// reporting errInjectedScan from Error() from that point on — the shape a
+// corrupt block partway through a node's edge list produces.
+type truncatingIter struct {
+	scanIterator
+	remaining int
+	failed    bool
+}
+
+func (t *truncatingIter) gate(ok bool) bool {
+	if t.failed || !ok {
+		return false
+	}
+	if t.remaining <= 0 {
+		t.failed = true
+		return false
+	}
+	t.remaining--
+	return true
+}
+
+func (t *truncatingIter) First() bool          { return t.gate(t.scanIterator.First()) }
+func (t *truncatingIter) SeekGE(k []byte) bool { return t.gate(t.scanIterator.SeekGE(k)) }
+func (t *truncatingIter) Next() bool           { return t.gate(t.scanIterator.Next()) }
+func (t *truncatingIter) Valid() bool          { return !t.failed && t.scanIterator.Valid() }
+func (t *truncatingIter) Error() error {
+	if t.failed {
+		return errInjectedScan
+	}
+	return t.scanIterator.Error()
+}
+
+// truncateForwardScansAfter arms iterFault for the 0x03 namespace only, so the
+// engram/endpoint reads the fixture needs are untouched.
+func truncateForwardScansAfter(n int) func([]byte, scanIterator) scanIterator {
+	return func(scanPrefix []byte, it scanIterator) scanIterator {
+		if len(scanPrefix) == 0 || scanPrefix[0] != prefix.AssocFwd {
+			return nil
+		}
+		return &truncatingIter{scanIterator: it, remaining: n}
+	}
+}
+
+// threeEdgeFixture writes src -> three distinct targets and returns src.
+func threeEdgeFixture(t *testing.T, store *PebbleStore, ws [8]byte) ULID {
+	t.Helper()
+	src := NewULID()
+	for _, w := range []float32{0.9, 0.6, 0.3} {
+		mustWriteAssoc(t, store, ws, src, NewULID(), w, RelCoActivated)
+	}
+	return src
+}
+
+// TestGetAssociations_TruncatedScanIsAnErrorNotAShortList is the live path:
+// GetAssociations is what recall traversal and currencyInDeclaredChain read
+// through. A scan that dies after one edge previously returned (1 edge, nil)
+// and wrote that truncated list into assocCache, where every OTHER reader
+// picked it up for the 2s TTL — a fault in one call contaminating callers that
+// never saw one.
+func TestGetAssociations_TruncatedScanIsAnErrorNotAShortList(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("assoc-iter-fault-fwd")
+
+	src := threeEdgeFixture(t, store, ws)
+
+	// Cold cache, so the call must go to Pebble.
+	fresh := newFreshStore(t, store.db)
+	fresh.iterFault = truncateForwardScansAfter(1)
+
+	got, err := fresh.GetAssociations(ctx, ws, []ULID{src}, 10)
+	fresh.iterFault = nil
+
+	if err == nil {
+		t.Fatalf("GetAssociations returned nil error under a mid-scan fault; got %d edges (want an error)", len(got[src]))
+	}
+	if !errors.Is(err, errInjectedScan) && !strings.Contains(err.Error(), errInjectedScan.Error()) {
+		t.Errorf("error does not carry the scan failure: %v", err)
+	}
+	if _, cached := fresh.assocCache.Get(assocCacheKey(ws, src)); cached {
+		t.Error("a truncated edge list was written into assocCache and will be served to every reader for the TTL")
+	}
+}
+
+// TestAssociationsForOne_TruncatedScanIsAnErrorNotAShortList pins the same
+// property on the single-source helper that carried the `// KNOWN GAP (#808)`
+// marker.
+func TestAssociationsForOne_TruncatedScanIsAnErrorNotAShortList(t *testing.T) {
+	store := newTestStore(t)
+	ws := store.VaultPrefix("assoc-iter-fault-one")
+
+	src := threeEdgeFixture(t, store, ws)
+
+	fresh := newFreshStore(t, store.db)
+	fresh.iterFault = truncateForwardScansAfter(1)
+
+	got, err := fresh.associationsForOne(ws, src, 10)
+	fresh.iterFault = nil
+
+	if err == nil {
+		t.Fatalf("associationsForOne returned nil error under a mid-scan fault; got %d edges (want an error)", len(got))
+	}
+	if !errors.Is(err, errInjectedScan) && !strings.Contains(err.Error(), errInjectedScan.Error()) {
+		t.Errorf("error does not carry the scan failure: %v", err)
+	}
+	if _, cached := fresh.assocCache.Get(assocCacheKey(ws, src)); cached {
+		t.Error("a truncated edge list was written into assocCache")
+	}
+}
+
+// TestScanIterSeamIsNilInProductionConstructors is the iterFault twin of
+// TestPointGetSeamIsNilInProductionConstructors: with the seam nil, scanIter is
+// the identity function, so nothing in these tests can change production
+// behaviour.
+func TestScanIterSeamIsNilInProductionConstructors(t *testing.T) {
+	store := newTestStore(t)
+	if store.iterFault != nil {
+		t.Fatal("iterFault must be nil on a store built by the production constructor")
+	}
+	var sentinel scanIterator = &truncatingIter{}
+	if got := store.scanIter([]byte{prefix.AssocFwd}, sentinel); got != sentinel {
+		t.Error("scanIter must be the identity function when iterFault is nil")
+	}
+}

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -175,12 +175,17 @@ func (ps *PebbleStore) GetAssociations(ctx context.Context, wsPrefix [8]byte, id
 		if entry, ok := ps.assocCache.Get(ck); ok {
 			// Determine slice length
 			n := len(entry.assocs)
-			if maxPerNode > 0 && n > maxPerNode {
-				n = maxPerNode
+			// A truncated entry can only answer a caller asking for no more
+			// than it holds; otherwise re-scan rather than silently under-serve
+			// (#820). Same rule as revAssocCache's hit path.
+			if !entry.truncated || maxPerNode > 0 && maxPerNode <= n {
+				if maxPerNode > 0 && n > maxPerNode {
+					n = maxPerNode
+				}
+				// Return a copy of the slice
+				result[id] = append([]Association(nil), entry.assocs[:n]...)
+				continue
 			}
-			// Return a copy of the slice
-			result[id] = append([]Association(nil), entry.assocs[:n]...)
-			continue
 		}
 		uncached = append(uncached, id)
 	}
@@ -196,18 +201,20 @@ func (ps *PebbleStore) GetAssociations(ctx context.Context, wsPrefix [8]byte, id
 	// Phase 3: open ONE iterator covering the entire 0x03|wsPrefix range (snapshot-aware).
 	lower := keys.AssocFwdRangeStart(wsPrefix)
 	upper := keys.AssocFwdRangeEnd(wsPrefix) // nil means unbounded (all-0xFF workspace)
-	iter, err := ps.pebbleReader(ctx).NewIter(&pebble.IterOptions{
+	rawIter, err := ps.pebbleReader(ctx).NewIter(&pebble.IterOptions{
 		LowerBound: lower,
 		UpperBound: upper,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("assoc iterator: %w", err)
 	}
+	iter := ps.scanIter(lower, rawIter)
 	defer iter.Close()
 
 	for _, id := range uncached {
 		prefix := keys.AssocFwdPrefixForID(wsPrefix, id) // 0x03 | ws | id (25 bytes)
 		var assocs []Association
+		truncated := false
 
 		// SeekGE positions at the first key >= prefix (strictly forward seek).
 		for iter.SeekGE(prefix); iter.Valid(); iter.Next() {
@@ -217,6 +224,7 @@ func (ps *PebbleStore) GetAssociations(ctx context.Context, wsPrefix [8]byte, id
 				break
 			}
 			if maxPerNode > 0 && len(assocs) >= maxPerNode {
+				truncated = true
 				break
 			}
 			// Key layout: 0x03 | ws(8) | srcID(16) | weightComplement(4) | dstID(16) = 45 bytes
@@ -242,8 +250,35 @@ func (ps *PebbleStore) GetAssociations(ctx context.Context, wsPrefix [8]byte, id
 			})
 		}
 
-		result[id] = assocs
-		ps.assocCache.Add(assocCacheKey(wsPrefix, id), &assocCacheEntry{assocs: assocs})
+		// #808: FAIL CLOSED on a mid-scan iterator failure, and do it BEFORE
+		// anything is returned or cached.
+		//
+		// This is the opposite call from the STO-12 endpoint-liveness guard
+		// (#803), which fails OPEN, and the difference is the loss direction.
+		// #803 is a WRITE guard: refusing on a read fault deletes a live edge
+		// that cannot be recovered. This is a READ: refusing costs the caller
+		// an error it can retry or report, and destroys nothing. Meanwhile
+		// proceeding does not stay local — the truncated list is written into
+		// assocCache and served for the 2s TTL to readers that never saw a
+		// fault, and "zero edges" is read as "not in a declared chain" by
+		// currencyInDeclaredChain, which is how a scan fault turns into a false
+		// `possibly_superseded_by` advisory (COG-25).
+		//
+		// One iterator serves every uncached id, so a failure anywhere is
+		// terminal for the whole call.
+		if err := iter.Error(); err != nil {
+			return nil, fmt.Errorf("assoc scan: %w", err)
+		}
+
+		ps.assocCache.Add(assocCacheKey(wsPrefix, id), &assocCacheEntry{assocs: assocs, truncated: truncated})
+		// COPY (#820). `assocs` is now the cache entry's backing array; the hit
+		// path above copies for the same reason, and this function's own doc
+		// comment promises it. Returning `assocs` published a live view of the
+		// cache entry to the first caller after every miss — safe only while no
+		// caller mutates and no caller forwards it, which is a property of
+		// today's callers, not of this function. One allocation per cold miss,
+		// against a Pebble scan.
+		result[id] = append([]Association(nil), assocs...)
 	}
 
 	return result, nil
@@ -269,12 +304,10 @@ func (ps *PebbleStore) GetAssociations(ctx context.Context, wsPrefix [8]byte, id
 // same shape (revAssocCache, keyed on the DESTINATION); the merged list is
 // never cached.
 //
-// Error handling differs between the two halves, and the difference is not
-// intentional design: rankingReverseEdges checks iter.Error() and propagates,
-// while the forward half inherits GetAssociations' unchecked iterator, which
-// reports a truncated scan as a short-but-successful list (#808). Fixing that
-// belongs to #808, not here — but a caller reading this should not assume the
-// two halves fail alike.
+// Both halves now fail alike on a mid-scan iterator failure: each checks
+// iter.Error() and propagates, before anything is cached (#808). They used to
+// differ — the forward half reported a truncated scan as a short-but-successful
+// list — and that difference was never intentional design.
 //
 // Both 0x03 and 0x04 order by weightComplement in the same key position, so
 // both streams arrive weight-DESCENDING and the cap is an exact top-N via a
@@ -461,14 +494,14 @@ func (ps *PebbleStore) rankingReverseEdges(ctx context.Context, wsPrefix [8]byte
 //
 // The returned slice is ALWAYS freshly allocated, including on the no-reverse-
 // edges shortcut, which used to return `fwd` as it stood. `fwd` comes from
-// GetAssociations, whose miss path returns the slice it just put in assocCache
-// (#820) — so that shortcut published a live cache entry to the caller for the
-// 2s TTL, but only for nodes with no inbound symmetric edges. An ownership
-// contract that holds for some nodes and not others, decided by data the caller
-// cannot see, is the trap; the extra copy here (<= maxPerNode entries: 20 in
-// phase4, 10 in BFS) buys uniformity. Fixing GetAssociations itself belongs to
-// #820, which owns its other consumers. Pinned by
-// TestGetRankingNeighbors_NoReverseEdgesDoesNotAliasTheCache.
+// GetAssociations, whose miss path used to return the slice it had just put in
+// assocCache (#820, now fixed at the source) — so that shortcut published a
+// live cache entry to the caller for the 2s TTL, but only for nodes with no
+// inbound symmetric edges. An ownership contract that holds for some nodes and
+// not others, decided by data the caller cannot see, is the trap; the copy here
+// (<= maxPerNode entries: 20 in phase4, 10 in BFS) is kept even now that the
+// source is fixed, so this function's contract does not depend on its
+// caller's. Pinned by TestGetRankingNeighbors_NoReverseEdgesDoesNotAliasTheCache.
 func mergeRankingNeighbors(fwd, rev []Association, maxPerNode int) []Association {
 	if len(rev) == 0 {
 		if maxPerNode > 0 && len(fwd) > maxPerNode {
@@ -536,25 +569,32 @@ func (ps *PebbleStore) associationsForOne(wsPrefix [8]byte, id ULID, maxPerNode 
 	ck := assocCacheKey(wsPrefix, id)
 	if entry, ok := ps.assocCache.Get(ck); ok {
 		n := len(entry.assocs)
-		if maxPerNode > 0 && n > maxPerNode {
-			n = maxPerNode
+		// A truncated entry can only answer a caller asking for no more than it
+		// holds; otherwise fall through and re-scan (#820).
+		if !entry.truncated || maxPerNode > 0 && maxPerNode <= n {
+			if maxPerNode > 0 && n > maxPerNode {
+				n = maxPerNode
+			}
+			return append([]Association(nil), entry.assocs[:n]...), nil
 		}
-		return append([]Association(nil), entry.assocs[:n]...), nil
 	}
 
 	// Build prefix: 0x03 | wsPrefix | id
 	prefix := keys.AssocFwdKey(wsPrefix, [16]byte(id), 1.0, [16]byte{})
 	prefix = prefix[0 : 1+8+16] // trim to just the prefix portion
 
-	iter, err := PrefixIterator(ps.db, prefix)
+	rawIter, err := PrefixIterator(ps.db, prefix)
 	if err != nil {
 		return nil, fmt.Errorf("prefix iterator: %w", err)
 	}
+	iter := ps.scanIter(prefix, rawIter)
 	defer iter.Close()
 
 	var assocs []Association
+	truncated := false
 	for iter.First(); iter.Valid(); iter.Next() {
 		if maxPerNode > 0 && len(assocs) >= maxPerNode {
+			truncated = true
 			break
 		}
 		// Key format: 0x03 | wsPrefix(8) | srcID(16) | weightComplement(4) | dstID(16)
@@ -585,16 +625,13 @@ func (ps *PebbleStore) associationsForOne(wsPrefix [8]byte, id ULID, maxPerNode 
 			RestoredAt:        restoredAt,
 		})
 	}
+	// #808: check the scan BEFORE anything is cached or returned. See the same
+	// guard in GetAssociations for the fail-closed reasoning.
+	if err := iter.Error(); err != nil {
+		return nil, fmt.Errorf("associationsForOne scan: %w", err)
+	}
 	// Populate cache — expirable.LRU enforces the TTL automatically.
-	//
-	// KNOWN GAP (#808): this loop never checks iter.Error(), so a scan that
-	// stops early on a corrupt block caches a TRUNCATED association list and
-	// returns it as complete — the same absence-vs-failure laundering this file
-	// fixed on the pointGet path, one seam over. It was deliberately deferred
-	// rather than fixed blind: the readFault seam mediates pointGet, not
-	// iteration, so a guard here has no deterministic RED and would ship
-	// unproven. Fixing it needs an iterator-level fault seam.
-	ps.assocCache.Add(ck, &assocCacheEntry{assocs: assocs})
+	ps.assocCache.Add(ck, &assocCacheEntry{assocs: assocs, truncated: truncated})
 	return assocs, nil
 }
 
@@ -1141,6 +1178,16 @@ func (ps *PebbleStore) DecayAssocWeights(ctx context.Context, wsPrefix [8]byte, 
 			return fmt.Errorf("decay assoc chunk commit: %w", err)
 		}
 		ps.replicateBatch(batch)
+		// #818: every entry in this chunk relocated, archived or deleted a
+		// 0x03 row (keyed on src) and its 0x04 mirror (keyed on dst), so both
+		// caches can be holding pre-decay weights. Evicted POST-COMMIT, per
+		// chunk, so a reader that misses immediately after re-scans the state
+		// this batch just committed. Weights, not membership, are usually what
+		// goes stale here — and weight is what ranking orders on.
+		for _, e := range chunk {
+			ps.assocCache.Remove(assocCacheKey(wsPrefix, ULID(e.src)))
+			ps.revAssocCache.Remove(assocCacheKey(wsPrefix, ULID(e.dst)))
+		}
 		chunk = chunk[:0]
 		return nil
 	}
@@ -1439,6 +1486,32 @@ func decodeContradictionValue(val []byte) (partner ULID, detectedAt time.Time, o
 	return partner, detectedAt, true
 }
 
+// readContradictionMarker reads the 0x0A marker at key and returns the moment
+// the contradiction FIRST became known.
+//
+// Three outcomes, not two — the same policy GetAssocWeight states one seam
+// over. A MISSING key is absence: (zero, false, nil). A key holding fewer than
+// 16 bytes cannot even name the partner, so it is not something any writer in
+// this package produced; that is corruption, and reporting it as absence is the
+// same laundering one layer down. Anything else is a read FAILURE.
+//
+// The two callers take deliberately OPPOSITE actions on that failure, because
+// their loss directions are opposite. See each call site.
+func (ps *PebbleStore) readContradictionMarker(key []byte) (detectedAt time.Time, exists bool, err error) {
+	val, err := ps.pointGet(key)
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("read contradiction marker: %w", err)
+	}
+	if val == nil {
+		return time.Time{}, false, nil
+	}
+	_, prior, ok := decodeContradictionValue(val)
+	if !ok {
+		return time.Time{}, false, fmt.Errorf("read contradiction marker: corrupt record: %d bytes, want at least 16", len(val))
+	}
+	return prior, true, nil
+}
+
 // FlagContradiction writes the 0x0A contradiction key for pair (a,b).
 //
 // The marker's value carries the moment the contradiction FIRST became known.
@@ -1471,11 +1544,33 @@ func (ps *PebbleStore) FlagContradiction(ctx context.Context, wsPrefix [8]byte, 
 	// times a worker re-observes the edge. Re-penalising compounds a single
 	// Bayesian update (1.0 -> 0.975 -> 0.797 -> 0.313 -> 0.0709) until BOTH
 	// memories — including the true one — fall out of recall entirely.
+	//
+	// FAILS CLOSED (#804), and that is the opposite call from the STO-12
+	// endpoint-liveness guard (#803), deliberately. Both are read faults; the
+	// loss directions are mirror images:
+	//
+	//   #803  refusing an association write on a read fault DESTROYS live data
+	//         (a real edge that can never be recovered), while proceeding costs
+	//         one repairable dangling row. So it fails OPEN, loudly.
+	//   here  proceeding on a read fault reports the pair NEWLY flagged and
+	//         restamps detectedAt with `now`. The first drives a repeat
+	//         confidence penalty on BOTH engrams, and BayesianUpdate is not
+	//         invertible (COG-23 residual) — unrecoverable. Refusing costs at
+	//         most one deferred penalty, which the next detection re-applies.
+	//
+	// So the read error propagates and NOTHING is written. The only production
+	// caller is ContradictWorker.processBatch, which already treats an error as
+	// "newness unknown, do not penalise" and continues — so this cannot fail a
+	// recall or a user-facing path on an otherwise-harmless corrupt block. The
+	// (false, err) return keeps that suppression true even for a caller that
+	// ignores the error.
 	newlyFlagged := true
 	detectedAt := time.Now()
-	if existing, closer, err := ps.db.Get(contraKey); err == nil {
-		_, prior, _ := decodeContradictionValue(existing)
-		_ = closer.Close()
+	prior, exists, rerr := ps.readContradictionMarker(contraKey)
+	if rerr != nil {
+		return false, fmt.Errorf("flag contradiction: %w", rerr)
+	}
+	if exists {
 		newlyFlagged = false
 		// Carry the prior stamp forward verbatim — INCLUDING a zero one from a
 		// legacy marker. Re-stamping an already-known contradiction with "now"

--- a/internal/storage/batch.go
+++ b/internal/storage/batch.go
@@ -34,6 +34,19 @@ type pebbleStoreBatch struct {
 	// stateUpdatedIDs tracks engrams whose state was changed by UpdateEngramState.
 	// Their cache entries are invalidated in Commit after the batch flushes to Pebble.
 	stateUpdatedIDs []stateUpdate
+	// assocEdges records every (src, dst) whose 0x03/0x04 rows this batch
+	// writes, so Commit can evict the forward cache (keyed on src) and the
+	// reverse cache (keyed on dst) — #818. Deferred to Commit deliberately:
+	// the batch may be Discarded, and evicting at queue time would drop a
+	// CORRECT cache entry on behalf of a write that never lands.
+	assocEdges []batchAssocEdge
+}
+
+// batchAssocEdge is one association-cache invalidation owed by a batch.
+type batchAssocEdge struct {
+	ws  [8]byte
+	src ULID
+	dst ULID
 }
 
 // batchPendingItem holds the data required for post-commit vault counter and
@@ -153,6 +166,11 @@ func (b *pebbleStoreBatch) WriteEngramOpDetails(ctx context.Context, wsPrefix [8
 		var wiBuf [4]byte
 		binary.BigEndian.PutUint32(wiBuf[:], math.Float32bits(assoc.Weight))
 		b.batch.Set(keys.AssocWeightIndexKey(wsPrefix, id16, [16]byte(assoc.TargetID)), wiBuf[:], nil)
+		// #818: the INLINE association writer sets the same 0x03/0x04 rows as
+		// WriteAssociation and owes the same post-commit eviction. The source
+		// is usually a brand-new engram with no cache entry, but the TARGET is
+		// an existing one whose reverse list is now stale.
+		b.assocEdges = append(b.assocEdges, batchAssocEdge{ws: wsPrefix, src: eng.ID, dst: assoc.TargetID})
 	}
 
 	// 0x0B: state index
@@ -210,6 +228,7 @@ func (b *pebbleStoreBatch) WriteAssociation(ctx context.Context, ws [8]byte, src
 	var weightBuf [4]byte
 	binary.BigEndian.PutUint32(weightBuf[:], math.Float32bits(assoc.Weight))
 	b.batch.Set(keys.AssocWeightIndexKey(ws, [16]byte(src), [16]byte(dst)), weightBuf[:], nil)
+	b.assocEdges = append(b.assocEdges, batchAssocEdge{ws: ws, src: src, dst: dst})
 	return nil
 }
 
@@ -383,6 +402,15 @@ func (b *pebbleStoreBatch) Commit() error {
 	for _, su := range b.stateUpdatedIDs {
 		b.ps.cache.Delete(su.ws, su.id)
 		b.ps.metaCache.Remove([16]byte(su.id))
+	}
+
+	// Association caches — #818. Same post-commit placement and the same
+	// forward-on-src / reverse-on-dst keying as PebbleStore.WriteAssociation.
+	// Without this an edge written through a batch was invisible from BOTH
+	// endpoints for the 2s TTL.
+	for _, e := range b.assocEdges {
+		b.ps.assocCache.Remove(assocCacheKey(e.ws, e.src))
+		b.ps.revAssocCache.Remove(assocCacheKey(e.ws, e.dst))
 	}
 
 	// Post-commit side effects — mirrors PebbleStore.WriteEngram post-commit work.

--- a/internal/storage/contradiction_read_error_test.go
+++ b/internal/storage/contradiction_read_error_test.go
@@ -1,0 +1,130 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/scrypster/muninndb/internal/prefix"
+	"github.com/scrypster/muninndb/internal/storage/keys"
+)
+
+// ---------------------------------------------------------------------------
+// #804 — the 0x0A idempotency token must not be fabricated from a failed read.
+//
+// The token is what makes the contradiction confidence penalty fire ONCE. A
+// failed read previously skipped the `err == nil` branch, so the pair was
+// reported NEWLY flagged and the marker was restamped with `now`. Re-penalising
+// compounds a Bayesian update on BOTH engrams (1.0 -> 0.975 -> 0.797 -> 0.313
+// -> 0.0709) and BayesianUpdate is not invertible.
+// ---------------------------------------------------------------------------
+
+// seedContradictionMarker writes the canonical 0x0A pair directly with a fixed
+// detection time, so a restamp is detectable without depending on clock
+// resolution. Returns the canonical (low, high) ULIDs.
+func seedContradictionMarker(t *testing.T, store *PebbleStore, ws [8]byte, a, b ULID, detectedAt time.Time) (ULID, ULID) {
+	t.Helper()
+	if CompareULIDs(a, b) > 0 {
+		a, b = b, a
+	}
+	aB, bB := [16]byte(a), [16]byte(b)
+	if err := store.db.Set(keys.ContradictionKey(ws, 0, 0, aB), encodeContradictionValue(bB, detectedAt), pebble.Sync); err != nil {
+		t.Fatalf("seed 0x0A a: %v", err)
+	}
+	if err := store.db.Set(keys.ContradictionKey(ws, 0, 0, bB), encodeContradictionValue(aB, detectedAt), pebble.Sync); err != nil {
+		t.Fatalf("seed 0x0A b: %v", err)
+	}
+	return a, b
+}
+
+// markerDetectedAt reads the stored detection time for the canonical marker.
+func markerDetectedAt(t *testing.T, store *PebbleStore, ws [8]byte, a ULID) time.Time {
+	t.Helper()
+	val, err := Get(store.db, keys.ContradictionKey(ws, 0, 0, [16]byte(a)))
+	if err != nil {
+		t.Fatalf("read 0x0A: %v", err)
+	}
+	if val == nil {
+		t.Fatal("0x0A marker missing")
+	}
+	_, detectedAt, ok := decodeContradictionValue(val)
+	if !ok {
+		t.Fatal("0x0A value too short to decode")
+	}
+	return detectedAt
+}
+
+// TestFlagContradiction_ReadFaultIsNotLaunderedIntoTheToken pins the fail-CLOSED
+// policy: an unreadable token surfaces as an error and writes nothing, rather
+// than becoming "newly flagged" with a fresh detectedAt.
+func TestFlagContradiction_ReadFaultIsNotLaunderedIntoTheToken(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("contra-flag-read-fault")
+
+	detected := time.Unix(1700000000, 0)
+	a, b := seedContradictionMarker(t, store, ws, NewULID(), NewULID(), detected)
+
+	// Healthy control: the pair is already known, so the penalty is suppressed
+	// and the original stamp survives.
+	newly, err := store.FlagContradiction(ctx, ws, a, b)
+	if err != nil {
+		t.Fatalf("healthy FlagContradiction: %v", err)
+	}
+	if newly {
+		t.Fatal("fixture broken: a re-flag of a seeded marker reported newlyFlagged=true")
+	}
+	if got := markerDetectedAt(t, store, ws, a); !got.Equal(detected) {
+		t.Fatalf("fixture broken: healthy re-flag restamped detectedAt to %v", got)
+	}
+
+	// Now the token read fails and nothing else does.
+	store.readFault = failReadsWithPrefix(prefix.Contradiction)
+	newly, err = store.FlagContradiction(ctx, ws, a, b)
+	store.readFault = nil
+
+	if newly {
+		t.Error("a failed token read reported the pair as NEWLY flagged — the confidence penalty would fire again on an already-known contradiction")
+	}
+	if err == nil {
+		t.Error("a failed token read returned a nil error, so the caller cannot tell newness was never established")
+	}
+	if got := markerDetectedAt(t, store, ws, a); !got.Equal(detected) {
+		t.Errorf("detectedAt was restamped over a live marker under a read fault: got %v, want %v", got, detected)
+	}
+}
+
+// TestUpdateConfidenceWithContradiction_ReadFaultDoesNotRestampTheMarker is the
+// same laundering one file over (engram.go), and lands on the OPPOSITE side of
+// the fail-open/fail-closed line: the confidence delta is the caller's primary
+// request and refusing the whole batch would drop it. So the confidence write
+// proceeds and only the marker rewrite is skipped.
+func TestUpdateConfidenceWithContradiction_ReadFaultDoesNotRestampTheMarker(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	ws := store.VaultPrefix("contra-conf-read-fault")
+
+	id := NewULID()
+	other := NewULID()
+	if _, err := store.WriteEngram(ctx, ws, &Engram{ID: id, Concept: "claim", Content: "the ledger balances", Confidence: 1.0}); err != nil {
+		t.Fatalf("WriteEngram: %v", err)
+	}
+
+	detected := time.Unix(1700000000, 0)
+	canonLow, _ := seedContradictionMarker(t, store, ws, id, other, detected)
+
+	store.readFault = failReadsWithPrefix(prefix.Contradiction)
+	prior, newConf, err := store.UpdateConfidenceWithContradiction(ctx, ws, id, -0.1, other, true)
+	store.readFault = nil
+
+	if err != nil {
+		t.Fatalf("UpdateConfidenceWithContradiction must not refuse the confidence write on a 0x0A read fault: %v", err)
+	}
+	if prior != 1.0 || newConf > 0.91 || newConf < 0.89 {
+		t.Errorf("confidence delta was not applied: prior=%v new=%v", prior, newConf)
+	}
+	if got := markerDetectedAt(t, store, ws, canonLow); !got.Equal(detected) {
+		t.Errorf("detectedAt was restamped over a live marker under a read fault: got %v, want %v", got, detected)
+	}
+}

--- a/internal/storage/engram.go
+++ b/internal/storage/engram.go
@@ -555,6 +555,13 @@ func (ps *PebbleStore) DeleteEngram(ctx context.Context, wsPrefix [8]byte, id UL
 	// assocCacheDirty collects the sources whose cached forward-association list
 	// names this engram; they are invalidated post-commit (STO-12, below).
 	assocCacheDirty := []ULID{id}
+	// revAssocCacheDirty is the 0x04 mirror (#818). revAssocCache is keyed on
+	// the DESTINATION, so the entries this delete invalidates are:
+	//   - id itself, whose inbound edges are all being removed, and
+	//   - every TARGET of an outbound edge, whose inbound list names id.
+	// Without it the dead engram stayed reachable INTO its former targets for
+	// the 2s TTL — the #803 forward eviction alone left the reverse half stale.
+	revAssocCacheDirty := []ULID{id}
 
 	// STO-11: the upper bound MUST carry-propagate (keys.PrefixUpperBound), not
 	// append a 0xFF sentinel. A 0x03 key is prefix(25)|weightComplement(4)|dst(16)
@@ -624,6 +631,9 @@ func (ps *PebbleStore) DeleteEngram(ctx context.Context, wsPrefix [8]byte, id UL
 			batch.Delete(k, nil) // forward key (exact live key)
 			batch.Delete(keys.AssocRevKey(wsPrefix, targetID, weight, [16]byte(id)), nil)
 			batch.Delete(keys.AssocWeightIndexKey(wsPrefix, [16]byte(id), targetID), nil)
+			// #818: the 0x04 row deleted above is keyed on targetID, so that
+			// target's cached REVERSE list still names this engram.
+			revAssocCacheDirty = append(revAssocCacheDirty, ULID(targetID))
 		}
 		fwdIter.Close()
 	}
@@ -767,6 +777,9 @@ func (ps *PebbleStore) DeleteEngram(ctx context.Context, wsPrefix [8]byte, id UL
 	ps.cache.Delete(wsPrefix, id)
 	for _, src := range assocCacheDirty {
 		ps.assocCache.Remove(assocCacheKey(wsPrefix, src))
+	}
+	for _, dst := range revAssocCacheDirty {
+		ps.revAssocCache.Remove(assocCacheKey(wsPrefix, dst))
 	}
 
 	// Decrement MentionCount on each entity that was linked to this engram.
@@ -1243,17 +1256,37 @@ func (ps *PebbleStore) UpdateConfidenceWithContradiction(ctx context.Context, ws
 		// "unknown" forever, and a marker that already carried a stamp had it
 		// erased on the next confidence adjustment — violating the "moment it
 		// FIRST became known" invariant (adversarial review of #754, finding 6).
+		//
+		// FAILS OPEN ON THE MARKER ONLY (#804), the opposite call from
+		// FlagContradiction and for a reason specific to this site: the
+		// confidence delta is the caller's request and is already computed;
+		// refusing the whole batch because the 0x0A stamp was unreadable would
+		// drop a write that has nothing to do with the faulting key. But a
+		// stamp that could not be read must never be REPLACED with `now` —
+		// that is the plausible-wrong-value failure. So the confidence keys are
+		// written and the marker rewrite is skipped, leaving whatever is on
+		// disk intact.
+		//
+		// A pair whose marker read fails and whose marker does not yet exist
+		// therefore goes unflagged this time; the contradiction detector
+		// re-observes and FlagContradiction writes it. A missed marker is
+		// recoverable; a restamped one is not.
 		detectedAt := time.Now()
 		contraKey := keys.ContradictionKey(wsPrefix, 0, 0, aBytes)
-		if existing, closer, err := ps.db.Get(contraKey); err == nil {
-			_, prior, _ := decodeContradictionValue(existing)
-			_ = closer.Close()
-			// Carry the prior stamp forward verbatim — including a zero one
-			// from a legacy marker (re-stamping invents a wrong time).
-			detectedAt = prior
+		prior, exists, rerr := ps.readContradictionMarker(contraKey)
+		if rerr != nil {
+			slog.Warn("storage: contradiction marker read failed; leaving the existing 0x0A marker untouched rather than restamping it",
+				"engram", id.String(), "other", other.String(),
+				"vault_prefix", fmt.Sprintf("%x", wsPrefix), "err", rerr)
+		} else {
+			if exists {
+				// Carry the prior stamp forward verbatim — including a zero one
+				// from a legacy marker (re-stamping invents a wrong time).
+				detectedAt = prior
+			}
+			batch.Set(contraKey, encodeContradictionValue(bBytes, detectedAt), nil)
+			batch.Set(keys.ContradictionKey(wsPrefix, 0, 0, bBytes), encodeContradictionValue(aBytes, detectedAt), nil)
 		}
-		batch.Set(contraKey, encodeContradictionValue(bBytes, detectedAt), nil)
-		batch.Set(keys.ContradictionKey(wsPrefix, 0, 0, bBytes), encodeContradictionValue(aBytes, detectedAt), nil)
 	}
 
 	if err := batch.Commit(pebble.NoSync); err != nil {

--- a/internal/storage/impl.go
+++ b/internal/storage/impl.go
@@ -130,6 +130,20 @@ type PebbleStore struct {
 	// Like decayNow, it is read without synchronization, so it MUST be set
 	// before the store is shared across goroutines.
 	readFault func(key []byte) error
+	// iterFault is a TEST-ONLY seam, nil in production — the ITERATOR sibling of
+	// readFault, which mediates point reads only. When non-nil it is consulted
+	// once per scan opened through scanIter, and may return a replacement
+	// iterator (typically one that truncates the scan and then reports an error
+	// from Error()). Returning nil leaves the real iterator in place.
+	//
+	// It exists because a mid-scan Pebble failure is otherwise unreproducible
+	// without corrupting a real .sst: closing the DB or deleting keys changes
+	// what the scan SEES, never whether it FAILED partway through — and the
+	// whole defect class (#808) is "a scan that stopped early is served as a
+	// short-but-complete list".
+	// Like decayNow and readFault, it is read without synchronization, so it
+	// MUST be set before the store is shared across goroutines.
+	iterFault func(scanPrefix []byte, it scanIterator) scanIterator
 	// guardReadFaults counts the times the STO-12 endpoint-liveness read failed
 	// and the guard failed open (see engramExists). guardReadFaultLoggedAt is
 	// the unix-nano stamp of the last WARN, used to rate-limit it.
@@ -158,20 +172,23 @@ func (ps *PebbleStore) now() time.Time {
 	return time.Now()
 }
 
-// assocCacheEntry holds a cached association list.
+// assocCacheEntry holds a cached FORWARD (0x03) association list.
 // TTL is enforced by the expirable.LRU cache (2s); no per-entry expiry field needed.
+//
+// truncated records that the scan stopped at the caller's maxPerNode rather
+// than at the end of the node's edge list, so a later caller asking for MORE is
+// re-scanned instead of silently served the shorter list (#820). Mirrors
+// revAssocCacheEntry, which has carried the flag since COG-31.
 type assocCacheEntry struct {
-	assocs []Association
+	assocs    []Association
+	truncated bool
 }
 
 // revAssocCacheEntry holds a cached REVERSE (0x04) ranking adjacency list.
 //
-// It carries `truncated` because the forward cache does not, and that gap is a
-// live latent bug there: GetAssociations caches the list it built UNDER the
-// caller's maxPerNode, so a later caller asking for MORE is silently served
-// the shorter list from cache. The reverse cache refuses to repeat it — a hit
-// whose entry was truncated below what this caller asked for is treated as a
-// miss and re-scanned.
+// A hit whose entry was truncated below what this caller asked for is treated
+// as a miss and re-scanned, rather than silently under-serving. The forward
+// cache carried the same gap and now carries the same flag (#820).
 type revAssocCacheEntry struct {
 	assocs    []Association
 	truncated bool

--- a/internal/storage/read_absence_vs_failure_test.go
+++ b/internal/storage/read_absence_vs_failure_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/scrypster/muninndb/internal/prefix"
 	"github.com/scrypster/muninndb/internal/storage/keys"
@@ -127,6 +128,47 @@ var absenceVsFailureCases = []absenceVsFailureCase{
 		corrupt: func(t *testing.T, s *PebbleStore, ws [8]byte, src, dst ULID) {
 			t.Helper()
 			setShort(t, s, keys.OrdinalKey(ws, [16]byte(src), [16]byte(dst)))
+		},
+	},
+	{
+		// #804. The 0x0A idempotency token: absence means "not yet flagged",
+		// which is what makes the contradiction confidence penalty fire once.
+		// A failed read reported as absence made the pair NEWLY flagged and
+		// restamped detectedAt with `now` — and BayesianUpdate is not
+		// invertible, so the compounded penalty (1.0 -> 0.975 -> 0.797 ->
+		// 0.313 -> 0.0709) removes BOTH memories from recall, the true one
+		// included. The two callers act oppositely on the error this returns;
+		// see readContradictionMarker and each call site.
+		method:         "readContradictionMarker",
+		routesPointGet: true,
+		faultPrefix:    prefix.Contradiction,
+		seed: func(t *testing.T, s *PebbleStore, ws [8]byte, src, dst ULID) []byte {
+			a, _ := seedContradictionMarker(t, s, ws, src, dst, time.Unix(1700000000, 0))
+			return keys.ContradictionKey(ws, 0, 0, [16]byte(a))
+		},
+		absent: func(s *PebbleStore, ws [8]byte, src, dst ULID) error {
+			_, _, err := s.readContradictionMarker(keys.ContradictionKey(ws, 0, 0, [16]byte(src)))
+			return err
+		},
+		call: func(s *PebbleStore, ws [8]byte, src, dst ULID) error {
+			a := src
+			if CompareULIDs(src, dst) > 0 {
+				a = dst
+			}
+			_, _, err := s.readContradictionMarker(keys.ContradictionKey(ws, 0, 0, [16]byte(a)))
+			return err
+		},
+		corrupt: func(t *testing.T, s *PebbleStore, ws [8]byte, src, dst ULID) {
+			t.Helper()
+			a := src
+			if CompareULIDs(src, dst) > 0 {
+				a = dst
+			}
+			// A value too short to even name the partner cannot be something
+			// any writer in this package produced. A bare 16-byte legacy
+			// marker is VALID and decodes to "detection time unknown"; only
+			// shorter than that is damage.
+			setShort(t, s, keys.ContradictionKey(ws, 0, 0, [16]byte(a)))
 		},
 	},
 	{

--- a/internal/storage/read_error_census_test.go
+++ b/internal/storage/read_error_census_test.go
@@ -142,10 +142,17 @@ func TestPointGetReadersAreCovered(t *testing.T) {
 
 // TestReadFaultIsArmedOnlyByTests asserts the structural fact that
 // TestPointGetSeamIsNilInProductionConstructors relies on and cannot itself
-// establish: nothing outside a _test.go file ever ASSIGNS PebbleStore.readFault,
-// so there is no production path that can arm the seam. The field is
-// unexported, so this package-local scan is complete for the whole program.
+// establish: nothing outside a _test.go file ever ASSIGNS PebbleStore.readFault
+// or PebbleStore.iterFault, so there is no production path that can arm either
+// seam. The fields are unexported, so this package-local scan is complete for
+// the whole program.
+//
+// iterFault (#808) is the iterator sibling of readFault and joined this scan
+// with it: a fault seam that production code can arm is not a test seam, and
+// the two must not drift into different guarantees.
 func TestReadFaultIsArmedOnlyByTests(t *testing.T) {
+	faultSeams := map[string]bool{"readFault": true, "iterFault": true}
+
 	files, err := filepath.Glob("*.go")
 	if err != nil {
 		t.Fatalf("glob: %v", err)
@@ -176,13 +183,13 @@ func TestReadFaultIsArmedOnlyByTests(t *testing.T) {
 			switch node := n.(type) {
 			case *ast.AssignStmt:
 				for _, lhs := range node.Lhs {
-					if sel, ok := lhs.(*ast.SelectorExpr); ok && sel.Sel.Name == "readFault" {
+					if sel, ok := lhs.(*ast.SelectorExpr); ok && faultSeams[sel.Sel.Name] {
 						record(node)
 					}
 				}
 			case *ast.KeyValueExpr:
 				// A composite literal field: PebbleStore{readFault: ...}.
-				if id, ok := node.Key.(*ast.Ident); ok && id.Name == "readFault" {
+				if id, ok := node.Key.(*ast.Ident); ok && faultSeams[id.Name] {
 					record(node)
 				}
 			}
@@ -194,7 +201,7 @@ func TestReadFaultIsArmedOnlyByTests(t *testing.T) {
 		t.Fatal("scan found no non-test files — wrong working directory?")
 	}
 	if len(offenders) > 0 {
-		t.Errorf("readFault is assigned in non-test source, so the fault seam is no longer test-only:\n  %s",
+		t.Errorf("a read/iterator fault seam is assigned in non-test source, so it is no longer test-only:\n  %s",
 			strings.Join(offenders, "\n  "))
 	}
 }

--- a/internal/storage/scan_iter.go
+++ b/internal/storage/scan_iter.go
@@ -1,0 +1,35 @@
+package storage
+
+// scanIterator is the subset of *pebble.Iterator that the association range
+// scans use. It exists so those scans can be handed a test-supplied iterator
+// that FAILS PARTWAY THROUGH — the one condition a real Pebble DB will not
+// produce on demand, and the exact condition #808 is about.
+//
+// *pebble.Iterator satisfies this interface as written; nothing in production
+// implements it.
+type scanIterator interface {
+	First() bool
+	SeekGE(key []byte) bool
+	Next() bool
+	Valid() bool
+	Key() []byte
+	Value() []byte
+	Error() error
+	Close() error
+}
+
+// scanIter returns the iterator a range scan should actually use, consulting
+// the TEST-ONLY iterFault seam. In production iterFault is nil and this is an
+// identity function; the AST census (TestIterFaultIsArmedOnlyByTests) pins that
+// no non-test file ever assigns the field.
+//
+// scanPrefix is passed through so a fault can be scoped to one namespace
+// instead of the whole store, the same way failReadsWithPrefix scopes readFault.
+func (ps *PebbleStore) scanIter(scanPrefix []byte, it scanIterator) scanIterator {
+	if ps.iterFault != nil {
+		if replacement := ps.iterFault(scanPrefix, it); replacement != nil {
+			return replacement
+		}
+	}
+	return it
+}


### PR DESCRIPTION
Four defects in the association layer, all in the same file and the same review round, so they land as one increment. Every one RED-proven before the fix.

## The fail-open / fail-closed decision, per site

The interesting part is that these do **not** all get the same policy, and the project already has precedent on both sides. #809 refuses on a read failure because proceeding would fabricate metadata over live data. #803's endpoint guard fails *open* because refusing would destroy live data. Opposite policies, opposite loss directions, same doctrine — so each site was decided on its own.

**#804 `FlagContradiction` → fail closed.** Proceeding fabricates `newlyFlagged=true`, which drives a repeat Bayesian confidence penalty on both engrams (`1.0 → 0.975 → 0.797 → 0.313 → 0.0709`, non-invertible per COG-23), plus a restamped `detectedAt`. Refusing costs at most one deferred penalty that the next detection re-applies. The issue suggested `(false, nil)`; that was rejected on evidence — the only production caller (`ContradictWorker.processBatch`) already logs and continues without penalising, so propagating gives identical suppression *plus* a signal.

**Its twin in `engram.go:1240` → fail open, marker only.** Not named in the issue, byte-identical laundering of the same key. The confidence delta is the caller's already-computed request, so refusing the whole batch would drop a write unrelated to the faulting key. Confidence keys are written; the marker rewrite is skipped with a WARN. A missed marker is recoverable by the next detection; a restamped one is not.

**#808 → fail closed.** This is a read, so refusing destroys nothing. And proceeding doesn't stay local: the truncated list enters `assocCache` and is served for 2s to readers that never saw a fault, where "zero edges" reads as "not in a declared chain" in `currencyInDeclaredChain` — a scan fault becoming a false `possibly_superseded_by` advisory (COG-25).

## Scope corrections found while building

**#808's named function has zero production callers.** `associationsForOne` is referenced only by its own test. The live path for the identical defect is `GetAssociations`' phase-3 scan, on recall traversal. Both fixed; the dead helper left in place rather than widening the diff.

**#818 re-verified against what #803 already landed.** DeleteEngram's forward eviction was already there; `revAssocCache` was not. Fixed that, plus `DecayAssocWeights` (both caches, per chunk, post-commit) and the batch writers (evict in `Commit`, never at queue time).

**#820's "optional" related trap was live.** `assocCacheEntry` gained `truncated`, mirroring `revAssocCacheEntry`, so a cap-1 entry no longer silently under-serves a cap-10 caller.

## Anti-masking check

A cache-eviction fix can hide a correctness bug by making a stale read impossible in the test but not in production. So: with #804/#808/#820 all fixed and *only* the three #818 evictions removed, the #818 tests still fail with identical output — they target the eviction, not a symptom another fix concealed.

## Evidence

Fixing #808 required a real iterator-fault seam (`scanIterator` + `iterFault`), which is also what makes an unchecked-`iter.Error()` census buildable later. Routing the marker read through `pointGet` immediately turned the existing `read_error_census_test.go` red and forced a table row — which is exactly what that census's doc comment predicted would happen.

Full RED output for all four in the commit. `go build`/`vet`/`gofmt` clean; `internal/storage` and `internal/engine` green; `-race` green on storage.

Cross-surface obligations walked: none apply. No new Pebble prefix, no MCP handler, no preset, no wire field.

## Deferred, explicitly

The fill-after-evict window #818 names (an eviction landing between a concurrent reader's scan and its `cache.Add`) needs a generation counter and is **not** in this increment — the issue asks for an explicit decision and this is it. Also deferred: the iterator census, and deleting the dead `associationsForOne`.

Closes #804, closes #808, closes #818, closes #820.
