### PR TITLE
test(engine): drain the reinforcement goroutine instead of racing a 15s budget (#813)

### DIFF
--- a/internal/engine/autoassoc/autoassoc_test.go
+++ b/internal/engine/autoassoc/autoassoc_test.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/scrypster/muninndb/internal/index/fts"
 	"github.com/scrypster/muninndb/internal/storage"
@@ -48,21 +47,10 @@ func (f *stubFTS) Search(_ context.Context, _ [8]byte, query string, _ int) ([]f
 	return f.results[query], nil
 }
 
-// drain waits for the worker queue to empty (for test determinism).
+// drain awaits every job enqueued so far, deterministically via the worker's
+// own WaitIdle seam instead of polling len(w.jobs) against a fixed sleep.
 func drain(w *Worker) {
-	// Poll until jobs channel is empty and workers are idle.
-	// We do this by sending a noop job and waiting for it to process.
-	// Simpler: Stop and restart. But since Stop closes the channel, we just
-	// give it a small sleep window.
-	for {
-		if len(w.jobs) == 0 {
-			time.Sleep(20 * time.Millisecond)
-			if len(w.jobs) == 0 {
-				return
-			}
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	w.WaitIdle()
 }
 
 // --- tests ---

--- a/internal/engine/engine_reinforcement_test.go
+++ b/internal/engine/engine_reinforcement_test.go
@@ -42,22 +42,30 @@ func TestRead_ReinforcesAccess(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 
+	// Explicit, distinct CreatedAt stamps (LastAccess defaults to CreatedAt
+	// at write time — normalizeEngramTimes) instead of a time.Sleep between
+	// the two writes to force clock-tick separation: #695 flagged the sleep
+	// as itself fragile under coarse clock resolution / CI load, and it was
+	// never addressed. This makes the "older"/"newer" ordering a property of
+	// the data, not of wall-clock scheduling.
+	base := time.Now()
 	older, err := eng.Write(ctx, &mbp.WriteRequest{
 		Vault: "reinforce-read", Concept: "older", Content: "older sibling content",
+		CreatedAt: timePtr(base.Add(-time.Second)),
 	})
 	if err != nil {
 		t.Fatalf("Write older: %v", err)
 	}
-	time.Sleep(5 * time.Millisecond)
 	newer, err := eng.Write(ctx, &mbp.WriteRequest{
 		Vault: "reinforce-read", Concept: "newer", Content: "newer sibling content",
+		CreatedAt: timePtr(base),
 	})
 	if err != nil {
 		t.Fatalf("Write newer: %v", err)
 	}
 
 	// Sanity: before reinforcing, "newer" is more recently accessed (it was
-	// written after "older" and LastAccess defaults to write time).
+	// stamped after "older" and LastAccess defaults to write time).
 	entries, err := eng.WhereLeftOff(ctx, "reinforce-read", 10, nil)
 	if err != nil {
 		t.Fatalf("WhereLeftOff (before): %v", err)
@@ -74,39 +82,38 @@ func TestRead_ReinforcesAccess(t *testing.T) {
 		t.Fatalf("AccessCount before any reinforcement = %d, want 0", before.AccessCount)
 	}
 
-	// Read "older" again — its own fire-and-forget TouchAccess must not
-	// deadlock or race with polling reads of itself.
-	//
-	// Budget: this asserts a CORRECTNESS property (the reinforcement lands),
-	// not a latency one — TouchAccess is a fire-and-forget goroutine, and 2s
-	// was inside scheduling-noise range on a loaded CI runner (failed there
-	// while passing 5/5 locally; the fourth timing flake of this shape, after
-	// #744, the import-cleanup test, and the abstention harness). There is no
-	// reason for the budget to be tight.
-	got := pollAccessCount(t, eng, "reinforce-read", older.ID, 1, 15*time.Second)
-	if got == 0 {
-		t.Fatalf("TouchAccess did not land within 15s of the reinforcing Read (AccessCount still 0) — " +
-			"that is a hang or a dropped reinforcement, not scheduling noise")
+	// Read "older" again — this spawns the #682 reinforcement (TouchAccess)
+	// as a fire-and-forget goroutine tracked by fireAndForgetWG. Drain it
+	// deterministically (docs/internals/testing-hermeticity.md, source #2)
+	// instead of polling against a wall-clock deadline — the same seam
+	// (waitFireAndForgetIdle) every sibling test in this file already uses.
+	if _, err := eng.Read(ctx, &mbp.ReadRequest{Vault: "reinforce-read", ID: older.ID}); err != nil {
+		t.Fatalf("Read (reinforcing): %v", err)
+	}
+	eng.waitFireAndForgetIdle()
+
+	after, err := eng.Read(ctx, &mbp.ReadRequest{Vault: "reinforce-read", ID: older.ID, ReadOnly: true})
+	if err != nil {
+		t.Fatalf("Read (after): %v", err)
+	}
+	if after.AccessCount == 0 {
+		t.Fatalf("TouchAccess did not land after draining fire-and-forget goroutines (AccessCount still 0) — " +
+			"a dropped reinforcement, not scheduling noise")
 	}
 
-	// LastAccess must now put "older" ahead of "newer" in WhereLeftOff.
-	deadline := time.Now().Add(15 * time.Second)
-	reordered := false
-	for time.Now().Before(deadline) {
-		entries, err := eng.WhereLeftOff(ctx, "reinforce-read", 10, nil)
-		if err != nil {
-			t.Fatalf("WhereLeftOff (after): %v", err)
-		}
-		if len(entries) > 0 && entries[0].ID.String() == older.ID {
-			reordered = true
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
+	// LastAccess must now put "older" ahead of "newer" in WhereLeftOff — no
+	// polling needed, the drain above already guarantees the 0x22 LastAccess
+	// index write (synchronous inside TouchAccess) has landed.
+	entries, err = eng.WhereLeftOff(ctx, "reinforce-read", 10, nil)
+	if err != nil {
+		t.Fatalf("WhereLeftOff (after): %v", err)
 	}
-	if !reordered {
-		t.Fatalf("WhereLeftOff did not reorder 'older' to the front after reinforcing its read")
+	if len(entries) == 0 || entries[0].ID.String() != older.ID {
+		t.Fatalf("WhereLeftOff did not reorder 'older' to the front after reinforcing its read: %v", entries)
 	}
 }
+
+func timePtr(t time.Time) *time.Time { return &t }
 
 // TestRead_ReadOnly_NoReinforce: engine.Read with observe-mode context (or
 // req.ReadOnly) must NOT bump AccessCount.

--- a/internal/engine/pas_test.go
+++ b/internal/engine/pas_test.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/scrypster/muninndb/internal/auth"
 	"github.com/scrypster/muninndb/internal/cognitive"
@@ -109,8 +108,10 @@ func TestPAS_TransitionRecording(t *testing.T) {
 		t.Fatal("Activate 1 returned 0 results")
 	}
 
-	// Allow drainLog goroutine to process the first activation's log entry.
-	time.Sleep(100 * time.Millisecond)
+	// Allow drainLog goroutine to process the first activation's log entry —
+	// deterministically (testing-hermeticity.md source #5) rather than a
+	// fixed sleep, which flakes under -race scheduling pressure.
+	eng.waitWriteTimeIdle()
 
 	// Activation 2: query about coffee beans (sequential after brewing)
 	resp2, err := eng.Activate(ctx, &mbp.ActivateRequest{
@@ -190,7 +191,9 @@ func TestPAS_TransitionBoostInScoreComponents(t *testing.T) {
 			MaxResults: 10,
 			Threshold:  0.01,
 		})
-		time.Sleep(100 * time.Millisecond)
+		// Deterministic drainLog wait (testing-hermeticity.md source #5)
+		// instead of a fixed sleep.
+		eng.waitWriteTimeIdle()
 
 		_, _ = eng.Activate(ctx, &mbp.ActivateRequest{
 			Vault:      "test",
@@ -198,7 +201,7 @@ func TestPAS_TransitionBoostInScoreComponents(t *testing.T) {
 			MaxResults: 10,
 			Threshold:  0.01,
 		})
-		time.Sleep(100 * time.Millisecond)
+		eng.waitWriteTimeIdle()
 	}
 
 	// Force-flush the transition worker to ensure all transitions are processed.


### PR DESCRIPTION
This flake cost three CI runs in one night, including one on `develop`. Raising its budget from 2s to 15s in 88c4d9f (#754) moved the failure *rate*, not the failure *mode* — which is the whole point of #813.

## The seam already existed, and that is the finding

The issue is scoped around adding a `WaitReinforceIdle`. There isn't one, and there doesn't need to be: `waitFireAndForgetIdle()` (`engine.go:809`) already covers Read's reinforcement goroutine, is documented as async source #2 in `testing-hermeticity.md`, and is **already used by every other test in the same file** — `TestRead_ReadOnly_NoReinforce`, `TestFeedbackUseful_BumpsAccessCount`, `TestRecall_DoesNotReinforce`, `TestReinforce_DoesNotEscalateTrust`.

Only the flaky test never called it. So this is **test-only**: zero production code changed, no new exported `*Engine` method, no append-mode census entry.

## Two different bug classes, which the original issue conflated

The `time.Sleep(5ms)` between the two writes — flagged in #695 and never addressed — is **not** a worker-drain race. It exists to make `LastAccess` differ between two engrams, i.e. it is a clock-resolution tie-break. A drain seam cannot fix that. Replaced with explicit distinct `CreatedAt` stamps, since `normalizeEngramTimes` defaults `LastAccess` to `CreatedAt` at write time — ordering becomes a data property rather than a clock race.

Worth separating, because the same shape appears at `content_hash_test.go:404` and would have been "fixed" wrongly by reaching for a seam.

## Evidence

Two REDs, because a flake fix is hard to prove — the test usually passes. These prove the *assertion depends on the drain*, not on luck:

- Drain made a no-op → **FAIL** (`AccessCount still 0`)
- Reinforcement itself disabled → **FAIL** (same message, so it still detects the real defect it exists to catch)

`-run TestRead_ReinforcesAccess -count=20 -race` → **20/20 pass**, each ~0.07–0.10s against up to 15s before. Constant-time, so the drain isn't secretly sleeping.

## Census, per the issue's ask

**Converted** — seams already existed and were simply unused by their own test files: `pas_test.go` (3 sites → `waitWriteTimeIdle`), `autoassoc_test.go` (a bespoke sleep-poll `drain()` helper at 7 call sites → the package's own `Worker.WaitIdle`).

**Left, needs a new seam — listed, not built:** `engine_evolve_provenance_test.go` (its own comment says "no exported drain"), `engine_pruning_test.go` (the counter-coalescer is only flushable white-box), `trigger/*_test.go` (TriggerWorker has no Wait/Flush at all), `cognitive/worker_test.go` and `transition_test.go` (generic `Worker[T]` has `SetFlushInterval` but no drain), `consolidation/worker_test.go` and one MCP contradiction test.

One caveat worth stating rather than burying: the consolidation test may legitimately be asserting on ticker *cadence* rather than downstream state, in which case a drain would be the wrong fix. Worth a look before anyone adds one.

**Not swept:** `internal/replication`, `internal/transport`, `wal_syncer_adaptive_test.go` — network-async by nature, where some deadline polling may be correct to the domain. Its own pass.

Closes #813.