### PR TITLE
fix(cli): a vault switch that could not persist said it had (#634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`muninn shell`'s `use <vault>` no longer reports success when the vault switch was not
+  persisted, and no longer clobbers unrelated keys in `~/.muninn/config`** (#634). The shell's
+  `use` command did call the persistence function (the issue's stated "does not persist"
+  mechanism did not reproduce), but that function, `saveDefaultVault`, discarded every error
+  from `MkdirAll`, `json.Marshal`, and `WriteFile` and always printed `Switched to vault
+  '<name>'` regardless of whether the write actually happened — a non-writable config path, a
+  full disk, or a permissions problem produced exactly the reported symptom of a stale default
+  vault surviving a switch the user was told succeeded. It also marshalled a fresh
+  `map[string]string{"default_vault": vault}` on every call, discarding any other key already
+  in the file. `saveDefaultVault` now returns an error, read-modify-writes to preserve unknown
+  keys, and `use` reports the failure and falls back to a session-only switch instead of
+  printing an unqualified success message.
+
 - **Consolidation now DECLARES supersession, closing a permanent recall hole over the fact it was meant to preserve** (#779).
   `muninn_consolidate` / `POST /api/consolidate` archived its source memories with a plain
   soft-delete: no `supersedes` edge, an open validity window. That is exactly the signature the

--- a/cmd/muninn/repl.go
+++ b/cmd/muninn/repl.go
@@ -171,8 +171,12 @@ func (r *replState) handleCommand(line string) bool {
 			return false
 		}
 		r.vault = args[0]
-		saveDefaultVault(r.vault)
-		fmt.Printf("Switched to vault '%s'\n", r.vault)
+		if err := saveDefaultVault(r.vault); err != nil {
+			fmt.Printf("Error: failed to save default vault: %v\n", err)
+			fmt.Printf("Switched to vault '%s' for this session only\n", r.vault)
+		} else {
+			fmt.Printf("Switched to vault '%s'\n", r.vault)
+		}
 
 	case "show vaults":
 		r.cmdShowVaults()

--- a/cmd/muninn/repl_client.go
+++ b/cmd/muninn/repl_client.go
@@ -462,12 +462,33 @@ func loadDefaultVault() string {
 	return ""
 }
 
-func saveDefaultVault(vault string) {
+// saveDefaultVault persists the selected vault to the config file, preserving
+// any other keys already present there. It reports failure to the caller
+// instead of failing silently: a non-writable config path, a full disk, or a
+// permissions problem must not present as a successful switch (#634).
+func saveDefaultVault(vault string) error {
 	path := configPath()
-	os.MkdirAll(filepath.Dir(path), 0700)
-	cfg := map[string]string{"default_vault": vault}
-	b, _ := json.Marshal(cfg)
-	os.WriteFile(path, b, 0644)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+
+	cfg := map[string]string{}
+	if b, err := os.ReadFile(path); err == nil {
+		// Best-effort: if the existing file is malformed we can't recover
+		// its contents, so we fall back to a fresh config rather than
+		// blocking the vault switch on it.
+		_ = json.Unmarshal(b, &cfg)
+	}
+	cfg["default_vault"] = vault
+
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("encode config: %w", err)
+	}
+	if err := os.WriteFile(path, b, 0644); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	return nil
 }
 
 // formatVaultTable prints vaults in a table format.

--- a/cmd/muninn/repl_client_test.go
+++ b/cmd/muninn/repl_client_test.go
@@ -175,6 +175,83 @@ func TestLoadSaveDefaultVault(t *testing.T) {
 	}
 }
 
+// TestUseCommand_WriteFailureIsReported verifies that when the config file
+// cannot be written, `use <vault>` reports the failure instead of printing
+// an unqualified "Switched to vault" success message (#634).
+//
+// The write is denied structurally rather than via chmod: ".muninn" is
+// created as a regular file, so the config directory can never be created
+// under it. A chmod-based permission denial does not apply when the test
+// runs as root, but this structural failure does regardless of privilege.
+func TestUseCommand_WriteFailureIsReported(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir) // os.UserHomeDir() checks USERPROFILE on Windows
+
+	if err := os.WriteFile(filepath.Join(tmpDir, ".muninn"), []byte("occupied"), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	r := &replState{}
+
+	oldStdout := os.Stdout
+	rp, wp, _ := os.Pipe()
+	os.Stdout = wp
+
+	r.handleCommand("use targetvault")
+
+	wp.Close()
+	os.Stdout = oldStdout
+
+	buf := make([]byte, 4096)
+	n, _ := rp.Read(buf)
+	output := string(buf[:n])
+
+	if strings.Contains(output, "Switched to vault 'targetvault'\n") {
+		t.Errorf("expected a failed persist to be reported, not a bare success message; got: %q", output)
+	}
+	if !strings.Contains(output, "Error") {
+		t.Errorf("expected the write failure to be reported to the user; got: %q", output)
+	}
+}
+
+// TestUseCommand_PreservesUnrelatedConfigKeys verifies that switching vaults
+// does not clobber other keys that may legitimately live in ~/.muninn/config
+// (#634).
+func TestUseCommand_PreservesUnrelatedConfigKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".muninn")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	configFile := filepath.Join(configDir, "config")
+	initial := `{"default_vault":"stalevault","future_setting":"keepme"}`
+	if err := os.WriteFile(configFile, []byte(initial), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	r := &replState{}
+	r.handleCommand("use targetvault")
+
+	b, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		t.Fatalf("config is not valid JSON after switch: %v", err)
+	}
+	if cfg["future_setting"] != "keepme" {
+		t.Errorf("expected unrelated config key to survive vault switch, got config: %s", string(b))
+	}
+	if cfg["default_vault"] != "targetvault" {
+		t.Errorf("expected default_vault updated to targetvault, got %v", cfg["default_vault"])
+	}
+}
+
 // TestCmdShowVaultsConnectionError verifies cmdShowVaults degrades gracefully
 // when the server is unreachable.
 func TestCmdShowVaultsConnectionError(t *testing.T) {


### PR DESCRIPTION
The issue's stated mechanism is wrong, and the symptom is real. Both worth recording.

## Not reproducible as filed

`case "use"` in `repl.go` **does** call `saveDefaultVault`, and has since before v0.8.0. So "`use` doesn't persist" is not what was happening.

## What was actually happening

`saveDefaultVault` discarded **every** error — `MkdirAll`, `json.Marshal` (`b, _ :=`), and `WriteFile` — while `repl.go` printed `Switched to vault '%s'` unconditionally.

So a non-writable `~/.muninn/config`, a full disk, or a permissions problem produces exactly the reported symptom: the success line prints and nothing persists. The reporter saw a real failure and reasonably attributed it one level too high.

That is the silent-substitution class this project treats as its worst — and it is the same shape as several others closed today: the drain reporting success it had not achieved, `selfUpdate` printing "Stopping daemon ✓" for a daemon it had not stopped, a census passing while losing five of its six sites.

## The second defect, which nobody reported

It marshalled a fresh `map[string]string{"default_vault": vault}` — so **every other key in the config was destroyed on each vault switch.**

Nothing else lives in that file today, which is precisely why this would have gone unnoticed until something did. Now a read-modify-write that preserves unknown keys, with a malformed file falling back to fresh rather than blocking the switch.

Enumerated the writers from the code rather than by name: `saveDefaultVault` is the **only** writer of that file, called from exactly one site. A read-modify-write in one place and a clobber in another would have been worse than two clobbers.

## The reporting change

On failure the shell now prints the error and falls back to `Switched to vault 'x' for this session only` instead of the unqualified success line, matching the existing in-shell `Error: %s` convention rather than inventing one.

**Judgment call, stated:** the session vault still switches on a write failure. In-shell state is cheap and reversible, so refusing the switch outright would be worse UX than switching with an honest qualifier. What is not acceptable is the unqualified success line, and that is gone.

## Evidence

```
expected a failed persist to be reported, not a bare success message;
  got: "Switched to vault 'targetvault'\n"

expected unrelated config key to survive vault switch,
  got config: {"default_vault":"targetvault"}
```

**The write-denial test is root-safe by construction.** Rather than chmod (which does nothing as root), it writes a plain **file** where `~/.muninn` needs to be a directory, so `MkdirAll` fails on filesystem shape. Deterministic for any user, no skip needed.

Build/vet/gofmt clean; `cmd/muninn` green. No `-race` — single-goroutine CLI file I/O, not storage or a worker.

Obligations walked: none of the fifteen apply. CHANGELOG updated, since a command that now reports failure where it printed success is user-visible.

Closes #634.
