### PR TITLE
fix(ci): bump Go to 1.26.6 — clears reachable stdlib advisories in vuln scan

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scrypster/muninndb
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/bits-and-blooms/bloom/v3 v3.7.1


### PR DESCRIPTION
Develop's CI is red on the Vulnerability scan — and so is every open PR against it, including #874. This bumps the `go` directive one patch release to clear it.

## Problem

`develop` @ `34b505f` (run [32142058965](https://github.com/scrypster/muninndb/actions/runs/32142058965)) fails `Vulnerability scan` — the only failing job. `govulncheck@v1.6.0` reports **6 reachable Go standard-library advisories** against the pinned `go 1.26.5`:

| Advisory | Package | Fixed in |
|---|---|---|
| GO-2026-6218 | net/url | go1.26.6 |
| GO-2026-6091 | html/template | go1.26.6 |
| GO-2026-6090 | crypto/tls | go1.26.6 |
| GO-2026-6089 | net/http | go1.26.6 |
| GO-2026-5972 | encoding/asn1 | go1.26.6 |
| GO-2026-5026 | net/http | go1.26.6 |

These advisories postdate the last green run (Aug 12) — the scan didn't regress from any commit; the vuln DB moved. All findings are stdlib/toolchain-level; no module dependency is involved.

## Fix

One line: `go 1.26.5` → `go 1.26.6` in `go.mod`. All five CI jobs resolve their toolchain via `go-version-file: go.mod`, so no workflow changes are needed. No `toolchain` directive is introduced (the repo doesn't use one); the directive floor is the mechanism CI already reads. No dependency changes.

## Verification

- `go build -tags localassets ./... && go vet -tags localassets ./... && gofmt -l .` — clean on 1.26.6.
- `govulncheck@v1.6.0 ./...` (same version CI pins) on the bumped tree: **"Your code is affected by 0 vulnerabilities"** — all 6 reachable stdlib findings gone. 3 unreachable module-level findings remain; those are pre-existing and non-failing (the scan gates on reachable code).
- Red state is develop's own, not diff-caused: the flagged call sites are pre-existing code (`internal/plugin/embed`, `internal/mcp`, `internal/metrics`, `internal/replication/tls.go`, `cmd/muninn/doctor.go`).

## Effect

Once this lands, #874's `Vulnerability scan` check clears (its red is inherited from develop, not from that PR's diff — the sole file overlap, `internal/transport/grpc/server.go`, flags a pre-existing `grpc.Server.Serve` → tls path unchanged by #874).
