### PR TITLE
ci: a leak guard contributors actually have, and fix the private one skipping in worktrees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,12 +366,33 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Run shellcheck
-        run: shellcheck install.sh scripts/check-build-tags.sh scripts/check-filename-build-constraints.sh
+        run: shellcheck install.sh scripts/check-build-tags.sh scripts/check-filename-build-constraints.sh scripts/check-leak-tells.sh
 
       - name: Check build tags
         run: bash scripts/check-build-tags.sh
+
+      - name: Check leak-tells selftest
+        run: bash scripts/check-leak-tells.sh --selftest
+
+      - name: Check leak-tells (added lines in this change)
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            RANGE="$BASE_SHA..$HEAD_SHA"
+          elif [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            RANGE="$BEFORE_SHA..$GITHUB_SHA"
+          else
+            RANGE="HEAD~1..HEAD"
+          fi
+          bash scripts/check-leak-tells.sh --range "$RANGE"
 
       # #814: a file named *_arm_test.go / *_386.go is excluded by the toolchain
       # on filename alone, with no //go:build line and no diagnostic. Lives here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,8 +165,27 @@ The rule, in committed content — source, tests, code comments, design records,
 This is not hypothetical. A vault name reached `origin/develop` in #715 and was scrubbed at the
 tip a day later by #734 — but a public repo's history is public forever, and a scrub of the tip
 is not a scrub. **Getting it right before the commit is the only version of this that works.**
-Maintainers additionally run a local pre-commit guard; do not rely on it, and note that
-contributors don't have it.
+
+Two mechanisms back this up, and neither is a substitute for the rule above:
+
+- **`scripts/check-leak-tells.sh`** is public and runs in CI (the Shellcheck job) against every
+  change's *added* lines, and is available to any contributor as an opt-in local pre-commit
+  hook (`--install-hook`; see `CONTRIBUTING.md`). It has no denylist by design — a list of real
+  names sitting in a public repo would publish the very association it exists to prevent — so
+  it can only catch a handful of *structurally*-shaped tells: an `.internal` hostname, an
+  AWS/GCP-style instance id, an "our/on the &lt;ProperNoun&gt; ..." phrase. It cannot catch a
+  bare project-internal codename with no such marker — which is the exact shape every leak in
+  this repo's history has actually taken (an ordinary-looking client name with no structural
+  tell, and a domain term indistinguishable from a real one). It is a net, not a proof.
+- Maintainers additionally run a private, gitignored pre-commit guard
+  (`.claude/maintainer/pre-commit-vault-guard.sh`) against a denylist of known client/product
+  names — the thing the public check structurally cannot have. It is maintainer-only tooling,
+  not present in a fresh contributor clone, and it does not run in CI.
+
+Between them: the public check is what every contributor gets and covers structural tells; the
+private one is what the maintainer gets and covers known names. Neither catches an unknown bare
+codename typed by someone who doesn't know it's sensitive — that gap is closed by reading your
+own diff before committing, which is the actual control both tools exist to remind you to do.
 
 **Keep CI fast and cheap.** The full gate must stay **under ~10 minutes** (baseline ~6–7
 min; job map in `drift-and-obligations.md`). Unit and invariant tests are nearly free —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,26 @@ go test -tags localassets ./...
 
 ---
 
+## Keeping real names out of a public repo
+
+MuninnDB is public. Vault, client, and host names may be *measured against* — the numbers
+are the point — but never *named* in what ships (see `CLAUDE.md`). `scripts/check-leak-tells.sh`
+is a public, structural check for the decidable shapes a leaked identifier tends to take (an
+`.internal` hostname, an AWS instance id, an "our/on the &lt;Name&gt; ..." phrase) in lines
+*added* by your change. It runs in CI automatically (part of the Shellcheck job) and you can
+install it as a local pre-commit hook:
+
+```bash
+bash scripts/check-leak-tells.sh --install-hook   # opt-in; not enabled by default
+bash scripts/check-leak-tells.sh --selftest       # exercise it against inline fixtures
+```
+
+It has no denylist — a denylist of real names can't live in a public repo without publishing
+the very thing it exists to prevent — so it can only catch identifiers with a structural tell.
+A bare project-internal codename with no such marker will pass through undetected; reading
+your own diff before committing is still the actual check. If it flags a false positive,
+`ALLOW_LEAK_TELLS=1 git commit …` bypasses it (logged, and still worth a second look).
+
 ## Branch Model (Git Flow)
 
 We use a **develop → main** flow:

--- a/scripts/check-leak-tells.sh
+++ b/scripts/check-leak-tells.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# check-leak-tells.sh — catch decidable, near-zero-false-positive shapes of
+# leaked infrastructure/host identifiers in ADDED lines only.
+#
+# MuninnDB is public. A vault, client, or host name must never be NAMED in
+# committed content (see CLAUDE.md). The maintainer runs an additional
+# denylist-based guard (.claude/maintainer/, gitignored — a list of real
+# names cannot itself live in a public repo). This script is the part of
+# that protection every contributor gets: it has no denylist, so it can only
+# catch identifiers with a STRUCTURAL tell — an .internal hostname, an AWS
+# instance id, an "our/on the <ProperNoun> ..." phrase. A bare
+# project-internal codename with no structural marker — the shape every
+# leak in this repo's history has actually taken — passes through
+# undetected. This is a net, not a proof.
+#
+# Rules considered and rejected (measured against this repo's own tree and
+# history — see the design note for the numbers):
+#   - email addresses: dependency lockfiles (composer.lock, pyproject.toml)
+#     carry dozens of legitimate third-party maintainer emails; noise with
+#     no history of being the leak vector.
+#   - RFC1918/link-local IP ranges (10.x, 192.168.x, 172.16-31.x, 169.254.x):
+#     used throughout as safe placeholder addresses in test fixtures and
+#     docs/cluster-operations.md, exactly like example.com — same failure
+#     shape as generic hostname TLDs, below.
+#   - hostnames with real TLDs, and the .local / .lan suffixes: real TLDs
+#     match ~2400 lines of legitimate open-source references (github.com,
+#     golang.org, npmjs.org, ...); .local and .lan are this repo's own
+#     placeholder convention in tests (flag.local, ui.example.lan, ...).
+#   - absolute paths under /Users/<name>/ or /home/<name>/: the maintainer's
+#     own design docs already carry ~28 legitimate "code read at
+#     /Users/<maintainer>/..." breadcrumbs; the only way to keep this rule
+#     from firing on them is a name-specific exemption, which would put a
+#     real name in tracked content to suppress itself. Rejected.
+#   - "Production <ProperNoun>" phrase: this codebase's own prose uses
+#     "Production" constantly as a plain adjective before a capitalized
+#     technical term or heading noun — "Production Hardening",
+#     "Production Readiness Verdict", "production OnWeightUpdate",
+#     "production GetEngrams", "production ContentMatch", "Production
+#     Checklist" all hit when scanned whole-tree. Ten real false positives;
+#     dropped in favor of the two narrower phrase tells below, which stayed
+#     at zero.
+#
+# Rules kept (zero hits across the tracked tree and the last ~200 commits'
+# added lines at the time this was written):
+#   - .internal hostname suffix (unlike .local/.lan, not used as a
+#     placeholder convention anywhere in this codebase).
+#   - "our <ProperNoun> server" / "on the <ProperNoun> box", restricted to a
+#     following Capitalized token to avoid "our own server" / "our mock
+#     server" generic-English hits.
+#   - AWS/GCP-style instance identifiers (EC2 instance ids, ARNs).
+#
+# Usage:
+#   scripts/check-leak-tells.sh                  # staged changes (local hook)
+#   scripts/check-leak-tells.sh --range A..B     # explicit diff range (CI)
+#   scripts/check-leak-tells.sh --install-hook   # opt-in local pre-commit hook
+#   scripts/check-leak-tells.sh --selftest       # exercise the rules on
+#                                                 # inline, invented fixtures
+#
+# Bypass (deliberate, logged): ALLOW_LEAK_TELLS=1 git commit …
+
+set -uo pipefail
+
+SELF_RELPATH="scripts/check-leak-tells.sh"
+
+# Patterns run against ADDED lines only (diff `+` lines, stripped of the
+# leading marker). One pattern per array entry; kept as extended regexes.
+PATTERNS=(
+  # .internal hostname suffix
+  '[A-Za-z0-9][A-Za-z0-9._-]*\.internal([^A-Za-z0-9]|$)'
+  # phrase-shaped tells — require a following Capitalized (proper-noun-shaped)
+  # token so ordinary English ("our own server", "our mock server") doesn't
+  # hit. "Production <ProperNoun>" was tried and dropped: this repo's own
+  # prose uses "Production"/"production" as a plain adjective before a
+  # capitalized technical term constantly (see the header note above).
+  '\<our[[:space:]]+[A-Z][A-Za-z0-9_-]{2,}[[:space:]]+server'
+  '\<on the[[:space:]]+[A-Z][A-Za-z0-9_-]{2,}[[:space:]]+box'
+  # AWS-style EC2 instance id / ARN
+  '\<i-[0-9a-f]{8,17}\>'
+  'arn:aws:'
+)
+
+usage() {
+  echo "usage: $(basename "$0") [--range A..B] [--install-hook] [--selftest]" >&2
+}
+
+install_hook() {
+  local common_dir hook line
+  # The hooks directory is shared across worktrees (through --git-common-dir);
+  # a linked worktree's own .git is a file, not a directory, so writing to
+  # "$(show-toplevel)/.git/hooks" fails there. But this script itself is
+  # TRACKED content, checked out fresh into every worktree — unlike the
+  # maintainer's private, gitignored denylist guard, it must be invoked via
+  # --show-toplevel (the current worktree) at run time, not the shared
+  # common-dir's parent (the main checkout, which may not have this file
+  # checked out at the branch a given worktree is on).
+  common_dir="$(git rev-parse --path-format=absolute --git-common-dir)"
+  hook="$common_dir/hooks/pre-commit"
+  # shellcheck disable=SC2016 # deliberately single-quoted: expands at hook-run time, not here.
+  line='bash "$(git rev-parse --show-toplevel)/'"${SELF_RELPATH}"'" || exit 1'
+  if [[ -f "$hook" ]] && grep -qF "$SELF_RELPATH" "$hook"; then
+    echo "already installed -> $hook"
+    return 0
+  fi
+  if [[ -f "$hook" ]]; then
+    printf '\n%s\n' "$line" >> "$hook"
+  else
+    printf '#!/usr/bin/env bash\n%s\n' "$line" > "$hook"
+  fi
+  chmod +x "$hook"
+  echo "installed -> $hook"
+}
+
+# Extract ADDED lines (without the leading '+') from a diff.
+added_lines_from_diff() {
+  grep -E '^\+' | grep -vE '^\+\+\+' | sed -E 's/^\+//'
+}
+
+get_added_lines_staged() {
+  git diff --cached --unified=0 -- . ":(exclude)${SELF_RELPATH}" | added_lines_from_diff
+}
+
+get_added_lines_range() {
+  local range="$1"
+  git diff --unified=0 "$range" -- . ":(exclude)${SELF_RELPATH}" | added_lines_from_diff
+}
+
+scan() {
+  local content="$1"
+  local hit=0 pat found
+  [[ -z "$content" ]] && return 0
+  for pat in "${PATTERNS[@]}"; do
+    found="$(printf '%s\n' "$content" | grep -nE "$pat" || true)"
+    if [[ -n "$found" ]]; then
+      hit=1
+      echo "  pattern: $pat"
+      printf '%s\n' "$found" | sed 's/^/    added: /'
+    fi
+  done
+  return $hit
+}
+
+selftest() {
+  local fail=0
+
+  # Positive fixtures: each shape below MUST be flagged. Names are invented.
+  local -a positive=(
+    "the archived config still lives on db1.internal, so the old default has to survive"
+    "our Coyotefleet server never saw the migration"
+    "on the Ranchhand box the timeout was still 30s"
+    "instance i-0a1b2c3d4e5f67890 never rejoined the cluster"
+    "arn:aws:iam::000000000000:role/example-role was over-scoped"
+  )
+  # Negative fixtures: ordinary content that must NOT be flagged.
+  local -a negative=(
+    "our own server handles this fine"
+    "our mock server returns a canned response"
+    "see https://github.com/scrypster/muninndb for the source"
+    "default listen host is 10.0.0.1 in the fixture"
+    "override.lan is used as the test placeholder domain"
+    "code read at /Users/maintainer/github.com/scrypster/muninndb"
+    "Production Hardening checklist, iteration ten"
+    "in production OnWeightUpdate feeds the engine"
+  )
+
+  local line
+  for line in "${positive[@]}"; do
+    if scan "$line" >/dev/null; then
+      echo "SELFTEST FAIL (expected hit, got none): $line"
+      fail=1
+    fi
+  done
+  for line in "${negative[@]}"; do
+    if ! scan "$line" >/dev/null; then
+      echo "SELFTEST FAIL (expected clean, got hit): $line"
+      fail=1
+    fi
+  done
+
+  if [[ "$fail" -eq 0 ]]; then
+    echo "selftest OK: ${#positive[@]} positive, ${#negative[@]} negative fixtures behaved as expected."
+  fi
+  return $fail
+}
+
+MODE="staged"
+RANGE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --range)
+      MODE="range"; RANGE="${2:-}"; shift 2 ;;
+    --install-hook)
+      install_hook; exit 0 ;;
+    --selftest)
+      selftest; exit $? ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ "${ALLOW_LEAK_TELLS:-}" == "1" ]]; then
+  echo "check-leak-tells: BYPASSED via ALLOW_LEAK_TELLS=1" >&2
+  exit 0
+fi
+
+case "$MODE" in
+  staged)
+    ADDED="$(get_added_lines_staged)"
+    ;;
+  range)
+    if [[ -z "$RANGE" ]]; then
+      echo "check-leak-tells: --range requires A..B" >&2
+      exit 2
+    fi
+    ADDED="$(get_added_lines_range "$RANGE")"
+    ;;
+esac
+
+echo "check-leak-tells: scanning added lines ($MODE)…"
+if scan "$ADDED"; then
+  exit 0
+fi
+
+cat >&2 <<'MSG'
+
+check-leak-tells: BLOCKED — a structurally-shaped infrastructure/host
+identifier was added.
+
+MuninnDB is public. Real hostnames, instance ids, and "our/on the <Name> ..."
+references to a real host must never be committed — rewrite the
+reference generically (e.g. "a production vault", "the affected host") and
+keep any measurement or number, which is the point.
+
+This check only catches identifiers with a structural tell. It is not a
+substitute for reading your own diff.
+
+Deliberate exception: ALLOW_LEAK_TELLS=1 git commit …
+MSG
+exit 1


### PR DESCRIPTION
This repo is public and its history is permanent. A vault name reached `origin/develop` in #715 and was scrubbed a day later by #734 — but a tip scrub is not a scrub. Last night a real production **host** name arrived in an outside contributor's PR and was caught only by a human reading the diff.

Three defects, all reproduced.

## 1. The private guard silently skipped in every worktree

It resolved its denylist via `git rev-parse --show-toplevel`, which in a linked worktree resolves to the **worktree**, not the main checkout where the gitignored `.claude/maintainer/` copy lives. Observed:

```
vault-guard: no denylist at .../.worktrees/guard/.claude/maintainer/vault-denylist.txt — skipping
exit 0
```

This repo does nearly all its work in linked worktrees, so **the protection was absent exactly where the work happens.** Now resolved through `--git-common-dir`; both a worktree and the main checkout scan.

## 2. It hard-failed when absent, which taught people to bypass it

In a fresh worktree the configured hook path does not exist and `git commit` died outright. Two agents responded by committing with `--no-verify` — the worst outcome, since the guard trained people around itself. An absent script is now a loud warning and exit 0. It is maintainer-only tooling and contributors legitimately do not have it.

## 3. Contributors had no guard at all

That is how the host name arrived. A denylist is inherently private, so the public guard cannot use one — it catches decidable structural tells instead, in added lines only.

**Kept** (zero false positives across the entire tree *and* the last ~200 commits): `.internal` hostname suffix · `our <ProperNoun> server` / `on the <ProperNoun> box`, capitalization-restricted · AWS/GCP instance ids and `arn:aws:`.

**Rejected, each with evidence** — the more important half, because a guard that cries wolf gets exemptions written to silence it, and exemptions decay:

| Candidate | Why rejected |
|---|---|
| email addresses | lockfiles carry dozens of legitimate third-party maintainer emails |
| RFC1918 / link-local IPs | ~106 legitimate hits; `10.0.0.1` is this repo's own test-fixture and doc convention |
| generic-TLD hostnames | ~2400 legitimate hits |
| `.local` / `.lan` | 46 hits — the repo's own placeholder convention |
| `/Users/<name>/` paths | 28 legitimate breadcrumbs in design docs; exempting them would require encoding a real name to suppress itself |
| `Production <ProperNoun>` | 10 real hits, found only by running it tree-wide — "Production Hardening", "Production Checklist", "production OnWeightUpdate", all ordinary technical prose |

That last one is worth noting: it is the rule that would most obviously have caught last night's leak, and it is **not clean enough to ship**. Said plainly in the docs rather than shipped noisy.

Rides the existing shellcheck job — no new CI job, the gate stays under ~10 minutes. Opt-in local hook, documented in CONTRIBUTING and beside the existing rule in CLAUDE.md, including **what it cannot catch**: a bare project-internal codename with no structural tell. It is a net, not a proof.

## The finding worth keeping

While writing the CLAUDE.md prose explaining what the public guard cannot catch, the agent initially cited the real historical leaked vault name as the concrete example — reintroducing the exact class of leak the task exists to prevent. The just-fixed private guard caught it before commit.

**Prose *about* a leak is a high-risk site for re-leaking it.**

Verification: both resolution paths shown scanning; script-absent warns and exits 0; five invented-shape fixtures blocked through a real `git commit` and through the CI-style range check; a clean commit passes; false-positive count zero. `shellcheck` clean; Go build/vet/gofmt clean.
