### PR TITLE
fix(cli): render the upgrade note inertly on the terminal

### DIFF
--- a/cmd/muninn/upgrade.go
+++ b/cmd/muninn/upgrade.go
@@ -171,7 +171,33 @@ func upgradeNote(body string) string {
 func stripMarkdownEmphasis(s string) string {
 	s = strings.ReplaceAll(s, "**", "")
 	s = strings.ReplaceAll(s, "`", "")
-	return s
+	return stripTerminalControlBytes(s)
+}
+
+// stripTerminalControlBytes removes C0/C1 control characters and DEL from s,
+// keeping only tab and newline.
+//
+// The upgrade note originates in a GitHub Release body and is printed straight
+// to the operator's terminal. An ESC there is an escape sequence, not a
+// character: it can reposition the cursor, recolour, or overwrite text the
+// operator has already read — so a release body could make the printed note say
+// something other than what a reviewer saw on the release page.
+//
+// Today only someone with release-publish access on this repo can reach it, so
+// the threat model is thin. That is a property of who currently holds a
+// permission, not a property of the code, and it is the kind of assumption that
+// is true until an org grows. Rendering untrusted bytes inertly costs nothing.
+func stripTerminalControlBytes(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '\n' || r == '\t':
+			return r
+		case r < 0x20, r == 0x7f, r >= 0x80 && r <= 0x9f:
+			return -1
+		default:
+			return r
+		}
+	}, s)
 }
 
 // wrapText breaks s into lines of at most width columns, splitting on spaces.

--- a/cmd/muninn/upgrade_control_bytes_test.go
+++ b/cmd/muninn/upgrade_control_bytes_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+// A release body reaches the operator's terminal verbatim. An ESC is an escape
+// sequence rather than a character, so an unsanitized note could move the
+// cursor or overwrite text the operator already read — printing something other
+// than what a reviewer saw on the release page.
+//
+// RED without stripTerminalControlBytes: the ESC and the bell survive into the
+// rendered note.
+func TestStripMarkdownEmphasis_DropsTerminalControlBytes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ansi colour escape", "safe\x1b[31mred", "safe[31mred"},
+		{"cursor reposition", "before\x1b[2Kafter", "before[2Kafter"},
+		{"bell", "ding\x07dong", "dingdong"},
+		{"carriage return overwrite", "real\rfake", "realfake"},
+		{"DEL", "a\x7fb", "ab"},
+		{"C1 CSI", "a\u009bb", "ab"},
+		{"raw invalid byte survives as U+FFFD, which is inert", "a\x9bb", "a\uFFFDb"},
+		{"tab and newline survive", "a\tb\nc", "a\tb\nc"},
+		{"plain text untouched", "an ordinary note", "an ordinary note"},
+		{"markdown still stripped", "**bold** and `code`", "bold and code"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripMarkdownEmphasis(tc.in); got != tc.want {
+				t.Errorf("stripMarkdownEmphasis(%q) = %q, want %q — a control byte reaching the terminal can rewrite what the operator sees", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Promised follow-up to #748, done on our side rather than sent back.

`muninn upgrade` prints the release's upgrade note straight to the operator's terminal. That text comes from a GitHub Release body, and **an ESC there is an escape sequence, not a character** — it can reposition the cursor, recolour, or overwrite text already on screen. A release body could therefore make the printed note say something other than what a reviewer saw on the release page.

Strips C0, C1 and DEL; keeps tab and newline.

**On the threat model, honestly:** today only someone with release-publish access on this repo can reach this. That is narrow. But it is a fact about who currently holds a permission, not a property of the code, and it stops being true the moment the org grows or a token leaks. Rendering untrusted bytes inertly costs one `strings.Map`.

**One distinction the test pins deliberately.** A lone `0x9B` byte is invalid UTF-8, decodes to U+FFFD, and is *kept* — it renders as a replacement character and cannot drive the terminal. A real C1 CSI (`\u009b`, two bytes) is stripped. My first fixture conflated those and failed against correct code; the test now covers both so a future "tighten this" change cannot quietly start discarding legitimate malformed text instead.

RED: with the stripper removed, the ANSI-colour and cursor-reposition cases return their input unchanged.

Build, vet, gofmt clean; `cmd/muninn` green.