### PR TITLE
feat(metrics): count engram writes stored without a caller-supplied summary

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1380,6 +1380,26 @@ func importanceFromRequest(p *float32) float32 {
 }
 
 // Write implements mbp.EngineAPI.Write.
+// observeWriteFloor records, per vault, an engram that was persisted with no
+// summary. It reads the ENGRAM rather than the WriteRequest, so it reflects what
+// was actually stored and therefore already respects the vault's InlineEnrichment
+// gating (under "background_only" the caller's fields are discarded by design).
+//
+// Called only from the sites where an engram genuinely becomes durable without
+// delegating: Write and the direct branch of WriteBatch. Deliberately NOT called
+// from the writeUpsert identical-content branch (a no-op: nothing is stored) nor
+// from upsertCreate (which delegates to Write and would double-count). The
+// upsert-evolve branch is not covered because the successor engram is not in
+// scope there, only its id.
+func observeWriteFloor(vaultName string, eng *storage.Engram) {
+	if eng == nil {
+		return
+	}
+	if strings.TrimSpace(eng.Summary) == "" {
+		metrics.WritesMissingFieldTotal.WithLabelValues(vaultName, "summary").Inc()
+	}
+}
+
 func (e *Engine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteResponse, error) {
 	// Cluster single-writer gate (#596). Additive methods have no append gate to
 	// hang this off, so they call it directly.
@@ -1897,6 +1917,7 @@ func (e *Engine) Write(ctx context.Context, req *mbp.WriteRequest) (*mbp.WriteRe
 	}
 
 	metrics.EngineWritesTotal.Inc()
+	observeWriteFloor(vaultName, eng)
 
 	d := time.Since(writeStart)
 	if e.latencyTracker != nil {
@@ -2670,6 +2691,7 @@ func (e *Engine) WriteBatch(ctx context.Context, reqs []*mbp.WriteRequest) ([]*m
 		}
 
 		metrics.EngineWritesTotal.Inc()
+		observeWriteFloor(p.vaultName, p.eng)
 	}
 
 	return responses, errs

--- a/internal/engine/write_floor_metric_test.go
+++ b/internal/engine/write_floor_metric_test.go
@@ -1,0 +1,117 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/scrypster/muninndb/internal/metrics"
+	"github.com/scrypster/muninndb/internal/transport/mbp"
+)
+
+// missingSummaryCount reads the current value of the summary counter for a
+// vault. The metric is process-global, so every assertion here is a DELTA.
+func missingSummaryCount(t *testing.T, vault string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(metrics.WritesMissingFieldTotal.WithLabelValues(vault, "summary"))
+}
+
+func TestObserveWriteFloor_SummaryPresence(t *testing.T) {
+	tests := []struct {
+		name    string
+		summary string
+		want    float64
+	}{
+		{"summary supplied", "a real one-line summary", 0},
+		{"summary absent", "", 1},
+		{"summary whitespace only", "   \t\n ", 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			eng, cleanup := testEnv(t)
+			defer cleanup()
+			ctx := context.Background()
+
+			before := missingSummaryCount(t, "default")
+			if _, err := eng.Write(ctx, &mbp.WriteRequest{
+				Vault: "default", Concept: "c-" + tc.name, Content: "content for " + tc.name,
+				Summary: tc.summary,
+			}); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			if got := missingSummaryCount(t, "default") - before; got != tc.want {
+				t.Errorf("delta = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestObserveWriteFloor_BatchCountsPerEngram(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	before := missingSummaryCount(t, "default")
+	reqs := []*mbp.WriteRequest{
+		{Vault: "default", Concept: "b1", Content: "batch one", Summary: "has a summary"},
+		{Vault: "default", Concept: "b2", Content: "batch two"},
+		{Vault: "default", Concept: "b3", Content: "batch three"},
+	}
+	_, errs := eng.WriteBatch(ctx, reqs)
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("WriteBatch[%d]: %v", i, err)
+		}
+	}
+	if got := missingSummaryCount(t, "default") - before; got != 2 {
+		t.Errorf("delta = %v, want 2 (only the two without a summary)", got)
+	}
+}
+
+// Regression guard for the placement decision: upsertCreate delegates to Write,
+// which observes on its own. Observing at BOTH sites would count one create
+// twice. This asserts exactly one observation for one upsert-create.
+func TestObserveWriteFloor_UpsertCreateNotDoubleCounted(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	before := missingSummaryCount(t, "default")
+	if _, err := eng.Write(ctx, &mbp.WriteRequest{
+		Vault: "default", Concept: "u1", Content: "upsert v1",
+		UpsertMode: true, IdempotentID: "upsert-key-1",
+	}); err != nil {
+		t.Fatalf("upsert create: %v", err)
+	}
+	if got := missingSummaryCount(t, "default") - before; got != 1 {
+		t.Errorf("delta = %v, want exactly 1 (2 would mean the delegated Write was double-observed)", got)
+	}
+}
+
+// Regression guard for the second placement decision: the identical-content
+// upsert branch is a no-op ("no write, no evolve, no index churn"), so nothing
+// was stored and nothing must be observed.
+func TestObserveWriteFloor_UpsertNoOpNotCounted(t *testing.T) {
+	eng, cleanup := testEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	req := func() *mbp.WriteRequest {
+		return &mbp.WriteRequest{
+			Vault: "default", Concept: "u2", Content: "identical content",
+			UpsertMode: true, IdempotentID: "upsert-key-2",
+		}
+	}
+	if _, err := eng.Write(ctx, req()); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	afterCreate := missingSummaryCount(t, "default")
+
+	if _, err := eng.Write(ctx, req()); err != nil {
+		t.Fatalf("second upsert (no-op): %v", err)
+	}
+	if got := missingSummaryCount(t, "default") - afterCreate; got != 0 {
+		t.Errorf("delta = %v, want 0 (the no-op branch stores nothing)", got)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -103,6 +103,22 @@ var (
 		Name: "muninn_mcp_auth_total",
 		Help: "Total authenticated MCP requests by credential source (api_key, capability, static_token, open).",
 	}, []string{"source"})
+
+	// WritesMissingFieldTotal counts engram writes that stored successfully but
+	// carried no value for a caller-supplied enrichment field, per vault and
+	// field. Paired with muninndb_engine_writes_total this gives an operator a
+	// rate(missing)/rate(total) signal for how fast a vault accumulates engrams
+	// that no later stage will fill in — on a deployment with no summarize stage
+	// registered, `summary` is caller-supplied-only and nothing ever backfills it.
+	//
+	// Deliberately a CounterVec with a `field` label rather than one counter per
+	// field, so another field can be added later without minting and then
+	// deprecating a metric name. The usual CounterVec property applies: a field
+	// with no violations emits no series at all, so absence reads as "none".
+	WritesMissingFieldTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "muninndb_engine_writes_missing_field_total",
+		Help: "Total engram writes stored without a value for a caller-supplied enrichment field, per vault and field.",
+	}, []string{"vault", "field"})
 )
 
 // VaultStore is the subset of storage.PebbleStore methods needed by VaultEngramCollector.


### PR DESCRIPTION

# feat(metrics): count engram writes stored without a caller-supplied summary

## Why

`summary` is caller-supplied on any deployment where no summarize stage runs. When
a caller omits it, the engram is stored successfully and nothing anywhere reports
that it happened — not a log line, not a status field, not a metric. The gap is
silent by construction, and it only becomes visible when someone goes looking.

Field data from one production deployment, measured offline against backup copies:

| month | engrams stored | stored without a summary |
|---|---|---|
| 2026-03 | 225 | 0 |
| 2026-04 | 140 | 0 |
| 2026-05 | 501 | 0 |
| 2026-06 | 1076 | 110 |
| 2026-07 | 427 | 37 |
| 2026-08 (partial) | 350 | 33 |

Zero for three months, then **180 of 1,853 (9.7%)** over the next three. The shape
is the point: this is not a steady background rate that an operator would have
noticed and priced in — it *started*, and then ran unobserved for about two months
before anyone measured it. It cost a 154-engram manual backfill to clear.

Whether a deployment cares depends on its enrichment config, which is exactly why
this should be a number the operator can scrape rather than a property they have to
go discover.

## What this adds

One `CounterVec`:

```go
// WritesMissingFieldTotal counts engram writes that stored successfully but
// carried no value for a caller-supplied enrichment field, per vault and field.
// Paired with muninndb_engine_writes_total it gives a rate(missing)/rate(total)
// signal for how fast a vault accumulates engrams that no later stage will fill.
//
// Deliberately a CounterVec with a `field` label rather than one counter per
// field, so a field can be added later without minting and then deprecating a
// metric name. Usual CounterVec property applies: a field with no violations
// emits no series at all, so absence reads as "none".
WritesMissingFieldTotal = promauto.NewCounterVec(prometheus.CounterOpts{
	Name: "muninndb_engine_writes_missing_field_total",
	Help: "Total engram writes stored without a value for a caller-supplied enrichment field, per vault and field.",
}, []string{"vault", "field"})
```

and a helper in `internal/engine`, kept there rather than in `internal/metrics` so
the metrics package does not take a new dependency on `transport/mbp`:

```go
// observeWriteFloor records, per vault, an engram persisted with no summary.
// It reads the ENGRAM rather than the request, so it reflects what was actually
// stored and therefore already respects the vault's InlineEnrichment gating
// (under "background_only" the caller's fields are discarded by design).
func observeWriteFloor(vaultName string, eng *storage.Engram) {
	if eng == nil {
		return
	}
	if strings.TrimSpace(eng.Summary) == "" {
		metrics.WritesMissingFieldTotal.WithLabelValues(vaultName, "summary").Inc()
	}
}
```

`strings` is already imported in `engine.go`; `vaultName` is already in scope at
every call site.

## Placement — and why not simply "next to every EngineWritesTotal.Inc()"

That was the obvious placement and it is wrong. `EngineWritesTotal` fires at five
sites in `engine.go`, and three of them must not carry a floor observation:

- **`writeUpsert`, identical-content branch** — its own comment reads *"Identical
  content: no-op. Cheap fast path — no write, no evolve, no index churn."* Nothing
  is stored, so there is nothing to observe.
- **`upsertCreate`** — delegates the write (`resp, err := e.Write(withSkipContentDedup(ctx), &createReq)`)
  and `Write` observes on its own path. Observing here too would double-count.
- **`writeUpsert`, evolve branch** — the successor engram is not in scope, only its
  id (`newID, evErr := e.evolveAtInternal(...)`). Observing it correctly would need
  an extra read, so it is left uncovered rather than guessed at. See below.

So the counter is placed at the two sites where an engram becomes durable and is in
scope: `Write` (`eng`) and the direct branch of `WriteBatch` (`p.eng`, `p.vaultName`).

Both exclusions are covered by regression tests that fail if the observation is
added back at those sites — see Tests.

Those same first two sites mean `muninndb_engine_writes_total` currently
double-counts upsert-creates and counts no-ops. That is fixed separately in #887,
kept apart so each PR stays single-purpose — but it matters here because that
counter is the natural denominator: until #887 lands, `rate(missing)/rate(total)`
reads slightly low. The numerator this PR adds is exact either way.

**Merge order:** #887 first if you take both. This branch is built on `develop` and
applies cleanly on top of #887 — verified by applying both patches in sequence to a
clean tree and running the combined suites.

## Known coverage gaps (disclosed, not fixed)

**Upsert-evolve** is uncovered for the scope reason above — an engram is stored, but
this PR cannot see its summary without an extra read. Worth noting that this is
exactly the path that produces summary-less engrams most reliably, since an evolve
successor is built with `Summary` unset by design.

**Tree writes.** `RememberTree` does not route through `Write`/`WriteBatch` — it builds its nodes
with `e.store.NewBatch()` + `batch.WriteEngram(...)` and never touches
`EngineWritesTotal`. Tree nodes are therefore absent from both the existing counter
and this one. Left alone deliberately so this PR matches the existing counter's
scope exactly rather than silently changing what "writes" means; happy to extend
in a follow-up if you want tree writes counted.

## Tests

`internal/engine/write_floor_metric_test.go`, four tests, all deltas (the metric is
process-global):

- `TestObserveWriteFloor_SummaryPresence` — summary supplied → 0; absent → 1;
  whitespace-only → 1.
- `TestObserveWriteFloor_BatchCountsPerEngram` — a 3-engram batch with one summary
  records exactly 2.
- `TestObserveWriteFloor_UpsertCreateNotDoubleCounted` — one upsert-create records
  exactly 1. **RED-checked**: adding the observation to `upsertCreate` makes it
  report `delta = 2`.
- `TestObserveWriteFloor_UpsertNoOpNotCounted` — a repeated identical upsert records
  0. **RED-checked**: adding the observation to the no-op branch makes it report
  `delta = 1`.

Verified against `develop` at `34b505f`: `gofmt` clean, `go vet` clean, full module
`go test ./...` **51 ok / 0 FAIL**, and `go test -race` on `internal/engine` and
`internal/metrics` clean with 0 data races.

## Unrelated observation while preparing this

A fresh checkout of `develop` shows `web/static/vendor/layout-base-2.0.1.js` as
modified with a ~120-line diff before any edit. `.gitattributes` marks it
`text: set` but the committed blob has CRLF, so git normalizes it on checkout. It
survives `git restore`. Harmless, but it silently inflates any PR raised from a
clean clone unless the author stages selectively — happy to send a one-line
`.gitattributes` fix separately if useful.
