### PR TITLE
docs,test(activation): CGDN has never executed — label it INERT and build the census for the class (#768, #805)

### DIFF
--- a/docs/feature-reference.md
+++ b/docs/feature-reference.md
@@ -99,7 +99,7 @@ The ACTIVATE pipeline has **6 phases**:
 
 #### Scoring Models
 - **ACT-R** (default, production) — `ContentMatch × softplus(BaseLevel + HebbianScale × HebbianBoost + TransitionBoost)`. Power-law temporal decay based on access count and recency. This is the only production scorer
-- **CGDN** (Cognitive-Gated Divisive Normalization) — experimental. Multiplicative cognitive gating with divisive normalization across candidates. Requires `experimental_cgdn: true` in vault plasticity config
+- **CGDN** (Cognitive-Gated Divisive Normalization) — experimental, and **currently inert at any positive activation threshold**: its component producer never sets the field the abstention gate reads, so `absolute` is 0.0 for every non-tag-pool candidate and every threshold above zero drops the whole result set (measured, #768 — see `docs/internals/decision-record.md`). Requires `experimental_cgdn: true` in vault plasticity config
 
 #### Score Components
 - Semantic Similarity (vector cosine)
@@ -348,7 +348,7 @@ Every cognitive behavior is tunable per vault:
 | `traversal_profile` | auto | string | Default traversal profile |
 | `actr_decay` | 0.5 | 0.01–2.0 | ACT-R power-law exponent |
 | `actr_heb_scale` | 4.0 | 0–50 | Hebbian amplifier in ACT-R |
-| `experimental_cgdn` | false | bool | Enable experimental CGDN scorer |
+| `experimental_cgdn` | false | bool | Enable experimental CGDN scorer. Accepted and stored, but the scorer is inert at any positive activation threshold (#768), so on the surface default (0.5) it returns nothing — see below |
 | `predictive_activation` | true | bool | Enable PAS |
 | `pas_max_injections` | 5 | 0–10 | Max PAS candidates to inject |
 | `behavior_mode` | `"autonomous"` | autonomous/prompted/selective/custom | How the AI should use memory (see below) |

--- a/docs/internals/decision-record.md
+++ b/docs/internals/decision-record.md
@@ -951,3 +951,161 @@ it was true of the wrong half of it. Phase 4 reads the graph and contributes; ph
 it and has never emitted a row. When a claim spans two mechanisms, measure them separately —
 and when one of them turns out to be redundant with a cheaper index it is built on top of,
 the finding is "delete the claim", not "tune the constant".**
+
+### CGDN has never executed, and the class now has a census (#768/#805, 2026-08-03)
+
+`computeComponents` — the component producer the CGDN scoring path uses — never sets
+`ScoreComponents.ContentMatch` (only `computeACTR` does; `computeComponents` is shared with
+the legacy weighted-sum path, which never reads that field, so the gap was invisible there).
+CGDN's abstention gate is
+
+	absolute := min(min(Raw, ContentMatch), 1.0) * Confidence
+	if absolute < req.Threshold && !inTagPool { continue }
+
+so `absolute` is exactly `0.0` for every non-tag-pool candidate on this path, and every
+`req.Threshold > 0` drops the entire result set. CGDN has never returned a live result in a
+passing configuration for the life of the feature — the same shape as #801, discovered by
+the same #763 review panel that found traversal, and deliberately not fixed there either.
+
+**The unclamped-`r` claim in #768 does not hold, and the record needs correcting rather than
+repeating it.** The issue also asserted the live ratio `r = a(d)^n / denom` was unbounded,
+citing a measured `8649.0`. It is not: the Pass-2 loop that computes `r` for LIVE candidates
+only runs `if len(cgdnCands) > 0`, and inside that branch `denom = sigma^n + sum(a_i^n)`
+where the sum runs over every candidate in the pool — including the one whose ratio is being
+computed. `denom >= a(d)^n` for that candidate by construction, so `r <= 1` always, on the
+live path, for every configuration. The measured `8649.0` came from the COG-28 SHADOW pass
+evaluated against an EMPTY live pool (`denom` degenerating to `sigma^n` alone at the 0.01
+fallback) — a path the code already clamps explicitly (`math.Min(r, 1.0)`) with a comment
+naming exactly this trap. Verified independently: read the loop guard and the shadow clamp
+in `internal/engine/activation/engine.go` before trusting either claim on faith (principle #9
+— severity and correctness both need independent verification, in either direction).
+
+**#805 is not a separate defect — it is the same phase's SECOND, independent reason nothing
+comes out, folded in here rather than tracked apart.** CGDN's Hebbian rescue term in
+`computeGatedActivation` is `rescue(d) = max(0, hebbianBoost - epsilon) * lambda`, with
+`epsilon = 0.01`. Association edge weights are clamped to `peakWeight * 0.05` in steady
+state (`internal/storage/association.go`), and a census of two production vault clones put
+the entire live `RelCoActivated` (Hebbian) population at a p50 of **0.0005** — twenty times
+below epsilon. So even after #768 is repaired, `hebbianBoost - epsilon` is negative for
+essentially every live edge and the rescue mechanism the function exists to provide is a
+no-op on its own terms — the same #801/#762 shape: a constant chosen against a write-time
+value (Hebbian cold-start seed 0.01, which epsilon was presumably set to match), applied to
+a quantity a decay pass moves 20x before anyone reads it.
+
+#### Disposition: kept, labelled INERT at both sites, not deleted, not flagged
+
+`computeComponents`, the CGDN branch of `phase6Score`, and `computeGatedActivation` **stay**,
+with the inertness recorded at the constant/gate in each case and pinned by
+`TestPhase6Score_CGDN_InertAtAnyPositiveThreshold`, which drives the real `phase6Score` CGDN
+path with a maximally strong candidate (perfect vector cosine, perfect FTS coverage) at the
+smallest representable positive threshold and asserts zero activations. Its RED control is
+the neighbouring `TestPhase6Score_CGDNPath`, which drives the SAME function over an
+equivalent fixture at `Threshold: 0.0` and DOES get output — proving the pin is not vacuous:
+raise the control's threshold above zero and it starts failing like the pin; lower the pin's
+threshold to zero and it passes trivially like the control. The two tests bound the defect
+exactly at zero, which is where it actually sits.
+
+This follows #801's disposition rule exactly, because the same two facts hold:
+
+- **CGDN has real, live per-vault configuration and transport surfaces**, checked before
+  deciding: `experimental_cgdn` (plasticity config, `internal/auth/plasticity.go`, all five
+  presets), `use_cgdn`/`cgdn_alpha`/`cgdn_beta`/`cgdn_power` (REST `openapi.yaml` and MBP
+  wire types, `internal/transport/mbp/types.go`), and `--mode cgdn` (the CLI REPL,
+  `cmd/muninn/repl_client.go`, with its own passthrough test). Deleting the scorer without
+  disposing of all of them turns an inert mechanism into silently-ignored explicit config —
+  principle #1's failure class arrived at by way of a cleanup, which is exactly what #801
+  named as the reason traversal was kept. (CGDN has no gRPC/proto or MCP surface today —
+  checked and confirmed absent — so this is a real but narrower surface footprint than
+  traversal's six; still enough to make deletion the wrong call.)
+- **Deletion cannot be undone cheaply, and repair is not free either.** Wiring
+  `ContentMatch` alone would surface a scorer whose OWN Hebbian floor (#805) still discards
+  essentially its entire live Hebbian-linked population — an honest fix is a coupled change
+  to both constants together, re-measured against a real vault, not a one-line patch. That
+  work is not done here; this entry records the finding and the disposition, not a repair.
+
+Comments at three sites carry the finding forward for the next reader: the CGDN branch in
+`phase6Score` (the gate itself, the corrected `r <= 1` proof, and why not to "fix"
+`ContentMatch` alone), `computeComponents`'s doc comment (the missing field, and why
+weighted-sum never noticed), and `computeGatedActivation`'s epsilon constant (the #805
+floor, restated at the site rather than only in this record).
+
+`docs/feature-reference.md` and `docs/retrieval-design.md` previously described CGDN as
+simply "experimental" with no caveat about output; both now state the inertness and cite
+this entry, mirroring what #801 did for `docs/feature-reference.md`'s traversal row.
+
+#### The census: a units/scale check for "constant vs. a decaying quantity", not "every threshold"
+
+#805 asked, as its own machine check: *"a units/scale census over every constant compared
+against an association weight: assert each is either derived per-vault or documented with
+the steady-state range it is meant to discriminate."* Built as
+`TestWeightGateCensus`/`TestWeightGateCensusMatcherFixture`
+(`internal/engine/activation/weight_gate_census_test.go`), in the shape of
+`TestLastAccessElapsedCensus` (`internal/storage/lastaccess_census_test.go`) — an AST walk
+of the whole module, a named-sites floor, and a SEPARATE matcher self-check driven by a
+synthetic fixture, because (as that census's own history records) a vacuity guard on a bare
+count can pass while the walk or the matcher has silently gone blind.
+
+**Scope, deliberately narrow.** "Every threshold in the engine" was tried and rejected as
+too broad to be useful. The rule that shipped: a **named, hardcoded numeric `const`**
+(function-local or file-scoped — never a variable, a struct field, or a plasticity-derived
+value, which are already per-vault by construction) compared (`<`,`<=`,`>`,`>=`) or
+subtracted against a quantity that is, or is transitively assigned from, a `.Weight`
+selector or the identifier `hebbianBoost`/`HebbianBoost` (case-insensitive) — this
+codebase's vocabulary for association-edge-derived strength. Two things were tried and
+explicitly rejected during development, both because they produced real noise measured
+against the actual tree, not hypothetically:
+
+- Matching bare numeric literals (not only named consts) — this additionally flagged
+  `update.Weight > restoreWeight*1.5` and `newCoAct >= existingCoAct+3` in
+  `internal/storage/association.go`, neither of which is the defect: a named constant is
+  specifically the signal that a human chose a number once and is unlikely to ever revisit
+  it, which is how both #801 and #805 went unnoticed since the initial commit.
+- Matching the substring "boost" instead of the exact `hebbianBoost` identifier — this
+  caught `entityBoostNoiseFloor` (`internal/engine/engine_entity_boost.go`), a named float
+  constant genuinely compared against a derived quantity (`contribution`), but that quantity
+  is `entityBoostFactor * idf` — an entity-rarity IDF score with no decay pass touching it,
+  not an association weight. A FALSE POSITIVE, kept in the matcher fixture
+  (`notAssociationWeight`) as the permanent regression case for that vocabulary choice.
+
+**Result on the real tree: three sites, zero false positives.** `minHopScore` (#801) and
+`epsilon` (#805) were the two the record already knew about. The census found a **third**,
+previously undocumented in this class: `internal/consolidation/transitive.go:minWeight`
+(`runPhase5TransitiveInference`, gating transitive-edge inference at
+`max(Weight, PeakWeight) >= 0.7`). Inspection showed it is the **healthy** counter-example:
+its own comment already reasons about the achievable range — autoassoc mints edges at 0.3,
+archive restore returns them at `peakWeight * 0.25`, so neither route can reach 0.7, which is
+exactly why the threshold was chosen there and why a dangling edge (the risk the comment
+names) cannot climb to it. It is recorded in `weightGateKnownSites` alongside the two dead
+ones specifically so a reader sees both outcomes of doing the range-check: two constants
+that were never checked and are dead, one that was checked and is fine. The census asserts a
+site is DOCUMENTED, not that it is healthy — both `weightGateKnownSites` entries `minHopScore`
+and `epsilon` remain intentionally live and undeleted per this entry's own disposition,
+while `minWeight` needed no change at all.
+
+**RED-verified, not merely asserted.** Neutering the transitive-taint fixpoint (so only a
+direct `.Weight` selector — never a locally-assigned intermediate like `propagated` or
+`effectiveAB` — counts as tainted) was tried as the sabotage: `TestWeightGateCensus` lost 2
+of its 3 known sites and failed loudly naming which; `TestWeightGateCensusMatcherFixture`
+failed on the exact fixture case exercising that shape. Restoring the fixpoint made both
+pass again. The census is not vacuous with respect to its own matcher, by demonstration, not
+assumption — the same discipline `TestLastAccessCensusMatcherSeesLaunderedCopies` established
+after that census's own count-only guard was shown to lose 5 of 6 sites silently.
+
+**What this does NOT claim.** The census does not, and cannot, cover #768's actual defect —
+a field that is never SET, not a constant compared against the wrong range. That shape (an
+uninitialized/never-populated component silently zeroing a downstream gate) is a different
+mechanism from "a hardcoded number vs. a decaying quantity", and is caught here only by the
+behavioural pin (`TestPhase6Score_CGDN_InertAtAnyPositiveThreshold`), not by the AST census.
+Naming this boundary matters more than pretending one machine check now covers the whole
+class — see the census's own "what it does NOT catch" section, which states four further
+gaps (inter-function taint, non-`.Weight`/non-Hebbian vocabulary, and others) rather than
+implying completeness.
+
+**Principle: the same review that measured #801 correctly getting the arithmetic right also
+carried forward an overstated corollary (`r` unbounded) that a second, independent look
+disproved — severity and correctness both need independent re-verification in EITHER
+direction (principle #9), and a corrected record is worth more than a consistent one. And
+the class both defects share — a constant a person chose once, compared against a quantity
+that a decay pass moves 20x before anyone reads it — is now a standing, self-checking
+machine test rather than something that needs a third independent analysis pass to
+rediscover a third time.**

--- a/docs/retrieval-design.md
+++ b/docs/retrieval-design.md
@@ -117,7 +117,7 @@ type ActivationItem struct {
 }
 ```
 
-The `Weights` struct controls the temporal/semantic/hebbian balance. ACT-R is the only production scoring path. CGDN is available as an experimental alternative when `experimental_cgdn: true` is set in the vault's plasticity config.
+The `Weights` struct controls the temporal/semantic/hebbian balance. ACT-R is the only production scoring path. CGDN is nominally available as an experimental alternative when `experimental_cgdn: true` is set in the vault's plasticity config, but it is currently inert at any positive activation threshold — see `docs/internals/decision-record.md` (#768) — so enabling it returns nothing on the surface default threshold.
 
 ---
 

--- a/internal/engine/activation/cgdn_inert_test.go
+++ b/internal/engine/activation/cgdn_inert_test.go
@@ -1,0 +1,80 @@
+package activation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// TestPhase6Score_CGDN_InertAtAnyPositiveThreshold pins the #768 finding as a
+// fact of the shipped code rather than as a comment that can rot.
+//
+// computeComponents — the component producer the CGDN path uses — never sets
+// ScoreComponents.ContentMatch (only computeACTR does), so it keeps its Go
+// zero value. CGDN's abstention gate is
+//
+//	absolute := min(min(Raw, ContentMatch), 1.0) * Confidence
+//	if absolute < req.Threshold && !inTagPool { continue }
+//
+// which is `min(Raw, 0.0) * Confidence == 0.0` for every non-tag-pool row, so
+// ANY positive threshold drops every candidate. This test drives the real
+// phase6Score CGDN branch with a maximally strong candidate — perfect vector
+// cosine, perfect FTS coverage — at the smallest representable positive
+// threshold, and asserts zero activations.
+//
+// It cannot pass vacuously. Its RED control is the neighbouring
+// TestPhase6Score_CGDNPath, which drives the SAME function over an
+// equivalent fixture at Threshold: 0.0 and DOES get output: raise this test's
+// threshold to 0.0 and it would pass trivially like that one; lower
+// TestPhase6Score_CGDNPath's threshold above zero and it would start failing
+// like this one. The two tests bound the defect exactly at zero.
+//
+// If this test starts failing because CGDN began emitting results, do not
+// treat that as a silent improvement — ContentMatch was wired without also
+// checking #805 (the Hebbian rescue floor sits 20x above the steady-state
+// Hebbian edge weight, so a live CGDN would still discard nearly its entire
+// Hebbian-linked population). Read docs/internals/decision-record.md
+// (#768/#805) first, then update it, CLAUDE.md and docs/feature-reference.md,
+// all of which currently describe CGDN as untested/experimental rather than
+// as live.
+func TestPhase6Score_CGDN_InertAtAnyPositiveThreshold(t *testing.T) {
+	store := newInternalStubStore()
+	e := newTestActivationEngine(store)
+	defer e.Close()
+
+	eng1 := &storage.Engram{
+		Concept: "cgdn inert probe", Content: "cgdn inert probe content",
+		Confidence: 1.0, Stability: 30.0, Relevance: 0.8,
+		State: storage.StateActive,
+	}
+	store.addEngram(eng1)
+
+	// A maximally strong candidate: perfect vector cosine and perfect FTS
+	// coverage. If CGDN's content gate were honestly computed this would
+	// clear any realistic threshold by a wide margin.
+	fused := []fusedCandidate{{id: eng1.ID, rrfScore: 0.5, ftsScore: 1.0, vectorScore: 1.0}}
+	p1 := &phase1Result{queryStr: "test"}
+
+	const tinyPositiveThreshold = 1e-9
+
+	result, err := e.phase6Score(context.Background(), &ActivateRequest{
+		MaxResults: 10, Threshold: tinyPositiveThreshold,
+		Weights: &Weights{
+			UseCGDN:            true,
+			SemanticSimilarity: 0.5,
+			FullTextRelevance:  0.3,
+		},
+	}, [8]byte{}, fused, nil, p1)
+
+	if err != nil {
+		t.Fatalf("phase6Score with CGDN: %v", err)
+	}
+	if len(result.Activations) != 0 {
+		t.Fatalf("phase6Score(CGDN) returned %d activation(s) at threshold %.1e for a maximally "+
+			"strong candidate; #768 says CGDN cannot clear any positive threshold because "+
+			"ContentMatch is never set on this path. If this is now wired correctly, see the "+
+			"doc-update list in this test's comment before treating it as a fix.",
+			len(result.Activations), tinyPositiveThreshold)
+	}
+}

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -2162,6 +2162,38 @@ func (e *ActivationEngine) phase6Score(
 	// Pass 1 computes gated activations a(d) for all candidates; Pass 2 normalizes.
 	// This replicates lateral inhibition in hippocampal retrieval: cognitive state
 	// multiplicatively gates content relevance, then candidates compete via division.
+	//
+	// INERT at any positive threshold (#768). `computeComponents` below — the
+	// component producer this path uses — never sets ScoreComponents.ContentMatch
+	// (that field is only populated by computeACTR); it keeps its Go zero value,
+	// 0.0. The gate a few lines down is
+	//
+	//	absolute := min(min(Raw, ContentMatch), 1.0) * Confidence
+	//
+	// so `absolute` is exactly 0.0 for every candidate on this path, and
+	// `absolute < req.Threshold` drops every non-tag-pool row unless
+	// req.Threshold <= 0. CGDN has never returned a live result in a passing
+	// configuration for the life of the feature. Pinned by
+	// TestPhase6Score_CGDN_InertAtAnyPositiveThreshold; its RED control is the
+	// neighbouring TestPhase6Score_CGDNPath (threshold 0.0), which already
+	// gets output — proving the pin is not vacuous: threshold 0 emits,
+	// threshold > 0 does not, on the identical candidate.
+	//
+	// The live ratio `r = a(d)^n / denom` just below is NOT unbounded, contra
+	// an earlier reading of this code (#768's second claim): the Pass-2 loop
+	// only runs `if len(cgdnCands) > 0`, and in that branch `denom = sigma^n +
+	// sum(a_i^n)` includes the candidate's own a(d)^n term in the sum, so
+	// `denom >= a(d)^n` and `r <= 1` by construction for every live row. The
+	// measured 8649.0 blowup came from the SHADOW pass below, over an EMPTY
+	// live pool, which is why that pass clamps explicitly and the live pass
+	// does not need to.
+	//
+	// Do NOT "fix" ContentMatch here as a standalone patch: #805 found the
+	// Hebbian rescue floor (`epsilon` in computeGatedActivation) sitting 20x
+	// above the steady-state Hebbian edge weight, so wiring ContentMatch alone
+	// would surface a mechanism whose OWN floor still discards the entire live
+	// Hebbian population. See docs/internals/decision-record.md (#768/#805)
+	// before touching either constant.
 	if w.UseCGDN {
 		type cgdnItem struct {
 			c interface {
@@ -2608,6 +2640,13 @@ func relevanceCalibration(w resolvedWeights) RelevanceCalibration {
 // computeComponents calculates all scoring components for a candidate engram.
 // Accepts *storage.Engram directly — avoids a separate GetMetadata call in phase6.
 // lastAccessNs is the nanosecond timestamp of last cache access (0 if not cached).
+//
+// NOTE (#768): the returned ScoreComponents does NOT set ContentMatch — that
+// field is only populated by computeACTR. computeComponents is the producer
+// used by both the legacy weighted-sum path AND the CGDN path; weighted-sum
+// never reads ContentMatch, so this was harmless there, but CGDN's abstention
+// gate does read it (`min(Raw, ContentMatch)`), which makes CGDN inert at any
+// positive threshold. See the INERT comment at the CGDN branch in phase6Score.
 func computeComponents(vectorScore, ftsScore, hebbianBoost float64, eng *storage.Engram, lastAccessNs int64, now time.Time, w resolvedWeights) ScoreComponents {
 	const accessFreqSaturation = 100.0
 	const recencyHalfLifeDays = 7.0
@@ -2927,10 +2966,24 @@ func computeRRFScore(rrfScore, hebbianBoost, transitionBoost float64, eng *stora
 //
 // This creates a 41x advantage for the Hebbian-linked stale vs unlinked stale,
 // replicating retrieval-induced forgetting counteraction (Anderson & Bjork 1994)
-// and memory reconsolidation (Nader et al. 2000).
+// and memory reconsolidation (Nader et al. 2000) — in THEORY. In practice this
+// whole path is INERT (#768, see the block comment at the CGDN branch above),
+// so the illustration in the doc comment above never executes on a real
+// candidate. Recorded anyway (#805) because epsilon is wrong on its own terms
+// even if CGDN becomes live: it is a write-time constant compared against a
+// quantity that decays. Association edge weights are clamped to
+// `peakWeight * 0.05` in steady state (internal/storage/association.go), and a
+// census of two production vault clones found the entire live Hebbian
+// population (`RelCoActivated`) sitting at a p50 of 0.0005 — 20x BELOW
+// epsilon. `hebbianBoost` here is a weight of that same shape, so
+// `hebbianBoost - epsilon` is negative for essentially every live edge and
+// `rescue` floors to 0: the Hebbian-rescue mechanism this function exists to
+// provide would be a no-op even after #768 is repaired. Do not "fix" epsilon
+// in isolation — see docs/internals/decision-record.md (#768/#805) for why
+// this is folded into the same disposition rather than tuned separately.
 func computeGatedActivation(vectorScore, normalizedFTS, decayFactor, hebbianBoost float64, w resolvedWeights) float64 {
 	const (
-		epsilon      = 0.01 // Hebbian floor — prevents zero rescue for unlinked engrams
+		epsilon      = 0.01 // INERT floor (#805) — 20x above steady-state Hebbian weight; see doc comment above
 		rescueLambda = 0.8  // Hebbian rescue strength — how much Hebbian can restore decay
 	)
 	rescue := math.Max(0, hebbianBoost-epsilon) * rescueLambda

--- a/internal/engine/activation/weight_gate_census_test.go
+++ b/internal/engine/activation/weight_gate_census_test.go
@@ -1,0 +1,661 @@
+package activation
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestWeightGateCensus is the machine check #805 asked for, generalized
+// beyond CGDN: "a units/scale census over every constant compared against an
+// association weight: assert each is either derived per-vault or documented
+// with the steady-state range it is meant to discriminate."
+//
+// # Why it exists
+//
+// #801 and #805 are the same defect twice: a hardcoded numeric constant
+// (minHopScore = 0.05, epsilon = 0.01) compared against a quantity derived
+// from an association edge weight, chosen against the value that quantity
+// has at WRITE time and never checked against what it looks like at STEADY
+// STATE — which a decay pass moves by 20x before anyone reads it. Both were
+// found by two independent human analysis passes, months apart, on the same
+// codebase. A rule that makes the shape checkable turns "rediscovered as a
+// bug report" into "caught by CI".
+//
+// # What it asserts
+//
+// For every named, function-local OR file-scoped `const` declaration in the
+// module holding a raw numeric literal (an untyped float or int constant, NOT
+// a variable, NOT a struct field, NOT a plasticity/config value — see
+// "scope", below), if that constant is used anywhere in the same function as
+// one operand of a `<`, `<=`, `>`, `>=` comparison, or a `-` subtraction,
+// whose OTHER operand is WEIGHT-TAINTED — a direct `.Weight` selector, an
+// identifier literally named `hebbianBoost`/`HebbianBoost` (the field/param
+// name this codebase uses for Hebbian association strength throughout
+// scoring), or a local variable transitively assigned from either — the
+// constant must be a named, documented site in censusKnownSites (or
+// censusExemptions, with a stated reason). An undocumented match fails the
+// test.
+//
+// # Scope — deliberately narrow, and why
+//
+// "Every threshold in the engine" was considered and rejected: separate
+// review during this same change found `dynamicFloor := peakWeight * 0.05`
+// (internal/storage/association.go) and `restoreWeight := existingPeak * 0.25`
+// compared against association weights, but neither is a NAMED CONST — both
+// are local variables computed from a per-edge `peakWeight`, i.e. already
+// self-scaled to that edge rather than a global magic number. A rule that
+// flagged those would be noise: the defect this census targets is a
+// **hardcoded** constant applied to a **decaying** quantity, not "a
+// comparison involving a weight" in general. Widening the match to bare
+// numeric literals (not just named consts) was also tried and rejected: it
+// would have flagged `update.Weight > restoreWeight*1.5` and
+// `newCoAct >= existingCoAct+3`, neither of which is this defect — a named
+// constant is the signal that a human chose this number once and is unlikely
+// to ever revisit it, which is exactly how #801 and #805 both went unnoticed
+// since the initial commit.
+//
+// `entityBoostNoiseFloor` (internal/engine/engine_entity_boost.go) was the
+// closest real near-miss during development of this census: it IS a named
+// float constant compared against a derived quantity (`contribution`), and an
+// earlier draft of the taint vocabulary matched on the substring "boost",
+// which caught it. It is a FALSE POSITIVE for this rule: `contribution` is
+// `entityBoostFactor * idf`, an entity-rarity (IDF) score, not an association
+// edge weight — no decay pass ever touches it 20x between write and read. The
+// vocabulary below matches only `.Weight` selectors and the exact
+// `hebbianBoost`/`HebbianBoost` identifier (this codebase's one carrier of
+// Hebbian association strength through scoring), not the word "boost" as a
+// substring — narrowed specifically to stop matching that site. Verified by
+// TestWeightGateCensusMatcherFixture's notAssociationWeight case.
+//
+// # What it does NOT catch — the honest boundary
+//
+//   - Bare numeric literals used inline (not through a named const) never
+//     match, by design (see "scope" above) — a literal magic number IS still
+//     the same defect shape, but distinguishing "a deliberate calibration
+//     constant" from "an incidental literal" (a loop bound, an index) from
+//     syntax alone is not reliable, and the false-positive cost was measured
+//     as real (the `1.5`/`+3` sites above).
+//   - INTER-FUNCTION taint, exactly as in TestLastAccessElapsedCensus: a
+//     helper taking a bare `float64` named `w` and comparing it to a constant
+//     is invisible here unless the taint is visible from the call site within
+//     the same function body.
+//   - Non-Hebbian, non-`.Weight` association-derived quantities that don't
+//     happen to route through an identifier named `hebbianBoost` (e.g. a
+//     future `transitionBoost`-only gate) are not covered by today's
+//     vocabulary and would need it extended, with the same false-positive
+//     check repeated against the whole module before shipping.
+func TestWeightGateCensus(t *testing.T) {
+	root := moduleRootForCensus(t)
+
+	fset := token.NewFileSet()
+	var files []*ast.File
+	var paths []string
+	scanned := 0
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name != "." && (strings.HasPrefix(name, ".") || name == "vendor" || name == "node_modules" || name == "testdata") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		src, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		f, perr := parser.ParseFile(fset, path, src, 0)
+		if perr != nil {
+			return perr
+		}
+		rel, _ := filepath.Rel(root, path)
+		files = append(files, f)
+		paths = append(paths, filepath.ToSlash(rel))
+		scanned++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	if scanned == 0 {
+		t.Fatalf("census scanned no non-test Go files under %s — wrong module root?", root)
+	}
+
+	type site struct {
+		rel   string
+		fn    string
+		name  string
+		pos   string
+		other string
+	}
+	var found []site
+	seenExempt := map[string]bool{}
+	foundKeys := map[string]bool{}
+
+	for i, f := range files {
+		rel := paths[i]
+		for _, unit := range gateCensusUnits(f) {
+			for _, m := range weightGatedConstants(unit.body) {
+				s := site{rel: rel, fn: unit.label, name: m.constName, pos: fset.Position(m.pos).String(), other: m.otherExpr}
+				key := rel + ":" + m.constName
+				foundKeys[key] = true
+				found = append(found, s)
+			}
+		}
+	}
+
+	var undocumented []site
+	for _, s := range found {
+		key := s.rel + ":" + s.name
+		if _, ok := weightGateKnownSites[key]; ok {
+			continue
+		}
+		if _, ok := weightGateExemptions[key]; ok {
+			seenExempt[key] = true
+			continue
+		}
+		undocumented = append(undocumented, s)
+	}
+
+	// The FLOOR on the input set, same rationale as TestLastAccessElapsedCensus's
+	// censusKnownSites: a walk or matcher change that stops seeing a known site
+	// must name it, not silently report fewer matches as a clean pass.
+	var missing []string
+	for key, why := range weightGateKnownSites {
+		if !foundKeys[key] {
+			missing = append(missing, "  "+key+"\n      "+why)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("weightGateKnownSites: %d of %d known site(s) were NOT found by this walk:\n%s\n\n"+
+			"Either the site was legitimately removed/renamed (update the map in the same commit and "+
+			"say what replaced it), or the walk/matcher stopped reaching it and the census is now blind "+
+			"there.", len(missing), len(weightGateKnownSites), strings.Join(missing, "\n"))
+	}
+
+	total := len(found) + len(seenExempt)
+	if total == 0 {
+		t.Fatalf("census scanned %d non-test files and found ZERO constant-vs-weight comparisons. "+
+			"That is not the expected state (minHopScore and epsilon should both be found) — the "+
+			"walk or matcher is broken, not the codebase clean. Re-point it or fix it; do not read this "+
+			"as a pass.", scanned)
+	}
+
+	if len(undocumented) > 0 {
+		sort.Slice(undocumented, func(i, j int) bool { return undocumented[i].pos < undocumented[j].pos })
+		var b strings.Builder
+		for _, s := range undocumented {
+			b.WriteString(fmt.Sprintf("\n  %s  in %s():  const %s vs %s", s.pos, s.fn, s.name, s.other))
+		}
+		t.Errorf("UNDOCUMENTED constant compared against an association-weight-derived quantity:%s\n\n"+
+			"A hardcoded constant compared against, or subtracted from, a value derived from an "+
+			"association edge weight is exactly the #801/#805 shape: a threshold chosen against a "+
+			"write-time value, applied to a quantity a decay pass moves by ~20x before anyone reads it "+
+			"(peakWeight * 0.05 in internal/storage/association.go). Either derive this constant "+
+			"per-vault (principle #11), or add it to weightGateKnownSites with the measured "+
+			"steady-state range it is meant to discriminate against, or to weightGateExemptions with a "+
+			"stated structural reason it cannot carry that risk.", b.String())
+	}
+
+	for key, reason := range weightGateExemptions {
+		if !seenExempt[key] {
+			t.Errorf("weightGateExemptions has a stale entry %q (%s): no matching comparison was found "+
+				"there anymore — drop the exemption so it stops reading as coverage.", key, reason)
+		}
+	}
+
+	sort.Slice(found, func(i, j int) bool { return found[i].pos < found[j].pos })
+	var g []string
+	for _, s := range found {
+		g = append(g, fmt.Sprintf("%s (%s): const %s vs %s", s.pos, s.fn, s.name, s.other))
+	}
+	t.Logf("census scanned %d non-test files; %d weight-gated constant site(s), %d exempt:\n  %s",
+		scanned, len(found), len(seenExempt), strings.Join(g, "\n  "))
+}
+
+// weightGateKnownSites is the census's floor on its own input set: every
+// "<relpath>:<constName>" here must be found by the walk, AND each entry
+// records whether the constant's range was actually checked — this census
+// asserts a site is DOCUMENTED, not that it is HEALTHY; runPhase5TransitiveInference's
+// minWeight is the "checked and fine" case, kept in the same map as the two
+// "checked and dead" cases so a reader sees both outcomes of doing the work.
+var weightGateKnownSites = map[string]string{
+	"internal/engine/activation/engine.go:minHopScore": "#801 — phase5Traverse's hop gate. Compared " +
+		"against `propagated`, which is `baseScore * assoc.Weight * boost * hopPenalty^depth`. " +
+		"Documented INERT at the constant with the measured seed-score ceiling (0.0686559 unfiltered) " +
+		"and pinned by TestPhase5Traverse_InertAtTheMeasuredSeedCeiling.",
+	"internal/engine/activation/engine.go:epsilon": "#805 — CGDN's Hebbian rescue floor in " +
+		"computeGatedActivation. Compared (via subtraction) against hebbianBoost, an association edge " +
+		"weight. Documented INERT-on-its-own-terms at the constant: steady-state RelCoActivated p50 " +
+		"is 0.0005, twenty times below epsilon=0.01, so `rescue` floors to 0 for essentially every " +
+		"live Hebbian edge even once #768 (CGDN's separate, prerequisite defect) is repaired.",
+	"internal/consolidation/transitive.go:minWeight": "Found by this census, not by prose — and the " +
+		"HEALTHY counter-example to the other two. runPhase5TransitiveInference gates transitive-edge " +
+		"inference at effectiveAB/effectiveBC >= 0.7 (max of Weight and PeakWeight). Its own comment " +
+		"already reasons about the achievable range: autoassoc mints edges at 0.3, archive restore " +
+		"returns them at peakWeight*0.25, so neither route can reach 0.7 — the threshold was chosen " +
+		"specifically to be unreachable by anything except a genuinely repeated co-activation, and a " +
+		"dangling edge (the risk the comment names) cannot climb to it. Left as-is: this is a constant " +
+		"correctly checked against the quantities that can actually reach it, which is what the other " +
+		"two entries in this map should have been.",
+}
+
+// weightGateExemptions maps "<relpath>:<constName>" to a stated structural
+// reason a constant-vs-weight comparison found by the walk needs no
+// documented steady-state range. Empty today; kept as a named map (not
+// removed) so the shape matches TestLastAccessElapsedCensus's censusExemptions
+// and a future legitimate exemption has somewhere to go without inventing the
+// convention under time pressure.
+var weightGateExemptions = map[string]string{}
+
+// gateCensusUnit is one function body the census analyses, with a label.
+type gateCensusUnit struct {
+	label string
+	body  *ast.BlockStmt
+}
+
+// gateCensusUnits returns every *ast.FuncDecl body in f, plus package-level
+// *ast.FuncLit bodies (mirrors TestLastAccessElapsedCensus's censusUnits —
+// see its comment for why the literal case matters).
+func gateCensusUnits(f *ast.File) []gateCensusUnit {
+	var out []gateCensusUnit
+	for _, decl := range f.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if d.Body != nil {
+				out = append(out, gateCensusUnit{label: gateFuncLabel(d), body: d.Body})
+			}
+		case *ast.GenDecl:
+			if d.Tok != token.CONST && d.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range d.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, v := range vs.Values {
+					name := "_"
+					if i < len(vs.Names) {
+						name = vs.Names[i].Name
+					}
+					n := 0
+					ast.Inspect(v, func(node ast.Node) bool {
+						fl, ok := node.(*ast.FuncLit)
+						if !ok {
+							return true
+						}
+						label := name + " (func literal)"
+						if n > 0 {
+							label = fmt.Sprintf("%s (func literal #%d)", name, n+1)
+						}
+						n++
+						out = append(out, gateCensusUnit{label: label, body: fl.Body})
+						return false
+					})
+				}
+			}
+		}
+	}
+	return out
+}
+
+func gateFuncLabel(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return fn.Name.Name
+	}
+	t := fn.Recv.List[0].Type
+	if star, ok := t.(*ast.StarExpr); ok {
+		t = star.X
+	}
+	if id, ok := t.(*ast.Ident); ok {
+		return id.Name + "." + fn.Name.Name
+	}
+	return fn.Name.Name
+}
+
+// weightGateMatch is one (constant vs weight-tainted quantity) site.
+type weightGateMatch struct {
+	constName string
+	pos       token.Pos
+	otherExpr string
+}
+
+// weightGatedConstants finds every local named numeric const in body, and
+// every place it is compared (<,<=,>,>=) or subtracted against a
+// weight-tainted expression elsewhere in the SAME body.
+func weightGatedConstants(body *ast.BlockStmt) []weightGateMatch {
+	consts := localNumericConstNames(body)
+	if len(consts) == 0 {
+		return nil
+	}
+	tainted := taintedWeightIdents(body)
+
+	var out []weightGateMatch
+	seen := map[string]bool{} // constName -> already reported once for this body
+	report := func(name string, pos token.Pos, other ast.Expr) {
+		if seen[name] {
+			return
+		}
+		seen[name] = true
+		out = append(out, weightGateMatch{constName: name, pos: pos, otherExpr: renderExpr(other)})
+	}
+
+	ast.Inspect(body, func(n ast.Node) bool {
+		bin, ok := n.(*ast.BinaryExpr)
+		if !ok {
+			return true
+		}
+		switch bin.Op {
+		case token.LSS, token.LEQ, token.GTR, token.GEQ, token.SUB:
+		default:
+			return true
+		}
+		xName, xIsConst := constIdentName(bin.X, consts)
+		yName, yIsConst := constIdentName(bin.Y, consts)
+		xTainted := isWeightTainted(bin.X, tainted)
+		yTainted := isWeightTainted(bin.Y, tainted)
+
+		if xIsConst && yTainted && !yIsConst {
+			report(xName, bin.Pos(), bin.Y)
+		}
+		if yIsConst && xTainted && !xIsConst {
+			report(yName, bin.Pos(), bin.X)
+		}
+		return true
+	})
+	return out
+}
+
+// localNumericConstNames returns the names of every const declared directly
+// inside body (via a const DeclStmt) whose value is a raw numeric literal
+// (INT or FLOAT BasicLit) — i.e. a hardcoded calibration constant, not a
+// computed value, a struct field, or a config-derived variable.
+func localNumericConstNames(body *ast.BlockStmt) map[string]bool {
+	out := map[string]bool{}
+	for _, stmt := range body.List {
+		decl, ok := stmt.(*ast.DeclStmt)
+		if !ok {
+			continue
+		}
+		gd, ok := decl.Decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) {
+					continue
+				}
+				if lit, ok := vs.Values[i].(*ast.BasicLit); ok &&
+					(lit.Kind == token.FLOAT || lit.Kind == token.INT) {
+					out[name.Name] = true
+				}
+			}
+		}
+	}
+	return out
+}
+
+// constIdentName reports whether e is a bare identifier naming one of consts,
+// and returns that name.
+func constIdentName(e ast.Expr, consts map[string]bool) (string, bool) {
+	id, ok := e.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	return id.Name, consts[id.Name]
+}
+
+// isWeightTainted reports whether e is, or was assigned from (transitively,
+// per taintedWeightIdents), an association edge weight.
+func isWeightTainted(e ast.Expr, tainted map[string]bool) bool {
+	if containsWeightSelectorOrIdent(e) {
+		return true
+	}
+	found := false
+	ast.Inspect(e, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok && tainted[id.Name] {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// containsWeightSelectorOrIdent reports whether e directly contains a
+// `.Weight` selector or the exact identifier hebbianBoost/HebbianBoost — the
+// two vocabulary items, deliberately narrow (see the test's doc comment for
+// why "boost" as a substring is rejected).
+func containsWeightSelectorOrIdent(e ast.Node) bool {
+	found := false
+	ast.Inspect(e, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.SelectorExpr:
+			if node.Sel.Name == "Weight" {
+				found = true
+			}
+		case *ast.Ident:
+			if strings.EqualFold(node.Name, "hebbianBoost") {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+// taintedWeightIdents computes the fixpoint of local identifiers assigned
+// (directly or transitively) from a weight-tainted expression, mirroring
+// TestLastAccessElapsedCensus's taintedLastAccessIdents.
+func taintedWeightIdents(body *ast.BlockStmt) map[string]bool {
+	tainted := map[string]bool{}
+	for round := 0; round < 8; round++ {
+		grew := false
+		mark := func(lhs ast.Expr, rhs ast.Expr) {
+			id, ok := lhs.(*ast.Ident)
+			if !ok || id.Name == "_" || rhs == nil {
+				return
+			}
+			if tainted[id.Name] {
+				return
+			}
+			if isWeightTainted(rhs, tainted) {
+				tainted[id.Name] = true
+				grew = true
+			}
+		}
+		ast.Inspect(body, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.AssignStmt:
+				for i, lhs := range node.Lhs {
+					switch {
+					case len(node.Rhs) == len(node.Lhs):
+						mark(lhs, node.Rhs[i])
+					case len(node.Rhs) == 1:
+						mark(lhs, node.Rhs[0])
+					}
+				}
+			case *ast.ValueSpec:
+				for i, name := range node.Names {
+					if i < len(node.Values) {
+						mark(name, node.Values[i])
+					} else if len(node.Values) == 1 {
+						mark(name, node.Values[0])
+					}
+				}
+			}
+			return true
+		})
+		if !grew {
+			break
+		}
+	}
+	return tainted
+}
+
+func renderExpr(e ast.Expr) string {
+	switch n := e.(type) {
+	case *ast.Ident:
+		return n.Name
+	case *ast.SelectorExpr:
+		return renderExpr(n.X) + "." + n.Sel.Name
+	case *ast.BinaryExpr:
+		return renderExpr(n.X) + " " + n.Op.String() + " " + renderExpr(n.Y)
+	case *ast.CallExpr:
+		fn := ""
+		switch f := n.Fun.(type) {
+		case *ast.Ident:
+			fn = f.Name
+		case *ast.SelectorExpr:
+			fn = renderExpr(f)
+		}
+		return fn + "(...)"
+	case *ast.BasicLit:
+		return n.Value
+	}
+	return "<expr>"
+}
+
+// moduleRootForCensus walks up from the working directory to the directory
+// holding go.mod. Separate from storage's moduleRoot (unexported, different
+// package) but identical in behaviour.
+func moduleRootForCensus(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod found above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// TestWeightGateCensusMatcherFixture is the census's self-check, mirroring
+// TestLastAccessCensusMatcherSeesLaunderedCopies: TestWeightGateCensus cannot
+// vouch for its own matcher, since a broken taint analysis or a narrowed walk
+// can both look identical to "the codebase is clean" (zero matches). This
+// pins the matcher directly against one function body per shape.
+func TestWeightGateCensusMatcherFixture(t *testing.T) {
+	const fixture = `package fixture
+
+type Assoc struct{ Weight float64 }
+
+func directWeightSelector(a Assoc) bool {
+	const gateFloor = 0.05
+	return a.Weight < gateFloor
+}
+
+func transitivelyTaintedLocal(a Assoc, boost, penalty float64) bool {
+	const minHop = 0.05
+	propagated := a.Weight * boost * penalty
+	return propagated < minHop
+}
+
+func subtractionForm(hebbianBoost float64) float64 {
+	const epsilon = 0.01
+	rescue := hebbianBoost - epsilon
+	return rescue
+}
+
+func hebbianBoostCaseInsensitive(HebbianBoost float64) bool {
+	const floor = 0.02
+	return HebbianBoost > floor
+}
+
+func notAssociationWeight(idf float64) bool {
+	// entityBoostNoiseFloor's real shape: a named float const compared
+	// against a derived quantity that has nothing to do with association
+	// weight. Must NOT match — this is the exact false positive an earlier
+	// vocabulary (matching the substring "boost") produced against
+	// internal/engine/engine_entity_boost.go.
+	const entityBoostFactor = 0.15
+	const noiseFloor = 0.001
+	contribution := entityBoostFactor * idf
+	return contribution < noiseFloor
+}
+
+func unrelatedConstant(x float64) bool {
+	const cap = 100.0
+	return x < cap
+}
+
+func constVsConstIsNotThisShape() bool {
+	const a = 0.05
+	const b = 0.1
+	return a < b
+}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "fixture.go", fixture, 0)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+
+	cases := map[string]struct {
+		wantConsts []string
+		why        string
+	}{
+		"directWeightSelector":        {[]string{"gateFloor"}, "the base case: const compared directly against a.Weight"},
+		"transitivelyTaintedLocal":    {[]string{"minHop"}, "taint must survive `propagated := a.Weight * boost * penalty` before the comparison"},
+		"subtractionForm":             {[]string{"epsilon"}, "the SUB shape (hebbianBoost - epsilon), not just comparison operators"},
+		"hebbianBoostCaseInsensitive": {[]string{"floor"}, "the vocabulary matches hebbianBoost/HebbianBoost case-insensitively"},
+		"notAssociationWeight":        {nil, "FALSE POSITIVE CHECK: entityBoostNoiseFloor's real shape must NOT match — " + "'boost' as a bare substring is not in the vocabulary, only .Weight and the exact hebbianBoost identifier"},
+		"unrelatedConstant":           {nil, "an ordinary constant with no weight/hebbian involvement must not match"},
+		"constVsConstIsNotThisShape":  {nil, "two named consts compared to each other is not this defect — neither is a decaying quantity"},
+	}
+
+	seen := map[string]bool{}
+	for _, unit := range gateCensusUnits(f) {
+		want, ok := cases[unit.label]
+		if !ok {
+			t.Errorf("fixture func %q has no expectation — add one, or the fixture is dead weight", unit.label)
+			continue
+		}
+		seen[unit.label] = true
+
+		got := weightGatedConstants(unit.body)
+		var gotNames []string
+		for _, m := range got {
+			gotNames = append(gotNames, m.constName)
+		}
+		sort.Strings(gotNames)
+		wantSorted := append([]string(nil), want.wantConsts...)
+		sort.Strings(wantSorted)
+
+		if strings.Join(gotNames, ",") != strings.Join(wantSorted, ",") {
+			t.Errorf("%s: matcher found consts %v, want %v — %s", unit.label, gotNames, want.wantConsts, want.why)
+		}
+	}
+	for name := range cases {
+		if !seen[name] {
+			t.Errorf("expectation %q has no unit in the fixture — it was renamed or dropped", name)
+		}
+	}
+}


### PR DESCRIPTION
CGDN has never executed. Same shape as #801: a gate compared against a quantity whose achievable range was never checked.

`computeComponents` never sets `ContentMatch` on the CGDN path, so the mechanism is inert at any positive threshold. #805's epsilon floor sitting 20× above the steady-state association weight is unobservable behind that, so it folds in rather than being tracked separately.

## #768's second claim is false, and the record now says so

The issue reports `r` exploding to 8649. Verified independently: the live Pass-2 loop only runs `if len(cgdnCands) > 0`, and in that branch `denom = σⁿ + Σaⁿ` always includes the candidate's own `aⁿ`, so **`denom ≥ aⁿ` and `r ≤ 1` by construction.** The 8649 came from the already-clamped *shadow* pass over an empty live pool.

An overstated claim is itself a defect here, so this is corrected rather than repeated.

## Disposition: kept and labelled INERT, not deleted

The deciding question was concrete — does CGDN have config surfaces someone could set? It does: `experimental_cgdn` in plasticity config across all five presets, `use_cgdn`/`cgdn_alpha`/`cgdn_beta`/`cgdn_power` in REST `openapi.yaml` and MBP wire types, and `--mode cgdn` in the CLI REPL with its own passthrough test. Absent from gRPC, MCP and the web console.

So deleting it would orphan five config keys across three live surfaces — turning an inert mechanism into **silently-ignored explicit config**, which is principle #1's failure class arrived at by way of a cleanup. Exactly the #801 disposition, for exactly the same reason.

The arithmetic is labelled at three sites, and `docs/feature-reference.md` and `docs/retrieval-design.md` are corrected where they claim it works.

## The pin is non-vacuous

`TestPhase6Score_CGDN_InertAtAnyPositiveThreshold` drives the real `phase6Score` with a maximally strong candidate at threshold `1e-9` and asserts zero activations. Its control is the pre-existing `TestPhase6Score_CGDNPath` at threshold `0.0`, which *does* get output on the identical fixture — so the two together bound the defect exactly at zero. Break the mechanism and one fails; revive it and the other does.

## The census — the generalisable half

#801, #768 and #805 are three instances of one thing: **a threshold compared against a quantity whose achievable range was never checked.** `TestWeightGateCensus` makes that detectable rather than rediscovered: any named hardcoded numeric const compared against a `.Weight`-selector or Hebbian-boost-tainted quantity must be documented or exempted.

**3 true positives, 0 false positives.** `minHopScore` (#801), `epsilon` (#805), and a third nobody had noticed — `consolidation/transitive.go:minWeight`, which turned out to be the *healthy* counter-example: its comment already reasons about the achievable range.

Two broader variants were tried and **rejected because they produced real false positives** — bare-literal matching hit `association.go`'s clamp arithmetic, and substring-"boost" matching hit `entityBoostNoiseFloor`, an unrelated entity-IDF constant now pinned as the permanent regression case. A census that cries wolf gets exemptions written to silence it, and exemptions decay.

RED-verified by neutering the taint fixpoint: both the known-sites floor and the matcher fixture failed loudly and named the lost sites. That two-part structure is deliberate — the `lastaccess` census shipped with a vacuity guard that could never fire, and passed while silently losing 5 of its 6 sites.

## Proof the mechanism truly never fired

The standing corpora are unchanged: `TestMeasureRecallQuerySet`, `TestMeasureAbstentionGate` and `TestMeasureRelevanceBandHint` all pass with identical numbers. If CGDN had ever contributed, labelling it could not have left every number where it was.

Deferred and named: an honest coupled fix — wire `ContentMatch` and fix `epsilon` together, re-measured on a real vault — is deliberately not attempted here. The decision-record entry says why.

Closes #768, closes #805.
