### PR TITLE
fix(engine,mcp): recall-health and auth-source metrics, and a Push fixture that proved nothing (#606, #648, #702)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -3068,9 +3068,30 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 	// Run activation
 	result, err := e.activation.Run(ctx, actReq)
 	if err != nil {
+		// #606: hard-failure counter, labelled by a coarse reason so an
+		// operator can separate a caller-side cancellation/timeout (expected
+		// under load, not an embed/activation defect) from an actual
+		// activation error.
+		reason := "activation_error"
+		if errors.Is(err, context.DeadlineExceeded) {
+			reason = "timeout"
+		} else if errors.Is(err, context.Canceled) {
+			reason = "canceled"
+		}
+		metrics.RecallErrorsTotal.WithLabelValues(req.Vault, reason).Inc()
 		return nil, fmt.Errorf("activation: %w", err)
 	}
 	metrics.EngineActivationsTotal.Inc()
+	// #606: recall-health signal for the silent embed->BM25 fallback (#578,
+	// hardened for reachability by #658). result.SemanticDegraded already
+	// surfaces per-call on the MCP/MBP response (principle #2's "loud"); this
+	// counter is the fleet-level counterpart — an operator can alert on
+	// rate(muninndb_recall_embed_fallback_total)/rate(muninndb_activate_duration_seconds_count)
+	// per vault instead of scraping logs for the WARN that fires on every
+	// degraded call.
+	if result.SemanticDegraded {
+		metrics.RecallEmbedFallbackTotal.WithLabelValues(req.Vault).Inc()
+	}
 
 	// Entity boost phase: spread activation through shared named entities.
 	// After BFS produces a scored set, any engram sharing a named entity with a

--- a/internal/engine/prospective_harness_test.go
+++ b/internal/engine/prospective_harness_test.go
@@ -238,6 +238,26 @@ func runProspectiveHarness(t *testing.T, enabled bool) harnessResult {
 }
 
 // TestProspectiveAcceptance_Gates1to3 is the non-gameable acceptance gate.
+//
+// Known scope limit (#702 followup, verified not a current failure): this
+// fixture does not discriminate the >=2-carrier corroboration branch in
+// NoticesForRecall (internal/engine/prospective.go) from a mechanism that
+// fires on a single carrier. Every should_fire call's genuine corroborating
+// memory outranks the intention's own engram closely enough that the
+// top-scored-result rule alone accounts for all 15 fires; the corroboration
+// branch and its self-exclusion loop are never exercised end-to-end here.
+// Confirmed by disabling that branch (`ci.count < 2` -> `ci.count < 1000` in
+// prospective.go) and observing this test stay green at 15/15,
+// precision 1.000, zero unrelated notices. That branch IS pinned — by
+// TestNoticesForRecall_GenuineCorroborationStillFires,
+// TestNoticesForRecall_SelfFocality_SelfCorroboration, and
+// TestNoticesForRecall_IntentionTopWithSingleTailCarrier_NoFire in
+// prospective_test.go, which construct ScoredResult sets directly rather than
+// depending on real BM25/embedding ranking to route through it. A future
+// wording-only edit to testdata/prospective_session.json that makes the
+// corroborating memory rank below the intention for some should_fire case
+// would start exercising this branch through the harness too, but is not
+// required for correctness coverage — the unit tests already own it.
 func TestProspectiveAcceptance_Gates1to3(t *testing.T) {
 	res := runProspectiveHarness(t, true)
 	t.Logf("harness: fired=%d fired∧wanted=%d precision=%.3f recall=%d/%d=%.3f unrelated_notices=%d",

--- a/internal/engine/prospective_test.go
+++ b/internal/engine/prospective_test.go
@@ -301,6 +301,57 @@ func TestNoticesForRecall_GenuineCorroborationStillFires(t *testing.T) {
 	}
 }
 
+// TestNoticesForRecall_IntentionTopWithSingleTailCarrier_NoFire pins the COG-21
+// case named in #702 (followup 3): the intention's own engram ranks the TOP
+// result (so the top-path is self-excluded, #693) and exactly ONE genuine
+// external carrier appears in the tail. That is still only one real
+// corroborator — below the >=2 threshold — so the notice must NOT fire.
+// Distinct from TestNoticesForRecall_SelfFocality_SelfCorroboration, which has
+// an UNRELATED result at top and the intention itself in the tail; here the
+// intention is the top-scored result, exercising the OTHER self-exclusion
+// branch (the one guarding the top-path, not the corroboration-path).
+//
+// #702 also observed that the JSON acceptance fixture (prospective_session.json
+// / TestProspectiveAcceptance_Gates1to3) never distinguishes this from a
+// mechanism that fires on a single carrier: every should_fire case in that
+// fixture is satisfied by the top-result rule alone (the genuine corroborating
+// memory consistently outranks the intention's own engram for a
+// closely-worded query), so the fixture never drives NoticesForRecall through
+// the >=2-carrier branch or its self-exclusion loop at all. Verified directly:
+// widening the corroboration threshold in prospective.go from `ci.count < 2`
+// to `ci.count < 1000` (disabling multi-carrier corroboration outright) still
+// leaves TestProspectiveAcceptance_Gates1to3 green (15/15, precision 1.000,
+// zero unrelated notices) — see the design record for the harness this pins.
+// The unit tests in this file (this one and the two above) are what actually
+// pin that branch; the acceptance fixture measures end-to-end ranking
+// precision/recall, not this particular guard.
+func TestNoticesForRecall_IntentionTopWithSingleTailCarrier_NoFire(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+	const vault = "push-selffocal-vault-c"
+
+	realCarrier := writeMemWithEntities(t, eng, vault, "notes about widget procurement", "widget")
+
+	intentID, err := eng.Intend(ctx, vault, "when widget comes up, mention the recall bug", []string{"widget"}, nil, false, nil)
+	if err != nil {
+		t.Fatalf("Intend: %v", err)
+	}
+
+	seen, _ := newSession()
+	results := []ScoredResult{
+		{ID: intentID, Score: 10}, // the intention's own engram is the TOP result
+		{ID: realCarrier, Score: 1},
+	}
+	notices, err := eng.NoticesForRecall(ctx, vault, results, seen, false)
+	if err != nil {
+		t.Fatalf("NoticesForRecall: %v", err)
+	}
+	if len(notices) != 0 {
+		t.Fatalf("COG-21: intention-as-top + single genuine tail carrier must NOT fire: got %d notices, want 0 (%+v)", len(notices), notices)
+	}
+}
+
 // TestNoticesForRecall_TimeSilences pins "time SILENCES, never fires": an
 // intention whose valid_until has passed does not fire even on a focal cue.
 func TestNoticesForRecall_TimeSilences(t *testing.T) {

--- a/internal/engine/recall_metrics_test.go
+++ b/internal/engine/recall_metrics_test.go
@@ -1,0 +1,125 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/scrypster/muninndb/internal/engine/activation"
+	"github.com/scrypster/muninndb/internal/index/fts"
+	"github.com/scrypster/muninndb/internal/metrics"
+	"github.com/scrypster/muninndb/internal/storage"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// stubHNSW is a non-nil activation.HNSWIndex so phase1's embedder branch is
+// entered (mirrors activation.minimalHNSW, unexported there — this is the
+// internal/engine-package equivalent needed to drive Engine.activateCore's
+// #606 metrics through the real pipeline instead of a hand-built result).
+type stubHNSW struct{}
+
+func (stubHNSW) Search(_ context.Context, _ [8]byte, _ []float32, _ int) ([]activation.ScoredID, error) {
+	return nil, nil
+}
+
+// zeroVecEmbedder always returns an all-zero, non-error embedding — the
+// "err==nil but unusable" degradation path phase1 treats identically to an
+// unreachable backend (see engine/activation/engine.go's isZeroVector doc).
+type zeroVecEmbedder struct{}
+
+func (zeroVecEmbedder) Embed(_ context.Context, _ []string) ([]float32, error) {
+	return make([]float32, 8), nil
+}
+func (zeroVecEmbedder) Tokenize(text string) []string { return []string{text} }
+
+// testEnvWithHNSW is like testEnv but wires a non-nil HNSWIndex so phase1
+// actually attempts to embed (testEnv's plain noopEmbedder path never
+// reaches the degradation checks because activation.New's caller leaves hnsw
+// nil, which phase1 short-circuits on).
+func testEnvWithHNSW(t *testing.T, embedder activation.Embedder) (*Engine, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := storage.OpenPebble(dir, storage.DefaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := storage.NewPebbleStore(db, storage.PebbleStoreConfig{CacheSize: 1000})
+	ftsIdx := fts.New(db)
+	actEngine := activation.New(store, &ftsAdapter{ftsIdx}, stubHNSW{}, embedder)
+	eng := NewEngine(EngineConfig{Store: store, FTSIndex: ftsIdx, ActivationEngine: actEngine, Embedder: embedder})
+	return eng, func() {
+		eng.Stop()
+		store.Close()
+	}
+}
+
+// TestActivate_SemanticDegraded_IncrementsRecallEmbedFallbackMetric proves
+// #606: an activation call whose embedding could not be trusted (here, an
+// all-zero vector from a non-erroring embedder — same degradation class as
+// an unreachable backend) increments muninndb_recall_embed_fallback_total
+// for that vault, in addition to the existing per-call SemanticDegraded
+// response field.
+func TestActivate_SemanticDegraded_IncrementsRecallEmbedFallbackMetric(t *testing.T) {
+	eng, cleanup := testEnvWithHNSW(t, zeroVecEmbedder{})
+	defer cleanup()
+	ctx := context.Background()
+	const vault = "recall-metrics-degraded-vault"
+
+	if _, err := eng.Write(ctx, &mbp.WriteRequest{Vault: vault, Content: "some memory content for the vault"}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	before := testutil.ToFloat64(metrics.RecallEmbedFallbackTotal.WithLabelValues(vault))
+
+	resp, err := eng.Activate(ctx, &mbp.ActivateRequest{
+		Vault:   vault,
+		Context: []string{"some memory content"},
+	})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if !resp.SemanticDegraded {
+		t.Fatalf("expected SemanticDegraded=true on the response (all-zero embedding), got false")
+	}
+
+	after := testutil.ToFloat64(metrics.RecallEmbedFallbackTotal.WithLabelValues(vault))
+	if after != before+1 {
+		t.Fatalf("muninndb_recall_embed_fallback_total{vault=%q} = %v, want %v", vault, after, before+1)
+	}
+}
+
+// TestActivate_HardError_IncrementsRecallErrorsMetric proves #606's error
+// counter: a hard activation failure (here, a context already cancelled
+// before Run) increments muninndb_recall_errors_total{vault,reason} — never
+// silently counted only as a returned error with no operator-visible signal.
+func TestActivate_HardError_IncrementsRecallErrorsMetric(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	const vault = "recall-metrics-error-vault"
+
+	if _, err := eng.Write(context.Background(), &mbp.WriteRequest{Vault: vault, Content: "seed memory"}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	before := testutil.ToFloat64(metrics.RecallErrorsTotal.WithLabelValues(vault, "timeout"))
+
+	// A context whose deadline is already past: Run's early ctx.Err() guards
+	// (and any deadline-derived sub-context) surface context.DeadlineExceeded.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	defer cancel()
+	time.Sleep(2 * time.Millisecond)
+
+	_, err := eng.Activate(ctx, &mbp.ActivateRequest{
+		Vault:   vault,
+		Context: []string{"seed"},
+	})
+	if err == nil {
+		t.Fatalf("expected Activate to fail with an already-expired context")
+	}
+
+	after := testutil.ToFloat64(metrics.RecallErrorsTotal.WithLabelValues(vault, "timeout"))
+	if after != before+1 {
+		t.Fatalf("muninndb_recall_errors_total{vault=%q,reason=timeout} = %v, want %v (err=%v)", vault, after, before+1, err)
+	}
+}

--- a/internal/mcp/auth_metrics_test.go
+++ b/internal/mcp/auth_metrics_test.go
@@ -1,0 +1,105 @@
+package mcp
+
+// auth_metrics_test.go — #648: observability for MCP auth source.
+//
+// authFromRequest already discriminates credential class structurally
+// (IsAPIKey / IsCapability / neither); these tests pin that the discrimination
+// is also surfaced as muninn_mcp_auth_total{source} for each of the four
+// authorized branches, and that a DENIED request emits nothing (only
+// authenticated traffic is counted — see #648's motivation: confirming zero
+// static-token traffic before a retirement).
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/scrypster/muninndb/internal/auth"
+	"github.com/scrypster/muninndb/internal/metrics"
+)
+
+func TestAuthFromRequest_MetricsSource_APIKey(t *testing.T) {
+	store := newMockKeyStore(auth.APIKey{ID: "metrics001", Vault: "v", Mode: auth.ModeFull})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer mk_metrics001")
+
+	before := testutil.ToFloat64(metrics.MCPAuthTotal.WithLabelValues(authSourceAPIKey))
+	a := authFromRequest(req, "mdb_static", store, nil)
+	if !a.Authorized {
+		t.Fatal("expected Authorized=true")
+	}
+	after := testutil.ToFloat64(metrics.MCPAuthTotal.WithLabelValues(authSourceAPIKey))
+	if after != before+1 {
+		t.Fatalf("muninn_mcp_auth_total{source=api_key} = %v, want %v", after, before+1)
+	}
+}
+
+func TestAuthFromRequest_MetricsSource_Capability(t *testing.T) {
+	stub := stubCapStore{cap: auth.Capability{Vault: "v", Mode: auth.ModeFull}}
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer cap_metrics001")
+
+	before := testutil.ToFloat64(metrics.MCPAuthTotal.WithLabelValues(authSourceCapability))
+	a := authFromRequest(req, "mdb_static", nil, stub)
+	if !a.Authorized {
+		t.Fatal("expected Authorized=true")
+	}
+	after := testutil.ToFloat64(metrics.MCPAuthTotal.WithLabelValues(authSourceCapability))
+	if after != before+1 {
+		t.Fatalf("muninn_mcp_auth_total{source=capability} = %v, want %v", after, before+1)
+	}
+}
+
+func TestAuthFromRequest_MetricsSource_StaticToken(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer mdb_metricstoken")
+
+	before := testutil.ToFloat64(metrics.MCPAuthTotal.WithLabelValues(authSourceStatic))
+	a := authFromRequest(req, "mdb_metricstoken", nil, nil)
+	if !a.Authorized {
+		t.Fatal("expected Authorized=true")
+	}
+	after := testutil.ToFloat64(metrics.MCPAuthTotal.WithLabelValues(authSourceStatic))
+	if after != before+1 {
+		t.Fatalf("muninn_mcp_auth_total{source=static_token} = %v, want %v", after, before+1)
+	}
+}
+
+func TestAuthFromRequest_MetricsSource_Open(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+
+	before := testutil.ToFloat64(metrics.MCPAuthTotal.WithLabelValues(authSourceOpen))
+	a := authFromRequest(req, "", nil, nil)
+	if !a.Authorized {
+		t.Fatal("expected Authorized=true (open-server mode)")
+	}
+	after := testutil.ToFloat64(metrics.MCPAuthTotal.WithLabelValues(authSourceOpen))
+	if after != before+1 {
+		t.Fatalf("muninn_mcp_auth_total{source=open} = %v, want %v", after, before+1)
+	}
+}
+
+// TestAuthFromRequest_MetricsSource_DeniedNotCounted proves a rejected
+// credential does not inflate any source counter — only authenticated
+// traffic is observable here (the request log / 401 response already carries
+// the denial signal).
+func TestAuthFromRequest_MetricsSource_DeniedNotCounted(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer mdb_wrong")
+
+	beforeStatic := testutil.ToFloat64(metrics.MCPAuthTotal.WithLabelValues(authSourceStatic))
+	beforeOpen := testutil.ToFloat64(metrics.MCPAuthTotal.WithLabelValues(authSourceOpen))
+
+	a := authFromRequest(req, "mdb_correct", nil, nil)
+	if a.Authorized {
+		t.Fatal("expected Authorized=false for wrong static token")
+	}
+
+	if got := testutil.ToFloat64(metrics.MCPAuthTotal.WithLabelValues(authSourceStatic)); got != beforeStatic {
+		t.Errorf("source=static_token counted a denied request: %v -> %v", beforeStatic, got)
+	}
+	if got := testutil.ToFloat64(metrics.MCPAuthTotal.WithLabelValues(authSourceOpen)); got != beforeOpen {
+		t.Errorf("source=open counted a denied request: %v -> %v", beforeOpen, got)
+	}
+}

--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/scrypster/muninndb/internal/auth"
+	"github.com/scrypster/muninndb/internal/metrics"
 )
 
 const mcpSessionHeader = "Mcp-Session-Id"
@@ -62,6 +63,17 @@ func authFromContext(ctx context.Context) AuthContext {
 // capStore may be nil to disable cap_ capability auth (pre-RFC #597 mode);
 // when non-nil, an invalid or expired cap_ token fails closed (never falls
 // through to open-server), mirroring the mk_ posture.
+
+// MCP auth source labels for muninn_mcp_auth_total (#648). Exported as
+// constants (not inlined at each call site) so the metric's label set is
+// defined once, next to the branches that emit it.
+const (
+	authSourceAPIKey     = "api_key"
+	authSourceCapability = "capability"
+	authSourceStatic     = "static_token"
+	authSourceOpen       = "open"
+)
+
 func authFromRequest(r *http.Request, requiredToken string, apiKeyStore apiKeyValidator, capStore capabilityValidator) AuthContext {
 	token, found := auth.ParseBearerToken(r.Header.Get("Authorization"))
 
@@ -70,6 +82,12 @@ func authFromRequest(r *http.Request, requiredToken string, apiKeyStore apiKeyVa
 	// isolation; an invalid or revoked key must never fall through to open access.
 	if found && len(token) > 3 && token[:3] == "mk_" && apiKeyStore != nil {
 		if key, err := apiKeyStore.ValidateAPIKey(token); err == nil {
+			// #648: emit the auth SOURCE only — never the token or any prefix
+			// of it. IsAPIKey/IsCapability already distinguish credential
+			// class structurally; this just makes that distinction
+			// observable to an operator deciding whether a static-token
+			// retirement is safe.
+			metrics.MCPAuthTotal.WithLabelValues(authSourceAPIKey).Inc()
 			return AuthContext{
 				Token:      token,
 				Authorized: true,
@@ -88,6 +106,7 @@ func authFromRequest(r *http.Request, requiredToken string, apiKeyStore apiKeyVa
 	// auth is disabled and the branch is skipped (backward-compatible).
 	if found && len(token) > 4 && token[:4] == "cap_" && capStore != nil {
 		if cap, err := capStore.ValidateCapability(token); err == nil {
+			metrics.MCPAuthTotal.WithLabelValues(authSourceCapability).Inc()
 			return AuthContext{
 				Token:        token,
 				Authorized:   true,
@@ -102,6 +121,7 @@ func authFromRequest(r *http.Request, requiredToken string, apiKeyStore apiKeyVa
 
 	// 2. Open-server mode — no static token required and no mk_ key presented.
 	if requiredToken == "" {
+		metrics.MCPAuthTotal.WithLabelValues(authSourceOpen).Inc()
 		return AuthContext{Authorized: true}
 	}
 
@@ -110,6 +130,7 @@ func authFromRequest(r *http.Request, requiredToken string, apiKeyStore apiKeyVa
 		return AuthContext{Authorized: false}
 	}
 	if auth.ValidateStaticToken(token, requiredToken) {
+		metrics.MCPAuthTotal.WithLabelValues(authSourceStatic).Inc()
 		return AuthContext{Token: token, Authorized: true}
 	}
 	return AuthContext{Authorized: false}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -69,6 +69,40 @@ var (
 		Name: "muninndb_embed_pending",
 		Help: "Number of engrams pending embedding",
 	})
+
+	// RecallEmbedFallbackTotal counts activation calls that degraded to
+	// BM25-only recall because the embed backend could not be trusted
+	// (unreachable, timed out even after #658's reserved budget, or returned
+	// a garbage/zero embedding). Paired with muninndb_activate_duration_seconds's
+	// per-vault _count (already the activation total) this gives an operator
+	// rate(fallback)/rate(total) embed-flakiness signal without a separate
+	// duplicate total counter (#606).
+	RecallEmbedFallbackTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "muninndb_recall_embed_fallback_total",
+		Help: "Total activation calls that degraded to BM25-only recall because the embed backend could not be trusted, per vault.",
+	}, []string{"vault"})
+
+	// RecallErrorsTotal counts activation calls that hard-failed (returned an
+	// error, not a degraded-but-successful result), labelled by a coarse
+	// reason so an operator can separate caller-side cancellation/timeout
+	// from an internal activation failure (#606).
+	RecallErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "muninndb_recall_errors_total",
+		Help: "Total activation calls that returned a hard error, per vault and reason.",
+	}, []string{"vault", "reason"})
+
+	// MCPAuthTotal counts each authenticated MCP request by the credential
+	// class that authenticated it. The three credential types are already
+	// structurally distinct (auth.AuthContext.IsAPIKey / IsCapability /
+	// neither-with-a-Token for the static mdb_ token / neither-with-no-Token
+	// for open-server mode) — this surfaces that existing distinction as a
+	// scrapeable signal so an operator can confirm zero static-token traffic
+	// before retiring it (#648). Never logs or labels the credential value
+	// itself, only its class.
+	MCPAuthTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "muninn_mcp_auth_total",
+		Help: "Total authenticated MCP requests by credential source (api_key, capability, static_token, open).",
+	}, []string{"source"})
 )
 
 // VaultStore is the subset of storage.PebbleStore methods needed by VaultEngramCollector.


### PR DESCRIPTION
Two observability gaps closed, and a finding in the Push acceptance harness that is the more important half.

## #702 — the acceptance fixture does not discriminate

Sabotaged `prospective.go`'s corroboration threshold — `ci.count < 2` → `ci.count < 1000`, disabling the multi-carrier branch **entirely** — and reran the gate:

```
harness: fired=15 fired∧wanted=15 precision=1.000 recall=15/15=1.000 unrelated_notices=0
--- PASS
```

**Green, with the mechanism switched off.** Every should-fire case's genuine corroborating memory outranks the intention's own engram closely enough that the top-result rule alone accounts for all 15 fires. The fixture never exercises the ≥2-carrier branch it was built to validate.

This is a test passing both ways on the harness that gates THE PUSH. Hardened with `TestNoticesForRecall_IntentionTopWithSingleTailCarrier_NoFire` — the COG-21 case the issue named as unpinned — and the gap is now documented directly on the acceptance test rather than left for the next person to rediscover.

```
COG-21: intention-as-top + single genuine tail carrier must NOT fire:
  got 1 notices, want 0
```

The JSON fixture itself is deliberately untouched: it is precision-tuned, and destabilising it to prove a point a unit test makes better would be the wrong trade.

**The 14/15 flake half is an honest negative** — `GOMAXPROCS=2 -race -count=20` gives **20/20**. The drain seam it needed already landed with #722. Grepped before building, found it in place. Second time today a "needs a seam" turned out to need only *using* the seam that existed.

## #606 — the fallback was already loud per-call, and blind per-fleet

Checked what existed first. `result.SemanticDegraded` already ships on every response via MCP and MBP/gRPC — that answers *"was this call degraded"*, which is the loud part of principle #2 and was never missing.

What was missing is the question an operator actually asks: **"is embed flaky right now, across the vault?"** A WARN on every degraded recall is noise nobody tails; a per-call field cannot be alerted on. So: two Prometheus counters at the single point in `activateCore` where `activation.Run` returns — `muninndb_recall_embed_fallback_total{vault}` and `muninndb_recall_errors_total{vault,reason}` with reason ∈ {timeout, canceled, activation_error}.

**Deviation, stated:** the issue also asked for a `muninndb_recall_total{vault}` denominator. Not added — `muninndb_activate_duration_seconds{vault}` already emits a `_count` that *is* that denominator, and a second counter would be a duplicate that can drift from it.

## #648 — surfacing, not deriving

`authFromRequest` already returns a structurally distinct `AuthContext` per credential class, so nothing needed deriving. Added `muninn_mcp_auth_total{source}` with `api_key`/`capability`/`static_token`/`open` at the four `Authorized: true` return points.

Denied requests are deliberately not counted (pinned by test), and **no credential or prefix of one is ever logged or used as a label.**

## Evidence

```
muninndb_recall_embed_fallback_total{vault="..."} = 0, want 1
muninndb_recall_errors_total{vault="...",reason=timeout} = 0, want 1
muninn_mcp_auth_total{source=api_key} = 0, want 1
  ... capability, static_token, open
```

Build/vet/gofmt clean; engine, mcp, auth, plugin, transport green; `-race` green on engine, mcp and metrics.

Obligations: none of the fifteen apply — no new tool, route, preset, prefix, `ActivateRequest` field or wire field. `SemanticDegraded` is existing and unmodified.

Closes #606, closes #648, closes #702.
