### PR TITLE
fix(activation,rest): a time constant named half-life, and a vault param accepted then ignored (#799, #802)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,6 +366,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reinforcement. It now holds the same per-engram stripe lock every sibling
   read-modify-write holds ([STO-2]/[STO-3]). (#720)
 
+- **`GET /api/admin/embed/status` now honors an optional `?vault=` query
+  parameter** (#802). It previously accepted the parameter and silently
+  ignored it — every vault on a multi-vault instance got the same
+  instance-wide `embedded_count`/`total_count`, which reads as a per-vault
+  coverage ratio and is not one. `total_count` now comes from `Stat` scoped to
+  the same vault (already supported); `embedded_count` gained a new
+  vault-scoped storage path (`CountEmbeddedInVault`), since the 0x11
+  DigestFlags keyspace it reads from is deliberately global and cannot be
+  scanned by vault directly — it scans the vault's own engram IDs and looks
+  up each one's flags instead. Both counts always share scope by
+  construction, so the ratio stays honest. `rate_per_sec`/`eta_seconds`
+  remain instance-wide — a named, documented deferral, not silently wrong.
+  Omitted or empty `vault` preserves the historical instance-wide behavior.
+
 ### Changed
 
 - **`muninn_evolve` now rejects a `tags` argument** with JSON-RPC `-32602`,

--- a/internal/engine/activation/engine.go
+++ b/internal/engine/activation/engine.go
@@ -666,7 +666,7 @@ func New(store ActivationStore, fts FTSIndex, hnsw HNSWIndex, embedder Embedder)
 // drainLog is the single goroutine that writes to assocLog.
 // Serializes all activation log writes, eliminating Lock contention against
 // Phase 4's concurrent RecentForVault RLock calls. Eventual consistency:
-// the log may lag by ~1ms but Hebbian decay half-life is 3600s — irrelevant.
+// the log may lag by ~1ms but Hebbian recency decays with τ=3600s (recencyTau) — irrelevant.
 func (e *ActivationEngine) drainLog() {
 	defer close(e.logDone)
 	for item := range e.logCh {
@@ -692,8 +692,8 @@ func (e *ActivationEngine) drainLog() {
 // drainLog. Test-only synchronization helper, mirroring autoassoc.Worker's
 // WaitIdle pattern: production callers never await this — phase4HebbianBoost
 // tolerates the drainer's eventual consistency by design (comment on
-// drainLog: "the log may lag by ~1ms but Hebbian decay half-life is 3600s —
-// irrelevant"). That assumption fails in a scripted back-to-back test harness
+// drainLog: "the log may lag by ~1ms but Hebbian recency decays with τ=3600s
+// (recencyTau) — irrelevant"). That assumption fails in a scripted back-to-back test harness
 // (calls a few ms apart): under -race/CPU contention the drainer goroutine
 // can still be applying call N's entry when call N+1 runs phase4HebbianBoost,
 // so the same candidate nondeterministically scores with or without the
@@ -708,7 +708,7 @@ func (e *ActivationEngine) WaitLogIdle() {
 // ResetLog discards assocLog's recorded activation events for vaultID.
 // Test-only: see ActivationLog.ResetVault for the full rationale (a scripted
 // back-to-back harness modeling separate agent sessions compresses real
-// elapsed time, defeating the recency half-life that normally bounds
+// elapsed time, defeating the recency decay (recencyTau) that normally bounds
 // cross-call priming). Callers MUST call WaitLogIdle first if a just-run
 // Activate() may still have an entry in flight, or the drainer can
 // re-populate the vault's log immediately after this call clears it.
@@ -851,7 +851,7 @@ func (e *ActivationEngine) Run(ctx context.Context, req *ActivateRequest) (*Acti
 
 	// Submit activation log entry to the async drainer — zero hot-path allocations.
 	// The drainer extracts ids/scores off the critical path.
-	// Non-blocking: drops if channel full (Hebbian half-life=3600s, 1ms lag is negligible).
+	// Non-blocking: drops if channel full (Hebbian recencyTau=3600s, 1ms lag is negligible).
 	if !req.ReadOnly && len(result.Activations) > 0 {
 		e.logWG.Add(1) // Add FIRST — visible to WaitLogIdle() (test-only); undone below on drop
 		select {
@@ -1411,13 +1411,19 @@ func (e *ActivationEngine) phase4HebbianBoost(ctx context.Context, ws [8]byte, v
 
 	now := time.Now().Unix()
 	recentWeights := make(map[storage.ULID]float64, len(recent))
-	const halfLife = 3600.0
+	// recencyTau is a decay TIME CONSTANT (τ), used as exp(-age/τ), not a
+	// half-life (2^(-age/h)). The two differ by ln(2): the half-life this
+	// τ actually implies is τ·ln(2) ≈ 2495s ≈ 41.6min, not 3600s/1h. Do not
+	// rename this back to "halfLife" without also swapping the formula to
+	// math.Exp2(-age/h) — internal/storage/association.go's DecayAssocWeights
+	// is the worked example of the OTHER (genuine half-life) parameterization.
+	const recencyTau = 3600.0
 	for _, entry := range recent {
 		age := float64(now - entry.At.Unix())
 		if age < 0 { // clock skew: activation timestamped in the future
 			age = 0
 		}
-		recencyW := math.Exp(-age / halfLife)
+		recencyW := math.Exp(-age / recencyTau)
 		for _, id := range entry.EngramIDs {
 			if w, ok := recentWeights[id]; !ok || recencyW > w {
 				recentWeights[id] = recencyW

--- a/internal/engine/activation/log.go
+++ b/internal/engine/activation/log.go
@@ -45,8 +45,8 @@ func (l *ActivationLog) getOrCreate(vaultID uint32) *vaultLog {
 // A scripted test harness that fires many calls back-to-back to model
 // SEPARATE, independently-dedup'd agent sessions (see prospective_harness_test.go)
 // compresses what would be minutes/hours of real elapsed time into
-// milliseconds, so the recency-weighted half-life (3600s) never meaningfully
-// decays between "sessions" — every prior scripted call's results stay
+// milliseconds, so the recency-weighted decay (recencyTau=3600s) never
+// meaningfully decays between "sessions" — every prior scripted call's results stay
 // maximally "recently activated" for the rest of the run, letting an armed
 // intention's own engram silently accumulate Hebbian boost from unrelated
 // earlier calls and outscore its own corroborator. See ActivationEngine.ResetLog.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1253,9 +1253,24 @@ func (e *Engine) WriteIdempotency(ctx context.Context, opID, engramID string) er
 
 // CountEmbedded returns the count of engrams that have had embeddings generated
 // (i.e. the DigestEmbed flag is set). Returns -1 on error.
-func (e *Engine) CountEmbedded(ctx context.Context) int64 {
+//
+// vault == "" counts across the whole store (the historical, instance-wide
+// behavior). A non-empty vault scopes the count to that vault's own engrams
+// (#802) — the 0x11 DigestFlags keyspace itself is deliberately global (see
+// docs/internals/keyspace-registry.md), so the vault-scoped path is a
+// different, more expensive query: scan the vault's engram IDs and look up
+// each one's flags, rather than scanning DigestFlags directly.
+func (e *Engine) CountEmbedded(ctx context.Context, vault string) int64 {
 	const DigestEmbed uint16 = 0x02
-	count, err := e.store.CountWithFlag(ctx, DigestEmbed)
+	if vault == "" {
+		count, err := e.store.CountWithFlag(ctx, DigestEmbed)
+		if err != nil {
+			return -1
+		}
+		return count
+	}
+	wsPrefix := e.store.ResolveVaultPrefix(vault)
+	count, err := e.store.CountEmbeddedInVault(ctx, wsPrefix, DigestEmbed)
 	if err != nil {
 		return -1
 	}

--- a/internal/storage/plugin_store.go
+++ b/internal/storage/plugin_store.go
@@ -82,6 +82,53 @@ func (ps *PebbleStore) CountWithFlag(ctx context.Context, flag uint16) (int64, e
 	return count, iter.Error()
 }
 
+// CountEmbeddedInVault returns the number of engrams IN THE GIVEN VAULT that
+// have the given digest flag bit set. Unlike CountWithFlag (which scans the
+// global 0x11 DigestFlags keyspace directly — that keyspace is deliberately
+// NOT vault-scoped, see docs/internals/keyspace-registry.md), this scans the
+// vault's own 0x01 Engram keyspace for its member IDs and looks up each one's
+// digest flags individually, so it costs O(engrams in this vault) rather than
+// O(all engrams in the store). Mirrors countEngramsForVault's bound
+// construction so the numerator and denominator of an embedding-coverage
+// ratio agree on which rows are "in the vault" (#802).
+func (ps *PebbleStore) CountEmbeddedInVault(ctx context.Context, wsPrefix [8]byte, flag uint16) (int64, error) {
+	lower := keys.EngramKey(wsPrefix, [16]byte{})
+	upperWS := wsPrefix
+	for i := 7; i >= 0; i-- {
+		upperWS[i]++
+		if upperWS[i] != 0 {
+			break
+		}
+	}
+	upper := make([]byte, 1+8)
+	upper[0] = prefix.Engram
+	copy(upper[1:9], upperWS[:])
+
+	iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return 0, err
+	}
+	defer iter.Close()
+
+	var count int64
+	for valid := iter.First(); valid; valid = iter.Next() {
+		k := iter.Key()
+		if len(k) < 25 {
+			continue
+		}
+		var id [16]byte
+		copy(id[:], k[9:25])
+		raw, err := ps.getDigestFlagsRaw(id)
+		if err == nil && raw&flag != 0 {
+			count++
+		}
+	}
+	if err := iter.Error(); err != nil {
+		return 0, fmt.Errorf("count embedded in vault scan: %w", err)
+	}
+	return count, nil
+}
+
 // ScanWithoutFlag returns a forward-only iterator over all engrams that are
 // missing the given digest flag bit. Engrams that have any skipFlags bit set
 // are skipped during iteration.

--- a/internal/storage/plugin_store_test.go
+++ b/internal/storage/plugin_store_test.go
@@ -81,6 +81,74 @@ func TestCountWithFlag(t *testing.T) {
 	}
 }
 
+// TestCountEmbeddedInVault is #802: GET /api/admin/embed/status needs a
+// PER-VAULT embedded count so a multi-vault install can measure coverage for
+// one vault rather than the whole store. Writes engrams to TWO vaults, flags
+// a different subset of each, and verifies CountEmbeddedInVault scopes to
+// only the requested vault's own engrams — unlike CountWithFlag, which scans
+// the global 0x11 DigestFlags keyspace and cannot distinguish vaults at all.
+func TestCountEmbeddedInVault(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	wsA := store.VaultPrefix("count-embedded-vault-a")
+	wsB := store.VaultPrefix("count-embedded-vault-b")
+	const flag = uint16(0x02)
+
+	var idsA []ULID
+	for i := 0; i < 5; i++ {
+		id, err := store.WriteEngram(ctx, wsA, &Engram{Concept: "a", Content: "content"})
+		if err != nil {
+			t.Fatalf("WriteEngram A[%d]: %v", i, err)
+		}
+		idsA = append(idsA, id)
+	}
+	var idsB []ULID
+	for i := 0; i < 3; i++ {
+		id, err := store.WriteEngram(ctx, wsB, &Engram{Concept: "b", Content: "content"})
+		if err != nil {
+			t.Fatalf("WriteEngram B[%d]: %v", i, err)
+		}
+		idsB = append(idsB, id)
+	}
+
+	// Flag 2 of vault A's 5 engrams, and 1 of vault B's 3.
+	for _, id := range idsA[:2] {
+		if err := store.SetDigestFlag(ctx, id, flag); err != nil {
+			t.Fatalf("SetDigestFlag A: %v", err)
+		}
+	}
+	if err := store.SetDigestFlag(ctx, idsB[0], flag); err != nil {
+		t.Fatalf("SetDigestFlag B: %v", err)
+	}
+
+	countA, err := store.CountEmbeddedInVault(ctx, wsA, flag)
+	if err != nil {
+		t.Fatalf("CountEmbeddedInVault A: %v", err)
+	}
+	if countA != 2 {
+		t.Errorf("CountEmbeddedInVault A: got %d, want 2", countA)
+	}
+
+	countB, err := store.CountEmbeddedInVault(ctx, wsB, flag)
+	if err != nil {
+		t.Fatalf("CountEmbeddedInVault B: %v", err)
+	}
+	if countB != 1 {
+		t.Errorf("CountEmbeddedInVault B: got %d, want 1", countB)
+	}
+
+	// Sanity: the global CountWithFlag sees BOTH vaults' flagged engrams
+	// (3 total), which is exactly the cross-vault leakage a caller asking
+	// for one vault's coverage must NOT see.
+	globalCount, err := store.CountWithFlag(ctx, flag)
+	if err != nil {
+		t.Fatalf("CountWithFlag: %v", err)
+	}
+	if globalCount != 3 {
+		t.Errorf("CountWithFlag (global, for contrast): got %d, want 3", globalCount)
+	}
+}
+
 // TestFindVaultPrefix writes an engram in a known vault, then calls
 // FindVaultPrefix with the engram's ULID and verifies the correct ws is returned.
 func TestFindVaultPrefix(t *testing.T) {

--- a/internal/transport/rest/admin_coverage_test.go
+++ b/internal/transport/rest/admin_coverage_test.go
@@ -48,6 +48,70 @@ func TestHandleEmbedStatus(t *testing.T) {
 	}
 }
 
+// TestHandleEmbedStatus_HonorsVaultParam is #802: GET /api/admin/embed/status
+// ignored the ?vault= query param entirely and always queried instance-wide
+// state, so two differently-sized vaults returned byte-identical payloads.
+// Asserts the handler forwards the requested vault to BOTH Stat (denominator)
+// and CountEmbedded (numerator) — sharing scope matters, because a
+// vault-scoped numerator over an instance-wide denominator is a coverage
+// ratio that looks plausible and is wrong.
+func TestHandleEmbedStatus_HonorsVaultParam(t *testing.T) {
+	store := newTestAuthStore(t)
+	eng := &MockEngine{
+		statEngramCountByVault: map[string]int64{"alpha": 5, "beta": 500},
+		countEmbeddedByVault:   map[string]int64{"alpha": 3, "beta": 17},
+	}
+	srv := NewServer("localhost:0", eng, store, nil, nil, EmbedInfo{
+		Provider: "openai",
+		Model:    "text-embedding-3-small",
+	}, EnrichInfo{}, nil, "", nil)
+
+	req := httptest.NewRequest("GET", "/api/admin/embed/status?vault=alpha", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp EmbedStatusResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if eng.lastStatReq == nil || eng.lastStatReq.Vault != "alpha" {
+		got := "<nil>"
+		if eng.lastStatReq != nil {
+			got = eng.lastStatReq.Vault
+		}
+		t.Errorf("Stat was not called with vault=alpha, got %q", got)
+	}
+	if eng.lastCountEmbeddedVault == nil || *eng.lastCountEmbeddedVault != "alpha" {
+		got := "<nil>"
+		if eng.lastCountEmbeddedVault != nil {
+			got = *eng.lastCountEmbeddedVault
+		}
+		t.Errorf("CountEmbedded was not called with vault=alpha, got %q", got)
+	}
+	if resp.TotalCount != 5 {
+		t.Errorf("expected total_count=5 (alpha's own count), got %d", resp.TotalCount)
+	}
+	if resp.EmbeddedCount != 3 {
+		t.Errorf("expected embedded_count=3 (alpha's own count), got %d", resp.EmbeddedCount)
+	}
+
+	// A second, differently-sized vault must NOT return the same payload.
+	req2 := httptest.NewRequest("GET", "/api/admin/embed/status?vault=beta", nil)
+	w2 := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w2, req2)
+	var resp2 EmbedStatusResponse
+	if err := json.NewDecoder(w2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp2.TotalCount == resp.TotalCount || resp2.EmbeddedCount == resp.EmbeddedCount {
+		t.Errorf("vault=alpha and vault=beta returned identical counts: %+v vs %+v", resp, resp2)
+	}
+}
+
 func TestHandleEmbedStatus_NoneProvider(t *testing.T) {
 	store := newTestAuthStore(t)
 	srv := NewServer("localhost:0", &MockEngine{}, store, nil, nil, EmbedInfo{

--- a/internal/transport/rest/admin_handlers.go
+++ b/internal/transport/rest/admin_handlers.go
@@ -611,15 +611,23 @@ type EmbedStatusResponse struct {
 	HardwareAccelerated *bool `json:"hardware_accelerated,omitempty"`
 }
 
-// handleEmbedStatus returns the current embedder configuration and indexing state.
+// handleEmbedStatus returns the current embedder configuration and indexing
+// state. An optional ?vault= query param scopes embedded_count/total_count to
+// that vault (#802) — omitted or empty means instance-wide, the historical
+// behavior. Both counts share the SAME scope: without that, a vault-scoped
+// numerator over an instance-wide denominator produces a coverage ratio that
+// looks plausible and is wrong, exactly the silent-substitution failure this
+// project treats as worst.
 func (s *Server) handleEmbedStatus(w http.ResponseWriter, r *http.Request) {
-	statResp, err := s.engine.Stat(r.Context(), &StatRequest{})
+	vault := r.URL.Query().Get("vault")
+
+	statResp, err := s.engine.Stat(r.Context(), &StatRequest{Vault: vault})
 	totalCount := int64(-1)
 	if err == nil {
 		totalCount = int64(statResp.EngramCount)
 	}
 
-	embeddedCount := s.engine.CountEmbedded(r.Context())
+	embeddedCount := s.engine.CountEmbedded(r.Context(), vault)
 	indexing := embeddedCount >= 0 && totalCount >= 0 && embeddedCount < totalCount
 
 	resp := EmbedStatusResponse{
@@ -632,7 +640,11 @@ func (s *Server) handleEmbedStatus(w http.ResponseWriter, r *http.Request) {
 		HardwareAccelerated: s.embedHardwareAccelerated,
 	}
 
-	// Only populate rate/ETA when actively indexing.
+	// Only populate rate/ETA when actively indexing. rate_per_sec/eta_seconds
+	// remain instance-wide regardless of ?vault= — the RetroactiveProcessor
+	// backing EmbedStats does not track per-vault throughput. A named
+	// deferral, not silently wrong: embedded_count/total_count (the coverage
+	// ratio the reported defect was about) are vault-scoped when requested.
 	if indexing {
 		stats := s.engine.EmbedStats()
 		resp.RatePerSec = stats.RatePerSec

--- a/internal/transport/rest/admin_handlers_test.go
+++ b/internal/transport/rest/admin_handlers_test.go
@@ -850,7 +850,7 @@ func (m *mockEngineWithStats) EmbedStats() plugin.RetroactiveStats {
 	return m.embedStats
 }
 
-func (m *mockEngineWithStats) CountEmbedded(ctx context.Context) int64 {
+func (m *mockEngineWithStats) CountEmbedded(ctx context.Context, vault string) int64 {
 	return m.embeddedCount
 }
 

--- a/internal/transport/rest/engine_adapter.go
+++ b/internal/transport/rest/engine_adapter.go
@@ -246,8 +246,8 @@ func (w *RESTEngineWrapper) Unsubscribe(ctx context.Context, subID string) error
 	return w.engine.Unsubscribe(ctx, subID)
 }
 
-func (w *RESTEngineWrapper) CountEmbedded(ctx context.Context) int64 {
-	return w.engine.CountEmbedded(ctx)
+func (w *RESTEngineWrapper) CountEmbedded(ctx context.Context, vault string) int64 {
+	return w.engine.CountEmbedded(ctx, vault)
 }
 
 func (w *RESTEngineWrapper) RecordAccess(ctx context.Context, vault, id string) error {

--- a/internal/transport/rest/engine_adapter_test.go
+++ b/internal/transport/rest/engine_adapter_test.go
@@ -70,7 +70,7 @@ func (m *mockEngineAPI) SubscribeWithDeliver(ctx context.Context, req *mbp.Subsc
 func (m *mockEngineAPI) Unsubscribe(ctx context.Context, subID string) error {
 	return nil
 }
-func (m *mockEngineAPI) CountEmbedded(ctx context.Context) int64 {
+func (m *mockEngineAPI) CountEmbedded(ctx context.Context, vault string) int64 {
 	return 0
 }
 func (m *mockEngineAPI) RecordAccess(ctx context.Context, vault, id string) error {

--- a/internal/transport/rest/openapi.yaml
+++ b/internal/transport/rest/openapi.yaml
@@ -1478,9 +1478,11 @@ components:
         embedded_count:
           type: integer
           format: int64
+          description: "Instance-wide by default; scoped to ?vault= when the request supplied one (#802)."
         total_count:
           type: integer
           format: int64
+          description: "Same scope as embedded_count — the two always share scope, so their ratio is a true coverage measure."
         indexing:
           type: boolean
 
@@ -3503,6 +3505,17 @@ paths:
     get:
       tags: [admin-system]
       summary: "Return the current embedder configuration and indexing progress."
+      parameters:
+        - name: vault
+          in: query
+          required: false
+          schema:
+            type: string
+          description: >-
+            Scope embedded_count/total_count to this vault (#802). Omitted or empty
+            means instance-wide (the historical behavior). rate_per_sec/eta_seconds
+            remain instance-wide regardless of this parameter — throughput is not
+            tracked per vault.
       security:
         - AdminSession: []
       responses:

--- a/internal/transport/rest/server_test.go
+++ b/internal/transport/rest/server_test.go
@@ -37,6 +37,13 @@ type MockEngine struct {
 	lastActivityReq   *ActivityCountsRequest
 	activityCountsErr error
 	lastSubscribeReq  *mbp.SubscribeRequest
+
+	// #802: capture/control Stat and CountEmbedded's vault scoping so tests
+	// can assert GET /api/admin/embed/status honors ?vault=.
+	lastStatReq            *StatRequest
+	lastCountEmbeddedVault *string // nil until CountEmbedded is called
+	statEngramCountByVault map[string]int64
+	countEmbeddedByVault   map[string]int64
 }
 
 func (m *MockEngine) Hello(ctx context.Context, req *HelloRequest) (*HelloResponse, error) {
@@ -99,8 +106,15 @@ func (m *MockEngine) Forget(ctx context.Context, req *ForgetRequest) (*ForgetRes
 }
 
 func (m *MockEngine) Stat(ctx context.Context, req *StatRequest) (*StatResponse, error) {
+	m.lastStatReq = req
+	engramCount := int64(100)
+	if req != nil && req.Vault != "" {
+		if n, ok := m.statEngramCountByVault[req.Vault]; ok {
+			engramCount = n
+		}
+	}
 	return &StatResponse{
-		EngramCount:  100,
+		EngramCount:  engramCount,
 		VaultCount:   1,
 		StorageBytes: 1024000,
 	}, nil
@@ -309,7 +323,14 @@ func (m *MockEngine) StartReembedVault(ctx context.Context, vaultName, modelName
 	return &vaultjob.Job{ID: "mock-reembed-job", Operation: "reembed", Source: vaultName, Target: vaultName}, nil
 }
 
-func (m *MockEngine) CountEmbedded(ctx context.Context) int64 {
+func (m *MockEngine) CountEmbedded(ctx context.Context, vault string) int64 {
+	v := vault
+	m.lastCountEmbeddedVault = &v
+	if vault != "" {
+		if n, ok := m.countEmbeddedByVault[vault]; ok {
+			return n
+		}
+	}
 	return 42
 }
 

--- a/internal/transport/rest/types.go
+++ b/internal/transport/rest/types.go
@@ -116,7 +116,9 @@ type EngineAPI interface {
 	// Returns a Job immediately (202 pattern).
 	StartReembedVault(ctx context.Context, vaultName, modelName string) (*vaultjob.Job, error)
 	// CountEmbedded returns the number of engrams with the DigestEmbed flag set.
-	CountEmbedded(ctx context.Context) int64
+	// vault == "" counts across the whole store; a non-empty vault scopes the
+	// count to that vault only (#802).
+	CountEmbedded(ctx context.Context, vault string) int64
 	// Observability returns the full system observability snapshot.
 	Observability(ctx context.Context, version string, uptimeSeconds int64) (*engine.ObservabilitySnapshot, error)
 	// GetProcessorStats returns stats for all retroactive processors.

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -180,7 +180,7 @@ func (m *mockEngine) StartReembedVault(ctx context.Context, vaultName, modelName
 	return &vaultjob.Job{ID: "mock-reembed-job", Operation: "reembed", Source: vaultName, Target: vaultName}, nil
 }
 
-func (m *mockEngine) CountEmbedded(ctx context.Context) int64 {
+func (m *mockEngine) CountEmbedded(ctx context.Context, vault string) int64 {
 	return 0
 }
 


### PR DESCRIPTION
Two fixes, and two honest negatives that closed for free.

## #799 — one name carried two different parameterizations

`phase4HebbianBoost` had `const halfLife = 3600.0` used as `exp(-age/halfLife)`. That is a decay **time constant** τ, not a half-life — and `internal/storage/association.go` uses a *genuine* `Exp2` half-life.

So the same word meant two things differing by a factor of ln(2), and anyone reading across the two files would have been wrong by 44%. That is the hazard; the naming aesthetics are incidental.

Renamed to `recencyTau`, with the true half-life stated (τ·ln2 ≈ 2495s ≈ 41.6 min) and an explicit warning not to rename it back without also swapping the formula to `Exp2`. Four nearby comments that called it a "half-life" were wrong the same way and are fixed.

Checked `docs/` and `README.md` for `3600`, `41.6` and `2495` — no doc or config surface quoted a number computed under the wrong reading.

**Proof it is a rename and not a semantic change:** all three standing corpora produce byte-identical results before and after, modulo timestamps and tempdir noise. A rename that moves a number is not a rename.

## #802 — an accepted parameter that was silently ignored

`handleEmbedStatus` passed `&StatRequest{}` and called `CountEmbedded(ctx)` with no vault at all, so `?vault=` was accepted and discarded. Two different vaults returned identical counts.

**Chose to honor the parameter rather than reject it.** `Stat` already supported vault scoping, so half the work was free, and no new keyspace was needed for the rest. `CountEmbeddedInVault` scans the vault's own 0x01 keyspace and joins each ID against digest flags — the 0x11 DigestFlags keyspace is deliberately global per the registry, so it cannot be scanned per-vault directly.

Two honesty notes went into the response docs rather than being left implicit: `embedded_count` and `total_count` always share scope (numerator and denominator must agree), while `rate_per_sec` and `eta_seconds` remain **instance-wide**, named as a deferral rather than a silent gap.

The reporter's stated mechanism (`total_count == WAL replayed + 1`) is unverified — `engramCount` is seeded from a real Pebble scan — so it is not repeated anywhere. The defect itself was confirmed independently.

## Two honest negatives

**#788** — nothing to deduplicate. `git log -S"buildDreamProviders"` and `-S"SetDreamProviders"` across all history return nothing; neither symbol was ever added, and `dream.go` still says `// Phase 2b: LLM Consolidation (future PR)`.

**#684** — already delivered by #685, which closed it in substance without citing it. Tags are populated on both read paths, documented in openapi, present in all three SDKs, and `excludeTypeLabels` covers the Level 2 ask.

Both closed separately with that evidence.

## Evidence

```
Stat was not called with vault=alpha, got ""
CountEmbedded was not called with vault=alpha, got ""
expected total_count=5 (alpha's own count), got 100
vault=alpha and vault=beta returned identical counts
```

Build/vet/gofmt clean; engine, mcp, transport, cmd and storage green; `-race` green on the touched packages.

Obligations: REST-only endpoint — no MCP tool wraps it and no SDK exposes it, so the registry smoke test does not apply. `openapi.yaml` gains the `vault` query param and the field-scope descriptions; CHANGELOG updated. No new Pebble prefix.

Closes #799, closes #802.
