### PR TITLE
fix(replication): per-key follower cache invalidation after apply — a connected lobe no longer serves deleted memories (#869)

### DIFF
--- a/cmd/muninn/server.go
+++ b/cmd/muninn/server.go
@@ -1251,9 +1251,10 @@ func runServer() {
 	// Wire ClusterCoordinator when cluster mode is enabled.
 	var coordinator *replication.ClusterCoordinator
 	var repLog *replication.ReplicationLog
+	var applier *replication.Applier
 	if clusterCfg.Enabled {
 		repLog = replication.NewReplicationLog(db)
-		applier := replication.NewApplier(db)
+		applier = replication.NewApplier(db)
 		epochStore, err := replication.NewEpochStore(db)
 		if err != nil {
 			slog.Error("create epoch store", "err", err)
@@ -1341,6 +1342,18 @@ func runServer() {
 	// Wire MOL into coordinator for periodic SafePrune.
 	if coordinator != nil {
 		coordinator.SetMOL(mol)
+	}
+
+	// #869: replicated writes are committed by the applier straight to Pebble,
+	// underneath this store's in-memory caches — a follower that had cached an
+	// engram kept serving it unchanged (deletes included) until restart. Feed
+	// every applied key back into the store so the touched cache entries drop.
+	// This is the mirror of storeCfg.RepLogAppend above: that hook carries
+	// local writes storage→replication; this one carries applied keys
+	// replication→storage. Both are wired here because neither package may
+	// import the other.
+	if applier != nil {
+		applier.SetInvalidate(store.InvalidateReplicatedKey)
 	}
 
 	// Build indexes

--- a/internal/replication/applier.go
+++ b/internal/replication/applier.go
@@ -20,7 +20,60 @@ type Applier struct {
 	db           *pebble.DB
 	lastApplied  uint64
 	appliedSince uint64 // entries since last explicit sync
-	mu           sync.Mutex
+	// invalidate, when non-nil, is called with every user key an applied entry
+	// touched, AFTER the write is committed to Pebble (#869). The applier holds
+	// a bare *pebble.DB, so a replicated mutation lands on disk underneath the
+	// storage layer's in-memory caches; a follower that had already cached an
+	// engram kept serving the stale copy — soft-deletes, evolve supersession,
+	// trust changes, every in-place mutation — until the process restarted.
+	// The callback is how the storage layer hears about applied keys without
+	// the applier importing storage (which would be an import cycle); it is
+	// wired at server construction, mirroring how the storage layer's
+	// RepLogAppend hook points the other way.
+	//
+	// Invalidation deliberately runs after Commit: invalidating first would
+	// let a concurrent read re-load the OLD value from Pebble and re-cache it
+	// just before the commit lands, resurrecting exactly the staleness this
+	// removes. After Commit, a racing read caches the new state, which is fine.
+	invalidate func(key []byte)
+	mu         sync.Mutex
+}
+
+// SetInvalidate installs the per-key cache-invalidation callback (#869).
+// It is a setter rather than a NewApplier parameter because of construction
+// order in cmd/muninn/server.go: the applier is built with the coordinator
+// before the storage layer exists, and the storage layer is what owns the
+// caches to invalidate. Call once during server wiring, before replication
+// traffic flows; the callback must be safe for concurrent use.
+func (a *Applier) SetInvalidate(fn func(key []byte)) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.invalidate = fn
+}
+
+// invalidateBatchKeys decodes an applied batch repr and feeds every user key
+// it touched to the invalidation callback. Called with a.mu held, after the
+// repr has been committed. A decode failure is logged and abandoned rather
+// than returned: the batch itself was applied successfully, and failing the
+// Apply here would make the follower re-request an entry it already holds.
+func (a *Applier) invalidateBatchKeys(repr []byte, seq uint64) {
+	if a.invalidate == nil {
+		return
+	}
+	r, _ := pebble.ReadBatch(repr)
+	for {
+		_, ukey, _, ok, err := r.Next()
+		if err != nil {
+			slog.Warn("applier: batch repr decode for cache invalidation failed — "+
+				"follower caches may serve stale entries for this batch",
+				"seq", seq, "err", err)
+			return
+		}
+		if !ok {
+			return
+		}
+		a.invalidate(ukey)
+	}
 }
 
 // NewApplier creates a new Applier for a Pebble database.
@@ -96,6 +149,9 @@ func (a *Applier) Apply(entry ReplicationEntry) (returnErr error) {
 		if err := markerBatch.Commit(pebble.NoSync); err != nil {
 			return err
 		}
+		// #869: the repr is committed — tell the storage layer which keys
+		// changed so its caches drop any entries the batch just mutated.
+		a.invalidateBatchKeys(entry.Value, entry.Seq)
 		a.lastApplied = entry.Seq
 		a.appliedSince++
 		if a.appliedSince >= applierSyncInterval {
@@ -123,6 +179,12 @@ func (a *Applier) Apply(entry ReplicationEntry) (returnErr error) {
 	// replication throughput proportional to fsync latency (~1 IOPS per entry).
 	if err := batch.Commit(pebble.NoSync); err != nil {
 		return err
+	}
+
+	// #869: single-key ops mutate exactly entry.Key — same invalidation
+	// contract as the OpBatch path, same after-commit ordering.
+	if a.invalidate != nil && len(entry.Key) > 0 {
+		a.invalidate(entry.Key)
 	}
 
 	a.lastApplied = entry.Seq

--- a/internal/replication/invalidation_869_test.go
+++ b/internal/replication/invalidation_869_test.go
@@ -1,0 +1,122 @@
+package replication_test
+
+// External test package: the #869 regression spans the replication/storage
+// seam, and storage is imported by this package's own dependency chain
+// (replication ← cognitive ← storage), so the test can only exist outside
+// both. That mirrors the production shape anyway — the two halves of the fix
+// are joined by a callback in cmd/muninn/server.go, not by an import.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scrypster/muninndb/internal/replication"
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// The #869 regression, end to end.
+//
+// A follower that has RECALLED an engram holds it in the L1 cache. A
+// replicated mutation of that engram (a soft-delete here — the privacy-worst
+// instance, but the same path carries evolve supersession, trust changes, tag
+// updates and restore) is committed by the applier straight to Pebble, which
+// the cache shadows. Without per-key invalidation the follower keeps serving
+// the cached copy as active until the process restarts — and because every
+// hit refreshes recency, the hottest memories are exactly the ones that never
+// heal.
+//
+// The wiring below is the same shape cmd/muninn/server.go uses: the primary
+// store's RepLogAppend hook captures what the storage layer would ship, the
+// follower's applier applies it, and SetInvalidate feeds applied keys back
+// into the follower store. The test fails without the applier's invalidation
+// calls (RED-checked by reverting them): the step-3 read then returns the
+// warmed StateActive copy instead of the applied StateSoftDeleted.
+func TestReplicatedSoftDelete_InvalidatesFollowerCache(t *testing.T) {
+	ctx := context.Background()
+
+	// Primary: a store whose replication hook captures every shipped entry.
+	pdb, err := storage.OpenPebble(t.TempDir(), storage.DefaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var shipped []replication.ReplicationEntry
+	var seq uint64
+	primary := storage.NewPebbleStore(pdb, storage.PebbleStoreConfig{
+		CacheSize: 1000,
+		RepLogAppend: func(op uint8, key, value []byte) error {
+			seq++
+			shipped = append(shipped, replication.ReplicationEntry{
+				Seq: seq,
+				Op:  replication.WALOp(op),
+				Key: append([]byte(nil), key...),
+				// Repr() buffers are reused after Close; the real stream copies
+				// via msgpack marshalling, so the capture copies too.
+				Value: append([]byte(nil), value...),
+			})
+			return nil
+		},
+	})
+	defer primary.Close()
+
+	// Follower: its own Pebble, its own store, an applier on the same DB,
+	// wired exactly as server.go wires them.
+	fdb, err := storage.OpenPebble(t.TempDir(), storage.DefaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	follower := storage.NewPebbleStore(fdb, storage.PebbleStoreConfig{CacheSize: 1000})
+	defer follower.Close()
+	applier := replication.NewApplier(fdb)
+	applier.SetInvalidate(follower.InvalidateReplicatedKey)
+
+	drain := func(stage string) {
+		t.Helper()
+		if len(shipped) == 0 {
+			t.Fatalf("%s: primary shipped no replication entries — capture hook not firing", stage)
+		}
+		for _, e := range shipped {
+			if err := applier.Apply(e); err != nil {
+				t.Fatalf("%s: apply seq %d: %v", stage, e.Seq, err)
+			}
+		}
+		shipped = shipped[:0]
+	}
+
+	var ws [8]byte
+
+	// 1. Create on the primary; stream to the follower.
+	id, err := primary.WriteEngram(ctx, ws, &storage.Engram{
+		Concept: "operator secret",
+		Content: "a memory the operator will explicitly forget",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	drain("create")
+
+	// 2. Recall on the follower — the read that loads the L1 cache and arms
+	// the bug. Asserting state here also proves the create replicated.
+	warmed, err := follower.GetEngram(ctx, ws, id)
+	if err != nil {
+		t.Fatalf("follower read after create: %v", err)
+	}
+	if warmed.State != storage.StateActive {
+		t.Fatalf("follower state after create = %v, want StateActive", warmed.State)
+	}
+
+	// 3. Forget on the primary; stream the deletion; recall again WITHOUT any
+	// restart. The follower must observe the deletion through its warm cache.
+	if err := primary.SoftDelete(ctx, ws, id); err != nil {
+		t.Fatal(err)
+	}
+	drain("soft-delete")
+
+	got, err := follower.GetEngram(ctx, ws, id)
+	if err != nil {
+		t.Fatalf("follower read after replicated delete: %v", err)
+	}
+	if got.State != storage.StateSoftDeleted {
+		t.Fatalf("follower state after replicated soft-delete = %v, want StateSoftDeleted — "+
+			"the warmed cache entry survived the applied mutation (#869)", got.State)
+	}
+}

--- a/internal/storage/replica_invalidation.go
+++ b/internal/storage/replica_invalidation.go
@@ -1,0 +1,58 @@
+package storage
+
+import (
+	"github.com/scrypster/muninndb/internal/prefix"
+)
+
+// InvalidateReplicatedKey drops any in-memory cache entry shadowing a key that
+// the replication applier just committed to Pebble (#869).
+//
+// On a follower, replicated writes bypass this store entirely: the applier
+// holds a bare *pebble.DB and commits batch reprs straight to disk. Every read
+// path here, though, is cache-first — GetEngram consults the L1 engram cache
+// and GetMetadata consults metaCache before touching Pebble. So a replicated
+// in-place mutation of an engram a follower had already read (soft-delete,
+// evolve supersession, not_true_since invalidation, trust or tag changes,
+// restore) landed in Pebble underneath a cache entry that kept serving the old
+// state — and because every cache hit refreshes recency, the hotter the
+// memory, the longer its mutation stayed invisible. A restart healed it only
+// because the caches die with the process.
+//
+// This is the storage half of the fix: the applier feeds every user key it
+// commits through a callback (wired in cmd/muninn/server.go), and this method
+// maps those keys back to cache entries. Only two key shapes can shadow a
+// cached read, and both are 25 bytes:
+//
+//	0x01 | ws(8) | id(16) — full engram record → L1 engram cache + metaCache
+//	0x02 | ws(8) | id(16) — metadata record    → metaCache
+//
+// The metaCache is keyed by engram ID alone (ULIDs are globally unique), so
+// the vault prefix only matters for the L1 delete. Every other prefix passes
+// through untouched: association and index keys have their own caches with
+// their own invalidation story (assocCache/revAssocCache carry a 2s TTL, so
+// replicated association churn ages out on its own — see #818 for the known
+// gaps there), and a follower applies constant Hebbian/decay traffic, so
+// clearing anything more than the touched keys would make the caches useless.
+//
+// Safe for concurrent use: L1Cache.Delete and metaCache.Remove are both
+// concurrency-safe, and the applier may call this while readers are active.
+// A miss is a no-op — invalidating a key that was never cached costs a map
+// lookup.
+func (ps *PebbleStore) InvalidateReplicatedKey(key []byte) {
+	if len(key) != 25 {
+		return
+	}
+	switch key[0] {
+	case prefix.Engram:
+		var ws [8]byte
+		copy(ws[:], key[1:9])
+		var id [16]byte
+		copy(id[:], key[9:25])
+		ps.cache.Delete(ws, ULID(id))
+		ps.metaCache.Remove(id)
+	case prefix.Meta:
+		var id [16]byte
+		copy(id[:], key[9:25])
+		ps.metaCache.Remove(id)
+	}
+}

--- a/internal/storage/replica_invalidation_test.go
+++ b/internal/storage/replica_invalidation_test.go
@@ -1,0 +1,50 @@
+package storage
+
+import (
+	"context"
+	"testing"
+)
+
+// The end-to-end #869 regression (replicated soft-delete must penetrate a
+// follower's warm cache) lives in internal/replication/invalidation_869_test.go
+// as an external test package: this package is imported by replication via
+// cognitive, so the cross-seam test cannot live here without a cycle.
+
+// Keys that are not engram or meta records must pass through untouched, and
+// arbitrary shapes must not panic the invalidator — the applier feeds it every
+// key of every replicated batch, including association, index and counter keys.
+func TestInvalidateReplicatedKey_IgnoresForeignKeys(t *testing.T) {
+	db, err := OpenPebble(t.TempDir(), DefaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ps := NewPebbleStore(db, PebbleStoreConfig{CacheSize: 10})
+	defer ps.Close()
+
+	var ws [8]byte
+	id, err := ps.WriteEngram(context.Background(), ws, &Engram{Concept: "c", Content: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ps.GetEngram(context.Background(), ws, id); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ps.cache.Get(ws, id); !ok {
+		t.Fatal("engram not cached after read")
+	}
+
+	for _, key := range [][]byte{
+		nil,
+		{},
+		{0x01},           // engram prefix, truncated
+		make([]byte, 24), // one byte short
+		make([]byte, 26), // one byte long
+		append([]byte{0x03}, make([]byte, 24)...), // assoc-shaped, 25 bytes, wrong prefix
+	} {
+		ps.InvalidateReplicatedKey(key)
+	}
+
+	if _, ok := ps.cache.Get(ws, id); !ok {
+		t.Fatal("foreign keys must not evict unrelated cache entries")
+	}
+}


### PR DESCRIPTION
Fixes #869. Taking you up on "it's yours" — implemented to the scope in your triage comment, traps included.

## The fix, in your frame

The applier gains an invalidation callback and feeds every user key an applied entry touched through it, **after** Commit. The OpBatch path decodes the applied repr with `pebble.ReadBatch`; single-key ops pass `entry.Key`. The storage half maps keys back to cache entries and drops exactly those.

**On the after-Commit ordering** (not in the triage, but load-bearing): invalidating before the commit would let a racing read re-load the *old* value from Pebble and re-cache it just before the commit lands — resurrecting exactly the staleness this removes. After Commit, a racing read caches the new state, which is fine.

## The four traps

1. **No storage dependency** — `Applier.SetInvalidate(func(key []byte))`, wired in `cmd/muninn/server.go` right next to `storeCfg.RepLogAppend`; the comment there names them as mirror images. It's a setter rather than a `NewApplier` parameter only because of construction order: server.go builds the applier with the coordinator before the store exists.
2. **Per-key, never a full clear** — only the touched keys drop. Foreign prefixes (assoc, index, counters, Hebbian/decay traffic) pass through unexamined; `assocCache`/`revAssocCache` have their own 2s TTL story and stay out of scope (#818).
3. **Both caches** — `0x01` engram keys drop the vault-scoped L1 entry *and* the metaCache entry; `0x02` meta keys drop the metaCache entry. metaCache is keyed by ID alone (ULIDs are globally unique), so the vault prefix only gates the L1 delete.
4. **The regression test fails without the fix** — verified by actually reverting it, not by assertion:

```
invalidation_869_test.go:119: follower state after replicated soft-delete = active,
want StateSoftDeleted — the warmed cache entry survived the applied mutation (#869)
```

`TestReplicatedSoftDelete_InvalidatesFollowerCache` follows your spec: primary store ships real `RepLogAppend` batches, a follower applier applies them, a read warms the follower's cache, the replicated soft-delete is applied, and recall must observe it **with no restart**. It lives in `internal/replication` as an *external* test package — the seam crosses the `replication ← cognitive ← storage` import cycle, which is also exactly why production joins the two halves in server.go rather than by import.

A second test pins the invalidator's edges: nil/truncated/oversized/wrong-prefix keys neither panic nor evict unrelated entries — the applier feeds it every key of every batch, so it must be indifferent to shapes it doesn't own.

## One behavior note

A decode failure in the applied repr is logged and abandoned rather than returned: the batch itself committed successfully, and failing the Apply would make the follower re-request an entry it already holds. The log line says which seq, and that caches may serve stale entries for that batch.

## Verification

- `go test ./internal/replication/ ./internal/storage/` — green (41.9s / 57.6s)
- `go vet`, `gofmt` — clean
- RED check as above

Next: deploying this build to one of my macOS observers and running the #869 repro live against it (write → recall-on-lobe to warm → forget on Cortex → recall-on-lobe again, no restart). I'll report the result on the issue either way.