### PR TITLE
fix(cluster): a panic that took the process down, hostname-derived node identity, and CLI cluster auth (#629, #630, #632)

### DIFF
--- a/cmd/muninn/cluster.go
+++ b/cmd/muninn/cluster.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/scrypster/muninndb/internal/config"
 )
 
 func runCluster(args []string) {
@@ -19,8 +21,19 @@ func runCluster(args []string) {
 		return
 	}
 
-	sub := args[0]
-	subArgs := args[1:]
+	// Parse MySQL-style admin auth flags (-u, -p, -h) up front, exactly like
+	// `muninn vault` does — the remaining args go to the subcommand's own
+	// flag set (#632). info/status/failover don't use these; they attach the
+	// cluster shared-secret bearer token instead (see httpGet/httpPost).
+	remaining, username, password, prompted := parseAdminFlags(args)
+	if len(remaining) == 0 {
+		printClusterHelp()
+		osExit(1)
+		return
+	}
+
+	sub := remaining[0]
+	subArgs := remaining[1:]
 
 	switch sub {
 	case "info":
@@ -34,8 +47,20 @@ func runCluster(args []string) {
 	case "remove-node":
 		runClusterRemoveNode(subArgs)
 	case "enable":
+		if err := authenticateAdmin(username, password, prompted); err != nil {
+			fmt.Fprintf(os.Stderr, "Authentication failed: %v\n", err)
+			fmt.Fprintln(os.Stderr, "Is muninn running? Try: muninn status")
+			osExit(1)
+			return
+		}
 		osExit(runClusterEnable(subArgs))
 	case "disable":
+		if err := authenticateAdmin(username, password, prompted); err != nil {
+			fmt.Fprintf(os.Stderr, "Authentication failed: %v\n", err)
+			fmt.Fprintln(os.Stderr, "Is muninn running? Try: muninn status")
+			osExit(1)
+			return
+		}
 		osExit(runClusterDisable(subArgs))
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown cluster subcommand: %q\n", sub)
@@ -398,9 +423,39 @@ func clusterAddrDefault() string {
 	return localScheme() + "://127.0.0.1:" + defaultRESTPort
 }
 
+// clusterSecretFromDisk reads the cluster shared secret from the local
+// cluster.yaml (or the cluster: section of muninn.yaml) in the daemon's data
+// directory, so CLI cluster subcommands can attach the same
+// "Authorization: Bearer <cluster_secret>" credential /v1/cluster/* and
+// /v1/replication/* require (withClusterAuth in internal/transport/rest) —
+// without it every `muninn cluster info|status|failover` 401'd against a
+// healthy, correctly-configured daemon (#632). Returns "" (no header
+// attached) if the config can't be read or has no secret set — the server's
+// own error response then explains why, rather than the CLI guessing.
+func clusterSecretFromDisk() string {
+	cfg, err := config.LoadClusterConfig(defaultDataDir())
+	if err != nil {
+		return ""
+	}
+	return cfg.ClusterSecret
+}
+
+// addClusterSecretAuth attaches the cluster shared-secret bearer token to a
+// request bound for /v1/cluster/* or /v1/replication/* (#632).
+func addClusterSecretAuth(req *http.Request) {
+	if secret := clusterSecretFromDisk(); secret != "" {
+		req.Header.Set("Authorization", "Bearer "+secret)
+	}
+}
+
 func httpGet(url string) ([]byte, error) {
 	client := httpClientForURL(url, 5*time.Second)
-	resp, err := client.Get(url)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	addClusterSecretAuth(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -420,7 +475,13 @@ func httpGet(url string) ([]byte, error) {
 
 func httpPost(url string) ([]byte, error) {
 	client := httpClientForURL(url, 5*time.Second)
-	resp, err := client.Post(url, "application/json", nil)
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	addClusterSecretAuth(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -438,6 +499,9 @@ func httpPost(url string) ([]byte, error) {
 	return body, nil
 }
 
+// httpPostJSON POSTs to an /api/admin/* route, attaching the admin session
+// cookie obtained by authenticateAdmin (mirrors doVaultRequestForce's use of
+// addSessionCookie for `muninn vault` — #632).
 func httpPostJSON(url string, body []byte) ([]byte, error) {
 	client := httpClientForURL(url, 10*time.Second)
 	var bodyReader *bytes.Reader
@@ -446,7 +510,13 @@ func httpPostJSON(url string, body []byte) ([]byte, error) {
 	} else {
 		bodyReader = bytes.NewReader([]byte{})
 	}
-	resp, err := client.Post(url, "application/json", bodyReader)
+	req, err := http.NewRequest(http.MethodPost, url, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	addSessionCookie(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/muninn/cluster_test.go
+++ b/cmd/muninn/cluster_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -141,6 +142,40 @@ func TestClusterCommands_ServerUnreachable(t *testing.T) {
 	}
 
 	w.Close()
+}
+
+// TestClusterCommands_AttachClusterSecretBearer reproduces #632: /v1/cluster/*
+// requires "Authorization: Bearer <cluster_secret>" (withClusterAuth in
+// internal/transport/rest/server.go) but the CLI sent no credential at all,
+// so every `muninn cluster info|status|failover` 401'd against a healthy,
+// correctly-configured daemon. The CLI should read the secret from the local
+// cluster.yaml next to the daemon's data directory (the suggested fix in the
+// issue) and attach it automatically.
+func TestClusterCommands_AttachClusterSecretBearer(t *testing.T) {
+	const secret = "test-cluster-secret"
+
+	dataDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dataDir, "cluster.yaml"),
+		[]byte("enabled: true\ncluster_secret: "+secret+"\n"), 0600); err != nil {
+		t.Fatalf("write cluster.yaml: %v", err)
+	}
+	t.Setenv("MUNINNDB_DATA", dataDir)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.Header.Get("Authorization")
+		if got != "Bearer "+secret {
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]any{"code": "cluster_auth_required"})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"enabled": true})
+	}))
+	defer server.Close()
+
+	if _, err := httpGet(server.URL + "/v1/cluster/info"); err != nil {
+		t.Errorf("expected httpGet to attach the cluster secret and succeed, got: %v", err)
+	}
 }
 
 // TestClusterCommands_AddNode verifies add-node prints instructions.
@@ -307,5 +342,80 @@ func TestClusterDisable_Success(t *testing.T) {
 	}
 	if !strings.Contains(result, "disabled") {
 		t.Errorf("expected 'disabled' in output, got: %s", result)
+	}
+}
+
+// TestClusterEnable_ViaDispatcher_AuthenticatesLikeVault reproduces the other
+// half of #632: `muninn cluster enable` must authenticate against
+// /api/admin/cluster/enable using the same -u/-p admin-session mechanism
+// `muninn vault` already uses (authenticateAdmin -> muninn_session cookie),
+// not send nothing. Exercised through the top-level runCluster dispatcher,
+// since that (like runVault) is where authentication happens once before
+// dispatch — runClusterEnable itself only attaches whatever cookie is
+// already set, exactly like runVaultCreate/doVaultRequestForce.
+func TestClusterEnable_ViaDispatcher_AuthenticatesLikeVault(t *testing.T) {
+	oldAdmin, oldUI, oldCookie := vaultAdminBase, vaultUIBase, vaultCookie
+	oldExit := osExit
+	defer func() {
+		vaultAdminBase, vaultUIBase, vaultCookie = oldAdmin, oldUI, oldCookie
+		osExit = oldExit
+	}()
+	vaultCookie = ""
+
+	loginServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/auth/login" {
+			http.SetCookie(w, &http.Cookie{Name: "muninn_session", Value: "dispatcher-test-session"})
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer loginServer.Close()
+	vaultUIBase = loginServer.URL
+
+	adminServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/admin/cluster/enable" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		c, err := r.Cookie("muninn_session")
+		if err != nil || c.Value != "dispatcher-test-session" {
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]any{"code": "admin_auth_required"})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"enabled": true, "role": "primary"})
+	}))
+	defer adminServer.Close()
+
+	var exitCode int
+	osExit = func(code int) { exitCode = code }
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	runCluster([]string{
+		"-u", "root", "-p" + "password",
+		"enable",
+		"--addr", adminServer.URL,
+		"--role", "primary",
+		"--bind-addr", "127.0.0.1:7778",
+		"--yes",
+	})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	output := make([]byte, 4096)
+	n, _ := r.Read(output)
+	result := string(output[:n])
+
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0 after authenticating like muninn vault does, got %d (output: %s)", exitCode, result)
+	}
+	if !strings.Contains(result, "enabled") {
+		t.Errorf("expected 'enabled' in output, got: %s", result)
 	}
 }

--- a/internal/config/cluster.go
+++ b/internal/config/cluster.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/oklog/ulid/v2"
 	"gopkg.in/yaml.v3"
 )
 
@@ -243,20 +244,96 @@ func applyEnvOverrides(cfg *ClusterConfig) {
 	}
 }
 
-// autoNodeID auto-generates a stable NodeID when cluster is enabled but
-// NodeID is not set. The format is {hostname}-{first8charsOfSHA256(dataDir)}.
+// hostnameFn resolves this host's hostname. A package variable so tests can
+// simulate a hostname change without touching the real OS hostname. Retained
+// only as the fallback identity source (see autoNodeID) — the primary source
+// is the persisted node identity file.
+var hostnameFn = os.Hostname
+
+// nodeIdentityFilename is the file in the data directory that persists a
+// stable node identity across restarts, independent of hostname (#630).
+const nodeIdentityFilename = "node-identity"
+
+// autoNodeID assigns a stable NodeID when cluster is enabled but NodeID is
+// not explicitly configured (via muninn.yaml, cluster.yaml, or
+// MUNINN_CLUSTER_NODE_ID — applyEnvOverrides runs before this, so an explicit
+// operator-set id always wins per the project's "explicit config is never
+// silently substituted" rule).
+//
+// The identity is a random ULID persisted to {dataDir}/node-identity on first
+// use and reused on every subsequent start, so it survives a hostname change.
+// The previous scheme derived NodeID from os.Hostname() at every startup:
+// macOS hostnames flap with network changes (mDNS renaming, captive
+// portals) and container hostnames can change across restarts, so the same
+// physical node minted a brand-new cluster identity each time — the old
+// registration was never reaped, poisoning quorum counting and pinning
+// MinReplicatedSeq at its last ack forever (SafePrune never advances) (#630).
+//
+// Existing deployments that already have ghost registrations from the old
+// hostname-derived scheme are NOT migrated automatically: this node's own
+// past registrations under old hostnames can't be distinguished from a
+// different real peer without an operator asserting "these are the same
+// machine", and reaping the wrong entry would silently drop a live node from
+// quorum — worse than leaving a known ghost for manual cleanup.
+// `muninn cluster remove-node` (DELETE /api/admin/cluster/nodes/{id}, already
+// shipped) remains the supported way to clear a confirmed ghost after
+// upgrading to this release. A node upgraded in place picks up a *new*
+// stable identity on its first start under this code (its data directory has
+// no node-identity file yet) — that registration event is itself indistinguishable
+// from a hostname flap to a running cluster, so it is still an operator's
+// call to remove the node's pre-upgrade registration(s) once confirmed dead.
 func autoNodeID(cfg *ClusterConfig, dataDir string) {
 	if !cfg.Enabled || cfg.NodeID != "" {
 		return
 	}
-	hostname, err := os.Hostname()
+	id, err := loadOrCreateNodeIdentity(dataDir)
 	if err != nil {
-		slog.Warn("autoNodeID: hostname lookup failed, falling back to \"node\"", "err", err)
+		// Falling back to the legacy hostname-derived scheme keeps a node
+		// startable even if the data directory is unwritable for some reason;
+		// an id that doesn't survive a hostname change is still better than a
+		// cluster node that refuses to start.
+		slog.Warn("autoNodeID: could not persist stable node identity, falling back to hostname-derived id",
+			"err", err, "dataDir", dataDir)
+		cfg.NodeID = legacyHostnameNodeID(dataDir)
+		return
+	}
+	cfg.NodeID = id
+}
+
+// loadOrCreateNodeIdentity returns the node identity persisted at
+// {dataDir}/node-identity, generating and persisting one on first use.
+func loadOrCreateNodeIdentity(dataDir string) (string, error) {
+	path := filepath.Join(dataDir, nodeIdentityFilename)
+	if data, err := os.ReadFile(path); err == nil {
+		if id := strings.TrimSpace(string(data)); id != "" {
+			return id, nil
+		}
+		// Empty/corrupt file: fall through and regenerate rather than
+		// persisting (or returning) a blank identity.
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		return "", fmt.Errorf("create data dir: %w", err)
+	}
+	id := "nid-" + ulid.Make().String()
+	if err := os.WriteFile(path, []byte(id+"\n"), 0600); err != nil {
+		return "", fmt.Errorf("persist node identity: %w", err)
+	}
+	return id, nil
+}
+
+// legacyHostnameNodeID reproduces the pre-#630 hostname-derived scheme, used
+// only when the data directory is unwritable and a persisted identity can't
+// be created.
+func legacyHostnameNodeID(dataDir string) string {
+	hostname, err := hostnameFn()
+	if err != nil {
 		hostname = "node"
 	}
 	sum := sha256.Sum256([]byte(dataDir))
-	shortHash := fmt.Sprintf("%x", sum[:4]) // 4 bytes = 8 hex chars
-	cfg.NodeID = hostname + "-" + shortHash
+	return hostname + "-" + fmt.Sprintf("%x", sum[:4])
 }
 
 var validRoles = map[string]bool{

--- a/internal/config/cluster_test.go
+++ b/internal/config/cluster_test.go
@@ -131,6 +131,43 @@ func TestClusterConfig_AutoNodeID(t *testing.T) {
 	}
 }
 
+// TestClusterConfig_AutoNodeID_StableAcrossHostnameChange reproduces #630: a
+// hostname change (macOS mDNS renaming, a container getting a fresh hostname
+// on restart) must not mint a new node identity for the same data directory.
+// A node_id that changes with the hostname mints a "ghost" registration that
+// out-lives the old identity, poisoning quorum counting and pinning
+// MinReplicatedSeq at its last ack forever.
+func TestClusterConfig_AutoNodeID_StableAcrossHostnameChange(t *testing.T) {
+	t.Setenv("MUNINN_CLUSTER_ENABLED", "true")
+	// Do not set MUNINN_CLUSTER_NODE_ID — exercise auto-derivation.
+
+	dataDir := t.TempDir()
+
+	orig := hostnameFn
+	defer func() { hostnameFn = orig }()
+
+	hostnameFn = func() (string, error) { return "MacBookPro-abcd1234", nil }
+	cfg1, err := LoadClusterConfig(dataDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg1.NodeID == "" {
+		t.Fatal("expected non-empty auto-generated NodeID")
+	}
+
+	// Same machine, same data directory, but the hostname flapped (a real,
+	// observed sequence: MacBookPro-<hash> -> Jareds-MacBook-Pro.local-<hash>).
+	hostnameFn = func() (string, error) { return "Jareds-MacBook-Pro.local", nil }
+	cfg2, err := LoadClusterConfig(dataDir)
+	if err != nil {
+		t.Fatalf("unexpected error on second load: %v", err)
+	}
+
+	if cfg1.NodeID != cfg2.NodeID {
+		t.Errorf("node identity must survive a hostname change: got %q then %q", cfg1.NodeID, cfg2.NodeID)
+	}
+}
+
 func TestClusterConfig_DisabledAlwaysValid(t *testing.T) {
 	cfg := ClusterConfig{
 		Enabled: false,

--- a/internal/replication/coordinator.go
+++ b/internal/replication/coordinator.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"net"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -94,6 +95,16 @@ type ClusterCoordinator struct {
 
 	role   NodeRole
 	roleMu sync.RWMutex
+
+	// roleCallbackMu serializes OnBecameCortex and OnBecameLobe invocations
+	// against each other. handlePromotion calls OnBecameCortex synchronously on
+	// the caller's goroutine while handleDemotion fires OnBecameLobe from a bare
+	// goroutine (it must not stall the MSP tick goroutine) — without this lock a
+	// promotion and a demotion racing each other (plausible under flapping
+	// quorum) invoke both callbacks concurrently, and both are wired in
+	// production (cmd/muninn/server.go) as closures over shared, unsynchronized
+	// worker-handle state (#629).
+	roleCallbackMu sync.Mutex
 
 	// roleCh carries promotion/demotion events to the supervisor loop (#522 Step 3).
 	roleCh chan roleEvent
@@ -1585,9 +1596,48 @@ func (c *ClusterCoordinator) handlePromotion(epoch uint64) {
 
 	c.pushRoleEvent(roleEvent{promoted: true})
 
-	if c.OnBecameCortex != nil {
-		c.OnBecameCortex(epoch)
+	c.invokeOnBecameCortex(epoch)
+}
+
+// invokeOnBecameCortex runs OnBecameCortex synchronously on the caller's
+// goroutine (handlePromotion has always blocked here, and nothing downstream
+// depends on it returning quickly), serialized against any concurrently
+// in-flight OnBecameLobe invocation and recovered so a callback panic can
+// never take the process down (#629).
+func (c *ClusterCoordinator) invokeOnBecameCortex(epoch uint64) {
+	if c.OnBecameCortex == nil {
+		return
 	}
+	c.roleCallbackMu.Lock()
+	defer c.roleCallbackMu.Unlock()
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("cluster: OnBecameCortex callback panicked",
+				"node", c.cfg.NodeID, "epoch", epoch, "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
+	c.OnBecameCortex(epoch)
+}
+
+// invokeOnBecameLobe runs OnBecameLobe asynchronously — it must not stall the
+// MSP tick goroutine that calls handleDemotion — but serialized against any
+// other role-transition callback via roleCallbackMu, and recovered so a
+// callback panic can never take the process down (#629).
+func (c *ClusterCoordinator) invokeOnBecameLobe() {
+	if c.OnBecameLobe == nil {
+		return
+	}
+	go func() {
+		c.roleCallbackMu.Lock()
+		defer c.roleCallbackMu.Unlock()
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("cluster: OnBecameLobe callback panicked",
+					"node", c.cfg.NodeID, "panic", r, "stack", string(debug.Stack()))
+			}
+		}()
+		c.OnBecameLobe()
+	}()
 }
 
 // pushRoleEvent delivers a role transition to the supervisor loop without
@@ -1633,9 +1683,9 @@ func (c *ClusterCoordinator) handleDemotion(cause demotionCause) {
 	// goroutine (via checkQuorumHealth), and OnBecameLobe stops cognitive workers
 	// which may block — it must not stall heartbeat processing. The role flip
 	// above already gates writes, so the worker teardown can complete out of band.
-	if c.OnBecameLobe != nil {
-		go c.OnBecameLobe()
-	}
+	// invokeOnBecameLobe serializes against any concurrent OnBecameCortex/
+	// OnBecameLobe invocation and recovers a callback panic (#629).
+	c.invokeOnBecameLobe()
 }
 
 // handleNewLeader is called when another node becomes Cortex.

--- a/internal/replication/coordinator_test.go
+++ b/internal/replication/coordinator_test.go
@@ -500,6 +500,103 @@ func TestClusterCoordinator_OnBecameLobe_Callback(t *testing.T) {
 	}
 }
 
+// TestClusterCoordinator_RoleCallbacks_UnsynchronizedStateRace mirrors how
+// cmd/muninn/server.go wires OnBecameCortex/OnBecameLobe: both close over a
+// shared worker-handle variable with no lock of their own, relying entirely on
+// the coordinator to never invoke them concurrently. handlePromotion calls
+// OnBecameCortex synchronously on the caller's goroutine while handleDemotion
+// fires OnBecameLobe in a bare, unsynchronized goroutine — so a promotion and a
+// demotion racing each other (a real possibility under flapping quorum) mutate
+// that shared state from two goroutines with no happens-before edge (#629
+// claim 1). Run with -race: this must not report a data race.
+func TestClusterCoordinator_RoleCallbacks_UnsynchronizedStateRace(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "auto")
+
+	type workerHandle struct{ epoch uint64 }
+	var handle *workerHandle
+
+	const iterations = 20
+	// Each iteration invokes exactly one of OnBecameCortex (sync) or
+	// OnBecameLobe (async, via a bare goroutine) — count every callback
+	// invocation so the test can wait deterministically for all of them to
+	// land before reading the shared state, rather than a wall-clock sleep.
+	invoked := make(chan struct{}, iterations*2)
+
+	coord.OnBecameCortex = func(epoch uint64) {
+		handle = &workerHandle{epoch: epoch}
+		invoked <- struct{}{}
+	}
+	coord.OnBecameLobe = func() {
+		handle = nil
+		invoked <- struct{}{}
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < iterations; i++ {
+		epoch := uint64(i + 1)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			simulatePromotion(coord, epoch)
+		}()
+		go func() {
+			defer wg.Done()
+			coord.handleDemotion(causeQuorumLoss)
+		}()
+	}
+	wg.Wait()
+
+	// Drain exactly the expected number of callback invocations. handleDemotion
+	// fires OnBecameLobe from a bare goroutine, so wg.Wait() (which only waits
+	// for handlePromotion/handleDemotion to return, not for that inner
+	// goroutine) is not sufficient — this is the deterministic completion
+	// signal instead of a sleep.
+	for i := 0; i < iterations*2; i++ {
+		select {
+		case <-invoked:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for callback invocation %d/%d", i+1, iterations*2)
+		}
+	}
+	_ = handle
+}
+
+// TestClusterCoordinator_OnBecameLobe_PanicRecovered proves a panicking
+// OnBecameLobe callback (e.g. cmd/muninn/server.go's cognitive worker
+// teardown hitting a nil pointer or a double-close) no longer takes the whole
+// process down (#629 claim 1) — it is caught, logged, and the coordinator
+// keeps functioning afterward.
+func TestClusterCoordinator_OnBecameLobe_PanicRecovered(t *testing.T) {
+	coord, _ := newTestCoordinator(t, "auto")
+
+	invoked := make(chan struct{}, 1)
+	coord.OnBecameLobe = func() {
+		defer func() { invoked <- struct{}{} }()
+		panic("simulated cognitive worker teardown failure")
+	}
+
+	simulatePromotion(coord, 1)
+	coord.handleDemotion(causeClaim)
+
+	select {
+	case <-invoked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for panicking OnBecameLobe to run")
+	}
+
+	// The process (and this test) is still alive to reach this line — that is
+	// the assertion. Confirm the coordinator still works after the panic.
+	if coord.Role() != RoleReplica {
+		t.Errorf("expected role=RoleReplica after demotion, got %v", coord.Role())
+	}
+	var secondCortex bool
+	coord.OnBecameCortex = func(uint64) { secondCortex = true }
+	simulatePromotion(coord, 2)
+	if !secondCortex {
+		t.Error("expected coordinator to keep processing role callbacks after a prior panic")
+	}
+}
+
 func TestClusterCoordinator_NilCallbacksSafe(t *testing.T) {
 	coord, _ := newTestCoordinator(t, "auto")
 


### PR DESCRIPTION
Three of @likesjx's cluster reports. One half of #629 was **already fixed** and is reported as such rather than re-fixed.

## #629 — two claims, two different answers

**Claim 2 (headless forever): already fixed on develop.** `waitQuorumTerm` (`coordinator.go:1023-1058`) holds leaderless, re-derives role each tick, and calls `election.StartElection` with backoff once a live voter quorum returns. No fix, no test — an honest negative on half the issue.

**Claim 1 (process exit): real.** `handlePromotion` calls `OnBecameCortex` synchronously on its caller's goroutine, but `handleDemotion` fired `OnBecameLobe` in a **bare, unsynchronized goroutine**. Production wiring closes both callbacks over shared `cogHeb`/`cogCancel`/`cogTransition` with no lock of their own.

Two REDs. The race detector fires on concurrent writes to the same address from the two callbacks. And with `recover()` removed, a panic in the demotion callback **crashes the whole test binary** — which is the reported "process exits" symptom, reproduced. Both callbacks now serialize behind one `roleCallbackMu` and recover with a logged stack.

## #630 — node identity was hostname-derived

`autoNodeID` built `hostname + "-" + sha256(dataDir)[:8]`, recomputed every start. `MinReplicatedSeq` takes the min over all registered `replicaSeqs` keys, so a ghost registration never advances SafePrune — a hostname flap silently wedges pruning forever. That ties directly to #724/#725.

Identity is now a `nid-<ULID>` persisted to `{dataDir}/node-identity` (0600) on first use, independent of hostname. RED used an injectable `hostnameFn` seam so a flap could be simulated without touching the real OS.

**Deliberately not built: an automatic ghost reaper.** An upgraded node's own past hostname-derived registrations cannot be distinguished from a genuinely different peer without operator judgment, and guessing wrong removes a live node. `muninn cluster remove-node` stays the supported cleanup. Upgrade behaviour is stated in the code: a node mints a fresh stable identity on first boot under the new code, which looks to the cluster exactly like a hostname flap.

## #632 — CLI cluster commands always 401

Both halves confirmed: `httpGet`/`httpPost` sent no `Authorization` against `/v1/cluster/*` (needs Bearer cluster-secret), and `runClusterEnable`/`runClusterDisable` sent nothing against `/api/admin/cluster/*` (needs an admin session cookie).

Fixed by extending the two mechanisms `muninn vault` already uses rather than inventing new ones (principle #7). **No auth check was weakened** — the routes are unchanged; the CLI now presents credentials it already had access to.

## Verification

`go build`/`vet`/`gofmt` clean under `localassets`. `internal/replication`, `cmd/muninn`, `internal/auth` green; `-race` green on replication (46s), config and cmd. Port 8750 was held by a live daemon and was not killed.

Obligations walked: none apply. No MCP handler, REST route, preset, Pebble prefix, or proto change. The one new surface is the persisted `node-identity` file, addressed above as data at rest.

Closes #629, closes #630, closes #632.