### PR TITLE
fix(metrics): stop double-counting upsert-creates and counting no-ops as engram writes

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2004,7 +2004,11 @@ func (e *Engine) writeUpsert(ctx context.Context, wsPrefix [8]byte, req *mbp.Wri
 		// Identical content: no-op. Cheap fast path — no write, no evolve, no
 		// index churn. Return the existing head id with the identical hint so
 		// callers can tell nothing changed.
-		metrics.EngineWritesTotal.Inc()
+		//
+		// No EngineWritesTotal increment: no engram is written on this path, and
+		// the counter is documented as "Total number of engrams written". The
+		// latency observations below stay — a call was served, and this is the
+		// only place that fast path is measured.
 		d := time.Since(start)
 		if e.latencyTracker != nil {
 			e.latencyTracker.Record(wsPrefix, "write", d)
@@ -2105,12 +2109,10 @@ func (e *Engine) upsertCreate(ctx context.Context, wsPrefix [8]byte, vaultName s
 	}
 	resp.Hint = "upsert-created"
 
-	metrics.EngineWritesTotal.Inc()
-	d := time.Since(start)
-	if e.latencyTracker != nil {
-		e.latencyTracker.Record(wsPrefix, "write", d)
-	}
-	metrics.WriteDuration.WithLabelValues(vaultName).Observe(d.Seconds())
+	// No write instrumentation here: this function delegates the actual write to
+	// e.Write() above, which already incremented EngineWritesTotal, recorded the
+	// latency sample and observed WriteDuration for this same write. Repeating
+	// them here double-counted every upsert-create.
 	return resp, nil
 }
 

--- a/internal/engine/writes_total_accounting_test.go
+++ b/internal/engine/writes_total_accounting_test.go
@@ -1,0 +1,130 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/scrypster/muninndb/internal/metrics"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// writesTotal reads the process-global engram-write counter. Every assertion
+// below is a DELTA, since the counter is shared across the test binary.
+func writesTotal(t *testing.T) float64 {
+	t.Helper()
+	return testutil.ToFloat64(metrics.EngineWritesTotal)
+}
+
+func TestEngineWritesTotal_PlainWriteCountedOnce(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	before := writesTotal(t)
+	if _, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "default", Concept: "plain", Content: "a plain write",
+	}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := writesTotal(t) - before; got != 1 {
+		t.Errorf("delta = %v, want 1", got)
+	}
+}
+
+// upsertCreate delegates the write to e.Write, which counts on its own. Before
+// the fix this path incremented in both places.
+func TestEngineWritesTotal_UpsertCreateCountedOnce(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	before := writesTotal(t)
+	if _, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "default", Concept: "u", Content: "upsert v1",
+		UpsertMode: true, IdempotentID: "acct-key-1",
+	}); err != nil {
+		t.Fatalf("upsert create: %v", err)
+	}
+	if got := writesTotal(t) - before; got != 1 {
+		t.Errorf("delta = %v, want 1 (2 = the delegated Write was counted twice)", got)
+	}
+}
+
+// The identical-content branch is a documented no-op: "no write, no evolve, no
+// index churn". Nothing is stored, so the engram counter must not move.
+func TestEngineWritesTotal_UpsertNoOpNotCounted(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	req := func() *mbp.WriteRequest {
+		return &mbp.WriteRequest{
+			Vault: "default", Concept: "u2", Content: "identical content",
+			UpsertMode: true, IdempotentID: "acct-key-2",
+		}
+	}
+	if _, err := eng.Write(ctx, req()); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	afterCreate := writesTotal(t)
+
+	resp, err := eng.Write(ctx, req())
+	if err != nil {
+		t.Fatalf("second upsert (no-op): %v", err)
+	}
+	if resp.Hint != "upsert-identical" {
+		t.Fatalf("expected the no-op branch, got hint %q", resp.Hint)
+	}
+	if got := writesTotal(t) - afterCreate; got != 0 {
+		t.Errorf("delta = %v, want 0 (nothing is written on the no-op path)", got)
+	}
+}
+
+// Guard that the fix did not silently stop counting the upsert-evolve path,
+// which is the only site that counts an evolve (evolveAtInternal does not).
+func TestEngineWritesTotal_UpsertEvolveStillCounted(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "default", Concept: "u3", Content: "original content",
+		UpsertMode: true, IdempotentID: "acct-key-3",
+	}); err != nil {
+		t.Fatalf("upsert create: %v", err)
+	}
+	afterCreate := writesTotal(t)
+
+	if _, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "default", Concept: "u3", Content: "CHANGED content",
+		UpsertMode: true, IdempotentID: "acct-key-3",
+	}); err != nil {
+		t.Fatalf("upsert evolve: %v", err)
+	}
+	if got := writesTotal(t) - afterCreate; got != 1 {
+		t.Errorf("delta = %v, want 1 (the evolve branch is the only counter for that path)", got)
+	}
+}
+
+func TestEngineWritesTotal_BatchCountsEachEngram(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	before := writesTotal(t)
+	_, errs := eng.WriteBatch(ctx, []*mbp.WriteRequest{
+		{Vault: "default", Concept: "b1", Content: "batch one"},
+		{Vault: "default", Concept: "b2", Content: "batch two"},
+		{Vault: "default", Concept: "b3", Content: "batch three"},
+	})
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("WriteBatch[%d]: %v", i, err)
+		}
+	}
+	if got := writesTotal(t) - before; got != 3 {
+		t.Errorf("delta = %v, want 3", got)
+	}
+}


### PR DESCRIPTION

# fix(metrics): stop double-counting upsert-creates and counting no-ops as engram writes

`muninndb_engine_writes_total` is documented as *"Total number of engrams written"*.
Two paths break that, both introduced together in #556 when the UPSERT write mode
was added — the new branches were instrumented without noticing that the path they
delegate to already instruments itself.

## 1. Upsert-create is counted twice

`upsertCreate` does not write anything itself. It delegates:

```go
resp, err := e.Write(withSkipContentDedup(ctx), &createReq)
```

`Write` then increments `EngineWritesTotal`, records the latency sample and observes
`WriteDuration`. `upsertCreate` repeats **all three** at the end of the same call, so
one upsert-create produces two increments, two latency samples and two duration
observations for a single write.

Fixed by removing the duplicated block; the delegated `Write` remains the single
point of instrumentation for that write.

## 2. The identical-content no-op is counted as a write

The branch whose own comment reads:

> Identical content: no-op. Cheap fast path — no write, no evolve, no index churn.

increments `EngineWritesTotal` before returning the existing id. No engram is
written, so the counter moves for something that by its own description is not a
write.

Fixed by removing only the increment. **The latency observations there are kept
deliberately** — a call *was* served, and that is the only place this fast path is
measured. The two changes differ for that reason: at `upsertCreate` the latency data
is a duplicate of the same work, whereas on the no-op path it is the sole
observation of a distinct operation.

## What is deliberately left alone

- **The upsert-evolve branch keeps its increment.** `evolveAtInternal` does not
  increment, so that site is the only counter for an evolve. A test guards it.
- **`RememberTree` still does not count.** It builds nodes with
  `e.store.NewBatch()` + `batch.WriteEngram(...)` and never routes through
  `Write`/`WriteBatch`, so tree nodes are absent from this counter entirely. Out of
  scope here, but worth knowing — the help text reads as though it covers them.
  Happy to fold them in, or narrow the help text, in a follow-up if you have a
  preference.

## If you disagree on the no-op

Counting a served no-op as *request* volume is a defensible thing to want; it is
just not what this counter's name and help text promise. If you would rather keep
that visibility, say so and I will drop that hunk and add a separate
`muninndb_engine_upsert_noop_total` instead — the double-count fix stands on its own
either way.

## Tests

`internal/engine/writes_total_accounting_test.go`, five tests, all deltas (the
counter is process-global):

- plain write → 1
- upsert-create → 1 — **RED-checked**: reverting the fix reports `delta = 2`
- upsert no-op → 0 — **RED-checked**: reverting the fix reports `delta = 1`
- upsert-evolve → 1 (guards that the fix did not silence the evolve path)
- 3-engram batch → 3

Verified against `develop` at `34b505f`: `gofmt` clean, `go vet` clean, full module
`go test ./...` **51 ok / 0 FAIL**, `go test -race ./internal/engine/` clean with 0
data races. The three non-bug tests pass both before and after the fix, which is
what shows the change is narrow.
