### PR TITLE
test(engine): fix -race flake in COG-29 contradiction-debt fixture (#875)

### DIFF
--- a/internal/engine/engine_contradiction_debt_test.go
+++ b/internal/engine/engine_contradiction_debt_test.go
@@ -50,8 +50,13 @@ func debtPairFixture(t *testing.T, eng *Engine, vault, subject, factA, factB str
 		t.Fatal(err)
 	}
 	ws := eng.Store().ResolveVaultPrefix(vault)
+	// Weight deliberately distinct from the auto-detected contradiction marker's
+	// weight. The contradiction worker emits its own (different-RelType) detected
+	// edge between these near-identical facts; if both edges land at the same
+	// (src, weight, target) the assoc_reltype_guard rejects the second write and
+	// the fixture flakes. The readout counts Declared edges regardless of weight.
 	if err := eng.Store().WriteAssociation(ctx, ws, idB, idA, &storage.Association{
-		TargetID: idA, RelType: storage.RelContradicts, Weight: 0.8, Confidence: 1,
+		TargetID: idA, RelType: storage.RelContradicts, Weight: 0.5, Confidence: 1,
 		CreatedAt: declaredAt,
 	}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fixes #875.

## Root cause

`TestContradictionDebt_ZeroDeclaredAtIsUnknownNotEpoch` (and other callers of `debtPairFixture`) flake under `-race` on a slow/contended runner (CI `ubuntu-latest`; reproduced in a `--cpus 0.5` linux container). `debtPairFixture` writes an explicit **declared** `RelContradicts` (rel_type 2) edge between two near-identical facts at weight 0.8. The contradiction worker independently **detects** the same near-identical pair and emits its own (different-RelType, 0x10) detected edge at the same weight. When the worker's edge lands first, `assoc_reltype_guard` rejects the fixture's declared write:

```
engine_contradiction_debt_test.go:320: association write would replace a different
rel_type at the same weight: existing rel_type 16 at weight 0.8 … new rel_type 2
```

and the fixture's `WriteAssociation` fatals. (A second failure mode — `Count:1` — is the same race observed downstream.)

The guard is intentionally one-RelType-per-`(src, weight, target)` (`assoc_reltype_guard.go`: "does not give multi-RelType coexistence … deliberately defers"), so a *declared* edge and an *auto-detected* marker cannot coexist at the same key.

## Fix

Give the fixture's declared edge a weight distinct from the worker's auto-detected marker (0.8 → 0.5). Both edges then land at different keys; the race window disappears. The readout counts Declared edges regardless of weight, so `Count` / `DeclaredAt` / `Oldest` assertions are unaffected. Minimal, test-only, with a comment explaining the collision.

## Verification (RED → GREEN on the reproduction environment)

Reproduced in a cpu-throttled linux container (`podman run --cpus 0.5 golang:1.26 …`), which matches CI's slow/contended timing:

```
# before this fix
$ go test -race -run TestContradictionDebt ./internal/engine/ -count=50   # (--cpus 0.5)
--- FAIL: TestContradictionDebt_ZeroDeclaredAtIsUnknownNotEpoch (0.06s)
    engine_contradiction_debt_test.go:320: …existing rel_type 16… new rel_type 2
FAIL

# after this fix
$ go test -race -run TestContradictionDebt ./internal/engine/ -count=100  # (--cpus 0.5)
ok  	github.com/scrypster/muninndb/internal/engine	172.061s
```

Functional assertions still pass (`--- PASS`, `Count==2`, zero-`DeclaredAt` sorts first). The flake does not reproduce off-CI on an unloaded macOS/linux host — it needs the contended-runner timing, which is why CI caught it and local `make` didn't.

## Scope

Test-only. Does not touch engine logic, the guard, or the worker. A separate, deeper question the fix does **not** address (out of scope here): `WaitWriteTimeIdle` drains `autoAssoc`/`neighborWorker`/`goalLinkWorker`/`fts`/`activation` but not the contradiction worker, and declared-vs-detected edges can't coexist at one key by design — both are latent and worth their own thread, but neither is needed to stop this flake.
