### PR TITLE
test(engine): name novelty/RelRefines in the COG-29 fixture comment

### DIFF
--- a/internal/engine/engine_contradiction_debt_test.go
+++ b/internal/engine/engine_contradiction_debt_test.go
@@ -50,11 +50,10 @@ func debtPairFixture(t *testing.T, eng *Engine, vault, subject, factA, factB str
 		t.Fatal(err)
 	}
 	ws := eng.Store().ResolveVaultPrefix(vault)
-	// Weight deliberately distinct from the auto-detected contradiction marker's
-	// weight. The contradiction worker emits its own (different-RelType) detected
-	// edge between these near-identical facts; if both edges land at the same
-	// (src, weight, target) the assoc_reltype_guard rejects the second write and
-	// the fixture flakes. The readout counts Declared edges regardless of weight.
+	// Weight 0.5 cannot collide with RelRefines (rel_type 16). The novelty
+	// worker writes RelRefines at Jaccard similarity, which is always >= 0.70
+	// (the frog pair is exactly 0.8). WaitWriteTimeIdle does not drain that
+	// worker. The readout counts Declared edges regardless of weight.
 	if err := eng.Store().WriteAssociation(ctx, ws, idB, idA, &storage.Association{
 		TargetID: idA, RelType: storage.RelContradicts, Weight: 0.5, Confidence: 1,
 		CreatedAt: declaredAt,


### PR DESCRIPTION
## Summary
Comment-only follow-up to #876. The 0.5 fixture weight stays. The comment now names the novelty worker and RelRefines (rel_type 16) instead of the contradiction worker.

## Test plan
- [x] Diff is the comment block only
- [ ] `go test -race -count=1 -timeout 10m ./internal/engine/ -run TestContradictionDebt`